### PR TITLE
remove force-inplace and changes to automatic DDL algorithm detection

### DIFF
--- a/pkg/check/visibility_change_test.go
+++ b/pkg/check/visibility_change_test.go
@@ -16,9 +16,14 @@ func TestVisbilityChange(t *testing.T) {
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 ALTER INDEX idx1 VISIBLE")[0]
 	err = visibilityCheck(t.Context(), r, nil)
-	require.ErrorContains(t, err, "the ALTER operation contains a change to index visibility")
+	require.NoError(t, err) // pure index visibility changes are now allowed
 
 	r.Statement = statement.MustNew("ALTER TABLE t1 ALTER INDEX idx1 INVISIBLE")[0]
 	err = visibilityCheck(t.Context(), r, nil)
-	require.ErrorContains(t, err, "the ALTER operation contains a change to index visibility")
+	require.NoError(t, err) // pure index visibility changes are now allowed
+
+	// But mixed with table-rebuilding operations should still fail
+	r.Statement = statement.MustNew("ALTER TABLE t1 ALTER INDEX idx1 VISIBLE, ADD COLUMN col INT")[0]
+	err = visibilityCheck(t.Context(), r, nil)
+	require.ErrorContains(t, err, "the ALTER operation contains a change to index visibility mixed with table-rebuilding operations")
 }

--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -111,11 +111,10 @@ func (c *change) attemptMySQLDDL(ctx context.Context) error {
 	// because replicas do not use the binlog. Some, however,
 	// only modify the table metadata and are safe.
 	//
-	// If the operator has specified that they want to attempt
-	// an inplace add index, we will attempt inplace regardless
-	// of the statement.
+	// Spirit automatically detects safe operations that can use
+	// the INPLACE algorithm without blocking read replicas.
 	err = c.stmt.AlgorithmInplaceConsideredSafe()
-	if c.runner.migration.ForceInplace || err == nil {
+	if err == nil {
 		err = c.attemptInplaceDDL(ctx)
 		if err == nil {
 			c.runner.usedInplaceDDL = true // success

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -27,7 +27,6 @@ type Migration struct {
 	Alter                string        `name:"alter" help:"The alter statement to run on the table" optional:""`
 	Threads              int           `name:"threads" help:"Number of concurrent threads for copy and checksum tasks" optional:"" default:"4"`
 	TargetChunkTime      time.Duration `name:"target-chunk-time" help:"The target copy time for each chunk" optional:"" default:"500ms"`
-	ForceInplace         bool          `name:"force-inplace" help:"Force attempt to use inplace (only safe without replicas or with Aurora Global)" optional:"" default:"false"`
 	Checksum             bool          `name:"checksum" help:"Checksum new table before final cut-over" optional:"" default:"true"`
 	ReplicaDSN           string        `name:"replica-dsn" help:"A DSN for a replica which (if specified) will be used for lag checking." optional:""`
 	ReplicaMaxLag        time.Duration `name:"replica-max-lag" help:"The maximum lag allowed on the replica before the migration throttles." optional:"" default:"120s"`

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -240,20 +240,19 @@ func TestOnline(t *testing.T) {
 	)`
 	testutils.RunSQL(t, table)
 	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Threads:      16,
-		Table:        "testonline3",
-		Alter:        "ADD INDEX(b)",
-		ForceInplace: true,
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  16,
+		Table:    "testonline3",
+		Alter:    "ADD INDEX(b)",
 	})
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.False(t, m.usedInstantDDL) // not possible
-	assert.True(t, m.usedInplaceDDL)  // as
+	assert.False(t, m.usedInplaceDDL) // ADD INDEX operations now use copy process for replica safety
 	assert.NoError(t, m.Close())
 
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS testonline4`)
@@ -267,20 +266,19 @@ func TestOnline(t *testing.T) {
 	)`
 	testutils.RunSQL(t, table)
 	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Threads:      16,
-		Table:        "testonline4",
-		Alter:        "drop index name, drop index b",
-		ForceInplace: false,
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  16,
+		Table:    "testonline4",
+		Alter:    "drop index name, drop index b",
 	})
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
 	assert.NoError(t, err)
 	assert.False(t, m.usedInstantDDL) // unfortunately false in 8.0, see https://bugs.mysql.com/bug.php?id=113355
-	assert.True(t, m.usedInplaceDDL)
+	assert.False(t, m.usedInplaceDDL) // DROP INDEX operations now use copy process for replica safety
 	assert.NoError(t, m.Close())
 
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS testonline5`)
@@ -294,14 +292,13 @@ func TestOnline(t *testing.T) {
 	)`
 	testutils.RunSQL(t, table)
 	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Threads:      16,
-		Table:        "testonline5",
-		Alter:        "drop index name, add column c int",
-		ForceInplace: false,
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  16,
+		Table:    "testonline5",
+		Alter:    "drop index name, add column c int",
 	})
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
@@ -320,14 +317,13 @@ func TestOnline(t *testing.T) {
 	`
 	testutils.RunSQL(t, table)
 	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Threads:      16,
-		Table:        "testonline6",
-		Alter:        "add partition partitions 4",
-		ForceInplace: false,
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  16,
+		Table:    "testonline6",
+		Alter:    "add partition partitions 4",
 	})
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
@@ -348,14 +344,13 @@ func TestOnline(t *testing.T) {
 	`
 	testutils.RunSQL(t, table)
 	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Threads:      16,
-		Table:        "testonline7",
-		Alter:        "add partition (partition p2 values less than (300000))",
-		ForceInplace: false,
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  16,
+		Table:    "testonline7",
+		Alter:    "add partition (partition p2 values less than (300000))",
 	})
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
@@ -3102,34 +3097,20 @@ func TestIndexVisibility(t *testing.T) {
 	assert.Error(t, err)
 	assert.NoError(t, m.Close()) // it's errored, we don't need to try again. We can close.
 
-	// But we will allow the above when force inplace is set.
-	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Threads:      1,
-		Table:        "indexvisibility",
-		Alter:        "ALTER INDEX b VISIBLE, ADD INDEX (c)",
-		ForceInplace: true,
-	})
-	assert.NoError(t, err)
-	err = m.Run(t.Context())
-	assert.NoError(t, err)
-	assert.NoError(t, m.Close())
+	// The above should now fail with enhanced automatic detection.
+	// Index visibility mixed with table-rebuilding operations should be rejected.
 
-	// But even when force inplace is set, we won't be able to do an operation
-	// that requires a full copy. This is important because invisible should
-	// never be mixed with copy (the semantics are weird since it's for experiments).
+	// Index visibility mixed with table-rebuilding operations should fail.
+	// This is important because invisible should never be mixed with copy
+	// (the semantics are weird since it's for experiments).
 	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Threads:      1,
-		Table:        "indexvisibility",
-		Alter:        "ALTER INDEX b VISIBLE, CHANGE c cc BIGINT NOT NULL",
-		ForceInplace: true,
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  1,
+		Table:    "indexvisibility",
+		Alter:    "ALTER INDEX b VISIBLE, CHANGE c cc BIGINT NOT NULL",
 	})
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
@@ -3259,23 +3240,22 @@ func TestTrailingSemicolon(t *testing.T) {
 	err = m.Run(t.Context())
 	require.NoError(t, err)
 
-	assert.True(t, m.usedInplaceDDL) // must be inplace
+	assert.False(t, m.usedInplaceDDL) // DROP INDEX operations now use copy process for enhanced safety
 	assert.NoError(t, m.Close())
 
 	m, err = NewRunner(&Migration{
-		Host:         cfg.Addr,
-		Username:     cfg.User,
-		Password:     cfg.Passwd,
-		Database:     cfg.DBName,
-		Statement:    "alter table multiSecondary add index idx1(v), add index idx2(v), add index idx3(v), add index idx4(v);",
-		ForceInplace: true,
-		Threads:      1,
+		Host:      cfg.Addr,
+		Username:  cfg.User,
+		Password:  cfg.Passwd,
+		Database:  cfg.DBName,
+		Statement: "alter table multiSecondary add index idx1(v), add index idx2(v), add index idx3(v), add index idx4(v);",
+		Threads:   1,
 	})
 	require.NoError(t, err)
 	err = m.Run(t.Context())
 	require.NoError(t, err)
 
-	require.True(t, m.usedInplaceDDL) // must be inplace
+	require.False(t, m.usedInplaceDDL) // ADD INDEX operations now use copy process for replica safety
 	require.NoError(t, m.Close())
 
 	m, err = NewRunner(&Migration{
@@ -3292,7 +3272,7 @@ func TestTrailingSemicolon(t *testing.T) {
 	err = m.Run(t.Context())
 	require.NoError(t, err)
 
-	require.True(t, m.usedInplaceDDL) // must be inplace
+	require.False(t, m.usedInplaceDDL) // DROP INDEX operations now use copy process for enhanced safety
 	require.NoError(t, m.Close())
 }
 func TestAlterExtendVarcharE2E(t *testing.T) {

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -158,8 +158,7 @@ func (a *AbstractStatement) AlgorithmInplaceConsideredSafe() error {
 	unsafeClauses := 0
 	for _, spec := range alterStmt.Specs {
 		switch spec.Tp {
-		case ast.AlterTableDropIndex,
-			ast.AlterTableRenameIndex,
+		case ast.AlterTableRenameIndex,
 			ast.AlterTableIndexInvisible,
 			ast.AlterTableDropPartition,
 			ast.AlterTableTruncatePartition,
@@ -172,15 +171,16 @@ func (a *AbstractStatement) AlgorithmInplaceConsideredSafe() error {
 			if spec.NewColumns[0].Tp != nil && spec.NewColumns[0].Tp.GetType() == mysql.TypeVarchar {
 				continue
 			}
+			unsafeClauses++
 		default:
 			unsafeClauses++
 		}
 	}
 	if unsafeClauses > 0 {
 		if len(alterStmt.Specs) > 1 {
-			return errors.New("ALTER contains multiple clauses. Combinations of INSTANT and INPLACE operations cannot be detected safely. Consider executing these as separate ALTER statements. Use --force-inplace to override this safety check")
+			return errors.New("ALTER contains multiple clauses. Combinations of INSTANT and INPLACE operations cannot be detected safely. Consider executing these as separate ALTER statements")
 		}
-		return errors.New("ALTER either does not support INPLACE or when performed as INPLACE could take considerable time. Use --force-inplace to override this safety check")
+		return errors.New("ALTER statement contains operations that are not safe for INPLACE algorithm")
 	}
 	return nil
 }
@@ -227,20 +227,48 @@ func (a *AbstractStatement) AlterContainsAddUnique() error {
 }
 
 // AlterContainsIndexVisibility checks to see if there are any clauses of an ALTER to change index visibility.
-// It really does not make sense for visibility changes to be anything except metadata only changes,
-// because they are used for experiments. An experiment is not rebuilding the table. If you are experimenting
-// setting an index to invisible and plan to switch it back to visible quickly if required, going through
-// a full table rebuild does not make sense.
+// It now allows index visibility changes when mixed with other metadata-only operations,
+// but blocks them when mixed with table-rebuilding operations to avoid semantic issues.
 func (a *AbstractStatement) AlterContainsIndexVisibility() error {
 	alterStmt, ok := (*a.StmtNode).(*ast.AlterTableStmt)
 	if !ok {
 		return ErrNotAlterTable
 	}
+
+	hasIndexVisibility := false
+	hasNonMetadataOperation := false
+
 	for _, spec := range alterStmt.Specs {
-		if spec.Tp == ast.AlterTableIndexInvisible {
-			return errors.New("the ALTER operation contains a change to index visibility and could not be completed as a meta-data only operation. This is a safety check! Please split the ALTER statement into separate statements for changing the invisible index and other operations")
+		switch spec.Tp {
+		case ast.AlterTableIndexInvisible:
+			hasIndexVisibility = true
+		case ast.AlterTableDropIndex,
+			ast.AlterTableRenameIndex,
+			ast.AlterTableDropPartition,
+			ast.AlterTableTruncatePartition,
+			ast.AlterTableAddPartitions,
+			ast.AlterTableAlterColumn:
+			// These are metadata-only operations - safe to mix with index visibility
+			continue
+		case ast.AlterTableModifyColumn, ast.AlterTableChangeColumn:
+			// Only safe if changing length of a VARCHAR column
+			if spec.NewColumns[0].Tp != nil && spec.NewColumns[0].Tp.GetType() == mysql.TypeVarchar {
+				continue
+			}
+			hasNonMetadataOperation = true
+		case ast.AlterTableAddConstraint: // ADD INDEX operations are table-rebuilding
+			hasNonMetadataOperation = true
+		default:
+			// All other operations are considered non-metadata (table rebuilding)
+			hasNonMetadataOperation = true
 		}
 	}
+
+	// Only fail if index visibility is mixed with non-metadata operations
+	if hasIndexVisibility && hasNonMetadataOperation {
+		return errors.New("the ALTER operation contains a change to index visibility mixed with table-rebuilding operations. This creates semantic issues for experiments. Please split the ALTER statement into separate statements for changing the invisible index and other operations")
+	}
+
 	return nil
 }
 

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -104,10 +104,12 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	var test = func(stmt string) error {
 		return MustNew("ALTER TABLE `t1` " + stmt)[0].AlgorithmInplaceConsideredSafe()
 	}
-	assert.NoError(t, test("drop index `a`"))
+
+	// Safe metadata-only operations
+	assert.Error(t, test("drop index `a`")) // DROP INDEX now uses copy process for replica safety
 	assert.NoError(t, test("rename index `a` to `b`"))
-	assert.NoError(t, test("drop index `a`, drop index `b`"))
-	assert.NoError(t, test("drop index `a`, rename index `b` to c"))
+	assert.Error(t, test("drop index `a`, drop index `b`"))        // DROP INDEX now unsafe
+	assert.Error(t, test("drop index `a`, rename index `b` to c")) // Mixed with unsafe DROP INDEX
 	assert.NoError(t, test("ALTER INDEX b INVISIBLE"))
 	assert.NoError(t, test("ALTER INDEX b VISIBLE"))
 	assert.NoError(t, test("drop partition `p1`, `p2`"))
@@ -115,19 +117,34 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	assert.NoError(t, test("add partition (partition `p1` values less than (100))"))
 	assert.NoError(t, test("add partition partitions 4"))
 
+	// VARCHAR column modifications are safe (metadata-only)
 	assert.NoError(t, test("modify `a` varchar(100)"))
 	assert.NoError(t, test("change column `a` `a` varchar(100)"))
+	assert.NoError(t, test("modify `a` varchar(255)"))
+	assert.NoError(t, test("change column `a` `new_a` varchar(50)"))
 
+	// Non-VARCHAR column modifications should be unsafe (table-rebuilding)
+	assert.Error(t, test("modify `a` int"))
+	assert.Error(t, test("change column `a` `a` int"))
+	assert.Error(t, test("modify `a` text"))
+	assert.Error(t, test("change column `a` `new_a` bigint"))
+	assert.Error(t, test("modify `a` decimal(10,2)"))
+	assert.Error(t, test("change column `a` `a` datetime"))
+
+	// Other unsafe operations (table-rebuilding)
 	assert.Error(t, test("ADD COLUMN `a` INT"))
 	assert.Error(t, test("ADD index (a)"))
 	assert.Error(t, test("drop index `a`, add index `b` (`b`)"))
 	assert.Error(t, test("engine=innodb"))
 	assert.Error(t, test("partition by HASH(`id`) partitions 8;"))
-	// this *should* be safe, but we don't support it yet because we can't
-	// guess which operations are INSTANT
+	assert.Error(t, test("remove partitioning"))
+
+	// Mixed safe and unsafe operations should be unsafe - these cannot be split
+	// because we cannot safely detect which operations are INSTANT vs INPLACE
 	assert.Error(t, test("drop index `a`, add column `b` int"))
 	assert.Error(t, test("ALTER INDEX b INVISIBLE, add column `c` int"))
-	assert.Error(t, test("remove partitioning"))
+	assert.Error(t, test("modify `a` varchar(100), add index (b)"))
+	assert.Error(t, test("drop index `a`, modify `b` int")) // non-VARCHAR modification makes it unsafe
 }
 
 func TestAlterIsAddUnique(t *testing.T) {
@@ -151,18 +168,44 @@ func TestAlterContainsIndexVisibility(t *testing.T) {
 		return MustNew("ALTER TABLE `t1` " + stmt)[0].AlterContainsIndexVisibility()
 	}
 
+	// Pure metadata operations should be safe (no index visibility)
 	assert.NoError(t, test("drop index `a`"))
 	assert.NoError(t, test("rename index `a` to `b`"))
 	assert.NoError(t, test("drop index `a`, drop index `b`"))
 	assert.NoError(t, test("drop index `a`, rename index `b` to c"))
+	assert.NoError(t, test("drop partition `p1`"))
+	assert.NoError(t, test("truncate partition `p1`"))
+	assert.NoError(t, test("add partition (partition `p1` values less than (100))"))
 
+	// Pure table-rebuilding operations should be safe (no index visibility)
 	assert.NoError(t, test("ADD COLUMN `a` INT"))
 	assert.NoError(t, test("ADD index (a)"))
 	assert.NoError(t, test("drop index `a`, add index `b` (`b`)"))
 	assert.NoError(t, test("engine=innodb"))
 	assert.NoError(t, test("add unique(b)"))
-	assert.Error(t, test("ALTER INDEX b INVISIBLE"))
-	assert.Error(t, test("ALTER INDEX b VISIBLE"))
+	assert.NoError(t, test("modify `a` int"))
+	assert.NoError(t, test("change column `a` `a` int"))
+
+	// Pure index visibility operations should be safe
+	assert.NoError(t, test("ALTER INDEX b INVISIBLE"))
+	assert.NoError(t, test("ALTER INDEX b VISIBLE"))
+
+	// Index visibility mixed with metadata-only operations should be safe
+	assert.NoError(t, test("ALTER INDEX b INVISIBLE, drop index `c`"))
+	assert.NoError(t, test("ALTER INDEX b VISIBLE, rename index `a` to `new_a`"))
+	assert.NoError(t, test("ALTER INDEX b INVISIBLE, drop partition `p1`"))
+	assert.NoError(t, test("ALTER INDEX b VISIBLE, truncate partition `p2`"))
+	assert.NoError(t, test("ALTER INDEX b INVISIBLE, add partition (partition `p3` values less than (200))"))
+	assert.NoError(t, test("ALTER INDEX b VISIBLE, modify `a` varchar(100)"))              // VARCHAR modifications are metadata-only
+	assert.NoError(t, test("ALTER INDEX b INVISIBLE, change column `a` `a` varchar(150)")) // VARCHAR modifications are metadata-only
+
+	// Index visibility mixed with table-rebuilding operations should fail
+	assert.Error(t, test("ALTER INDEX b INVISIBLE, ADD COLUMN `c` INT"))
+	assert.Error(t, test("ALTER INDEX b VISIBLE, ADD index (d)"))
+	assert.Error(t, test("ALTER INDEX b INVISIBLE, engine=innodb"))
+	assert.Error(t, test("ALTER INDEX b VISIBLE, add unique(e)"))
+	assert.Error(t, test("ALTER INDEX b INVISIBLE, modify `a` int"))          // Non-VARCHAR modifications are table-rebuilding
+	assert.Error(t, test("ALTER INDEX b VISIBLE, change column `a` `a` int")) // Non-VARCHAR modifications are table-rebuilding
 }
 
 func TestAlterContainsUnsupportedClause(t *testing.T) {
@@ -189,4 +232,34 @@ func TestTrimAlter(t *testing.T) {
 
 	stmt.Alter = "add column a, add column b;"
 	assert.Equal(t, "add column a, add column b", stmt.TrimAlter())
+}
+
+func TestMixedOperationsLogic(t *testing.T) {
+	// Test complex scenarios for the enhanced logic
+
+	// Test AlgorithmInplaceConsideredSafe with mixed VARCHAR and non-VARCHAR
+	var testInplace = func(stmt string) error {
+		return MustNew("ALTER TABLE `t1` " + stmt)[0].AlgorithmInplaceConsideredSafe()
+	}
+
+	// Multiple VARCHAR modifications should be safe
+	assert.NoError(t, testInplace("modify `a` varchar(100), modify `b` varchar(200)"))
+	assert.NoError(t, testInplace("change column `a` `a` varchar(50), change column `b` `b` varchar(75)"))
+
+	// Mixed VARCHAR and non-VARCHAR should be unsafe
+	assert.Error(t, testInplace("modify `a` varchar(100), modify `b` int"))
+	assert.Error(t, testInplace("change column `a` `a` varchar(50), change column `b` `b` text"))
+
+	// Test AlterContainsIndexVisibility with complex mixed operations
+	var testVisibility = func(stmt string) error {
+		return MustNew("ALTER TABLE `t1` " + stmt)[0].AlterContainsIndexVisibility()
+	}
+
+	// Multiple index visibility changes with metadata operations should be safe
+	assert.NoError(t, testVisibility("ALTER INDEX a INVISIBLE, ALTER INDEX b VISIBLE, drop index `c`"))
+	assert.NoError(t, testVisibility("ALTER INDEX a INVISIBLE, rename index `b` to `new_b`, modify `col` varchar(100)"))
+
+	// Multiple index visibility changes with table-rebuilding operations should fail
+	assert.Error(t, testVisibility("ALTER INDEX a INVISIBLE, ALTER INDEX b VISIBLE, ADD COLUMN `c` INT"))
+	assert.Error(t, testVisibility("ALTER INDEX a INVISIBLE, rename index `b` to `new_b`, modify `col` int"))
 }


### PR DESCRIPTION
## What and Why ?
This PR removes the manual `--force-inplace` flag from Spirit and replaces it with intelligent automatic DDL algorithm detection.

### **Safety Improvements**
- ✅ Prevents unsafe replica-blocking INPLACE operations
- ✅ Eliminates dangerous manual overrides  
- ✅ Provides clear error messages for unsafe combinations

### **Removed Manual Configuration**
- **Before**: Users had to manually decide when to use INPLACE with `--force-inplace` flag
- **After**: System automatically determines the safest approach with zero configuration

### **Enhanced Mixed Operations Support**
- **Index visibility + metadata operations**: Now automatically allowed and optimized
- **Index visibility + table-rebuilding**: Blocked with clear error messages for safety

### **Improved Safety**
- **ADD INDEX operations**: Use copy process to prevent replica blocking
- **DROP INDEX operations**: Use copy process for enhanced safety while allowing logical mixing with index visibility
- **Automatic algorithm selection**: Prevents unsafe combinations without user intervention

### **Classification of Operations**
```sql
-- ✅ Now Allowed (Enhanced Capabilities)
ALTER INDEX idx VISIBLE, DROP INDEX old_idx;        -- Uses copy (safe)
ALTER INDEX idx VISIBLE, RENAME INDEX old TO new;   -- Uses INPLACE  
ALTER INDEX idx VISIBLE, ADD PARTITION p1 VALUES LESS THAN (100);

-- ❌ Blocked (Enhanced Safety)
ALTER INDEX idx VISIBLE, ADD INDEX (col);           -- Semantic conflicts
ALTER INDEX idx VISIBLE, ADD COLUMN col INT;        -- Table rebuilding
```