### PR TITLE
fix: validate binlog position before creating replClient on resume

### DIFF
--- a/pkg/migration/resume-from-checkpoint.md
+++ b/pkg/migration/resume-from-checkpoint.md
@@ -34,22 +34,40 @@ When a new Runner starts (`Runner.Run()` → `setup()`), it always attempts `res
 
 If any step fails (and strict mode is not enabled), Spirit logs the reason and falls back to `newMigration()`, which starts the migration from scratch. This means resume is best-effort — Spirit will always make forward progress even if the checkpoint is unusable.
 
+## Background: how MySQL binary logs work
+
+MySQL binary logs (binlogs) are a sequence of files that record every data-changing operation on the server. MySQL creates a series of numbered files — `mysql-bin.000001`, `mysql-bin.000002`, etc. — rotating to a new file when the current one reaches `max_binlog_size` (default 1GB) or the server restarts. Every INSERT, UPDATE, DELETE, and DDL statement is recorded.
+
+Spirit uses binlogs to keep the shadow table in sync while the row copy is running. A replication client streams binlog events from the saved position and replays changes onto the shadow table. The checkpoint records which binlog file and position Spirit was at, so it can pick up where it left off.
+
+MySQL automatically deletes old binlog files based on `binlog_expire_logs_seconds` (default 30 days on MySQL 8.0, via the deprecated `expire_logs_days` on older versions). This is called **purging**. Once a file is purged, it's gone — any writes recorded in that file are no longer available. If Spirit's checkpoint references a purged file, there's a gap in the change stream and Spirit can't guarantee the shadow table is consistent.
+
 ## When resume fails
 
-The most common reason for resume failure is **binlog expiry**. MySQL automatically purges old binary log files based on `binlog_expire_logs_seconds` (or the deprecated `expire_logs_days`). If the checkpoint references a binlog file that has been purged, Spirit cannot resume because there would be a gap in the replication stream — changes made between the checkpoint and the purge point would be lost.
+One reason resume can fail is **binlog expiry**. If the checkpoint references a binlog file that has been purged, Spirit cannot resume because changes in the gap would be lost.
 
-Spirit detects this early by checking `SHOW BINARY LOGS` before creating any resources. If the file is missing, it returns immediately and `setup()` falls back to `newMigration()`. This avoids partially initializing resources that would need cleanup.
+Spirit detects this early by checking `SHOW BINARY LOGS` before creating any resources. If the file is missing, it returns `status.ErrBinlogNotFound` immediately, avoiding partial initialization that would need cleanup.
+
+What happens next depends on whether strict mode is enabled:
+
+- **Without `--strict`:** Spirit logs the reason and falls back to `newMigration()`, restarting the copy from scratch. All checkpoint progress is lost silently.
+- **With `--strict`:** Spirit returns `status.ErrBinlogNotFound` to the caller. This lets automation detect the problem and alert an operator rather than silently discarding hours of copy work.
 
 The tradeoff of falling back to `newMigration()` is that all copy progress is lost. For a large table this could mean hours of wasted work. To avoid this:
 
 - **Keep binlog retention longer than your longest expected migration pause.** If you expect to pause migrations for up to a week, make sure `binlog_expire_logs_seconds` is set to at least 7 days. The MySQL 8.0 default is 30 days (`2592000`), which is usually sufficient.
-- **Use `--strict` mode if losing progress silently is unacceptable.** In strict mode, Spirit will exit with an error rather than silently restarting. This lets your automation detect the problem and alert an operator.
+- **Use `--strict` mode if losing progress silently is unacceptable.** In strict mode, Spirit surfaces both DDL mismatches (`status.ErrMismatchedAlter`) and binlog expiry (`status.ErrBinlogNotFound`) as errors. Callers can use `errors.Is()` to handle each case.
 - **Be aware of your binlog retention window.** If Spirit is paused longer than the retention period, the checkpoint's binlog file will be purged and resume will fail. Some managed MySQL services disable retention by default.
 
 ## Strict mode
 
-By default, Spirit treats checkpoint resume as best-effort. If the checkpoint is invalid for any reason — mismatched DDL statement, missing binlog file, corrupt checkpoint data — Spirit discards it and starts a new migration.
+By default, Spirit treats checkpoint resume as best-effort. If the checkpoint is invalid for any reason — mismatched DDL statement, expired binlog, corrupt checkpoint data — Spirit discards it and starts a new migration.
 
-With `Strict: true`, Spirit will refuse to proceed if it finds an existing checkpoint with a different DDL statement. This prevents the scenario where an operator changes the `--alter` parameter between runs and unknowingly loses all progress from the previous migration. See [strict](../docs/migrate.md#strict) for more details.
+With `Strict: true`, Spirit returns a hard error for two specific resume failures:
 
-Note that strict mode only protects against DDL mismatches. Binlog expiry still causes a fallback to `newMigration()` in both strict and non-strict mode, since there is no safe way to resume with a gap in the replication stream.
+- **`status.ErrMismatchedAlter`** — the checkpoint's DDL statement doesn't match the current `--alter`. This prevents the scenario where an operator changes the alter between runs and unknowingly loses all progress.
+- **`status.ErrBinlogNotFound`** — the checkpoint's binlog file has been purged from the server. This prevents silently restarting a multi-hour copy from scratch.
+
+Both errors work with `errors.Is()`, letting callers handle each case differently. See [strict](../docs/migrate.md#strict) for more details.
+
+Other resume failures (missing shadow table, corrupt checkpoint data) still fall through to `newMigration()` in both modes, since these typically indicate there was nothing valid to resume.

--- a/pkg/status/state.go
+++ b/pkg/status/state.go
@@ -10,6 +10,7 @@ type State int32
 
 var (
 	ErrMismatchedAlter         = errors.New("alter statement in checkpoint table does not match the alter statement specified here")
+	ErrBinlogNotFound          = errors.New("checkpoint binlog file not found on server")
 	ErrCouldNotWriteCheckpoint = errors.New("could not write checkpoint")
 	ErrWatermarkNotReady       = errors.New("watermark not ready")
 )


### PR DESCRIPTION
## Summary

When `resumeFromCheckpoint` runs after a stop/start cycle (e.g., volume change), the checkpoint's binlog position may reference a purged file. Previously, this was detected late — after creating the replClient and adding subscriptions — causing `newMigration` to fail with "subscription already exists for table X".

Now we validate the binlog file exists (via `SHOW BINARY LOGS`) early in `resumeFromCheckpoint`, before creating any resources. If the file is gone, we return immediately and let `setup()` fall back to `newMigration` with no partial state to clean up.