### PR TITLE
fix RDS hostname detection to prevent subdomain spoofing - fix for issue-508

### DIFF
--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -29,9 +29,11 @@ const (
 )
 
 // rdsAddr matches Amazon RDS hostnames with optional :port suffix.
-// It's used to automatically load the Amazon RDS CA and enable TLS
+// It's used to automatically load the Amazon RDS CA and enable TLS.
+// The leading \. ensures only legitimate *.rds.amazonaws.com subdomains match,
+// preventing subdomain spoofing attacks (e.g., fake-rds.amazonaws.com).
 var (
-	rdsAddr = regexp.MustCompile(`rds\.amazonaws\.com(:\d+)?$`)
+	rdsAddr = regexp.MustCompile(`\.rds\.amazonaws\.com(:\d+)?$`)
 	once    sync.Once
 	// https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
 	//go:embed rdsGlobalBundle.pem

--- a/pkg/dbconn/simple_tls_test.go
+++ b/pkg/dbconn/simple_tls_test.go
@@ -19,8 +19,16 @@ func TestSimpleIsRDSHost(t *testing.T) {
 		host     string
 		expected bool
 	}{
+		// Valid RDS hostnames
 		{"myhost.us-west-2.rds.amazonaws.com", true},
 		{"myhost.us-west-2.rds.amazonaws.com:3306", true},
+
+		// Security test cases - subdomain spoofing attempts
+		{"fake-rds.amazonaws.com", false},
+		{"evil-rds.amazonaws.com", false},
+		{"malicious-rds.amazonaws.com:3306", false},
+
+		// Invalid hostnames
 		{"myhost.example.com", false},
 		{"localhost", false},
 	}


### PR DESCRIPTION
## What and Why ?
Fixes  https://github.com/block/spirit/issues/508
The leading dot (\.) in the regex ensures that only legitimate AWS RDS subdomains like mydb.us-west-2.rds.amazonaws.com are matched, while malicious domains like fake-rds.amazonaws.com are correctly rejected. This prevents potential subdomain spoofing where one could trick Spirit into applying RDS certificate trust to non-AWS servers.
