### PR TITLE
Fix some of the easiest feedback items

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,8 +1,0 @@
-Non-blocking:
-- Some of the argument lists to create a NewCopier or NewReplicationClient have gotten long. I should change it to accept a struct as input.
-- Add in github.com/platinummonkey/go-concurrency-limits for throttling (need to determine if this will work: if the throttling is based on request time, it is variable anyway based on Feedback. Currently in staging we are using 2 threads because there is no replica monitor available.)
-
-TODO (non technical):
-- Decide on a name. Keep spirit?
-- Rollout plan - easiest cases first, target staging for all cases supported? What's next? opt in using LD flag per service? Target only some cases?
-- I assume we should open source, but on what timeline? Great benefit to others who have our use-case (larger tables and no read-replicas). However, some risk of support obligations. Typically not practical to say "no support".

--- a/pkg/checksum/checker.go
+++ b/pkg/checksum/checker.go
@@ -133,7 +133,7 @@ func (c *Checker) Run(ctx context.Context) error {
 
 	g := new(errgroup.Group)
 	g.SetLimit(c.concurrency)
-	for i := 0; !c.table.Chunker.IsRead() && c.isHealthy(); i++ {
+	for !c.table.Chunker.IsRead() && c.isHealthy() {
 		g.Go(func() error {
 			chunk, err := c.table.Chunker.Next()
 			if err != nil {

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
-	"github.com/squareup/spirit/pkg/copier"
 	"github.com/squareup/spirit/pkg/repl"
+	"github.com/squareup/spirit/pkg/row"
 	"github.com/squareup/spirit/pkg/table"
 
 	"github.com/stretchr/testify/assert"
@@ -599,7 +599,7 @@ func TestETA(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	logger := logrus.New()
-	m.copier, err = copier.NewCopier(nil, nil, nil, 4, true, logger)
+	m.copier, err = row.NewCopier(nil, nil, nil, 4, true, logger)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "Due", m.getETAFromRowsPerSecond(true))
@@ -677,7 +677,7 @@ func TestCheckpoint(t *testing.T) {
 		logger := logrus.New()
 		m.feed = repl.NewClient(m.db, m.host, m.table, m.shadowTable, m.username, m.password, logger)
 		var err error
-		m.copier, err = copier.NewCopier(m.db, m.table, m.shadowTable, m.optConcurrency, m.optChecksum, logger)
+		m.copier, err = row.NewCopier(m.db, m.table, m.shadowTable, m.optConcurrency, m.optChecksum, logger)
 		assert.NoError(t, err)
 		err = m.feed.Run()
 		assert.NoError(t, err)
@@ -824,7 +824,7 @@ func TestCheckpointDifferentRestoreOptions(t *testing.T) {
 	assert.NoError(t, m.table.Chunker.Open())
 	logger := logrus.New()
 	m.feed = repl.NewClient(m.db, m.host, m.table, m.shadowTable, m.username, m.password, logger)
-	m.copier, err = copier.NewCopier(m.db, m.table, m.shadowTable, m.optConcurrency, m.optChecksum, logger)
+	m.copier, err = row.NewCopier(m.db, m.table, m.shadowTable, m.optConcurrency, m.optChecksum, logger)
 	assert.NoError(t, err)
 	err = m.feed.Run()
 	assert.NoError(t, err)
@@ -940,7 +940,7 @@ func TestE2EBinlogSubscribing(t *testing.T) {
 		assert.NoError(t, m.table.Chunker.Open())
 		logger := logrus.New()
 		m.feed = repl.NewClient(m.db, m.host, m.table, m.shadowTable, m.username, m.password, logger)
-		m.copier, err = copier.NewCopier(m.db, m.table, m.shadowTable, m.optConcurrency, m.optChecksum, logger)
+		m.copier, err = row.NewCopier(m.db, m.table, m.shadowTable, m.optConcurrency, m.optChecksum, logger)
 		assert.NoError(t, err)
 		err = m.feed.Run()
 		assert.NoError(t, err)

--- a/pkg/row/copier.go
+++ b/pkg/row/copier.go
@@ -1,7 +1,7 @@
-// Package copier copies rows from one table to another.
+// Package row copies rows from one table to another.
 // it makes use of tableinfo.Chunker, and does the parallelism
 // and retries here. It fails on the first error.
-package copier
+package row
 
 import (
 	"context"

--- a/pkg/row/copier_test.go
+++ b/pkg/row/copier_test.go
@@ -1,4 +1,4 @@
-package copier
+package row
 
 import (
 	"context"

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -128,7 +128,7 @@ func (t *TableInfo) AttachChunker(chunkerTargetMs int64, disableTrivialChunker b
 func (t *TableInfo) RunDiscovery(db *sql.DB) error {
 	// Discover row estimate
 	if err := t.discoverRowEstimate(db); err != nil {
-		return fmt.Errorf("err: are you sure table %s exists?", t.QuotedName())
+		return err
 	}
 	// Discover columns
 	rows, err := db.Query("SELECT column_name FROM information_schema.columns WHERE table_schema=? AND table_name=? ORDER BY ORDINAL_POSITION",
@@ -187,7 +187,7 @@ func (t *TableInfo) discoverRowEstimate(db *sql.DB) error {
 	}
 	err = db.QueryRow("SELECT IFNULL(table_rows,0) FROM information_schema.tables WHERE table_schema=? AND table_name=?", t.SchemaName, t.TableName).Scan(&t.EstimatedRows)
 	if err != nil {
-		return fmt.Errorf("err: are you sure table %s exists?", t.QuotedName())
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes the following issues from https://github.com/squareup/spirit/issues/13 : 

- 12, 17: fix error message to return error
- 6: make start time more accurate
- 9: add a db ping to sql.Open
- 44: i is not used in for loop
- 30: rename copier to row.