### PR TITLE
Fix multi-chunker bugs

### DIFF
--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -283,19 +283,14 @@ func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, _ uint64) {
 // which (due to parallelism) could be significantly behind the high watermark.
 // The value is discovered via ChunkerFeedback(), and when retrieved from this func
 // can be used to write a checkpoint for restoration.
-//
-// For final chunks (UpperBound == nil), we allow the watermark to be returned
-// since it represents a valid "table complete" state.
 func (t *chunkerOptimistic) GetLowWatermark() (string, error) {
 	t.Lock()
 	defer t.Unlock()
 
-	if t.watermark == nil || t.watermark.LowerBound == nil {
+	if t.watermark == nil || t.watermark.UpperBound == nil || t.watermark.LowerBound == nil {
 		return "", errors.New("watermark not yet ready")
 	}
 
-	// For final chunks, UpperBound can be nil - this is valid and represents completion
-	// We only require LowerBound to be present for a valid watermark
 	return t.watermark.JSON(), nil
 }
 
@@ -320,16 +315,8 @@ func (t *chunkerOptimistic) isSpecialRestoredChunk(chunk *Chunk) bool {
 //     stored chunk map is checked to see if an existing chunk lowerBound aligns with the new watermark.
 //   - If any stored chunk aligns, it is deleted off the map and the watermark is bumped.
 //   - This process repeats until there is no more alignment from the stored map *or* the map is empty.
-//
-// Special handling for final chunks: Final chunks have UpperBound == nil, but we still need to
-// update the watermark to indicate progress, especially for multi-table migrations where
-// checkpoint writing continues until all tables are complete.
 func (t *chunkerOptimistic) bumpWatermark(chunk *Chunk) {
-	// Handle final chunks (UpperBound == nil) specially
 	if chunk.UpperBound == nil {
-		// For final chunks, we set the watermark to indicate this table is complete
-		// We create a synthetic watermark that represents "table complete" state
-		t.watermark = chunk
 		return
 	}
 	// Check if this is the first chunk or it's the special restored chunk.


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Part of https://github.com/block/spirit/issues/388

Fixes some bugs discovered in testing:

1. There can be a starvation issue where there is no candidate chunker which meets the minProgressPercent criteria. The logic is modified so it always picks the first candidate without evaluating other criteria, then refines if it can do better.
2. Some tables might not have watermarks ready. They no longer hold up the multi-chunker watermark, and on restore from watermark, if the table is not mentioned, it's just opened as new instead.