### PR TITLE
Fix table chunker to not be part of tableinfo

### DIFF
--- a/pkg/migration/utils.go
+++ b/pkg/migration/utils.go
@@ -25,8 +25,8 @@ func IsCompatible(migration *Migration) bool {
 	if err := m.table.RunDiscovery(m.db); err != nil {
 		return false
 	}
-	// Attach the correct chunker.
-	if err := m.table.AttachChunker(m.optTargetChunkMs, m.optDisableTrivialChunker, m.logger); err != nil {
+	// Check that we can get a chunker.
+	if _, err := table.NewChunker(m.table, m.optTargetChunkMs, m.optDisableTrivialChunker, m.logger); err != nil {
 		return false
 	}
 	return true

--- a/pkg/row/copier.go
+++ b/pkg/row/copier.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/siddontang/go-log/loggers"
+	"github.com/sirupsen/logrus"
 	"github.com/squareup/spirit/pkg/dbconn"
 	"github.com/squareup/spirit/pkg/table"
 	"github.com/squareup/spirit/pkg/throttler"
@@ -25,6 +26,7 @@ type Copier struct {
 	db                *sql.DB
 	table             *table.TableInfo
 	shadowTable       *table.TableInfo
+	chunker           table.Chunker
 	concurrency       int
 	finalChecksum     bool
 	CopyRowsStartTime time.Time
@@ -37,25 +39,62 @@ type Copier struct {
 	logger            loggers.Advanced
 }
 
-func NewCopier(db *sql.DB, table, shadowTable *table.TableInfo, concurrency int, finalChecksum bool, logger loggers.Advanced) (*Copier, error) {
-	if concurrency == 0 {
-		concurrency = 4
+type CopierConfig struct {
+	Concurrency           int
+	TargetMs              int64
+	FinalChecksum         bool
+	DisableTrivialChunker bool
+	Throttler             throttler.Throttler
+	Logger                loggers.Advanced
+}
+
+// NewCopierDefaultConfig returns a default config for the copier.
+func NewCopierDefaultConfig() *CopierConfig {
+	return &CopierConfig{
+		Concurrency:           4,
+		TargetMs:              1000,
+		FinalChecksum:         true,
+		DisableTrivialChunker: false,
+		Throttler:             &throttler.Noop{},
+		Logger:                logrus.New(),
 	}
-	if shadowTable == nil || table == nil {
+}
+
+// NewCopier creates a new copier object.
+func NewCopier(db *sql.DB, tbl, shadowTable *table.TableInfo, config *CopierConfig) (*Copier, error) {
+	if shadowTable == nil || tbl == nil {
 		return nil, errors.New("table and shadowTable must be non-nil")
 	}
-	if table.Chunker == nil {
-		return nil, errors.New("table must have a chunker attached")
+	chunker, err := table.NewChunker(tbl, config.TargetMs, config.DisableTrivialChunker, config.Logger)
+	if err != nil {
+		return nil, err
 	}
 	return &Copier{
 		db:            db,
-		table:         table,
+		table:         tbl,
 		shadowTable:   shadowTable,
-		concurrency:   concurrency,
-		finalChecksum: finalChecksum,
-		Throttler:     &throttler.Noop{},
-		logger:        logger,
+		concurrency:   config.Concurrency,
+		finalChecksum: config.FinalChecksum,
+		Throttler:     config.Throttler,
+		chunker:       chunker,
+		logger:        config.Logger,
 	}, nil
+}
+
+// NewCopierFromCheckpoint creates a new copier object, from a checkpoint (copyRowsAt, copyRows)
+func NewCopierFromCheckpoint(db *sql.DB, tbl, shadowTable *table.TableInfo, config *CopierConfig, copyRowsAt string, copyRows int64) (*Copier, error) {
+	c, err := NewCopier(db, tbl, shadowTable, config)
+	if err != nil {
+		return c, err
+	}
+	// Overwrite the previously attached chunker with one at a specific watermark.
+	if err := c.chunker.OpenAtWatermark(copyRowsAt); err != nil {
+		return c, err
+	}
+	// Success from this point on
+	// Overwrite copy-rows
+	atomic.StoreInt64(&c.CopyRowsCount, copyRows)
+	return c, nil
 }
 
 // MigrateChunk copies a chunk from the table to the shadowTable.
@@ -82,7 +121,7 @@ func (c *Copier) MigrateChunk(ctx context.Context, chunk *table.Chunk) error {
 	atomic.AddInt64(&c.CopyChunksCount, 1)
 	// Send feedback which can be used by the chunker
 	// and infoschema to create a low watermark.
-	c.table.Chunker.Feedback(chunk, time.Since(startTime))
+	c.chunker.Feedback(chunk, time.Since(startTime))
 	return nil
 }
 
@@ -94,15 +133,18 @@ func (c *Copier) isHealthy() bool {
 
 func (c *Copier) Run(ctx context.Context) error {
 	c.CopyRowsStartTime = time.Now()
+	if err := c.chunker.Open(); err != nil {
+		return err
+	}
 	defer func() {
 		c.logger.Info("copy rows complete")
 		c.CopyRowsExecTime = time.Since(c.CopyRowsStartTime)
 	}()
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(c.concurrency)
-	for !c.table.Chunker.IsRead() && c.isHealthy() {
+	for !c.chunker.IsRead() && c.isHealthy() {
 		g.Go(func() error {
-			chunk, err := c.table.Chunker.Next()
+			chunk, err := c.chunker.Next()
 			if err != nil {
 				if err == table.ErrTableIsRead {
 					return nil
@@ -130,4 +172,30 @@ func (c *Copier) SetThrottler(throttler throttler.Throttler) {
 	c.Lock()
 	defer c.Unlock()
 	c.Throttler = throttler
+}
+
+// The following funcs proxy to the chunker.
+// This is done so we don't need to export the chunker,
+
+// KeyAboveHighWatermark returns true if the key is above where the chunker is currently at.
+func (c *Copier) KeyAboveHighWatermark(key interface{}) bool {
+	return c.chunker.KeyAboveHighWatermark(key)
+}
+
+// GetLowWatermark returns the low watermark of the chunker, i.e. the lowest key that has been
+// guaranteed to be written to the shadow table.
+func (c *Copier) GetLowWatermark() (string, error) {
+	return c.chunker.GetLowWatermark()
+}
+
+// Next4Test is typically only used in integration tests that don't want to actually migrate data,
+// but need to advance the chunker.
+func (c *Copier) Next4Test() (*table.Chunk, error) {
+	return c.chunker.Next()
+}
+
+// Open4Test is typically only used in integration tests that don't want to actually migrate data,
+// but need to open the chunker.
+func (c *Copier) Open4Test() error {
+	return c.chunker.Open()
 }

--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -1,0 +1,80 @@
+package table
+
+import (
+	"time"
+
+	"github.com/siddontang/loggers"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// StartingChunkSize is the original value of chunkSize.
+	// We use it in some threshold calculations.
+	StartingChunkSize = 1000
+
+	// MaxDynamicScaleFactor is the maximum factor dynamic scaling can change the chunkSize from
+	// the setting chunkSize. For example, if the factor is 10, and chunkSize is 1000, then the
+	// values will be in the range of 100 to 10000.
+	MaxDynamicScaleFactor = 50
+	// MaxDynamicStepFactor is the maximum amount each recalculation of the dynamic chunkSize can
+	// increase by. For example, if the newTarget is 5000 but the current target is 1000, the newTarget
+	// will be capped back down to 1500. Over time the number 5000 will be reached, but not straight away.
+	MaxDynamicStepFactor = 1.5
+	// MinDynamicChunkSize is the minimum chunkSize that can be used when dynamic chunkSize is enabled.
+	// This helps prevent a scenario where the chunk size is too small (it can never be less than 1).
+	MinDynamicRowSize = 10
+	// DynamicPanicFactor is the factor by which the feedback process takes immediate action when
+	// the chunkSize appears to be too large. For example, if the PanicFactor is 5, and the target *time*
+	// is 50ms, an actual time 250ms+ will cause the dynamic chunk size to immediately be reduced.
+	DynamicPanicFactor = 5
+)
+
+type Chunker interface {
+	Open() error
+	OpenAtWatermark(string) error
+	IsRead() bool
+	Close() error
+	Next() (*Chunk, error)
+	Feedback(*Chunk, time.Duration)
+	GetLowWatermark() (string, error)
+	KeyAboveHighWatermark(interface{}) bool
+	SetDynamicChunking(bool)
+}
+
+var _ Chunker = &chunkerBase{}
+
+func NewChunker(t *TableInfo, chunkerTargetMs int64, disableTrivialChunker bool, logger loggers.Advanced) (Chunker, error) {
+	if logger == nil {
+		logger = logrus.New()
+	}
+	if t.EstimatedRows < trivialChunkerThreshold && !disableTrivialChunker {
+		// If the row count is low we attach the trivial chunker,
+		// which will return everything as one chunk.
+		return &chunkerBase{Ti: t, logger: logger}, nil
+	}
+	if chunkerTargetMs == 0 {
+		chunkerTargetMs = 100
+	}
+	chunkerBase := &chunkerBase{
+		Ti:              t,
+		chunkSize:       uint64(1000),    // later this might become configurable.
+		ChunkerTargetMs: chunkerTargetMs, // this is the main chunker target.
+		logger:          logger,
+	}
+	switch mySQLTypeToSimplifiedKeyType(t.primaryKeyType) {
+	case signedType:
+		return &chunkerSigned{
+			chunkerBase: chunkerBase,
+		}, nil
+	case unsignedType:
+		return &chunkerUnsigned{
+			chunkerBase: chunkerBase,
+		}, nil
+	case binaryType:
+		return &chunkerBinary{
+			chunkerBase: chunkerBase,
+		}, nil
+	default:
+		return nil, ErrUnsupportedPKType
+	}
+}

--- a/pkg/table/chunker_base_test.go
+++ b/pkg/table/chunker_base_test.go
@@ -3,6 +3,7 @@ package table
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,13 +14,15 @@ func TestBaseChunker(t *testing.T) {
 	t1.primaryKeyType = "varbinary(100)"
 	t1.primaryKeyIsAutoInc = true
 	t1.Columns = []string{"id", "name"}
-	assert.NoError(t, t1.AttachChunker(100, false, nil))
 
-	assert.NoError(t, t1.Chunker.Open())
-	_, err := t1.Chunker.Next()
+	chunker, err := NewChunker(t1, 100, false, logrus.New())
 	assert.NoError(t, err)
 
-	_, err = t1.Chunker.Next()
+	assert.NoError(t, chunker.Open())
+	_, err = chunker.Next()
+	assert.NoError(t, err)
+
+	_, err = chunker.Next()
 	assert.Error(t, err) // trivial chunker is done! only 1 chunk.
 }
 
@@ -30,12 +33,13 @@ func TestBaseChunkerIntSigned(t *testing.T) {
 	t1.primaryKeyType = "bigint"
 	t1.primaryKeyIsAutoInc = true
 	t1.Columns = []string{"id", "name"}
-	assert.NoError(t, t1.AttachChunker(100, false, nil))
-
-	assert.NoError(t, t1.Chunker.Open())
-	_, err := t1.Chunker.Next()
+	chunker, err := NewChunker(t1, 100, false, logrus.New())
 	assert.NoError(t, err)
 
-	_, err = t1.Chunker.Next()
+	assert.NoError(t, chunker.Open())
+	_, err = chunker.Next()
+	assert.NoError(t, err)
+
+	_, err = chunker.Next()
 	assert.Error(t, err) // trivial chunker is done! only 1 chunk.
 }

--- a/pkg/table/chunker_unsigned_test.go
+++ b/pkg/table/chunker_unsigned_test.go
@@ -3,6 +3,7 @@ package table
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,19 +17,20 @@ func TestUnsignedChunker(t *testing.T) {
 	t1.minValue = uint64(1)
 	t1.maxValue = uint64(101)
 	t1.Columns = []string{"id", "name"}
-	assert.NoError(t, t1.AttachChunker(100, true, nil))
 
-	assert.NoError(t, t1.Chunker.Open())
+	chunker, err := NewChunker(t1, 100, true, logrus.New())
+	assert.NoError(t, err)
+	assert.NoError(t, chunker.Open())
 
-	_, err := t1.Chunker.Next() // min
+	_, err = chunker.Next() // min
 	assert.NoError(t, err)
 
-	_, err = t1.Chunker.Next() // 1 row in between
+	_, err = chunker.Next() // 1 row in between
 	assert.NoError(t, err)
 
-	_, err = t1.Chunker.Next() // max
+	_, err = chunker.Next() // max
 	assert.NoError(t, err)
 
-	_, err = t1.Chunker.Next()
+	_, err = chunker.Next()
 	assert.Error(t, err) // is read
 }


### PR DESCRIPTION
checker and copier now have their own chunkers, not associated with tableInfos.

Fixes #26 and fixes #27