### PR TITLE
Increase timeouts - on a busy system they may be too short

### DIFF
--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -28,7 +28,7 @@ func NewTrxPool(ctx context.Context, db *sql.DB, count int) (*TrxPool, error) {
 			return nil, err
 		}
 		// Set SQL mode, charset, etc.
-		if err := standardizeTrx(ctx, trx); err != nil {
+		if err := standardizeTrx(ctx, trx, i); err != nil {
 			return nil, err
 		}
 		checksumTxns = append(checksumTxns, trx)


### PR DESCRIPTION
This increases the timeouts, after we had an issue where with retry the 1s timeout on a data lock was too short. This led to the migration failing.

~In future we might make it configurable (not ideal), or exponentially increase (better). But for now, let's make it a lot more likely to succeed.~

I've changed it to extend the timeout by 1s with each retry.