### PR TITLE
Delete the applied chunk key correctly from watermarkMap

### DIFF
--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -365,6 +365,10 @@ func TestCompositeLowWatermark(t *testing.T) {
 	}
 	assert.Len(t, chunker.chunkTimingInfo, 0)
 	assert.Equal(t, 15, int(chunker.chunkSize)) // scales up a maximum of 50% at a time.
+
+	// Test that we have applied all stored chunks and the map is empty,
+	// as we gave Feedback for all chunks.
+	assert.Equal(t, 0, len(chunker.lowerBoundWatermarkMap))
 }
 
 func TestCompositeSmallTable(t *testing.T) {

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -164,6 +164,10 @@ func TestLowWatermark(t *testing.T) {
 	watermark, err = chunker.GetLowWatermark()
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"Key\":[\"id\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\": [\"5001\"],\"Inclusive\":true},\"UpperBound\":{\"Value\": [\"6001\"],\"Inclusive\":false}}", watermark)
+
+	// Test that we have applied all stored chunks and the map is empty,
+	// as we gave Feedback for all chunks.
+	assert.Equal(t, 0, len(chunker.lowerBoundWatermarkMap))
 }
 
 func TestOptimisticDynamicChunking(t *testing.T) {

--- a/pkg/table/core_chunker.go
+++ b/pkg/table/core_chunker.go
@@ -99,9 +99,10 @@ applyStoredChunks:
 	// If there are any, bump the watermark and delete from the map.
 	// If there are none, we're done.
 	for t.waterMarkMapNotEmpty() && t.watermark.UpperBound != nil && t.lowerBoundWatermarkMap[t.watermark.UpperBound.valuesString()] != nil {
-		nextWatermark := t.lowerBoundWatermarkMap[t.watermark.UpperBound.valuesString()]
+		key := t.watermark.UpperBound.valuesString()
+		nextWatermark := t.lowerBoundWatermarkMap[key]
 		t.watermark = nextWatermark
-		delete(t.lowerBoundWatermarkMap, nextWatermark.String())
+		delete(t.lowerBoundWatermarkMap, key)
 	}
 }
 


### PR DESCRIPTION
Fixes small bug introduced in fix for https://github.com/squareup/spirit/issues/182.

Not a correctness bug, but we aren't deleting the right entry from map after applying it. So we are effectively keeping all the chunks in map using more memory than needed.
