### PR TITLE
[checks] Reintroduce hasTriggers check as a Preflight check

### DIFF
--- a/pkg/check/triggers.go
+++ b/pkg/check/triggers.go
@@ -1,0 +1,30 @@
+package check
+
+import (
+	"context"
+	"errors"
+
+	"github.com/siddontang/loggers"
+)
+
+func init() {
+	registerCheck("hastriggers", hasTriggersCheck, ScopePreflight)
+}
+
+// hasTriggersCheck check if table has triggers associated with it, which is not supported
+func hasTriggersCheck(ctx context.Context, r Resources, logger loggers.Advanced) error {
+	sql := `SELECT * FROM information_schema.triggers WHERE 
+	(event_object_schema=? AND event_object_table=?)`
+	rows, err := r.DB.QueryContext(ctx, sql, r.Table.SchemaName, r.Table.TableName)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	if rows.Next() {
+		return errors.New("tables with triggers associated are not supported")
+	}
+	if rows.Err() != nil {
+		return rows.Err()
+	}
+	return nil
+}

--- a/pkg/check/triggers_test.go
+++ b/pkg/check/triggers_test.go
@@ -1,0 +1,50 @@
+package check
+
+import (
+	"context"
+	"database/sql"
+
+	"testing"
+
+	"github.com/cashapp/spirit/pkg/statement"
+	"github.com/cashapp/spirit/pkg/table"
+	"github.com/cashapp/spirit/pkg/testutils"
+	"github.com/sirupsen/logrus"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasTriggers(t *testing.T) {
+	db, err := sql.Open("mysql", testutils.DSN())
+	assert.NoError(t, err)
+
+	_, err = db.Exec(`drop table if exists account`)
+	assert.NoError(t, err)
+	_, err = db.Exec(`drop trigger if exists ins_sum`)
+	assert.NoError(t, err)
+	sql := `CREATE TABLE account (
+		acct_num INT,
+		amount DECIMAL (10,2),
+		PRIMARY KEY (acct_num)
+	);`
+	_, err = db.Exec(sql)
+	assert.NoError(t, err)
+	sql = `CREATE TRIGGER ins_sum BEFORE INSERT ON account
+		FOR EACH ROW SET @sum = @sum + NEW.amount;`
+	_, err = db.Exec(sql)
+	assert.NoError(t, err)
+
+	r := Resources{
+		DB:    db,
+		Table: &table.TableInfo{SchemaName: "test", TableName: "account"},
+		Statement: statement.MustNew("ALTER TABLE account Engine=innodb"),
+	}
+
+	err = hasTriggersCheck(context.Background(), r, logrus.New())
+	assert.ErrorContains(t, err, "tables with triggers associated are not supported") // already has a trigger associated.
+
+	_, err = db.Exec(`drop trigger if exists ins_sum`)
+	assert.NoError(t, err)
+	err = hasTriggersCheck(context.Background(), r, logrus.New())
+	assert.NoError(t, err) // no longer said to have trigger associated.
+}

--- a/pkg/check/triggers_test.go
+++ b/pkg/check/triggers_test.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"database/sql"
 
 	"testing"
@@ -35,16 +34,16 @@ func TestHasTriggers(t *testing.T) {
 	assert.NoError(t, err)
 
 	r := Resources{
-		DB:    db,
-		Table: &table.TableInfo{SchemaName: "test", TableName: "account"},
+		DB:        db,
+		Table:     &table.TableInfo{SchemaName: "test", TableName: "account"},
 		Statement: statement.MustNew("ALTER TABLE account Engine=innodb"),
 	}
 
-	err = hasTriggersCheck(context.Background(), r, logrus.New())
+	err = hasTriggersCheck(t.Context(), r, logrus.New())
 	assert.ErrorContains(t, err, "tables with triggers associated are not supported") // already has a trigger associated.
 
 	_, err = db.Exec(`drop trigger if exists ins_sum`)
 	assert.NoError(t, err)
-	err = hasTriggersCheck(context.Background(), r, logrus.New())
+	err = hasTriggersCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // no longer said to have trigger associated.
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/block/spirit/issues/419. Brings back the hasTriggers check as a preflight check, along with its test. This explicitly leaves out the previously named `addTriggersCheck` since `CREAE TRIGGER` is not supported by the tidb parser and the migration wouldn't make it this far anyway.

## Testing

- new and existing tests pass
- ran through a local test with the binary and got the expected results:

**DB state**
```
mysql> show triggers\G
*************************** 1. row ***************************
             Trigger: test_table_audit
               Event: INSERT
               Table: test_table
           Statement: INSERT INTO audit_log (table_name, action, record_id)
  VALUES ('test_table', 'INSERT', NEW.id)
              Timing: AFTER
             Created: 2025-07-21 17:23:04.56
            sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
             Definer: root@localhost
character_set_client: utf8mb4
collation_connection: utf8mb4_0900_ai_ci
  Database Collation: utf8mb4_0900_ai_ci
1 row in set (0.00 sec)

mysql> show create table test_table\G
*************************** 1. row ***************************
       Table: test_table
Create Table: CREATE TABLE `test_table` (
  `id` bigint NOT NULL AUTO_INCREMENT,
  `user_preferences` json DEFAULT NULL,
  `other_json_column` json DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
1 row in set (0.01 sec)
```

**Running command**
```
❯ go build ./cmd/spirit
❯ ./spirit --host localhost:3306 --database test --username spirit-osc --password $supersecret --table test_table --alter "MODIFY COLUMN other_json_column varchar(100)"
INFO[0000] Starting spirit migration: concurrency=4 target-chunk-size=500ms table='test.test_table' alter=MODIFY COLUMN other_json_column varchar(100)
INFO[0000] attempting to acquire metadata lock
INFO[0000] acquired metadata lock: test.test_table-2a2519ce
INFO[0000] unable to use INPLACE: ALTER either does not support INPLACE or when performed as INPLACE could take considerable time. Use --force-inplace to override this safety check
INFO[0000] releasing metadata lock: test.test_table-2a2519ce
spirit: error: tables with triggers associated are not supported
```

## Reviewers
