### PR TITLE
Activate granted roles before privilege check

### DIFF
--- a/pkg/migration/check/privileges.go
+++ b/pkg/migration/check/privileges.go
@@ -22,6 +22,13 @@ func init() {
 func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 	// This is a re-implementation of the gh-ost check
 	// validateGrants() in gh-ost/go/logic/inspect.go
+	// Activate all granted roles so their privileges appear in SHOW GRANTS.
+	// Without this, roles that aren't SET DEFAULT ROLE won't expand their
+	// privileges (e.g. rds_superuser_role on Amazon RDS).
+	if _, err := r.DB.ExecContext(ctx, `SET ROLE ALL`); err != nil {
+		logger.Warn("SET ROLE ALL failed (may not have granted roles)", "error", err)
+	}
+
 	var foundAll, foundSuper, foundReplicationClient, foundReplicationSlave, foundDBAll, foundReload, foundConnectionAdmin, foundProcess bool
 	rows, err := r.DB.QueryContext(ctx, `SHOW GRANTS`)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Runs `SET ROLE ALL` before `SHOW GRANTS` in the preflight privilege check
- Without this, privileges inherited from granted roles (that aren't set as `DEFAULT ROLE`) don't appear in `SHOW GRANTS` output, causing the check to fail even though the user has sufficient privileges at runtime
- Fixes privilege check failures on Amazon RDS where the super user's privileges come from `rds_superuser_role`

### Before

```
SHOW GRANTS;
+---------------------------------------------------+
| GRANT USAGE ON *.* TO `admin`@`%`                 |
| GRANT `rds_superuser_role`@`%` TO `admin`@`%`     |
+---------------------------------------------------+
-- Spirit sees no PROCESS, REPLICATION SLAVE, etc. → check fails
```

### After

```
SET ROLE ALL;
SHOW GRANTS;
+---------------------------------------------------+
| GRANT SELECT, INSERT, ... PROCESS, ... ON *.*     |
| GRANT `rds_superuser_role`@`%` TO `admin`@`%`     |
+---------------------------------------------------+
-- Spirit sees expanded privileges → check passes
```