### PR TITLE
fix race

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -209,7 +209,6 @@ func ForceExec(ctx context.Context, db *sql.DB, tables []*table.TableInfo, dbCon
 	// We always apply the threshold since in this path ForceKill is always true.
 	threshold := time.Duration(float64(dbConfig.LockWaitTimeout)*lockWaitTimeoutForceKillMultiplier) * time.Second
 	timer := time.AfterFunc(threshold, func() {
-		logger.Warnf("waited for %v; trying to kill locking transactions", threshold)
 		err := KillLockingTransactions(ctx, db, tables, dbConfig, logger, []int{connId})
 		if err != nil {
 			logger.Errorf("failed to kill locking transactions: %v", err)

--- a/pkg/dbconn/tablelock.go
+++ b/pkg/dbconn/tablelock.go
@@ -55,7 +55,6 @@ func NewTableLock(ctx context.Context, db *sql.DB, tables []*table.TableInfo, co
 		// If ForceKill is true, we will wait for 90% of the configured LockWaitTimeout
 		threshold := time.Duration(float64(config.LockWaitTimeout)*lockWaitTimeoutForceKillMultiplier) * time.Second
 		timer := time.AfterFunc(threshold, func() {
-			logger.Warnf("waited for %v; trying to kill locking transactions", threshold)
 			err := KillLockingTransactions(ctx, db, tables, config, logger, []int{pid})
 			if err != nil {
 				logger.Errorf("failed to kill locking transactions: %v", err)


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

I am getting a race in my downstream service on this log line introduced in https://github.com/block/spirit/pull/506

I think it is because I have tests around cancelling a schema change by terminating the context. The race is because when the kill code finally runs, its too late, and it writes to the log when there is another part of the code reading from the log (hence the race).

The fix is easy: remove the log line.

The reason why this fixes it, is in the next line `KillLockingTransactions` will do a DB call with a context, which will discover the context is canceled and cleanup. So no more race on the log.
