### PR TITLE
fix MDL lock waits

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -18,10 +18,10 @@ const (
 )
 
 var (
-	innodbLockWaitTimeout = 3   // usually fine, since it's a lock on a row.
-	mdlLockWaitTimeout    = 120 // safer to make slightly longer.
-	MaxRetries            = 10  // each retry extends both lock timeouts by 1 second.
-	maximumLockTime       = 120 // safety measure incase we make changes: don't allow any lock longer than this
+	innodbLockWaitTimeout = 3  // usually fine, since it's a lock on a row.
+	MdlLockWaitTimeout    = 50 // safer to make slightly longer.
+	MaxRetries            = 10 // each retry extends both lock timeouts by 1 second.
+	maximumLockTime       = 60 // safety measure incase we make changes: don't allow any lock longer than this
 )
 
 func standardizeTrx(ctx context.Context, trx *sql.Tx, retryNumber int) error {
@@ -48,7 +48,7 @@ func standardizeTrx(ctx context.Context, trx *sql.Tx, retryNumber int) error {
 	if err != nil {
 		return err
 	}
-	_, err = trx.ExecContext(ctx, "SET lock_wait_timeout=?", utils.BoundaryCheck(mdlLockWaitTimeout+retryNumber, maximumLockTime))
+	_, err = trx.ExecContext(ctx, "SET lock_wait_timeout=?", utils.BoundaryCheck(MdlLockWaitTimeout+retryNumber, maximumLockTime))
 	if err != nil {
 		return err
 	}

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -58,7 +58,7 @@ func TestLockWaitTimeouts(t *testing.T) {
 	// Check the timeouts are shorter
 	mysqlVar, err = getVariable(trx, "lock_wait_timeout", true)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprint(mdlLockWaitTimeout), mysqlVar)
+	assert.Equal(t, fmt.Sprint(MdlLockWaitTimeout), mysqlVar)
 	mysqlVar, err = getVariable(trx, "innodb_lock_wait_timeout", true)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprint(innodbLockWaitTimeout), mysqlVar)
@@ -68,7 +68,7 @@ func TestLockWaitTimeouts(t *testing.T) {
 	assert.NoError(t, err)
 	mysqlVar, err = getVariable(trx, "lock_wait_timeout", true)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprint(mdlLockWaitTimeout+2), mysqlVar)
+	assert.Equal(t, fmt.Sprint(MdlLockWaitTimeout+2), mysqlVar)
 	mysqlVar, err = getVariable(trx, "innodb_lock_wait_timeout", true)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprint(innodbLockWaitTimeout+2), mysqlVar)

--- a/pkg/dbconn/tablelock.go
+++ b/pkg/dbconn/tablelock.go
@@ -26,7 +26,7 @@ type TableLock struct {
 // and acquire the lock again.
 func NewTableLock(ctx context.Context, db *sql.DB, table *table.TableInfo, logger loggers.Advanced) (*TableLock, error) {
 	lockTxn, _ := db.BeginTx(ctx, nil)
-	_, err := lockTxn.ExecContext(ctx, "SET SESSION lock_wait_timeout = ?", mdlLockWaitTimeout)
+	_, err := lockTxn.ExecContext(ctx, "SET SESSION lock_wait_timeout = ?", MdlLockWaitTimeout)
 	if err != nil {
 		return nil, err // could not change timeout.
 	}
@@ -35,7 +35,7 @@ func NewTableLock(ctx context.Context, db *sql.DB, table *table.TableInfo, logge
 		// this might prevent a weird case that we don't handle yet.
 		// instead, we DROP IF EXISTS just before the rename, which
 		// has a brief race.
-		logger.Warnf("trying to acquire table lock, timeout: %d", mdlLockWaitTimeout)
+		logger.Warnf("trying to acquire table lock, timeout: %d", MdlLockWaitTimeout)
 		// TODO: We acquire a READ LOCK which I believe is sufficient (just need to prevent modifications to table).
 		// Ghost however, acquires a WRITE LOCK. We can't do that because the slowly arriving
 		// changes in BlockWait() will block because they won't be able to read the source table.

--- a/pkg/dbconn/tablelock_test.go
+++ b/pkg/dbconn/tablelock_test.go
@@ -42,7 +42,7 @@ func TestTableLockFail(t *testing.T) {
 	defer db.Close()
 
 	MaxRetries = 1
-	mdlLockWaitTimeout = 1
+	MdlLockWaitTimeout = 1
 
 	err = DBExec(context.Background(), db, "DROP TABLE IF EXISTS test.testlockfail")
 	assert.NoError(t, err)

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -23,7 +23,7 @@ type CutOver struct {
 }
 
 var (
-	maxCutoverRetries = 100
+	maxCutoverRetries = 5
 )
 
 // NewCutOver contains the logic to perform the final cut over. It requires the original table,

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
+	"github.com/squareup/spirit/pkg/dbconn"
 	"github.com/squareup/spirit/pkg/repl"
 	"github.com/squareup/spirit/pkg/table"
 	"github.com/stretchr/testify/assert"
@@ -98,8 +99,9 @@ func TestMDLLockFails(t *testing.T) {
 	assert.NoError(t, err)
 
 	maxCutoverRetries = 2
+	dbconn.MdlLockWaitTimeout = 1
 	defer func() {
-		maxCutoverRetries = 100
+		maxCutoverRetries = 5
 	}()
 
 	t1 := table.NewTableInfo(db, "test", "mdllocks")


### PR DESCRIPTION
This is a more proper fix for https://github.com/squareup/spirit/pull/152 which was pushed in an emergency.

Yes - some of the lock waits will be long, but after a 2 day migration this is for now our preferred behavior.