### PR TITLE
table: remove SetDynamicChunking from the chunker interface

### DIFF
--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -37,7 +37,6 @@ type Chunker interface {
 	Feedback(*Chunk, time.Duration)
 	GetLowWatermark() (string, error)
 	KeyAboveHighWatermark(interface{}) bool
-	SetDynamicChunking(bool)
 }
 
 func NewChunker(t *TableInfo, chunkerTarget time.Duration, logger loggers.Advanced) (Chunker, error) {

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -22,10 +22,6 @@ type chunkerComposite struct {
 	chunkTimingInfo []time.Duration
 	ChunkerTarget   time.Duration // i.e. 500ms for target
 
-	// Some options which are usually good, but might want to be disabled
-	// particularly for the test suite.
-	DisableDynamicChunker bool // optimization to adjust chunk size.
-
 	// This is used for restore.
 	watermark             *Chunk
 	watermarkQueuedChunks []*Chunk
@@ -107,12 +103,6 @@ func (t *chunkerComposite) Open() (err error) {
 	return t.open()
 }
 
-func (t *chunkerComposite) SetDynamicChunking(newValue bool) {
-	t.Lock()
-	defer t.Unlock()
-	t.DisableDynamicChunker = !newValue
-}
-
 func (t *chunkerComposite) OpenAtWatermark(cp string) error {
 	t.Lock()
 	defer t.Unlock()
@@ -150,8 +140,8 @@ func (t *chunkerComposite) Feedback(chunk *Chunk, d time.Duration) {
 
 	// Check if the feedback is based on an earlier chunker size.
 	// if it is, it is misleading to incorporate feedback now.
-	// We should just skip it. We also skip if dynamic chunking is disabled.
-	if chunk.ChunkSize != t.chunkSize || t.DisableDynamicChunker {
+	// We should just skip it.
+	if chunk.ChunkSize != t.chunkSize {
 		return
 	}
 

--- a/pkg/table/chunker_universal.go
+++ b/pkg/table/chunker_universal.go
@@ -24,9 +24,7 @@ type chunkerUniversal struct {
 	chunkTimingInfo []time.Duration
 	ChunkerTarget   time.Duration // i.e. 500ms for target
 
-	// Some options which are usually good, but might want to be disabled
-	// particularly for the test suite.
-	DisableDynamicChunker bool // optimization to adjust chunk size.
+	disableDynamicChunker bool // only used by the test suite
 
 	// This is used for restore.
 	watermark             *Chunk
@@ -163,10 +161,10 @@ func (t *chunkerUniversal) Open() (err error) {
 	return t.open()
 }
 
-func (t *chunkerUniversal) SetDynamicChunking(newValue bool) {
+func (t *chunkerUniversal) setDynamicChunking(newValue bool) {
 	t.Lock()
 	defer t.Unlock()
-	t.DisableDynamicChunker = !newValue
+	t.disableDynamicChunker = !newValue
 }
 
 func (t *chunkerUniversal) OpenAtWatermark(cp string) error {
@@ -207,7 +205,7 @@ func (t *chunkerUniversal) Feedback(chunk *Chunk, d time.Duration) {
 	// Check if the feedback is based on an earlier chunker size.
 	// if it is, it is misleading to incorporate feedback now.
 	// We should just skip it. We also skip if dynamic chunking is disabled.
-	if chunk.ChunkSize != t.chunkSize || t.DisableDynamicChunker {
+	if chunk.ChunkSize != t.chunkSize || t.disableDynamicChunker {
 		return
 	}
 


### PR DESCRIPTION
Ref https://github.com/squareup/spirit/issues/48

Only the universal chunker needs to support disabling dynamic chunking for some certain tests (although maybe in future we can have a static chunker if we need this functionality..)

It makes sense to remove it from the interface so other chunkers don't need to implement it.. namely the composite chunker.