### PR TITLE
Fix bug in resume-from-checkpoint, workaround large-last-chunk

### DIFF
--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -37,9 +37,9 @@ const (
 )
 
 const (
-	checkpointDumpInterval  = 5 * time.Second
-	tableStatUpdateInterval = 5 * time.Minute
-	statusInterval          = 2 * time.Second
+	checkpointDumpInterval  = 50 * time.Second
+	tableStatUpdateInterval = 30 * time.Second
+	statusInterval          = 10 * time.Second
 	copyEstimateInterval    = 5 * time.Second
 	// binlogPerodicFlushInterval is the time that the client will flush all binlog changes to disk.
 	// Longer values require more memory, but permit more merging.


### PR DESCRIPTION
This fixes a bug where the resume from checkpoint seems to have recently been broken. It is regrettably difficult to E2E test due to https://github.com/squareup/spirit/issues/69

This also includes a workaround (not a fix) for https://github.com/squareup/spirit/issues/68 (lower `tableStatUpdateInterval`).

I changed the checkpoint `checkpointDumpInterval` and `statusInterval` to be less frequent as well.