### PR TITLE
stabalize linter version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v1.51.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/pkg/repl/myeventhandler.go
+++ b/pkg/repl/myeventhandler.go
@@ -31,9 +31,6 @@ func (h *MyEventHandler) OnRow(e *canal.RowsEvent) error {
 			continue // key can be ignored
 		}
 		switch e.Action {
-		// TODO: check if the modification to the table was a DDL
-		// If there were any other DDLs, we need to abandon this.
-		// It's not safe to continue.
 		case canal.InsertAction, canal.UpdateAction:
 			h.client.keyHasChanged(key, false)
 		case canal.DeleteAction:


### PR DESCRIPTION
Use the same version available in homebrew for now, although it looks like good stuff is coming in latest.

Edit: It looks like the breakage is between 1.51.0 and 1.51.1.