### PR TITLE
fix panic on close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.so
 *.dylib
 
+cmd/spirit/spirit
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
I experienced the following panic while testing under load:
```
WARN[0041] table lock released
WARN[0041] final cut over operation complete
INFO[0041] apply complete. instant-ddl: false inplace-ddl: false total-chunks: 457 duration: 41.571598084s
INFO[0041] table structure changed, clear table cache: finch.balances
INFO[0041] table structure changed, clear table cache: finch._balances_shadow
INFO[0041] table structure changed, clear table cache: finch._balances_shadow
INFO[0041] closing canal
INFO[0041] syncer is closing...
INFO[0041] table structure changed, clear table cache: finch._balances_chkpnt
ERRO[0041] canal start sync binlog err: Sync was closed
ERRO[0041] canal has failed. error: Sync was closed
panic: canal has failed

goroutine 8 [running]:
github.com/squareup/spirit/pkg/repl.(*Client).startCanal(0xc00033c0c0)
	/Users/mtocker/go/src/github.com/squareup/spirit/pkg/repl/client.go:254 +0x196
created by github.com/squareup/spirit/pkg/repl.(*Client).Run
	/Users/mtocker/go/src/github.com/squareup/spirit/pkg/repl/client.go:209 +0x399
```

It looks like this is caused by `canal.Close()` sometimes causing the `canal.RunFrom()` to return an error. I wouldn't expect that from canal, but we can workaround this bug by having a flag for `isClosed`.