### PR TITLE
allow legitimate same-table sequential operations

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -138,7 +138,14 @@ func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, er
 	}
 
 	if len(stmts) > 1 && !m.EnableExperimentalMultiTableSupport {
-		return nil, errors.New("multiple statements detected. To enable this experimental feature, please specify --enable-experimental-multi-table-support")
+		// Check if all statements are for the same table
+		firstTable := stmts[0].Table
+		firstSchema := stmts[0].Schema
+		for _, stmt := range stmts[1:] {
+			if stmt.Table != firstTable || stmt.Schema != firstSchema {
+				return nil, errors.New("multiple tables detected. To enable this experimental feature, please specify --enable-experimental-multi-table-support")
+			}
+		}
 	}
 	return stmts, err
 }


### PR DESCRIPTION
## What and Why ?
Allow legitimate same-table sequential operations esp when some of those hit TiDB parser limitations. To address - https://github.com/block/spirit/issues/487.

## Before
```
ζ ./spirit --host="127.0.0.1:8033" --username="tsandbox" --password="msandbox" \                                                                                                                                                         
  --database="test_spirit" \
  --statement="ALTER TABLE json_table ADD COLUMN price DECIMAL(10,2) GENERATED ALWAYS AS (JSON_EXTRACT(metadata, '$.price')), ADD INDEX idx_price_category ((JSON_EXTRACT(metadata, '$.category'), JSON_EXTRACT(metadata, '$.price')))"
spirit: error: could not parse SQL statement: ALTER TABLE json_table ADD COLUMN price DECIMAL(10,2) GENERATED ALWAYS AS (JSON_EXTRACT(metadata, '$.price')), ADD INDEX idx_price_category ((JSON_EXTRACT(metadata, '$.category'), JSON_EXTRACT(metadata, '$.price')))
```

## After
```
./spirit --host="127.0.0.1:8033" --username="tsandbox" --password="msandbox" \
  --database="test_spirit" \
  --statement="ALTER TABLE user_accounts ADD COLUMN status ENUM('active','inactive') DEFAULT 'active'; ALTER TABLE user_accounts ADD INDEX idx_status (status)"
INFO[0000] Starting spirit migration: concurrency=4 target-chunk-size=500ms
INFO[0000] attempting to acquire metadata lock
INFO[0000] acquired metadata lock: test_spirit.user_accounts-c294803c
INFO[0000] apply complete: instant-ddl=true inplace-ddl=false
INFO[0000] releasing metadata lock: test_spirit.user_accounts-c294803c
```