### PR TITLE
Fix syntax errors when running drop/truncate partition inplace

### DIFF
--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -116,6 +116,17 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	assert.Error(t, test("ALTER INDEX b INVISIBLE, add column `c` int"))
 }
 
+func TestSafeForDirect(t *testing.T) {
+	var test = func(stmt string) error {
+		return MustNew("ALTER TABLE `t1` " + stmt).SafeForDirect()
+	}
+	assert.NoError(t, test("drop partition `p1`, `p2`"))
+	assert.NoError(t, test("truncate partition `p1`, `p3`"))
+	assert.Error(t, test("engine=innodb"))
+	// This runs with ALGORITHM=COPY by default
+	assert.Error(t, test("drop index `a`, drop partition `p1`"))
+}
+
 func TestAlterIsAddUnique(t *testing.T) {
 	var test = func(stmt string) error {
 		return MustNew("ALTER TABLE `t1` " + stmt).AlterContainsAddUnique()


### PR DESCRIPTION
This follows https://github.com/cashapp/spirit/pull/387 and fixes https://github.com/cashapp/spirit/issues/383.
`DROP` and `TRUNCATE` PARTITION statements don't allow explicit `ALGORITHM` or `LOCK` settings. See the [comment](https://block.atlassian.net/browse/PLAT-21130?focusedCommentId=9616869) for details. 

Testing:
Confirmed that this didn't work before the change ([jira](https://block.atlassian.net/browse/PLAT-21130?focusedCommentId=9614285)) and does work after the change ([jira](https://block.atlassian.net/browse/PLAT-21130?focusedCommentId=9617794)).
