### PR TITLE
fix data races in tests

### DIFF
--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -101,7 +101,7 @@ func NewClient(db *sql.DB, host string, username, password string, config *Clien
 	if config.WriteDB == nil {
 		config.WriteDB = db // default to using the read DB for writes
 	}
-	client := &Client{
+	return &Client{
 		db:                         db,
 		dbConfig:                   dbconn.NewDBConfig(),
 		host:                       host,
@@ -109,6 +109,7 @@ func NewClient(db *sql.DB, host string, username, password string, config *Clien
 		password:                   password,
 		logger:                     config.Logger,
 		targetBatchTime:            config.TargetBatchTime,
+		targetBatchSize:            DefaultBatchSize, // initial starting value.
 		concurrency:                config.Concurrency,
 		subscriptions:              make(map[string]Subscription),
 		onDDL:                      config.OnDDL,
@@ -116,10 +117,6 @@ func NewClient(db *sql.DB, host string, username, password string, config *Clien
 		useExperimentalBufferedMap: config.UseExperimentalBufferedMap,
 		writeDB:                    config.WriteDB,
 	}
-	// Initialize targetBatchSize atomically to avoid data race
-	// since it's accessed atomically elsewhere in the code
-	atomic.StoreInt64(&client.targetBatchSize, DefaultBatchSize)
-	return client
 }
 
 type ClientConfig struct {


### PR DESCRIPTION
I've seen persistent [data races in tests lately](https://github.com/block/spirit/actions/runs/18603224304/job/53046474106?pr=492#step:3:11472) and I asked goose to go figure it out. This is the PR it proposed.

@morgo you have better familiarity with this part of the code than I do. Does it look like the proposed change to execute `r.replClient.SetDDLNotificationChannel(nil)` before `close(r.ddlNotification)` is safe or do you think this might be problematic?

