### PR TITLE
migration: advance checkpoint during checkpoint

### DIFF
--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -832,11 +832,8 @@ func (r *Runner) dumpCheckpointContinuously(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// Continue to checkpoint until we exit copy-rows.
-			// Ideally in future we can continue further than this,
-			// but unfortunately this currently results in a
-			// "watermark not ready" error.
-			if r.getCurrentState() > stateCopyRows {
+			// Continue to checkpoint until we exit the checksum.
+			if r.getCurrentState() >= stateCutOver {
 				return
 			}
 			if err := r.dumpCheckpoint(ctx); err != nil {


### PR DESCRIPTION
The PR https://github.com/squareup/spirit/pull/192 was incomplete.

It advanced the binlog apply during checksum, but did not advance the checkpoint. This is fixed in this PR.