### PR TITLE
Refactor migration to support multi chunker

### DIFF
--- a/pkg/check/dropadd_test.go
+++ b/pkg/check/dropadd_test.go
@@ -11,13 +11,13 @@ import (
 func TestDropAdd(t *testing.T) {
 	var err error
 	r := Resources{
-		Statement: statement.MustNew("ALTER TABLE t1 DROP COLUMN b, ADD COLUMN b INT"),
+		Statement: statement.MustNew("ALTER TABLE t1 DROP COLUMN b, ADD COLUMN b INT")[0],
 	}
 	err = dropAddCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "column b is mentioned 2 times in the same statement")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 DROP b1, ADD b2 INT")
+	r.Statement = statement.MustNew("ALTER TABLE t1 DROP b1, ADD b2 INT")[0]
 	err = dropAddCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err)
 }

--- a/pkg/check/foreignkey_test.go
+++ b/pkg/check/foreignkey_test.go
@@ -14,13 +14,13 @@ import (
 func TestAddForeignKey(t *testing.T) {
 	var err error
 	r := Resources{
-		Statement: statement.MustNew("ALTER TABLE t1 ADD FOREIGN KEY (customer_id) REFERENCES customers (id)"),
+		Statement: statement.MustNew("ALTER TABLE t1 ADD FOREIGN KEY (customer_id) REFERENCES customers (id)")[0],
 	}
 	err = addForeignKeyCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // add foreign key
 	assert.ErrorContains(t, err, "adding foreign key constraints is not supported")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 DROP COLUMN foo")
+	r.Statement = statement.MustNew("ALTER TABLE t1 DROP COLUMN foo")[0]
 	err = addForeignKeyCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // regular DDL
 }
@@ -56,20 +56,20 @@ func TestHasForeignKey(t *testing.T) {
 	r := Resources{
 		DB:        db,
 		Table:     &table.TableInfo{SchemaName: "test", TableName: "customers"},
-		Statement: statement.MustNew("ALTER TABLE customers ENGINE=innodb"),
+		Statement: statement.MustNew("ALTER TABLE customers ENGINE=innodb")[0],
 	}
 	err = hasForeignKeysCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // already has foreign keys.
 
 	r.Table.TableName = "customer_contacts"
-	r.Statement = statement.MustNew("ALTER TABLE customer_contacts ENGINE=innodb")
+	r.Statement = statement.MustNew("ALTER TABLE customer_contacts ENGINE=innodb")[0]
 	err = hasForeignKeysCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // already has foreign keys.
 
 	_, err = db.Exec(`drop table if exists customer_contacts`)
 	assert.NoError(t, err)
 	r.Table.TableName = "customers"
-	r.Statement = statement.MustNew("ALTER TABLE customers ENGINE=innodb")
+	r.Statement = statement.MustNew("ALTER TABLE customers ENGINE=innodb")[0]
 	err = hasForeignKeysCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // no longer said to have foreign keys.
 }

--- a/pkg/check/illegalclause_test.go
+++ b/pkg/check/illegalclause_test.go
@@ -10,23 +10,23 @@ import (
 
 func TestIllegalClauseCheck(t *testing.T) {
 	r := Resources{
-		Statement: statement.MustNew("ALTER TABLE t1 ADD INDEX (b), ALGORITHM=INPLACE"),
+		Statement: statement.MustNew("ALTER TABLE t1 ADD INDEX (b), ALGORITHM=INPLACE")[0],
 	}
 	err := illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1  ADD c INT, ALGORITHM=INPLACE, LOCK=shared")
+	r.Statement = statement.MustNew("ALTER TABLE t1  ADD c INT, ALGORITHM=INPLACE, LOCK=shared")[0]
 	err = illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1  ADD c INT, lock=none")
+	r.Statement = statement.MustNew("ALTER TABLE t1  ADD c INT, lock=none")[0]
 	err = illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 engine=innodb, algorithm=copy")
+	r.Statement = statement.MustNew("ALTER TABLE t1 engine=innodb, algorithm=copy")[0]
 	err = illegalClauseCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "contains unsupported clause")

--- a/pkg/check/primarykey_test.go
+++ b/pkg/check/primarykey_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestPrimaryKey(t *testing.T) {
 	r := Resources{
-		Statement: statement.MustNew("ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (anothercol)"),
+		Statement: statement.MustNew("ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (anothercol)")[0],
 	}
 	err := primaryKeyCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err) // drop primary key
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 ADD INDEX (anothercol)")
+	r.Statement = statement.MustNew("ALTER TABLE t1 ADD INDEX (anothercol)")[0]
 	err = primaryKeyCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // safe modification
 }

--- a/pkg/check/rename_test.go
+++ b/pkg/check/rename_test.go
@@ -11,27 +11,27 @@ import (
 
 func TestRename(t *testing.T) {
 	r := Resources{
-		Statement: statement.MustNew("ALTER TABLE t1 RENAME TO newtablename"),
+		Statement: statement.MustNew("ALTER TABLE t1 RENAME TO newtablename")[0],
 	}
 	err := renameCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "renames are not supported")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 RENAME COLUMN c1 TO c2")
+	r.Statement = statement.MustNew("ALTER TABLE t1 RENAME COLUMN c1 TO c2")[0]
 	err = renameCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "renames are not supported")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c2 VARCHAR(100)")
+	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c2 VARCHAR(100)")[0]
 	err = renameCheck(t.Context(), r, logrus.New())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "renames are not supported")
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c1 VARCHAR(100)") //nolint: dupword
+	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c1 VARCHAR(100)")[0] //nolint: dupword
 	err = renameCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err)
 
-	r.Statement = statement.MustNew("ALTER TABLE t1 ADD INDEX (anothercol)")
+	r.Statement = statement.MustNew("ALTER TABLE t1 ADD INDEX (anothercol)")[0]
 	err = renameCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // safe modification
 }

--- a/pkg/check/replicahealth_test.go
+++ b/pkg/check/replicahealth_test.go
@@ -15,7 +15,7 @@ import (
 func TestReplicaHealth(t *testing.T) {
 	r := Resources{
 		Table:     &table.TableInfo{TableName: "test"},
-		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename"),
+		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename")[0],
 	}
 	err := replicaHealth(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // if no replica, it returns no error.

--- a/pkg/check/replicaprivileges_test.go
+++ b/pkg/check/replicaprivileges_test.go
@@ -19,7 +19,7 @@ func TestReplicaPrivileges(t *testing.T) {
 	}
 	r := Resources{
 		Table:     &table.TableInfo{TableName: "test"},
-		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename"),
+		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename")[0],
 	}
 	err := replicaPrivilegeCheck(t.Context(), r, logrus.New())
 	assert.NoError(t, err) // if no replica, it returns no error.

--- a/pkg/check/triggers_test.go
+++ b/pkg/check/triggers_test.go
@@ -36,7 +36,7 @@ func TestHasTriggers(t *testing.T) {
 	r := Resources{
 		DB:        db,
 		Table:     &table.TableInfo{SchemaName: "test", TableName: "account"},
-		Statement: statement.MustNew("ALTER TABLE account Engine=innodb"),
+		Statement: statement.MustNew("ALTER TABLE account Engine=innodb")[0],
 	}
 
 	err = hasTriggersCheck(t.Context(), r, logrus.New())

--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -22,7 +22,7 @@ type change struct {
 
 func (c *change) createNewTable(ctx context.Context) error {
 	newName := fmt.Sprintf(check.NameFormatNew, c.table.TableName)
-	// drop both if we've decided to call this func.
+	// drop the newName if we've decided to call this func.
 	if err := dbconn.Exec(ctx, c.runner.db, "DROP TABLE IF EXISTS %n.%n", c.table.SchemaName, newName); err != nil {
 		return err
 	}

--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -1,0 +1,138 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/block/spirit/pkg/check"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/statement"
+	"github.com/block/spirit/pkg/table"
+)
+
+type change struct {
+	stmt     *statement.AbstractStatement
+	table    *table.TableInfo
+	newTable *table.TableInfo
+
+	// Store a pointer back to the migration runner
+	// (for compatibility, we want to eventually remove this)
+	runner *Runner
+}
+
+func (c *change) createNewTable(ctx context.Context) error {
+	newName := fmt.Sprintf(check.NameFormatNew, c.table.TableName)
+	// drop both if we've decided to call this func.
+	if err := dbconn.Exec(ctx, c.runner.db, "DROP TABLE IF EXISTS %n.%n", c.table.SchemaName, newName); err != nil {
+		return err
+	}
+	if err := dbconn.Exec(ctx, c.runner.db, "CREATE TABLE %n.%n LIKE %n.%n",
+		c.table.SchemaName, newName, c.table.SchemaName, c.table.TableName); err != nil {
+		return err
+	}
+	c.newTable = table.NewTableInfo(c.runner.db, c.stmt.Schema, newName)
+	if err := c.newTable.SetInfo(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// alterNewTable applies the ALTER to the new table.
+// It has been pre-checked it is not a rename, or modifying the PRIMARY KEY.
+// We first attempt to do this using ALGORITHM=COPY so we don't burn
+// an INSTANT version. But surprisingly this is not supported for all DDLs (issue #277)
+func (c *change) alterNewTable(ctx context.Context) error {
+	if err := dbconn.Exec(ctx, c.runner.db, "ALTER TABLE %n.%n "+c.stmt.TrimAlter()+", ALGORITHM=COPY",
+		c.newTable.SchemaName, c.newTable.TableName); err != nil {
+		// Retry without the ALGORITHM=COPY. If there is a second error, then the DDL itself
+		// is not supported. It could be a syntax error, in which case we return the second error,
+		// which will probably be easier to read because it is unaltered.
+		if err := dbconn.Exec(ctx, c.runner.db, "ALTER TABLE %n.%n "+c.stmt.Alter, c.newTable.SchemaName, c.newTable.TableName); err != nil {
+			return err
+		}
+	}
+	// Call GetInfo on the table again, since the columns
+	// might have changed and this will affect the row copiers intersect func.
+	return c.newTable.SetInfo(ctx)
+}
+
+func (c *change) dropOldTable(ctx context.Context) error {
+	return dbconn.Exec(ctx, c.runner.db, "DROP TABLE IF EXISTS %n.%n", c.table.SchemaName, c.oldTableName())
+}
+
+func (c *change) oldTableName() string {
+	// By default we just set the old table name to _<table>_old
+	// but if they've enabled SkipDropAfterCutover, we add a timestamp
+	if !c.runner.migration.SkipDropAfterCutover {
+		return fmt.Sprintf(check.NameFormatOld, c.table.TableName)
+	}
+	return fmt.Sprintf(check.NameFormatOldTimeStamp, c.table.TableName, c.runner.startTime.UTC().Format(check.NameFormatTimestamp))
+}
+
+func (c *change) attemptInstantDDL(ctx context.Context) error {
+	return dbconn.Exec(ctx, c.runner.db, "ALTER TABLE %n.%n ALGORITHM=INSTANT, "+c.stmt.Alter, c.table.SchemaName, c.table.TableName)
+}
+
+func (c *change) attemptInplaceDDL(ctx context.Context) error {
+	return dbconn.Exec(ctx, c.runner.db, "ALTER TABLE %n.%n ALGORITHM=INPLACE, LOCK=NONE, "+c.stmt.Alter, c.table.SchemaName, c.table.TableName)
+}
+
+func (c *change) cleanup(ctx context.Context) error {
+	if c.newTable != nil {
+		if err := dbconn.Exec(ctx, c.runner.db, "DROP TABLE IF EXISTS %n.%n", c.newTable.SchemaName, c.newTable.TableName); err != nil {
+			return err
+		}
+	}
+	// TODO: only cleanup this migration, not the checkpoint table.
+	if c.runner.checkpointTable != nil {
+		if err := c.runner.dropCheckpoint(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// attemptMySQLDDL "attempts" to use DDL directly on MySQL with an assertion
+// such as ALGORITHM=INSTANT. If MySQL is able to use the INSTANT algorithm,
+// it will perform the operation without error. If it can't, it will return
+// an error. It is important to let MySQL decide if it can handle the DDL
+// operation, because keeping track of which operations are "INSTANT"
+// is incredibly difficult. It will depend on MySQL minor version,
+// and could possibly be specific to the table.
+func (c *change) attemptMySQLDDL(ctx context.Context) error {
+	err := c.attemptInstantDDL(ctx)
+	if err == nil {
+		c.runner.usedInstantDDL = true // success
+		return nil
+	}
+
+	// Many "inplace" operations (such as adding an index)
+	// are only online-safe to do in Aurora GLOBAL
+	// because replicas do not use the binlog. Some, however,
+	// only modify the table metadata and are safe.
+	//
+	// If the operator has specified that they want to attempt
+	// an inplace add index, we will attempt inplace regardless
+	// of the statement.
+	err = c.stmt.AlgorithmInplaceConsideredSafe()
+	if c.runner.migration.ForceInplace || err == nil {
+		err = c.attemptInplaceDDL(ctx)
+		if err == nil {
+			c.runner.usedInplaceDDL = true // success
+			return nil
+		}
+	}
+	c.runner.logger.Infof("unable to use INPLACE: %v", err)
+
+	// Failure is expected, since MySQL DDL only applies in limited scenarios
+	// Return the error, which will be ignored by the caller.
+	// Proceed with regular copy algorithm.
+	return err
+}
+
+func (c *change) Close() error {
+	if c.table != nil {
+		return c.table.Close()
+	}
+	return nil
+}

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -27,8 +27,8 @@ type cutoverConfig struct {
 	oldTableName string
 }
 
-// NewCutOver contains the logic to perform the final cut over. It requires the original table,
-// new table, and a replication feed which is used to ensure consistency before the cut over.
+// NewCutOver contains the logic to perform the final cut over. It can cutover multiple tables
+// at once based on config. A replication feed which is used to ensure consistency before the cut over.
 func NewCutOver(db *sql.DB, config []*cutoverConfig, feed *repl.Client, dbConfig *dbconn.DBConfig, logger loggers.Advanced) (*CutOver, error) {
 	if feed == nil {
 		return nil, errors.New("feed must be non-nil")

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/repl"
@@ -13,35 +14,40 @@ import (
 )
 
 type CutOver struct {
-	db           *sql.DB
+	db       *sql.DB
+	feed     *repl.Client
+	config   []*cutoverConfig
+	dbConfig *dbconn.DBConfig
+	logger   loggers.Advanced
+}
+
+type cutoverConfig struct {
 	table        *table.TableInfo
 	newTable     *table.TableInfo
 	oldTableName string
-	feed         *repl.Client
-	dbConfig     *dbconn.DBConfig
-	logger       loggers.Advanced
 }
 
 // NewCutOver contains the logic to perform the final cut over. It requires the original table,
 // new table, and a replication feed which is used to ensure consistency before the cut over.
-func NewCutOver(db *sql.DB, table, newTable *table.TableInfo, oldTableName string, feed *repl.Client, dbConfig *dbconn.DBConfig, logger loggers.Advanced) (*CutOver, error) {
+func NewCutOver(db *sql.DB, config []*cutoverConfig, feed *repl.Client, dbConfig *dbconn.DBConfig, logger loggers.Advanced) (*CutOver, error) {
 	if feed == nil {
 		return nil, errors.New("feed must be non-nil")
 	}
-	if table == nil || newTable == nil {
-		return nil, errors.New("table and newTable must be non-nil")
-	}
-	if oldTableName == "" {
-		return nil, errors.New("oldTableName must be non-empty")
+	// validate the cutoverConfig
+	for _, cfg := range config {
+		if cfg.table == nil || cfg.newTable == nil {
+			return nil, errors.New("table and newTable must be non-nil")
+		}
+		if cfg.oldTableName == "" {
+			return nil, errors.New("oldTableName must be non-empty")
+		}
 	}
 	return &CutOver{
-		db:           db,
-		table:        table,
-		newTable:     newTable,
-		oldTableName: oldTableName,
-		feed:         feed,
-		dbConfig:     dbConfig,
-		logger:       logger,
+		db:       db,
+		config:   config,
+		feed:     feed,
+		dbConfig: dbConfig,
+		logger:   logger,
 	}, nil
 }
 
@@ -86,7 +92,17 @@ func (c *CutOver) Run(ctx context.Context) error {
 func (c *CutOver) algorithmRenameUnderLock(ctx context.Context) error {
 	// Lock the source table in a trx
 	// so the connection is not used by others
-	tableLock, err := dbconn.NewTableLock(ctx, c.db, []*table.TableInfo{c.table, c.newTable}, c.dbConfig, c.logger)
+	tablesToLock := []*table.TableInfo{}
+	renameFragments := []string{}
+	for _, cfg := range c.config {
+		tablesToLock = append(tablesToLock, cfg.table, cfg.newTable)
+		oldQuotedName := fmt.Sprintf("`%s`.`%s`", cfg.table.SchemaName, cfg.oldTableName)
+		renameFragments = append(renameFragments,
+			fmt.Sprintf("%s TO %s", cfg.table.QuotedName, oldQuotedName),
+			fmt.Sprintf("%s TO %s", cfg.newTable.QuotedName, cfg.table.QuotedName),
+		)
+	}
+	tableLock, err := dbconn.NewTableLock(ctx, c.db, tablesToLock, c.dbConfig, c.logger)
 	if err != nil {
 		return err
 	}
@@ -97,10 +113,7 @@ func (c *CutOver) algorithmRenameUnderLock(ctx context.Context) error {
 	if !c.feed.AllChangesFlushed() {
 		return errors.New("not all changes flushed, final flush might be broken")
 	}
-	oldQuotedName := fmt.Sprintf("`%s`.`%s`", c.table.SchemaName, c.oldTableName)
-	renameStatement := fmt.Sprintf("RENAME TABLE %s TO %s, %s TO %s",
-		c.table.QuotedName, oldQuotedName,
-		c.newTable.QuotedName, c.table.QuotedName,
-	)
+
+	renameStatement := "RENAME TABLE " + strings.Join(renameFragments, ", ")
 	return tableLock.ExecUnderLock(ctx, renameStatement)
 }

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -15,7 +15,6 @@ import (
 	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/repl"
 	"github.com/block/spirit/pkg/row"
-	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/throttler"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -37,10 +36,11 @@ type Runner struct {
 	db              *sql.DB
 	dbConfig        *dbconn.DBConfig
 	replica         *sql.DB
-	table           *table.TableInfo
-	newTable        *table.TableInfo
-	checkpointTable *table.TableInfo
-	stmt            *statement.AbstractStatement
+	checkpointTable *table.TableInfo // remains on struct.
+
+	// Changes enccapsulates all changes
+	// With a stmt, alter, table, newTable.
+	changes []*change
 
 	currentState migrationState // must use atomic to get/set
 	replClient   *repl.Client   // feed contains all binlog subscription activity.
@@ -83,16 +83,26 @@ type Progress struct {
 }
 
 func NewRunner(m *Migration) (*Runner, error) {
-	stmt, err := m.normalizeOptions()
+	stmts, err := m.normalizeOptions()
 	if err != nil {
 		return nil, err
 	}
-	return &Runner{
+	changes := make([]*change, 0, len(stmts))
+	for _, stmt := range stmts {
+		changes = append(changes, &change{
+			stmt: stmt,
+		})
+	}
+	runner := &Runner{
 		migration:   m,
 		logger:      logrus.New(),
 		metricsSink: &metrics.NoopSink{},
-		stmt:        stmt,
-	}, nil
+		changes:     changes,
+	}
+	for _, change := range changes {
+		change.runner = runner // link back.
+	}
+	return runner, nil
 }
 
 func (r *Runner) SetMetricsSink(sink metrics.Sink) {
@@ -107,8 +117,9 @@ func (r *Runner) Run(originalCtx context.Context) error {
 	ctx, cancel := context.WithCancel(originalCtx)
 	defer cancel()
 	r.startTime = time.Now()
-	r.logger.Infof("Starting spirit migration: concurrency=%d target-chunk-size=%s table='%s.%s' alter=%s ",
-		r.migration.Threads, r.migration.TargetChunkTime, r.stmt.Schema, r.stmt.Table, r.stmt.Alter,
+	r.logger.Infof("Starting spirit migration: concurrency=%d target-chunk-size=%s",
+		r.migration.Threads,
+		r.migration.TargetChunkTime,
 	)
 
 	// Create a database connection
@@ -137,44 +148,56 @@ func (r *Runner) Run(originalCtx context.Context) error {
 		return err
 	}
 
-	// If it's not an alter table, that means it is a CREATE TABLE, DROP TABLE, or RENAME table.
-	// We should execute it immediately before acquiring TableInfo.
-	if !r.stmt.IsAlterTable() {
-		err := dbconn.Exec(ctx, r.db, r.stmt.Statement)
+	if !r.migration.Multi {
+		// If it's not an alter table, that means it is a CREATE TABLE, DROP TABLE, or RENAME table.
+		// We should execute it immediately before acquiring TableInfo.
+		if !r.changes[0].stmt.IsAlterTable() {
+			err := dbconn.Exec(ctx, r.db, r.changes[0].stmt.Statement)
+			if err != nil {
+				return err
+			}
+			r.logger.Infof("apply complete")
+			return nil
+		}
+
+		// Only need to setInfo for the main table for now.
+		r.changes[0].table = table.NewTableInfo(r.db, r.changes[0].stmt.Schema, r.changes[0].stmt.Table)
+		if err = r.changes[0].table.SetInfo(ctx); err != nil {
+			return err
+		}
+
+		// Take a metadata lock to prevent other migrations from running concurrently.
+		// We release the lock when this function finishes executing.
+		// We need to call this after r.table is ready - otherwise we'd move this to
+		// the start of the execution.
+		metadataLock, err := dbconn.NewMetadataLock(ctx, r.dsn(), r.changes[0].table, r.logger)
 		if err != nil {
 			return err
 		}
-		r.logger.Infof("apply complete")
-		return nil
-	}
-
-	// Get Table Info
-	r.table = table.NewTableInfo(r.db, r.stmt.Schema, r.stmt.Table)
-	if err := r.table.SetInfo(ctx); err != nil {
-		return err
-	}
-
-	// Take a metadata lock to prevent other migrations from running concurrently.
-	// We release the lock when this function finishes executing.
-	// We need to call this after r.table is ready - otherwise we'd move this to
-	// the start of the execution.
-	metadataLock, err := dbconn.NewMetadataLock(ctx, r.dsn(), r.table, r.logger)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := metadataLock.Close(); err != nil {
-			r.logger.Errorf("failed to release metadata lock: %v", err)
+		defer func() {
+			if err := metadataLock.Close(); err != nil {
+				r.logger.Errorf("failed to release metadata lock: %v", err)
+			}
+		}()
+		// This step is technically optional, but first we attempt to
+		// use MySQL's built-in DDL. This is because it's usually faster
+		// when it is compatible. If it returns no error, that means it
+		// has been successful and the DDL is complete.
+		err = r.changes[0].attemptMySQLDDL(ctx)
+		if err == nil {
+			r.logger.Infof("apply complete: instant-ddl=%v inplace-ddl=%v", r.usedInstantDDL, r.usedInplaceDDL)
+			return nil // success!
 		}
-	}()
-	// This step is technically optional, but first we attempt to
-	// use MySQL's built-in DDL. This is because it's usually faster
-	// when it is compatible. If it returns no error, that means it
-	// has been successful and the DDL is complete.
-	err = r.attemptMySQLDDL(ctx)
-	if err == nil {
-		r.logger.Infof("apply complete: instant-ddl=%v inplace-ddl=%v", r.usedInstantDDL, r.usedInplaceDDL)
-		return nil // success!
+	} else {
+		// We don't (yet) support a lot of features in multi-schema changes, and
+		// we never attempt instant/inplace DDL. So for now all we need to do
+		// is setup and call SetInfo on each of the tables.
+		for _, change := range r.changes {
+			change.table = table.NewTableInfo(r.db, change.stmt.Schema, change.stmt.Table)
+			if err := change.table.SetInfo(ctx); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Perform preflight basic checks.
@@ -192,18 +215,19 @@ func (r *Runner) Run(originalCtx context.Context) error {
 	// Force enable the checksum if it's an ADD UNIQUE INDEX operation
 	// https://github.com/block/spirit/issues/266
 	if !r.migration.Checksum {
-		if err := r.stmt.AlterContainsAddUnique(); err != nil {
+		if err := r.changes[0].stmt.AlterContainsAddUnique(); err != nil {
 			r.logger.Warnf("force enabling checksum: %v", err)
 			r.migration.Checksum = true
 		}
 	}
 
+	// TODO: push this into checks!
 	// We don't want to allow visibility changes
 	// This is because we've already attempted MySQL DDL as INPLACE, and it didn't work.
 	// It likely means the user is combining this operation with other unsafe operations,
 	// which is not a good idea. We need to protect them by not allowing it.
 	// https://github.com/block/spirit/issues/283
-	if err := r.stmt.AlterContainsIndexVisibility(); err != nil {
+	if err := r.changes[0].stmt.AlterContainsIndexVisibility(); err != nil {
 		return err
 	}
 
@@ -212,9 +236,11 @@ func (r *Runner) Run(originalCtx context.Context) error {
 		return err
 	}
 
-	go r.dumpStatus(ctx)                 // start periodically writing status
-	go r.dumpCheckpointContinuously(ctx) // start periodically dumping the checkpoint.
+	go r.dumpStatus(ctx) // start periodically writing status
 
+	if !r.migration.Multi {
+		go r.dumpCheckpointContinuously(ctx) // start periodically dumping the checkpoint.
+	}
 	// Perform the main copy rows task. This is where the majority
 	// of migrations usually spend time. It is not strictly necessary,
 	// but we always recopy the last-bit, even if we are resuming
@@ -252,28 +278,40 @@ func (r *Runner) Run(originalCtx context.Context) error {
 	// It's time for the final cut-over, where
 	// the tables are swapped under a lock.
 	r.setCurrentState(stateCutOver)
-	cutover, err := NewCutOver(r.db, r.table, r.newTable, r.oldTableName(), r.replClient, r.dbConfig, r.logger)
+	cutoverCfg := []*cutoverConfig{}
+	for _, change := range r.changes {
+		cutoverCfg = append(cutoverCfg, &cutoverConfig{
+			table:        change.table,
+			newTable:     change.newTable,
+			oldTableName: change.oldTableName(),
+		})
+	}
+	cutover, err := NewCutOver(r.db, cutoverCfg, r.replClient, r.dbConfig, r.logger)
 	if err != nil {
 		return err
 	}
 	// Drop the _old table if it exists. This ensures
 	// that the rename will succeed (although there is a brief race)
-	if err := r.dropOldTable(ctx); err != nil {
-		return err
+	for _, change := range r.changes {
+		if err := change.dropOldTable(ctx); err != nil {
+			return err
+		}
 	}
 	if err := cutover.Run(ctx); err != nil {
 		return err
 	}
 	if !r.migration.SkipDropAfterCutover {
-		if err := r.dropOldTable(ctx); err != nil {
-			// Don't return the error because our automation
-			// will retry the migration (but it's already happened)
-			r.logger.Errorf("migration successful but failed to drop old table: %s - %v", r.oldTableName(), err)
-		} else {
-			r.logger.Info("successfully dropped old table: ", r.oldTableName())
+		for _, change := range r.changes {
+			if err := change.dropOldTable(ctx); err != nil {
+				// Don't return the error because our automation
+				// will retry the migration (but it's already happened)
+				r.logger.Errorf("migration successful but failed to drop old table: %s - %v", change.oldTableName(), err)
+			} else {
+				r.logger.Info("successfully dropped old table: ", change.oldTableName())
+			}
 		}
 	} else {
-		r.logger.Info("skipped dropping old table: ", r.oldTableName())
+		r.logger.Info("skipped dropping old table")
 	}
 	checksumTime := time.Duration(0)
 	if r.checker != nil {
@@ -289,7 +327,13 @@ func (r *Runner) Run(originalCtx context.Context) error {
 		time.Since(r.startTime).Round(time.Second),
 		r.db.Stats().InUse,
 	)
-	return r.cleanup(ctx)
+	// cleanup all the tables
+	for _, change := range r.changes {
+		if err := change.cleanup(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // prepareForCutover performs steps to prepare for the final cutover.
@@ -313,27 +357,29 @@ func (r *Runner) prepareForCutover(ctx context.Context) error {
 	// to be out of date.
 	r.setCurrentState(stateAnalyzeTable)
 	r.logger.Infof("Running ANALYZE TABLE")
-	if err := dbconn.Exec(ctx, r.db, "ANALYZE TABLE %n.%n", r.newTable.SchemaName, r.newTable.TableName); err != nil {
-		return err
-	}
+	for _, change := range r.changes {
+		if err := dbconn.Exec(ctx, r.db, "ANALYZE TABLE %n.%n", change.newTable.SchemaName, change.newTable.TableName); err != nil {
+			return err
+		}
 
-	// Disable the auto-update statistics go routine. This is because the
-	// checksum uses a consistent read and doesn't see any of the new rows in the
-	// table anyway. Chunking in the space where the consistent reads may need
-	// to read a lot of older versions is *much* slower.
-	// In a previous migration:
-	// - The checksum chunks were about 100K rows each
-	// - When the checksum reached the point at which the copier had reached,
-	//   the chunks slowed down to about 30 rows(!)
-	// - The checksum task should have finished in the next 5 minutes, but instead
-	//   the projected time was another 40 hours.
-	// My understanding of MVCC in MySQL is that the consistent read threads may
-	// have had to follow pointers to older versions of rows in UNDO, which is a
-	// linked list to find the specific versions these transactions needed. It
-	// appears that it is likely N^2 complexity, and we are better off to just
-	// have the last chunk of the checksum be slow and do this once rather than
-	// repeatedly chunking in this range.
-	r.table.DisableAutoUpdateStatistics.Store(true)
+		// Disable the auto-update statistics go routine. This is because the
+		// checksum uses a consistent read and doesn't see any of the new rows in the
+		// table anyway. Chunking in the space where the consistent reads may need
+		// to read a lot of older versions is *much* slower.
+		// In a previous migration:
+		// - The checksum chunks were about 100K rows each
+		// - When the checksum reached the point at which the copier had reached,
+		//   the chunks slowed down to about 30 rows(!)
+		// - The checksum task should have finished in the next 5 minutes, but instead
+		//   the projected time was another 40 hours.
+		// My understanding of MVCC in MySQL is that the consistent read threads may
+		// have had to follow pointers to older versions of rows in UNDO, which is a
+		// linked list to find the specific versions these transactions needed. It
+		// appears that it is likely N^2 complexity, and we are better off to just
+		// have the last chunk of the checksum be slow and do this once rather than
+		// repeatedly chunking in this range.
+		change.table.DisableAutoUpdateStatistics.Store(true)
+	}
 
 	// The checksum is (usually) optional, but it is ONLINE after an initial lock
 	// for consistency. It is the main way that we determine that
@@ -350,71 +396,41 @@ func (r *Runner) prepareForCutover(ctx context.Context) error {
 }
 
 // runChecks wraps around check.RunChecks and adds the context of this migration
+// We redundantly run checks, once per change.
 func (r *Runner) runChecks(ctx context.Context, scope check.ScopeFlag) error {
-	return check.RunChecks(ctx, check.Resources{
-		DB:              r.db,
-		Replica:         r.replica,
-		Table:           r.table,
-		Statement:       r.stmt,
-		TargetChunkTime: r.migration.TargetChunkTime,
-		Threads:         r.migration.Threads,
-		ReplicaMaxLag:   r.migration.ReplicaMaxLag,
-		ForceKill:       r.migration.ForceKill,
-		// For the pre-run checks we don't have a DB connection yet.
-		// Instead we check the credentials provided.
-		Host:                 r.migration.Host,
-		Username:             r.migration.Username,
-		Password:             r.migration.Password,
-		SkipDropAfterCutover: r.migration.SkipDropAfterCutover,
-	}, r.logger, scope)
-}
-
-// attemptMySQLDDL "attempts" to use DDL directly on MySQL with an assertion
-// such as ALGORITHM=INSTANT. If MySQL is able to use the INSTANT algorithm,
-// it will perform the operation without error. If it can't, it will return
-// an error. It is important to let MySQL decide if it can handle the DDL
-// operation, because keeping track of which operations are "INSTANT"
-// is incredibly difficult. It will depend on MySQL minor version,
-// and could possibly be specific to the table.
-func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
-	err := r.attemptInstantDDL(ctx)
-	if err == nil {
-		r.usedInstantDDL = true // success
-		return nil
-	}
-
-	// Many "inplace" operations (such as adding an index)
-	// are only online-safe to do in Aurora GLOBAL
-	// because replicas do not use the binlog. Some, however,
-	// only modify the table metadata and are safe.
-	//
-	// If the operator has specified that they want to attempt
-	// an inplace add index, we will attempt inplace regardless
-	// of the statement.
-	err = r.stmt.AlgorithmInplaceConsideredSafe()
-	if r.migration.ForceInplace || err == nil {
-		err = r.attemptInplaceDDL(ctx)
-		if err == nil {
-			r.usedInplaceDDL = true // success
-			return nil
+	for _, change := range r.changes {
+		if err := check.RunChecks(ctx, check.Resources{
+			DB:              r.db,
+			Replica:         r.replica,
+			Table:           change.table,
+			Statement:       change.stmt,
+			TargetChunkTime: r.migration.TargetChunkTime,
+			Threads:         r.migration.Threads,
+			ReplicaMaxLag:   r.migration.ReplicaMaxLag,
+			ForceKill:       r.migration.ForceKill,
+			// For the pre-run checks we don't have a DB connection yet.
+			// Instead we check the credentials provided.
+			Host:                 r.migration.Host,
+			Username:             r.migration.Username,
+			Password:             r.migration.Password,
+			SkipDropAfterCutover: r.migration.SkipDropAfterCutover,
+		}, r.logger, scope); err != nil {
+			return err
 		}
 	}
-	r.logger.Infof("unable to use INPLACE: %v", err)
-
-	// Failure is expected, since MySQL DDL only applies in limited scenarios
-	// Return the error, which will be ignored by the caller.
-	// Proceed with regular copy algorithm.
-	return err
+	return nil
 }
 
 func (r *Runner) dsn() string {
-	return fmt.Sprintf("%s:%s@tcp(%s)/%s", r.migration.Username, r.migration.Password, r.migration.Host, r.stmt.Schema)
+	return fmt.Sprintf("%s:%s@tcp(%s)/%s", r.migration.Username, r.migration.Password, r.migration.Host, r.changes[0].stmt.Schema)
 }
 
 func (r *Runner) setup(ctx context.Context) error {
 	// Drop the old table. It shouldn't exist, but it could.
-	if err := r.dropOldTable(ctx); err != nil {
-		return err
+	for _, change := range r.changes {
+		if err := change.dropOldTable(ctx); err != nil {
+			return err
+		}
 	}
 	// Start subscribing to changes immediately.
 	r.ddlNotification = make(chan string, 1)
@@ -429,12 +445,27 @@ func (r *Runner) setup(ctx context.Context) error {
 			return err
 		}
 
-		if err := r.createNewTable(ctx); err != nil {
-			return err
+		chunkers := make([]table.Chunker, 0, len(r.changes))
+
+		for _, change := range r.changes {
+			if err := change.createNewTable(ctx); err != nil {
+				return err
+			}
+			if err := change.alterNewTable(ctx); err != nil {
+				return err
+			}
+			// Create chunker first with destination table info, then create copier with it
+			chunker, err := table.NewChunker(change.table, change.newTable, r.migration.TargetChunkTime, r.logger)
+			if err != nil {
+				return err
+			}
+			// For now we always "open" the chunker, but that might become obsolete later.
+			if err := chunker.Open(); err != nil {
+				return err
+			}
+			chunkers = append(chunkers, chunker)
 		}
-		if err := r.alterNewTable(ctx); err != nil {
-			return err
-		}
+
 		if err := r.createCheckpointTable(ctx); err != nil {
 			return err
 		}
@@ -445,19 +476,11 @@ func (r *Runner) setup(ctx context.Context) error {
 			}
 		}
 
-		// Create chunker first with destination table info, then create copier with it
-		r.copyChunker, err = table.NewChunker(r.table, r.newTable, r.migration.TargetChunkTime, r.logger)
-		if err != nil {
-			return err
-		}
-		// For now we always "open" the chunker, but that might become obsolete later.
-		if err := r.copyChunker.Open(); err != nil {
-			return err
-		}
-
 		if r.migration.Multi {
 			// Wrap the chunker in a multi-chunker
-			r.copyChunker = table.NewMultiChunker(r.copyChunker)
+			r.copyChunker = table.NewMultiChunker(chunkers[0]) // TODO: support variable chunkers
+		} else {
+			r.copyChunker = chunkers[0]
 		}
 
 		r.copier, err = row.NewCopier(r.db, r.copyChunker, &row.CopierConfig{
@@ -479,8 +502,11 @@ func (r *Runner) setup(ctx context.Context) error {
 			OnDDL:           r.ddlNotification,
 			ServerID:        repl.NewServerID(),
 		})
-		if err := r.replClient.AddSubscription(r.table, r.newTable, r.copier.KeyAboveHighWatermark); err != nil {
-			return err
+
+		for _, change := range r.changes {
+			if err := r.replClient.AddSubscription(change.table, change.newTable, r.copier.KeyAboveHighWatermark); err != nil {
+				return err
+			}
 		}
 		// Start the binary log feed now
 		if err := r.replClient.Run(ctx); err != nil {
@@ -519,7 +545,9 @@ func (r *Runner) setup(ctx context.Context) error {
 	// These will both be stopped when the copier finishes
 	// and checksum starts, although the PeriodicFlush
 	// will be restarted again after.
-	go r.table.AutoUpdateStatistics(ctx, tableStatUpdateInterval, r.logger)
+	for _, change := range r.changes {
+		go change.table.AutoUpdateStatistics(ctx, tableStatUpdateInterval, r.logger)
+	}
 	go r.replClient.StartPeriodicFlush(ctx, repl.DefaultFlushInterval)
 	go r.tableChangeNotification(ctx)
 	return nil
@@ -530,9 +558,11 @@ func (r *Runner) setup(ctx context.Context) error {
 // if they are acceptable or not.
 func (r *Runner) tableChangeNotification(ctx context.Context) {
 	defer r.replClient.SetDDLNotificationChannel(nil)
-
-	newTableEncoded := repl.EncodeSchemaTable(r.newTable.SchemaName, r.newTable.TableName)
-	tableEncoded := repl.EncodeSchemaTable(r.table.SchemaName, r.table.TableName)
+	if r.migration.Multi {
+		return // not yet supported.
+	}
+	newTableEncoded := repl.EncodeSchemaTable(r.changes[0].newTable.SchemaName, r.changes[0].newTable.TableName)
+	tableEncoded := repl.EncodeSchemaTable(r.changes[0].table.SchemaName, r.changes[0].table.TableName)
 
 	for {
 		select {
@@ -563,70 +593,21 @@ func (r *Runner) tableChangeNotification(ctx context.Context) {
 }
 
 func (r *Runner) dropCheckpoint(ctx context.Context) error {
+	if r.migration.Multi {
+		// For now we only support checkpoints in non-atomic migrations
+		return nil
+	}
 	return dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.checkpointTable.SchemaName, r.checkpointTable.TableName)
 }
 
-func (r *Runner) createNewTable(ctx context.Context) error {
-	newName := fmt.Sprintf(check.NameFormatNew, r.table.TableName)
-	// drop both if we've decided to call this func.
-	if err := dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.table.SchemaName, newName); err != nil {
-		return err
-	}
-	if err := dbconn.Exec(ctx, r.db, "CREATE TABLE %n.%n LIKE %n.%n",
-		r.table.SchemaName, newName, r.table.SchemaName, r.table.TableName); err != nil {
-		return err
-	}
-	r.newTable = table.NewTableInfo(r.db, r.stmt.Schema, newName)
-	if err := r.newTable.SetInfo(ctx); err != nil {
-		return err
-	}
-	return nil
-}
-
-// alterNewTable applies the ALTER to the new table.
-// It has been pre-checked it is not a rename, or modifying the PRIMARY KEY.
-// We first attempt to do this using ALGORITHM=COPY so we don't burn
-// an INSTANT version. But surprisingly this is not supported for all DDLs (issue #277)
-func (r *Runner) alterNewTable(ctx context.Context) error {
-	if err := dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n "+r.stmt.TrimAlter()+", ALGORITHM=COPY",
-		r.newTable.SchemaName, r.newTable.TableName); err != nil {
-		// Retry without the ALGORITHM=COPY. If there is a second error, then the DDL itself
-		// is not supported. It could be a syntax error, in which case we return the second error,
-		// which will probably be easier to read because it is unaltered.
-		if err := dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n "+r.stmt.Alter, r.newTable.SchemaName, r.newTable.TableName); err != nil {
-			return err
-		}
-	}
-	// Call GetInfo on the table again, since the columns
-	// might have changed and this will affect the row copiers intersect func.
-	return r.newTable.SetInfo(ctx)
-}
-
-func (r *Runner) dropOldTable(ctx context.Context) error {
-	return dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.table.SchemaName, r.oldTableName())
-}
-
-func (r *Runner) oldTableName() string {
-	// By default we just set the old table name to _<table>_old
-	// but if they've enabled SkipDropAfterCutover, we add a timestamp
-	if !r.migration.SkipDropAfterCutover {
-		return fmt.Sprintf(check.NameFormatOld, r.table.TableName)
-	}
-	return fmt.Sprintf(check.NameFormatOldTimeStamp, r.table.TableName, r.startTime.UTC().Format(check.NameFormatTimestamp))
-}
-
-func (r *Runner) attemptInstantDDL(ctx context.Context) error {
-	return dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n ALGORITHM=INSTANT, "+r.stmt.Alter, r.table.SchemaName, r.table.TableName)
-}
-
-func (r *Runner) attemptInplaceDDL(ctx context.Context) error {
-	return dbconn.Exec(ctx, r.db, "ALTER TABLE %n.%n ALGORITHM=INPLACE, LOCK=NONE, "+r.stmt.Alter, r.table.SchemaName, r.table.TableName)
-}
-
 func (r *Runner) createCheckpointTable(ctx context.Context) error {
-	cpName := fmt.Sprintf(check.NameFormatCheckpoint, r.table.TableName)
+	if r.migration.Multi {
+		// For now we only support checkpoints in non-atomic migrations
+		return nil
+	}
+	cpName := fmt.Sprintf(check.NameFormatCheckpoint, r.changes[0].table.TableName)
 	// drop both if we've decided to call this func.
-	if err := dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.table.SchemaName, cpName); err != nil {
+	if err := dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.changes[0].table.SchemaName, cpName); err != nil {
 		return err
 	}
 	if err := dbconn.Exec(ctx, r.db, `CREATE TABLE %n.%n (
@@ -638,10 +619,10 @@ func (r *Runner) createCheckpointTable(ctx context.Context) error {
 	rows_copied BIGINT,
 	alter_statement TEXT
 	)`,
-		r.table.SchemaName, cpName); err != nil {
+		r.changes[0].table.SchemaName, cpName); err != nil {
 		return err
 	}
-	r.checkpointTable = table.NewTableInfo(r.db, r.table.SchemaName, cpName)
+	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, cpName)
 	return nil
 }
 
@@ -670,37 +651,23 @@ func (r *Runner) GetProgress() Progress {
 }
 
 func (r *Runner) sentinelTableName() string {
-	return fmt.Sprintf(check.NameFormatSentinel, r.table.TableName)
+	return fmt.Sprintf(check.NameFormatSentinel, r.changes[0].table.TableName)
 }
 
 func (r *Runner) createSentinelTable(ctx context.Context) error {
-	if err := dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.table.SchemaName, r.sentinelTableName()); err != nil {
+	if err := dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.changes[0].table.SchemaName, r.sentinelTableName()); err != nil {
 		return err
 	}
-	if err := dbconn.Exec(ctx, r.db, "CREATE TABLE %n.%n (id int NOT NULL PRIMARY KEY)", r.table.SchemaName, r.sentinelTableName()); err != nil {
+	if err := dbconn.Exec(ctx, r.db, "CREATE TABLE %n.%n (id int NOT NULL PRIMARY KEY)", r.changes[0].table.SchemaName, r.sentinelTableName()); err != nil {
 		return err
-	}
-	return nil
-}
-
-func (r *Runner) cleanup(ctx context.Context) error {
-	if r.newTable != nil {
-		if err := dbconn.Exec(ctx, r.db, "DROP TABLE IF EXISTS %n.%n", r.newTable.SchemaName, r.newTable.TableName); err != nil {
-			return err
-		}
-	}
-	if r.checkpointTable != nil {
-		if err := r.dropCheckpoint(ctx); err != nil {
-			return err
-		}
 	}
 	return nil
 }
 
 func (r *Runner) Close() error {
 	r.setCurrentState(stateClose)
-	if r.table != nil {
-		err := r.table.Close()
+	for _, change := range r.changes {
+		err := change.Close()
 		if err != nil {
 			return err
 		}
@@ -733,17 +700,20 @@ func (r *Runner) Close() error {
 }
 
 func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
+	if r.migration.Multi {
+		return errors.New("resume-from-checkpoint is not yet supported in multi-statement migrations")
+	}
 	// Check that the new table exists and the checkpoint table
 	// has at least one row in it.
 
 	// The objects for these are not available until we confirm
 	// tables exist and we
-	newName := fmt.Sprintf(check.NameFormatNew, r.table.TableName)
-	cpName := fmt.Sprintf(check.NameFormatCheckpoint, r.table.TableName)
+	newName := fmt.Sprintf(check.NameFormatNew, r.changes[0].table.TableName)
+	cpName := fmt.Sprintf(check.NameFormatCheckpoint, r.changes[0].table.TableName)
 
 	// Make sure we can read from the new table.
 	if err := dbconn.Exec(ctx, r.db, "SELECT * FROM %n.%n LIMIT 1",
-		r.stmt.Schema, newName); err != nil {
+		r.changes[0].table.SchemaName, newName); err != nil {
 		return fmt.Errorf("could not find any checkpoints in table '%s'", newName)
 	}
 
@@ -752,7 +722,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	// was created by either an earlier or later version of spirit, in which case
 	// we do not support recovery.
 	query := fmt.Sprintf("SELECT * FROM `%s`.`%s` ORDER BY id DESC LIMIT 1",
-		r.stmt.Schema, cpName)
+		r.changes[0].stmt.Schema, cpName)
 	var copierWatermark, binlogName, alterStatement string
 	var id, binlogPos int
 	var rowsCopied uint64
@@ -760,12 +730,12 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not read from table '%s', err:%v", cpName, err)
 	}
-	if r.stmt.Alter != alterStatement {
+	if r.changes[0].stmt.Alter != alterStatement {
 		return ErrMismatchedAlter
 	}
 	// Populate the objects that would have been set in the other funcs.
-	r.newTable = table.NewTableInfo(r.db, r.stmt.Schema, newName)
-	if err := r.newTable.SetInfo(ctx); err != nil {
+	r.changes[0].newTable = table.NewTableInfo(r.db, r.changes[0].stmt.Schema, newName)
+	if err := r.changes[0].newTable.SetInfo(ctx); err != nil {
 		return err
 	}
 
@@ -779,14 +749,14 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	r.migration.Checksum = true
 
 	// Create chunker first and open at the checkpoint watermark
-	chunker, err := table.NewChunker(r.table, r.newTable, r.migration.TargetChunkTime, r.logger)
+	chunker, err := table.NewChunker(r.changes[0].table, r.changes[0].newTable, r.migration.TargetChunkTime, r.logger)
 	if err != nil {
 		return err
 	}
 
 	// Open chunker at the specified watermark
 	// For high watermark, use the type of old table, not the new one.
-	highPtr := table.NewDatum(r.newTable.MaxValue().Val, r.table.MaxValue().Tp)
+	highPtr := table.NewDatum(r.changes[0].newTable.MaxValue().Val, r.changes[0].table.MaxValue().Tp)
 	if err := chunker.OpenAtWatermark(copierWatermark, highPtr, rowsCopied); err != nil {
 		return err
 	}
@@ -820,7 +790,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 		OnDDL:           r.ddlNotification,
 		ServerID:        repl.NewServerID(),
 	})
-	if err := r.replClient.AddSubscription(r.table, r.newTable, r.copier.KeyAboveHighWatermark); err != nil {
+	if err := r.replClient.AddSubscription(r.changes[0].table, r.changes[0].newTable, r.copier.KeyAboveHighWatermark); err != nil {
 		return err
 	}
 	r.replClient.SetFlushedPos(mysql.Position{
@@ -828,7 +798,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 		Pos:  uint32(binlogPos),
 	})
 
-	r.checkpointTable = table.NewTableInfo(r.db, r.table.SchemaName, cpName)
+	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, cpName)
 
 	// Start the replClient now. This is because if the checkpoint is so old there
 	// are no longer binary log files, we want to abandon resume-from-checkpoint
@@ -846,6 +816,10 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 // checksum creates the checksum which opens the read view.
 func (r *Runner) checksum(ctx context.Context) error {
 	r.setCurrentState(stateChecksum)
+	if r.migration.Multi {
+		return nil // not yet supported.
+	}
+
 	// The checksum keeps the pool threads open, so we need to extend
 	// by more than +1 on threads as we did previously. We have:
 	// - background flushing
@@ -864,12 +838,12 @@ func (r *Runner) checksum(ctx context.Context) error {
 		r.checkerLock.Lock()
 
 		// Create a chunker
-		r.checksumChunker, err = table.NewChunker(r.table, r.newTable, r.migration.TargetChunkTime, r.logger)
+		r.checksumChunker, err = table.NewChunker(r.changes[0].table, r.changes[0].newTable, r.migration.TargetChunkTime, r.logger)
 		if err != nil {
 			return err
 		}
 		if r.checksumWatermark != "" {
-			if err := r.checksumChunker.OpenAtWatermark(r.checksumWatermark, r.newTable.MaxValue(), 0); err != nil {
+			if err := r.checksumChunker.OpenAtWatermark(r.checksumWatermark, r.changes[0].newTable.MaxValue(), 0); err != nil {
 				return err
 			}
 		} else {
@@ -908,7 +882,8 @@ func (r *Runner) checksum(ctx context.Context) error {
 			// then the checksum will fail. This is entirely expected, and not considered a bug. We should
 			// do our best-case to differentiate that we believe this ALTER statement is lossy, and
 			// customize the returned error based on it.
-			if err := r.stmt.AlterContainsAddUnique(); err != nil {
+			// TODO: fix me.
+			if err := r.changes[0].stmt.AlterContainsAddUnique(); err != nil {
 				return errors.New("checksum failed after 3 attempts. Check that the ALTER statement is not adding a UNIQUE INDEX to non-unique data")
 			}
 			return errors.New("checksum failed after 3 attempts. This likely indicates either a bug in Spirit, or a manual modification to the _new table outside of Spirit. Please report @ github.com/block/spirit")
@@ -965,16 +940,20 @@ func (r *Runner) dumpCheckpoint(ctx context.Context) error {
 	// We believe this is OK but may change it in the future. Please do not
 	// add any other fields to this log line.
 	r.logger.Infof("checkpoint: low-watermark=%s log-file=%s log-pos=%d rows-copied=%d", copierWatermark, binlog.Name, binlog.Pos, copyRows)
-	return dbconn.Exec(ctx, r.db, "INSERT INTO %n.%n (copier_watermark, checksum_watermark, binlog_name, binlog_pos, rows_copied, alter_statement) VALUES (%?, %?, %?, %?, %?, %?)",
-		r.checkpointTable.SchemaName,
-		r.checkpointTable.TableName,
+	err = dbconn.Exec(ctx, r.db, "INSERT INTO %n.%n (copier_watermark, checksum_watermark, binlog_name, binlog_pos, rows_copied, alter_statement) VALUES (%?, %?, %?, %?, %?, %?)",
+		r.checkpointTable.SchemaName, //TODO: fixme
+		r.checkpointTable.TableName,  //TODO: fixme
 		copierWatermark,
 		checksumWatermark,
 		binlog.Name,
 		binlog.Pos,
 		copyRows,
-		r.stmt.Alter,
+		r.changes[0].stmt.Alter, //TODO: fixme
 	)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *Runner) dumpCheckpointContinuously(ctx context.Context) {
@@ -1026,7 +1005,7 @@ func (r *Runner) dumpStatus(ctx context.Context) {
 			case stateWaitingOnSentinelTable:
 				r.logger.Infof("migration status: state=%s sentinel-table=%s.%s total-time=%s sentinel-wait-time=%s sentinel-max-wait-time=%s conns-in-use=%d",
 					r.getCurrentState().String(),
-					r.table.SchemaName,
+					r.changes[0].table.SchemaName,
 					r.sentinelTableName(),
 					time.Since(r.startTime).Round(time.Second),
 					time.Since(r.sentinelWaitStartTime).Round(time.Second),
@@ -1065,7 +1044,7 @@ func (r *Runner) dumpStatus(ctx context.Context) {
 func (r *Runner) sentinelTableExists(ctx context.Context) (bool, error) {
 	sql := "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?"
 	var sentinelTableExists int
-	err := r.db.QueryRowContext(ctx, sql, r.table.SchemaName, r.sentinelTableName()).Scan(&sentinelTableExists)
+	err := r.db.QueryRowContext(ctx, sql, r.changes[0].table.SchemaName, r.sentinelTableName()).Scan(&sentinelTableExists)
 	if err != nil {
 		return false, err
 	}
@@ -1074,6 +1053,10 @@ func (r *Runner) sentinelTableExists(ctx context.Context) (bool, error) {
 
 // Check every sentinelCheckInterval up to sentinelWaitLimit to see if sentinelTable has been dropped
 func (r *Runner) waitOnSentinelTable(ctx context.Context) error {
+	if r.migration.Multi {
+		// For now we only support sentinels in non-atomic migrations
+		return nil
+	}
 	if sentinelExists, err := r.sentinelTableExists(ctx); err != nil {
 		return err
 	} else if !sentinelExists {
@@ -1081,7 +1064,7 @@ func (r *Runner) waitOnSentinelTable(ctx context.Context) error {
 		return nil
 	}
 
-	r.logger.Warnf("cutover deferred while sentinel table %s.%s exists; will wait %s", r.table.SchemaName, r.sentinelTableName(), sentinelWaitLimit)
+	r.logger.Warnf("cutover deferred while sentinel table %s.%s exists; will wait %s", r.changes[0].table.SchemaName, r.sentinelTableName(), sentinelWaitLimit)
 
 	timer := time.NewTimer(sentinelWaitLimit)
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -477,8 +477,8 @@ func (r *Runner) setup(ctx context.Context) error {
 		}
 
 		if r.migration.Multi {
-			// Wrap the chunker in a multi-chunker
-			r.copyChunker = table.NewMultiChunker(chunkers[0]) // TODO: support variable chunkers
+			r.copyChunker = table.NewMultiChunker(chunkers...)
+			_ = r.copyChunker.Open() // redundant, but required for now.
 		} else {
 			r.copyChunker = chunkers[0]
 		}

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -33,92 +33,105 @@ func New(statement string) ([]*AbstractStatement, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(stmtNodes) != 1 {
-		return nil, errors.New("only one statement may be specified at once")
-	}
-	switch stmtNodes[0].(type) {
-	case *ast.AlterTableStmt:
-		// type assert stmtNodes[0] as an AlterTableStmt and then
-		// extract the table and alter from it.
-		alterStmt := stmtNodes[0].(*ast.AlterTableStmt)
-		// if the schema name is included it could be different from the --database
-		// specified, which causes all sorts of problems. The easiest way to handle this
-		// it just to not permit it.
-		var sb strings.Builder
-		sb.Reset()
-		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
-		if err = alterStmt.Restore(rCtx); err != nil {
-			return nil, fmt.Errorf("could not restore alter clause statement: %s", err)
-		}
-		normalizedStmt := sb.String()
-		trimLen := len(alterStmt.Table.Name.String()) + 15 // len ALTER TABLE + quotes
-		if len(alterStmt.Table.Schema.String()) > 0 {
-			trimLen += len(alterStmt.Table.Schema.String()) + 3 // len schema + quotes and dot.
-		}
-		return []*AbstractStatement{
-			{
+	stmts := make([]*AbstractStatement, 0, len(stmtNodes))
+	var mustBeOnlyStatement bool
+	for _, node := range stmtNodes {
+		switch node.(type) {
+		case *ast.AlterTableStmt:
+			// type assert node as an AlterTableStmt and then
+			// extract the table and alter from it.
+			alterStmt := node.(*ast.AlterTableStmt)
+			// if the schema name is included it could be different from the --database
+			// specified, which causes all sorts of problems. The easiest way to handle this
+			// it just to not permit it.
+			var sb strings.Builder
+			sb.Reset()
+			rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
+			if err = alterStmt.Restore(rCtx); err != nil {
+				return nil, fmt.Errorf("could not restore alter clause statement: %s", err)
+			}
+			normalizedStmt := sb.String()
+			trimLen := len(alterStmt.Table.Name.String()) + 15 // len ALTER TABLE + quotes
+			if len(alterStmt.Table.Schema.String()) > 0 {
+				trimLen += len(alterStmt.Table.Schema.String()) + 3 // len schema + quotes and dot.
+			}
+			stmts = append(stmts, &AbstractStatement{
 				Schema:    alterStmt.Table.Schema.String(),
 				Table:     alterStmt.Table.Name.String(),
 				Alter:     normalizedStmt[trimLen:],
 				Statement: statement,
-				StmtNode:  &stmtNodes[0],
-			},
-		}, nil
-	case *ast.CreateIndexStmt:
-		// Need to rewrite to a corresponding ALTER TABLE statement
-		return convertCreateIndexToAlterTable(stmtNodes[0])
-	// returning an empty alter means we are allowed to run it
-	// but it's not a spirit migration. But the table should be specified.
-	case *ast.CreateTableStmt:
-		stmt := stmtNodes[0].(*ast.CreateTableStmt)
-		return []*AbstractStatement{
-			{
-				Schema:    stmt.Table.Schema.String(),
-				Table:     stmt.Table.Name.String(),
-				Statement: statement,
-				StmtNode:  &stmtNodes[0],
-			},
-		}, err
-	case *ast.DropTableStmt:
-		stmt := stmtNodes[0].(*ast.DropTableStmt)
-		distinctSchemas := make(map[string]struct{})
-		for _, table := range stmt.Tables {
-			distinctSchemas[table.Schema.String()] = struct{}{}
-		}
-		if len(distinctSchemas) > 1 {
-			return nil, errors.New("statement attempts to drop tables from multiple schemas")
-		}
-		return []*AbstractStatement{
-			{
-				Schema:    stmt.Tables[0].Schema.String(),
-				Table:     stmt.Tables[0].Name.String(),
-				Statement: statement,
-				StmtNode:  &stmtNodes[0],
-			},
-		}, err
-	case *ast.RenameTableStmt:
-		stmt := stmtNodes[0].(*ast.RenameTableStmt)
-		distinctSchemas := make(map[string]struct{})
-		for _, clause := range stmt.TableToTables {
-			if clause.OldTable.Schema.String() != clause.NewTable.Schema.String() {
-				return nil, errors.New("statement attempts to move table between schemas")
+				StmtNode:  &node,
+			})
+		case *ast.CreateIndexStmt:
+			// Need to rewrite to a corresponding ALTER TABLE statement
+			stmt, err := convertCreateIndexToAlterTable(node)
+			if err != nil {
+				return nil, err
 			}
-			distinctSchemas[clause.OldTable.Schema.String()] = struct{}{}
+			stmts = append(stmts, stmt)
+		// returning an empty alter means we are allowed to run it
+		// but it's not a spirit migration. But the table should be specified.
+		case *ast.CreateTableStmt:
+			mustBeOnlyStatement = true
+			stmt := node.(*ast.CreateTableStmt)
+			return []*AbstractStatement{
+				{
+					Schema:    stmt.Table.Schema.String(),
+					Table:     stmt.Table.Name.String(),
+					Statement: statement,
+					StmtNode:  &node,
+				},
+			}, err
+		case *ast.DropTableStmt:
+			mustBeOnlyStatement = true
+			stmt := node.(*ast.DropTableStmt)
+			distinctSchemas := make(map[string]struct{})
+			for _, table := range stmt.Tables {
+				distinctSchemas[table.Schema.String()] = struct{}{}
+			}
+			if len(distinctSchemas) > 1 {
+				return nil, errors.New("statement attempts to drop tables from multiple schemas")
+			}
+			return []*AbstractStatement{
+				{
+					Schema:    stmt.Tables[0].Schema.String(),
+					Table:     stmt.Tables[0].Name.String(),
+					Statement: statement,
+					StmtNode:  &node,
+				},
+			}, err
+		case *ast.RenameTableStmt:
+			mustBeOnlyStatement = true
+			stmt := node.(*ast.RenameTableStmt)
+			distinctSchemas := make(map[string]struct{})
+			for _, clause := range stmt.TableToTables {
+				if clause.OldTable.Schema.String() != clause.NewTable.Schema.String() {
+					return nil, errors.New("statement attempts to move table between schemas")
+				}
+				distinctSchemas[clause.OldTable.Schema.String()] = struct{}{}
+			}
+			if len(distinctSchemas) > 1 {
+				return nil, errors.New("statement attempts to rename tables in multiple schemas")
+			}
+			return []*AbstractStatement{
+				{
+					Schema:    stmt.TableToTables[0].OldTable.Schema.String(),
+					Table:     stmt.TableToTables[0].OldTable.Name.String(),
+					Statement: statement,
+					StmtNode:  &node,
+				},
+			}, err
 		}
-		if len(distinctSchemas) > 1 {
-			return nil, errors.New("statement attempts to rename tables in multiple schemas")
-		}
-		return []*AbstractStatement{
-			{
-				Schema:    stmt.TableToTables[0].OldTable.Schema.String(),
-				Table:     stmt.TableToTables[0].OldTable.Name.String(),
-				Statement: statement,
-				StmtNode:  &stmtNodes[0],
-			},
-		}, err
 	}
-	// default:
-	return nil, ErrNotSupportedStatement
+
+	if len(stmts) > 1 && mustBeOnlyStatement {
+		return nil, errors.New("statement must be executed alone")
+	}
+	if len(stmts) < 1 {
+		return nil, errors.New("could not find any compatible statements to execute")
+	}
+
+	return stmts, nil
 }
 
 // MustNew is like New but panics if the statement cannot be parsed.
@@ -243,7 +256,7 @@ func (a *AbstractStatement) TrimAlter() string {
 	return strings.TrimSuffix(strings.TrimSpace(a.Alter), ";")
 }
 
-func convertCreateIndexToAlterTable(stmt ast.StmtNode) ([]*AbstractStatement, error) {
+func convertCreateIndexToAlterTable(stmt ast.StmtNode) (*AbstractStatement, error) {
 	ciStmt, isCreateIndexStmt := stmt.(*ast.CreateIndexStmt)
 	if !isCreateIndexStmt {
 		return nil, errors.New("not a CREATE INDEX statement")
@@ -276,13 +289,11 @@ func convertCreateIndexToAlterTable(stmt ast.StmtNode) ([]*AbstractStatement, er
 	if len(stmtNodes) != 1 {
 		return nil, errors.New("only one statement may be specified at once")
 	}
-	return []*AbstractStatement{
-		{
-			Schema:    ciStmt.Table.Schema.String(),
-			Table:     ciStmt.Table.Name.String(),
-			Alter:     alterStmt,
-			Statement: statement,
-			StmtNode:  &stmtNodes[0],
-		},
+	return &AbstractStatement{
+		Schema:    ciStmt.Table.Schema.String(),
+		Table:     ciStmt.Table.Name.String(),
+		Alter:     alterStmt,
+		Statement: statement,
+		StmtNode:  &stmtNodes[0],
 	}, err
 }

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -20,8 +20,6 @@ type AbstractStatement struct {
 	Alter     string // may be empty.
 	Statement string
 	StmtNode  *ast.StmtNode
-
-	// TODO: Add table and newTable here?
 }
 
 var (
@@ -93,7 +91,7 @@ func New(statement string) ([]*AbstractStatement, error) {
 		return []*AbstractStatement{
 			{
 				Schema:    stmt.Tables[0].Schema.String(),
-				Table:     stmt.Tables[0].Name.String(), // TODO: this is just used in log lines, but there could be more than one!
+				Table:     stmt.Tables[0].Name.String(),
 				Statement: statement,
 				StmtNode:  &stmtNodes[0],
 			},
@@ -113,7 +111,7 @@ func New(statement string) ([]*AbstractStatement, error) {
 		return []*AbstractStatement{
 			{
 				Schema:    stmt.TableToTables[0].OldTable.Schema.String(),
-				Table:     stmt.TableToTables[0].OldTable.Name.String(), // TODO: this is just used in log lines, but there could be more than one!
+				Table:     stmt.TableToTables[0].OldTable.Name.String(),
 				Statement: statement,
 				StmtNode:  &stmtNodes[0],
 			},

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -42,7 +42,12 @@ func TestExtractFromStatement(t *testing.T) {
 	assert.False(t, abstractStmt[0].IsAlterTable())
 
 	// Try and extract multiple statements.
+	// This works
 	_, err = New("ALTER TABLE t1 ADD INDEX (something); ALTER TABLE t2 ADD INDEX (something)")
+	assert.NoError(t, err)
+
+	// This doesn't though:
+	_, err = New("CREATE TABLE tnn (a int); ALTER TABLE t2 ADD INDEX (something)")
 	assert.Error(t, err)
 
 	// Include the schema name.
@@ -70,7 +75,6 @@ func TestExtractFromStatement(t *testing.T) {
 	// test unsupported.
 	_, err = New("INSERT INTO t1 (a) VALUES (1)")
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "not a supported statement type")
 
 	// drop table
 	abstractStmt, err = New("DROP TABLE t1")

--- a/pkg/table/chunker_multi.go
+++ b/pkg/table/chunker_multi.go
@@ -88,9 +88,9 @@ func (m *multiChunker) Next() (*Chunk, error) {
 
 	// Find the chunker with the least progress (lowest percentage)
 	var selectedChunker Chunker
-	var minProgressPercent float64 = 2.0 // Start higher than 100% so any real progress is selected
+	var minProgressPercent = 2.0 // Start higher than 100% so any real progress is selected
 	var maxTotalRows uint64 = 0
-	var hasActiveChunkers bool = false
+	var hasActiveChunkers = false
 
 	for _, chunker := range m.chunkers {
 		if chunker.IsRead() {

--- a/pkg/table/chunker_multi.go
+++ b/pkg/table/chunker_multi.go
@@ -1,8 +1,199 @@
 package table
 
-// This is a placeholder for the multi-chunker.
-// We don't strictly need to implement it now.
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
 
-func NewMultiChunker(c Chunker) Chunker {
-	return c
+// multiChunker wraps multiple chunkers and distributes Next() calls
+// to the chunker that has made the least progress
+type multiChunker struct {
+	sync.Mutex
+	chunkers []Chunker
+	isOpen   bool
+}
+
+var _ Chunker = &multiChunker{}
+
+// NewMultiChunker creates a new multi-chunker that wraps multiple chunkers
+func NewMultiChunker(c ...Chunker) Chunker {
+	if len(c) == 0 {
+		return nil
+	}
+	if len(c) == 1 {
+		return c[0]
+	}
+	return &multiChunker{
+		chunkers: c,
+	}
+}
+
+// Open opens all wrapped chunkers
+func (m *multiChunker) Open() error {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.isOpen {
+		return errors.New("multi-chunker is already open")
+	}
+
+	// For now, The child chunkers are already open.
+	m.isOpen = true
+	return nil
+}
+
+// IsRead returns true if all chunkers are read
+func (m *multiChunker) IsRead() bool {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, chunker := range m.chunkers {
+		if !chunker.IsRead() {
+			return false
+		}
+	}
+	return true
+}
+
+// Close closes all wrapped chunkers
+func (m *multiChunker) Close() error {
+	m.Lock()
+	defer m.Unlock()
+
+	var errs []error
+	for i, chunker := range m.chunkers {
+		if err := chunker.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close chunker %d: %w", i, err))
+		}
+	}
+
+	m.isOpen = false
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors closing chunkers: %v", errs)
+	}
+	return nil
+}
+
+// Next returns the next chunk from the chunker that has made the least progress (by percentage)
+func (m *multiChunker) Next() (*Chunk, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	if !m.isOpen {
+		return nil, ErrTableNotOpen
+	}
+
+	// Find the chunker with the least progress (lowest percentage)
+	var selectedChunker Chunker
+	var minProgressPercent float64 = 2.0 // Start higher than 100% so any real progress is selected
+	var maxTotalRows uint64 = 0
+	var hasActiveChunkers bool = false
+
+	for _, chunker := range m.chunkers {
+		if chunker.IsRead() {
+			continue // skip chunkers that are done
+		}
+
+		hasActiveChunkers = true
+		rowsCopied, _, totalRowsExpected := chunker.Progress()
+
+		// Calculate progress percentage
+		var progressPercent float64
+		if totalRowsExpected > 0 {
+			progressPercent = float64(rowsCopied) / float64(totalRowsExpected)
+		} else {
+			progressPercent = 0.0
+		}
+
+		// Select chunker with lowest progress percentage
+		// If percentages are equal (including both 0), prefer the one with more total rows
+		if progressPercent < minProgressPercent ||
+			(progressPercent == minProgressPercent && totalRowsExpected > maxTotalRows) {
+			minProgressPercent = progressPercent
+			maxTotalRows = totalRowsExpected
+			selectedChunker = chunker
+		}
+	}
+
+	// If no active chunkers are available, all are done
+	if !hasActiveChunkers || selectedChunker == nil {
+		return nil, ErrTableIsRead
+	}
+	return selectedChunker.Next()
+}
+
+// Feedback forwards feedback to the appropriate chunker based on the chunk's table
+func (m *multiChunker) Feedback(chunk *Chunk, duration time.Duration, actualRows uint64) {
+	m.Lock()
+	defer m.Unlock()
+
+	// Find the chunker that handles this table
+	for _, chunker := range m.chunkers {
+		tables := chunker.Tables()
+		for _, table := range tables {
+			if table == chunk.Table {
+				chunker.Feedback(chunk, duration, actualRows)
+				return
+			}
+		}
+	}
+}
+
+// KeyAboveHighWatermark currently not supported for multi-chunker
+// The interface will need to be changed to accept (table, key) to route properly
+func (m *multiChunker) KeyAboveHighWatermark(key any) bool {
+	// TODO: Interface needs to be changed to KeyAboveHighWatermark(table, key)
+	// to properly route to the correct underlying chunker
+	return false
+}
+
+// Progress returns aggregate progress across all chunkers
+func (m *multiChunker) Progress() (uint64, uint64, uint64) {
+	m.Lock()
+	defer m.Unlock()
+
+	var totalRowsCopied, totalChunksCopied, totalRowsExpected uint64
+
+	for _, chunker := range m.chunkers {
+		rowsCopied, chunksCopied, rowsExpected := chunker.Progress()
+		totalRowsCopied += rowsCopied
+		totalChunksCopied += chunksCopied
+		totalRowsExpected += rowsExpected
+	}
+
+	return totalRowsCopied, totalChunksCopied, totalRowsExpected
+}
+
+// OpenAtWatermark is not yet implemented for multi-chunker
+func (m *multiChunker) OpenAtWatermark(watermark string, datum Datum, rowsCopied uint64) error {
+	return errors.New("OpenAtWatermark not yet implemented for multi-chunker")
+}
+
+// GetLowWatermark is not yet implemented for multi-chunker
+func (m *multiChunker) GetLowWatermark() (string, error) {
+	return "", errors.New("GetLowWatermark not yet implemented for multi-chunker")
+}
+
+// Tables returns all tables from all chunkers
+func (m *multiChunker) Tables() []*TableInfo {
+	m.Lock()
+	defer m.Unlock()
+
+	var allTables []*TableInfo
+	seen := make(map[*TableInfo]bool)
+
+	for _, chunker := range m.chunkers {
+		tables := chunker.Tables()
+		for _, table := range tables {
+			if !seen[table] {
+				allTables = append(allTables, table)
+				seen[table] = true
+			}
+		}
+	}
+
+	return allTables
 }

--- a/pkg/table/chunker_multi.go
+++ b/pkg/table/chunker_multi.go
@@ -68,11 +68,9 @@ func (m *multiChunker) Close() error {
 			errs = append(errs, fmt.Errorf("failed to close chunker %d: %w", i, err))
 		}
 	}
-
 	m.isOpen = false
-
-	if len(errs) > 0 {
-		return fmt.Errorf("errors closing chunkers: %v", errs)
+	if err := errors.Join(errs...); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Fixes https://github.com/block/spirit/issues/394
Fixes https://github.com/block/spirit/issues/393
Fixes https://github.com/block/spirit/issues/435

The multi path does not yet support checkpoints, checksum, resuming, sentinel tables. There are no tests for multi-path yet: it is working end to end though:

```
mtocker@BLKD5234QXY40 spirit % go run . --statement="ALTER TABLE bigtable ENGINE=innodb; ALTER TABLE bigtable2 ENGINE=innodb;" --multi --threads=8 --target-chunk-time=5s
INFO[0000] Starting spirit migration: concurrency=8 target-chunk-size=5s
INFO[0000] could not resume from checkpoint: reason=resume-from-checkpoint is not yet supported in multi-statement migrations
INFO[0000] create BinlogSyncer with config {ServerID:1149 Flavor:mysql Host:127.0.0.1 Port:3306 User:spirit Password: Localhost: Charset: SemiSyncEnabled:false RawModeEnabled:false TLSConfig:<nil> ParseTime:false TimestampStringLocation:UTC UseDecimal:false RecvBufferSize:0 HeartbeatPeriod:0s ReadTimeout:0s MaxReconnectAttempts:0 DisableRetrySync:false VerifyChecksum:false DumpCommandFlag:0 Option:<nil> Logger:0x1400028b580 Dialer:0x1007de8f0 RowsEventDecodeFunc:<nil> TableMapOptionalMetaDecodeFunc:<nil> DiscardGTIDSet:false EventCacheCount:10240}
INFO[0000] begin to sync binlog from position (BLKD5234QXY40-bin.015432, 682188214)
INFO[0030] migration status: state=copyRows copy-progress=7545795/40094411 18.82% binlog-deltas=0 total-time=30s copier-time=30s copier-remaining-time=TBD copier-is-throttled=false conns-in-use=9
INFO[0030] finished periodic flush of binary log: total-duration=1.527833ms batch-size=1000

INFO[0060] finished periodic flush of binary log: total-duration=1.158083ms batch-size=1000
INFO[0060] migration status: state=copyRows copy-progress=14320591/40094411 35.72% binlog-deltas=0 total-time=1m0s copier-time=1m0s copier-remaining-time=2m43s copier-is-throttled=false conns-in-use=8
WARN[0067] dynamic chunking is not working as expected: target-time=5s p90-time=1.924584ms new-target-rows=259796402 max-dynamic-row-size=100000
WARN[0067] switching to prefetch algorithm
WARN[0067] disabling chunk prefetching: min-val=13731117 max-val=13732618 max-dynamic-row-size=100000
INFO[0090] migration status: state=copyRows copy-progress=21786956/40094411 54.34% binlog-deltas=0 total-time=1m30s copier-time=1m30s copier-remaining-time=2m21s (±0m from 0s ago) copier-is-throttled=false conns-in-use=8
INFO[0090] finished periodic flush of binary log: total-duration=1.569583ms batch-size=1000
INFO[0120] migration status: state=copyRows copy-progress=26471270/40094411 66.02% binlog-deltas=0 total-time=2m0s copier-time=2m0s copier-remaining-time=1m20s (±0m from 1m ago) copier-is-throttled=false conns-in-use=8
INFO[0120] finished periodic flush of binary log: total-duration=1.10875ms batch-size=1000
INFO[0150] migration status: state=copyRows copy-progress=30598135/40094411 76.32% binlog-deltas=0 total-time=2m30s copier-time=2m30s copier-remaining-time=1m2s (±0m from 1m ago) copier-is-throttled=false conns-in-use=9
INFO[0150] finished periodic flush of binary log: total-duration=1.240709ms batch-size=1000
INFO[0180] approaching the end of the table, synchronously updating statistics
INFO[0180] finished periodic flush of binary log: total-duration=1.372917ms batch-size=1000
INFO[0180] migration status: state=copyRows copy-progress=35555319/40094411 88.68% binlog-deltas=0 total-time=3m0s copier-time=3m0s copier-remaining-time=24s (±0m from 2m ago) copier-is-throttled=false conns-in-use=8
INFO[0192] copy rows complete
INFO[0192] waiting to catch up to source position: (BLKD5234QXY40-bin.015458, 300798619), current position is: (BLKD5234QXY40-bin.015458, 243865612)
INFO[0192] Running ANALYZE TABLE
INFO[0192] waiting to catch up to source position: (BLKD5234QXY40-bin.015460, 997), current position is: (BLKD5234QXY40-bin.015460, 997)
WARN[0192] Attempting final cut over operation (attempt 1/5)
WARN[0192] trying to acquire table locks, timeout: 30
WARN[0192] table lock(s) acquired
INFO[0192] waiting to catch up to source position: (BLKD5234QXY40-bin.015461, 197), current position is: (BLKD5234QXY40-bin.015461, 197)
WARN[0192] table lock released
WARN[0192] final cut over operation complete
INFO[0194] successfully dropped old table: _bigtable_old
INFO[0195] successfully dropped old table: _bigtable2_old
INFO[0195] apply complete: instant-ddl=false inplace-ddl=false total-chunks=860 copy-rows-time=3m12s checksum-time=0s total-time=3m15s conns-in-use=0
INFO[0195] syncer is closing...
INFO[0195] kill last connection id 34863
INFO[0195] syncer is closed

```