### PR TITLE
Fix blockwait requiring FLUSH BINARY LOGS

### DIFF
--- a/pkg/checksum/checker_test.go
+++ b/pkg/checksum/checker_test.go
@@ -32,9 +32,10 @@ func runSQL(t *testing.T, stmt string) {
 }
 
 func TestBasicChecksum(t *testing.T) {
-	runSQL(t, "DROP TABLE IF EXISTS t1, t2")
+	runSQL(t, "DROP TABLE IF EXISTS t1, t2, _t1_cp")
 	runSQL(t, "CREATE TABLE t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
 	runSQL(t, "CREATE TABLE t2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	runSQL(t, "CREATE TABLE _t1_cp (a INT)") // for binlog advancement
 	runSQL(t, "INSERT INTO t1 VALUES (1, 2, 3)")
 	runSQL(t, "INSERT INTO t2 VALUES (1, 2, 3)")
 
@@ -60,9 +61,10 @@ func TestBasicChecksum(t *testing.T) {
 }
 
 func TestBasicValidation(t *testing.T) {
-	runSQL(t, "DROP TABLE IF EXISTS t1, t2")
+	runSQL(t, "DROP TABLE IF EXISTS t1, t2, _t1_cp")
 	runSQL(t, "CREATE TABLE t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
 	runSQL(t, "CREATE TABLE t2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	runSQL(t, "CREATE TABLE _t1_cp (a INT)") // for binlog advancement
 	runSQL(t, "INSERT INTO t1 VALUES (1, 2, 3)")
 	runSQL(t, "INSERT INTO t2 VALUES (1, 2, 3)")
 
@@ -94,9 +96,10 @@ func TestBasicValidation(t *testing.T) {
 }
 
 func TestCorruptChecksum(t *testing.T) {
-	runSQL(t, "DROP TABLE IF EXISTS t1, t2")
+	runSQL(t, "DROP TABLE IF EXISTS t1, t2, _t1_cp")
 	runSQL(t, "CREATE TABLE t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
 	runSQL(t, "CREATE TABLE t2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	runSQL(t, "CREATE TABLE _t1_cp (a INT)") // for binlog advancement
 	runSQL(t, "INSERT INTO t1 VALUES (1, 2, 3)")
 	runSQL(t, "INSERT INTO t2 VALUES (1, 2, 3)")
 	runSQL(t, "INSERT INTO t2 VALUES (2, 2, 3)") // corrupt

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -22,7 +22,7 @@ func dsn() string {
 }
 
 func TestCutOver(t *testing.T) {
-	runSQL(t, `DROP TABLE IF EXISTS cutovert1, _cutovert1_shadow, _cutovert1_old`)
+	runSQL(t, `DROP TABLE IF EXISTS cutovert1, _cutovert1_shadow, _cutovert1_old, _cutovert1_cp`)
 	tbl := `CREATE TABLE cutovert1 (
 		id int(11) NOT NULL AUTO_INCREMENT,
 		name varchar(255) NOT NULL,
@@ -35,6 +35,8 @@ func TestCutOver(t *testing.T) {
 		PRIMARY KEY (id)
 	)`
 	runSQL(t, tbl)
+	runSQL(t, `CREATE TABLE _cutovert1_cp (a int)`) // for binlog advancement
+
 	// The structure is the same, but insert 2 rows in t1 so
 	// we can differentiate after the cutover.
 	runSQL(t, `INSERT INTO cutovert1 VALUES (1, 2), (2,2)`)
@@ -70,7 +72,7 @@ func TestCutOver(t *testing.T) {
 }
 
 func TestMDLLockFails(t *testing.T) {
-	runSQL(t, `DROP TABLE IF EXISTS mdllocks, _mdllocks_shadow, mdllocks_old`)
+	runSQL(t, `DROP TABLE IF EXISTS mdllocks, _mdllocks_shadow, _mdllocks_old, _mdllocks_cp`)
 	tbl := `CREATE TABLE mdllocks (
 		id int(11) NOT NULL AUTO_INCREMENT,
 		name varchar(255) NOT NULL,
@@ -83,6 +85,7 @@ func TestMDLLockFails(t *testing.T) {
 		PRIMARY KEY (id)
 	)`
 	runSQL(t, tbl)
+	runSQL(t, `CREATE TABLE _mdllocks_cp (a int)`) // for binlog advancement
 	// The structure is the same, but insert 2 rows in t1 so
 	// we can differentiate after the cutover.
 	runSQL(t, `INSERT INTO mdllocks VALUES (1, 2), (2,2)`)

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -34,9 +34,10 @@ func TestReplClient(t *testing.T) {
 	db, err := sql.Open("mysql", dsn())
 	assert.NoError(t, err)
 
-	runSQL(t, "DROP TABLE IF EXISTS replt1, replt2")
+	runSQL(t, "DROP TABLE IF EXISTS replt1, replt2, _replt1_cp")
 	runSQL(t, "CREATE TABLE replt1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
 	runSQL(t, "CREATE TABLE replt2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	runSQL(t, "CREATE TABLE _replt1_cp (a int)") // just used to advance binlog
 
 	t1 := table.NewTableInfo("test", "replt1")
 	assert.NoError(t, t1.RunDiscovery(db))
@@ -68,9 +69,11 @@ func TestReplClientComplex(t *testing.T) {
 	db, err := sql.Open("mysql", dsn())
 	assert.NoError(t, err)
 
-	runSQL(t, "DROP TABLE IF EXISTS replcomplext1, replcomplext2")
+	runSQL(t, "DROP TABLE IF EXISTS replcomplext1, replcomplext2, _replcomplext1_cp")
 	runSQL(t, "CREATE TABLE replcomplext1 (a INT NOT NULL auto_increment, b INT, c INT, PRIMARY KEY (a))")
 	runSQL(t, "CREATE TABLE replcomplext2 (a INT NOT NULL  auto_increment, b INT, c INT, PRIMARY KEY (a))")
+	runSQL(t, "CREATE TABLE _replcomplext1_cp (a int)") // just used to advance binlog
+
 	runSQL(t, "INSERT INTO replcomplext1 (a, b, c) SELECT NULL, 1, 1 FROM dual")
 	runSQL(t, "INSERT INTO replcomplext1 (a, b, c) SELECT NULL, 1, 1 FROM replcomplext1 a JOIN replcomplext1 b JOIN replcomplext1 c LIMIT 100000")
 	runSQL(t, "INSERT INTO replcomplext1 (a, b, c) SELECT NULL, 1, 1 FROM replcomplext1 a JOIN replcomplext1 b JOIN replcomplext1 c LIMIT 100000")
@@ -134,9 +137,10 @@ func TestReplClientResumeFromImpossible(t *testing.T) {
 	db, err := sql.Open("mysql", dsn())
 	assert.NoError(t, err)
 
-	runSQL(t, "DROP TABLE IF EXISTS replresumet1, replresumet2")
+	runSQL(t, "DROP TABLE IF EXISTS replresumet1, replresumet2, _replresumet1_cp")
 	runSQL(t, "CREATE TABLE replresumet1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
 	runSQL(t, "CREATE TABLE replresumet2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	runSQL(t, "CREATE TABLE _replresumet1_cp (a int)") // just used to advance binlog
 
 	t1 := table.NewTableInfo("test", "replresumet1")
 	assert.NoError(t, t1.RunDiscovery(db))
@@ -183,9 +187,11 @@ func TestReplClientOpts(t *testing.T) {
 	db, err := sql.Open("mysql", dsn())
 	assert.NoError(t, err)
 
-	runSQL(t, "DROP TABLE IF EXISTS replclientoptst1, replclientoptst2")
+	runSQL(t, "DROP TABLE IF EXISTS replclientoptst1, replclientoptst2, _replclientoptst1_cp")
 	runSQL(t, "CREATE TABLE replclientoptst1 (a INT NOT NULL auto_increment, b INT, c INT, PRIMARY KEY (a))")
 	runSQL(t, "CREATE TABLE replclientoptst2 (a INT NOT NULL  auto_increment, b INT, c INT, PRIMARY KEY (a))")
+	runSQL(t, "CREATE TABLE _replclientoptst1_cp (a int)") // just used to advance binlog
+
 	runSQL(t, "INSERT INTO replclientoptst1 (a, b, c) SELECT NULL, 1, 1 FROM dual")
 	runSQL(t, "INSERT INTO replclientoptst1 (a, b, c) SELECT NULL, 1, 1 FROM replclientoptst1 a JOIN replclientoptst1 b JOIN replclientoptst1 c LIMIT 100000")
 	runSQL(t, "INSERT INTO replclientoptst1 (a, b, c) SELECT NULL, 1, 1 FROM replclientoptst1 a JOIN replclientoptst1 b JOIN replclientoptst1 c LIMIT 100000")


### PR DESCRIPTION
Previously `BlockWait` used canal's `WaitUntilPos`. This advances the binary log constantly via a `FLUSH BINARY LOGS` statement, which tern won't have permission to execute.

It now uses it's own implementation, which uses a trivial ALTER on a known to exist table to advance.