### PR TITLE
Move memcomparable checks outside of chunker

### DIFF
--- a/pkg/check/memcomparable.go
+++ b/pkg/check/memcomparable.go
@@ -1,0 +1,18 @@
+package check
+
+import (
+	"context"
+
+	"github.com/siddontang/loggers"
+)
+
+func init() {
+	registerCheck("memcomparable", memcomparableCheck, ScopePreflight)
+}
+
+// memcomparableCheck checks if the key is memory comparable.
+// This is required for spirit's Delta Map, but
+// not specifically required for the chunker.
+func memcomparableCheck(ctx context.Context, r Resources, logger loggers.Advanced) error {
+	return r.Table.PrimaryKeyIsMemoryComparable()
+}

--- a/pkg/check/memcomparable_test.go
+++ b/pkg/check/memcomparable_test.go
@@ -1,0 +1,46 @@
+package check
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/squareup/spirit/pkg/table"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemcomparable(t *testing.T) {
+	db, err := sql.Open("mysql", dsn())
+	assert.NoError(t, err)
+
+	_, err = db.Exec(`drop table if exists memcomparablecheck_t1, memcomparablecheck_t2`)
+	assert.NoError(t, err)
+	sql := `CREATE TABLE memcomparablecheck_t1 (
+		id INT NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		PRIMARY KEY (name)
+	);`
+	_, err = db.Exec(sql)
+	assert.NoError(t, err)
+	sql = `CREATE TABLE memcomparablecheck_t2 (
+		id INT NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		PRIMARY KEY (id)
+	);`
+	_, err = db.Exec(sql)
+	assert.NoError(t, err)
+
+	r := Resources{
+		DB:    db,
+		Table: table.NewTableInfo(db, "test", "memcomparablecheck_t1"),
+	}
+	assert.NoError(t, r.Table.SetInfo(context.Background()))
+	err = memcomparableCheck(context.Background(), r, logrus.New())
+	assert.Error(t, err) // not good.
+
+	r.Table = table.NewTableInfo(db, "test", "memcomparablecheck_t2")
+	assert.NoError(t, r.Table.SetInfo(context.Background()))
+	err = memcomparableCheck(context.Background(), r, logrus.New())
+	assert.NoError(t, err) // noerror
+}

--- a/pkg/migration/utils.go
+++ b/pkg/migration/utils.go
@@ -26,6 +26,10 @@ func IsCompatible(ctx context.Context, migration *Migration) bool {
 	if err := m.table.SetInfo(ctx); err != nil {
 		return false
 	}
+	// check that it's memory comparable.
+	if err := m.table.PrimaryKeyIsMemoryComparable(); err != nil {
+		return false
+	}
 	// Check that we can get a chunker.
 	if _, err := table.NewChunker(m.table, m.migration.TargetChunkTime, m.logger); err != nil {
 		return false

--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -43,12 +43,6 @@ func NewChunker(t *TableInfo, chunkerTarget time.Duration, logger loggers.Advanc
 	if chunkerTarget == 0 {
 		chunkerTarget = ChunkerDefaultTarget
 	}
-	// Currently we always check if the key is memory comparable.
-	// This is required for spirit's Delta Map, but
-	// not specifically required for the chunker.
-	if err := t.isMemoryComparable(); err != nil {
-		return nil, err
-	}
 	// Use the optimistic chunker for auto_increment
 	// tables with a single column key.
 	if len(t.KeyColumns) == 1 && t.KeyIsAutoInc {

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -32,13 +32,13 @@ func TestOptimisticChunkerBasic(t *testing.T) {
 	}
 	chunker.setDynamicChunking(false)
 
-	assert.NoError(t, t1.isMemoryComparable())
+	assert.NoError(t, t1.PrimaryKeyIsMemoryComparable())
 	t1.keyColumnsMySQLTp[0] = "varchar"
 	t1.keyDatums[0] = unknownType
-	assert.Error(t, t1.isMemoryComparable())
+	assert.Error(t, t1.PrimaryKeyIsMemoryComparable())
 	t1.keyColumnsMySQLTp[0] = "bigint"
 	t1.keyDatums[0] = signedType
-	assert.NoError(t, t1.isMemoryComparable())
+	assert.NoError(t, t1.PrimaryKeyIsMemoryComparable())
 
 	assert.Equal(t, "`test`.`t1`", t1.QuotedName)
 
@@ -83,7 +83,7 @@ func TestLowWatermark(t *testing.T) {
 	t1.KeyIsAutoInc = true
 	t1.Columns = []string{"id", "name"}
 
-	assert.NoError(t, t1.isMemoryComparable())
+	assert.NoError(t, t1.PrimaryKeyIsMemoryComparable())
 	chunker := &chunkerOptimistic{
 		Ti:            t1,
 		ChunkerTarget: ChunkerDefaultTarget,


### PR DESCRIPTION
Previously, the chunker would refuse to allow chunking on non-memcomparable keys. It did this because (1) it didn't know how to do key-above-watermark for a non-comparable key (2) the delta map feature won't work with non mem comparable.

Because (1) has ostensibly been solved by disabling this optimization, and (2) is not a requirement of the chunker, but a requirement of migration, this changes the chunker to freely permit chunking on such keys. It is up to the migration (package checks) to verify if the key is memory comparable if it depends on such functionality.