### PR TITLE
docs(lint): clarify linting philosophy and categorize linters

### DIFF
--- a/docs/lint.md
+++ b/docs/lint.md
@@ -12,6 +12,15 @@ Spirit's linters focus on **migration safety and policy enforcement**, not seman
 
 Spirit linters do **not** perform semantic validation of SQL correctness. They assume input schemas are syntactically valid. For example, linters will not detect if an index references a non-existent column—MySQL itself will reject such statements. If you need semantic validation, test your schemas against MySQL before linting.
 
+**Best practice:** When using `lint` or `diff`, it is recommended to use the `CREATE TABLE` statements returned from MySQL's `SHOW CREATE TABLE` output. MySQL normalizes SQL in ways the linter may not fully replicate. For example:
+- `SERIAL` becomes `BIGINT UNSIGNED NOT NULL AUTO_INCREMENT`
+- `BOOL` and `BOOLEAN` become `TINYINT(1)`
+- Inline `PRIMARY KEY` on a column becomes a table-level `PRIMARY KEY (col)` clause
+- `INTEGER` becomes `INT`
+- Default character sets and collations are made explicit
+
+Using `SHOW CREATE TABLE` output ensures the linter sees the same SQL that MySQL uses internally.
+
 Basic usage:
 
 ```bash


### PR DESCRIPTION
## Summary

Improves the lint documentation to clarify Spirit's linting philosophy and better organize the built-in linters.

**Changes:**

- **Add Philosophy section** - Explains that Spirit linters focus on migration safety and policy enforcement, not semantic validation. Clarifies that linters assume input schemas are syntactically valid and won't catch things like index references to non-existent columns (MySQL will reject those).

- **Reorganize linter table** - Groups linters into three categories:
  - **Migration Safety**: `has_foreign_key`, `invisible_index_before_drop`, `multiple_alter_table`, `unsafe`
  - **Data Type Safety**: `auto_inc_capacity`, `has_float`, `primary_key`, `zero_date`
  - **Policy Enforcement**: `allow_charset`, `allow_engine`, `name_case`, `redundant_indexes`, `reserved_words`

- **Improve descriptions** - Each linter now explains *why* the check matters, not just what it does.

## Context

This came out of a discussion about whether Spirit should lint for semantic errors that MySQL would reject anyway (like an index on a non-existent column). The conclusion was that Spirit linters are safety-focused, not semantic validation focused. This PR documents that philosophy.