### PR TITLE
stabalize tests: increase timeout, allow without DSN specified

### DIFF
--- a/pkg/checksum/checker_test.go
+++ b/pkg/checksum/checker_test.go
@@ -18,7 +18,7 @@ import (
 func dsn() string {
 	dsn := os.Getenv("MYSQL_DSN")
 	if dsn == "" {
-		panic("MYSQL_DSN is not set")
+		return "msandbox:msandbox@tcp(127.0.0.1:8030)/test"
 	}
 	return dsn
 }

--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -18,7 +18,8 @@ import (
 func dsn() string {
 	dsn := os.Getenv("MYSQL_DSN")
 	if dsn == "" {
-		panic("MYSQL_DSN is not set")
+		// DSN is not set, use the default.
+		return "msandbox:msandbox@tcp(127.0.0.1:8030)/test"
 	}
 	return dsn
 }
@@ -250,14 +251,14 @@ func TestLockWaitTimeoutRetryExceeded(t *testing.T) {
 	t2 := table.NewTableInfo("test", "lock2t2")
 	assert.NoError(t, t2.RunDiscovery(db))
 
-	// Lock again but for 10 seconds.
+	// Lock again but for 12 seconds.
 	// This will cause a failure.
 	go func() {
 		tx, err := db.Begin()
 		assert.NoError(t, err)
 		_, err = tx.Exec("SELECT * FROM lock2t2 WHERE a = 1 FOR UPDATE")
 		assert.NoError(t, err)
-		time.Sleep(10 * time.Second)
+		time.Sleep(12 * time.Second)
 		err = tx.Rollback()
 		assert.NoError(t, err)
 	}()

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -16,7 +16,7 @@ import (
 func dsn() string {
 	dsn := os.Getenv("MYSQL_DSN")
 	if dsn == "" {
-		panic("MYSQL_DSN is not set")
+		return "msandbox:msandbox@tcp(127.0.0.1:8030)/test"
 	}
 	return dsn
 }

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -17,7 +17,7 @@ import (
 func dsn() string {
 	dsn := os.Getenv("MYSQL_DSN")
 	if dsn == "" {
-		panic("MYSQL_DSN is not set")
+		return "msandbox:msandbox@tcp(127.0.0.1:8030)/test"
 	}
 	return dsn
 }

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -395,7 +395,7 @@ func TestDynamicChunking(t *testing.T) {
 func dsn() string {
 	dsn := os.Getenv("MYSQL_DSN")
 	if dsn == "" {
-		panic("MYSQL_DSN is not set")
+		return "msandbox:msandbox@tcp(127.0.0.1:8030)/test"
 	}
 	return dsn
 }


### PR DESCRIPTION
By assuming a default without a `MYSQL_DSN` specified, it's possible to run each test adhoc in VSCode.