### PR TITLE
add table.LoadSchemaFromDB

### DIFF
--- a/pkg/lint/load.go
+++ b/pkg/lint/load.go
@@ -9,56 +9,34 @@ import (
 	"strings"
 
 	"github.com/block/spirit/pkg/statement"
+	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 	_ "github.com/go-sql-driver/mysql"
 )
 
 // LoadSchemaFromDSN connects to a MySQL server and retrieves all CREATE TABLE
-// statements from the connected database.
+// statements from the connected database, parsed into structured CreateTable objects.
 func LoadSchemaFromDSN(ctx context.Context, dsn string) ([]*statement.CreateTable, error) {
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 	defer utils.CloseAndLog(db)
-
 	if err := db.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
-
-	rows, err := db.QueryContext(ctx, "SHOW TABLES")
+	rawTables, err := table.LoadSchemaFromDB(ctx, db)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list tables: %w", err)
+		return nil, err
 	}
-	defer utils.CloseAndLog(rows)
-
-	var tableNames []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, fmt.Errorf("failed to scan table name: %w", err)
-		}
-		tableNames = append(tableNames, name)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating tables: %w", err)
-	}
-
 	var tables []*statement.CreateTable
-	for _, name := range tableNames {
-		var tbl, createStmt string
-		err := db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE `%s`", name)).Scan(&tbl, &createStmt)
+	for _, raw := range rawTables {
+		ct, err := statement.ParseCreateTable(raw.Schema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get CREATE TABLE for %s: %w", name, err)
-		}
-
-		ct, err := statement.ParseCreateTable(createStmt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse CREATE TABLE for %s: %w", name, err)
+			return nil, fmt.Errorf("failed to parse CREATE TABLE for %s: %w", raw.Name, err)
 		}
 		tables = append(tables, ct)
 	}
-
 	return tables, nil
 }
 

--- a/pkg/table/table_schema.go
+++ b/pkg/table/table_schema.go
@@ -1,0 +1,48 @@
+package table
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// TableSchema represents a table's name and its raw CREATE TABLE DDL statement.
+// This is the common representation used across spirit, strata, and gap for
+// passing schema information between components.
+type TableSchema struct {
+	Name   string // Table name
+	Schema string // CREATE TABLE DDL statement
+}
+
+// LoadSchemaFromDB retrieves all table schemas from the database using the
+// provided connection. It returns raw DDL strings without any filtering or
+// transformation, making it suitable for use with any sql.DB driver
+// (e.g. mysql, mysql-rds, strata).
+func LoadSchemaFromDB(ctx context.Context, db *sql.DB) ([]TableSchema, error) {
+	rows, err := db.QueryContext(ctx, "SHOW TABLES")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var tableNames []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("failed to scan table name: %w", err)
+		}
+		tableNames = append(tableNames, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating tables: %w", err)
+	}
+	var tables []TableSchema
+	for _, name := range tableNames {
+		var tbl, createStmt string
+		err := db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE `%s`", name)).Scan(&tbl, &createStmt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get CREATE TABLE for %s: %w", name, err)
+		}
+		tables = append(tables, TableSchema{Name: tbl, Schema: createStmt})
+	}
+	return tables, nil
+}

--- a/pkg/table/table_schema_test.go
+++ b/pkg/table/table_schema_test.go
@@ -1,0 +1,79 @@
+package table
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSchemaFromDB(t *testing.T) {
+	dbName := testutils.CreateUniqueTestDatabase(t)
+	testutils.RunSQLInDatabase(t, dbName, `CREATE TABLE users (
+		id bigint unsigned NOT NULL AUTO_INCREMENT,
+		name varchar(100) DEFAULT NULL,
+		PRIMARY KEY (id)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+	testutils.RunSQLInDatabase(t, dbName, `CREATE TABLE orders (
+		id bigint unsigned NOT NULL AUTO_INCREMENT,
+		user_id bigint unsigned NOT NULL,
+		amount decimal(10,2) NOT NULL,
+		PRIMARY KEY (id),
+		KEY idx_user_id (user_id)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	db, err := sql.Open("mysql", testutils.DSNForDatabase(dbName))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tables, err := LoadSchemaFromDB(t.Context(), db)
+	require.NoError(t, err)
+	assert.Len(t, tables, 2)
+
+	// Build a map for easier assertions
+	byName := make(map[string]TableSchema)
+	for _, ts := range tables {
+		byName[ts.Name] = ts
+	}
+
+	assert.Contains(t, byName, "users")
+	assert.Contains(t, byName, "orders")
+	assert.Contains(t, byName["users"].Schema, "CREATE TABLE")
+	assert.Contains(t, byName["users"].Schema, "`name` varchar(100)")
+	assert.Contains(t, byName["orders"].Schema, "`amount` decimal(10,2)")
+}
+
+func TestLoadSchemaFromDB_EmptyDatabase(t *testing.T) {
+	dbName := testutils.CreateUniqueTestDatabase(t)
+
+	db, err := sql.Open("mysql", testutils.DSNForDatabase(dbName))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tables, err := LoadSchemaFromDB(t.Context(), db)
+	require.NoError(t, err)
+	assert.Empty(t, tables)
+}
+
+func TestLoadSchemaFromDB_PreservesAutoIncrement(t *testing.T) {
+	// Verify that LoadSchemaFromDB returns the raw DDL including AUTO_INCREMENT
+	// values. Consumers that need to strip it (e.g. for diffing) do so themselves.
+	dbName := testutils.CreateUniqueTestDatabase(t)
+	testutils.RunSQLInDatabase(t, dbName, `CREATE TABLE counters (
+		id bigint unsigned NOT NULL AUTO_INCREMENT,
+		PRIMARY KEY (id)
+	) ENGINE=InnoDB AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8mb4`)
+
+	db, err := sql.Open("mysql", testutils.DSNForDatabase(dbName))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tables, err := LoadSchemaFromDB(t.Context(), db)
+	require.NoError(t, err)
+	require.Len(t, tables, 1)
+	assert.Equal(t, "counters", tables[0].Name)
+	assert.Contains(t, tables[0].Schema, "AUTO_INCREMENT=")
+}


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

This adds a LoadSchemaFromDB function. I have 2 other implementations of this in other internal code based which all depend on spirit. So it's easier to just unify them.

Because the table package is imported by utils, there is no CloseAndLog function, leading to some ugly defers.

This is functionality neutral.