### PR TITLE
Test kill capability directly instead of parsing privilege labels

### DIFF
--- a/pkg/migration/check/privileges.go
+++ b/pkg/migration/check/privileges.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
+	gmysql "github.com/go-sql-driver/mysql"
 )
 
 func init() {
@@ -22,17 +24,14 @@ func init() {
 func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 	// This is a re-implementation of the gh-ost check
 	// validateGrants() in gh-ost/go/logic/inspect.go
-	var foundAll, foundSuper, foundReplicationClient, foundReplicationSlave, foundDBAll, foundReload, foundConnectionAdmin, foundProcess bool
-	rows, err := r.DB.QueryContext(ctx, `SHOW GRANTS`)
+
+	grants, err := showGrantsWithRoles(ctx, r.DB, logger)
 	if err != nil {
 		return err
 	}
-	defer utils.CloseAndLog(rows)
-	for rows.Next() {
-		var grant string
-		if err := rows.Scan(&grant); err != nil {
-			return err
-		}
+
+	var foundAll, foundSuper, foundReplicationClient, foundReplicationSlave, foundDBAll, foundReload, foundConnectionAdmin, foundProcess bool
+	for _, grant := range grants {
 		if strings.Contains(grant, `GRANT ALL PRIVILEGES ON *.*`) {
 			foundAll = true
 		}
@@ -67,16 +66,15 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 			foundProcess = true
 		}
 	}
-	if rows.Err() != nil {
-		return rows.Err()
-	}
 	if foundAll {
 		return nil
 	}
 
 	if r.ForceKill {
 		var errs []error
-		// Parsing performance_schema grants seems really hard, so we just try to execute the queries and see if they succeed.
+		// Rather than parsing grants for specific privilege labels (which vary
+		// across MySQL variants — e.g. managed services may grant the capability
+		// through roles without exposing the label), we test the actual capabilities.
 		if _, err := dbconn.GetTableLocks(ctx, r.DB, []*table.TableInfo{r.Table}, logger, nil); err != nil {
 			errs = append(errs, err)
 		}
@@ -84,7 +82,11 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 			errs = append(errs, err)
 		}
 		if !foundConnectionAdmin && !foundSuper && !foundAll {
-			errs = append(errs, errors.New("missing CONNECTION_ADMIN privilege"))
+			// CONNECTION_ADMIN not visible in grants (may be hidden behind roles
+			// on managed services like RDS). Fall back to a direct capability probe.
+			if err := canKillConnections(ctx, r.DB, r.Host); err != nil {
+				errs = append(errs, fmt.Errorf("cannot kill connections (need CONNECTION_ADMIN, SUPER, or equivalent): %w", err))
+			}
 		}
 		if !foundProcess && !foundAll {
 			errs = append(errs, errors.New("missing PROCESS privilege"))
@@ -102,6 +104,106 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 	}
 
 	return errors.New("insufficient privileges to run a migration. Needed: SUPER|REPLICATION CLIENT, RELOAD, REPLICATION SLAVE and ALL on %s.*")
+}
+
+// showGrantsWithRoles activates all granted roles and returns the SHOW GRANTS
+// output on a single connection. SET ROLE ALL is session-scoped, so a pinned
+// connection ensures SHOW GRANTS sees the expanded role privileges.
+// This handles environments like Amazon RDS where privileges are assigned via
+// roles (e.g. rds_superuser_role) that aren't set as DEFAULT ROLE.
+func showGrantsWithRoles(ctx context.Context, db *sql.DB, logger *slog.Logger) ([]string, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire connection: %w", err)
+	}
+	defer utils.CloseAndLog(conn)
+
+	// Activate all granted roles for this connection.
+	if _, err := conn.ExecContext(ctx, `SET ROLE ALL`); err != nil {
+		// Not fatal — user may have no granted roles.
+		logger.Warn("SET ROLE ALL failed (roles may not be supported)", "error", err)
+	}
+
+	rows, err := conn.QueryContext(ctx, `SHOW GRANTS`)
+	if err != nil {
+		return nil, err
+	}
+	defer utils.CloseAndLog(rows)
+
+	var grants []string
+	for rows.Next() {
+		var grant string
+		if err := rows.Scan(&grant); err != nil {
+			return nil, err
+		}
+		grants = append(grants, grant)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return grants, nil
+}
+
+// canKillConnections tests whether the current user can kill other users'
+// connections by creating a temporary "victim" connection from a disposable
+// MySQL user and attempting to KILL it.
+//
+// MySQL only checks kill privileges when the target thread belongs to a
+// different user — same-user kills always succeed, and non-existent thread IDs
+// skip the privilege check entirely (returning ER_NO_SUCH_THREAD regardless of
+// privilege). So we must target a real connection from a different user.
+//
+// The victim connection is purpose-built for this test, so there is no risk
+// to active workloads.
+func canKillConnections(ctx context.Context, db *sql.DB, host string) error {
+	const probeUser = "_spirit_kill_probe"
+
+	// Create a temporary user to own the victim connection.
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", probeUser)); err != nil {
+		return fmt.Errorf("cannot verify kill capability (DROP USER failed): %w", err)
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE USER %s", probeUser)); err != nil {
+		return fmt.Errorf("cannot verify kill capability (CREATE USER failed): %w", err)
+	}
+	defer func() {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP USER IF EXISTS %s", probeUser))
+	}()
+
+	// Connect as the probe user to create the victim connection.
+	victimCfg := gmysql.NewConfig()
+	victimCfg.User = probeUser
+	victimCfg.Net = "tcp"
+	victimCfg.Addr = host
+	victimDB, err := sql.Open("mysql", victimCfg.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("cannot verify kill capability (connect probe user): %w", err)
+	}
+	defer utils.CloseAndLog(victimDB)
+
+	// Pin a connection and get its ID.
+	victimConn, err := victimDB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot verify kill capability (pin probe connection): %w", err)
+	}
+	defer utils.CloseAndLog(victimConn)
+
+	var victimID int64
+	if err := victimConn.QueryRowContext(ctx, "SELECT CONNECTION_ID()").Scan(&victimID); err != nil {
+		return fmt.Errorf("cannot verify kill capability (get connection ID): %w", err)
+	}
+
+	// Try to KILL the victim from the caller's connection.
+	// ER_KILL_DENIED_ERROR (1095) = caller lacks the privilege.
+	// Success or ER_NO_SUCH_THREAD (1094) = caller has the privilege.
+	_, killErr := db.ExecContext(ctx, fmt.Sprintf("KILL %d", victimID))
+	if killErr == nil {
+		return nil
+	}
+	errStr := killErr.Error()
+	if strings.Contains(errStr, "1094") || strings.Contains(errStr, "Unknown thread id") {
+		return nil // Thread already gone, but we had permission to try.
+	}
+	return fmt.Errorf("KILL privilege test failed: %w", killErr)
 }
 
 // stringContainsAll returns true if `s` contains all non empty given `substrings`

--- a/pkg/migration/check/privileges_test.go
+++ b/pkg/migration/check/privileges_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	"github.com/block/spirit/pkg/utils"
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrivileges(t *testing.T) {
@@ -39,6 +41,7 @@ func TestPrivileges(t *testing.T) {
 		DB:        lowPrivDB,
 		Table:     &table.TableInfo{TableName: "test", SchemaName: "test"},
 		ForceKill: true, // default behavior
+		Host:      config.Addr,
 	}
 	err = privilegesCheck(t.Context(), r, slog.Default())
 	assert.Error(t, err) // privileges fail, since user has nothing granted.
@@ -61,8 +64,10 @@ func TestPrivileges(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = privilegesCheck(t.Context(), r, slog.Default())
-	assert.Error(t, err) // still not enough, needs connection_admin
+	assert.Error(t, err) // still not enough, needs kill capability
 
+	// Grant CONNECTION_ADMIN so the user can kill connections.
+	// privilegesCheck() detects this via grant parsing (after SET ROLE ALL).
 	_, err = db.ExecContext(t.Context(), "GRANT CONNECTION_ADMIN ON *.* TO testprivsuser")
 	assert.NoError(t, err)
 
@@ -138,4 +143,54 @@ func TestPrivilegesWithSkipForceKill(t *testing.T) {
 	// No CONNECTION_ADMIN, PROCESS, or performance_schema access needed.
 	err = privilegesCheck(t.Context(), r, slog.Default())
 	assert.NoError(t, err)
+}
+
+// TestCanKillConnections verifies the kill capability probe by spawning a
+// victim connection from a temporary user and attempting to KILL it.
+func TestCanKillConnections(t *testing.T) {
+	config, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	config.User = "root"
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s", config.User, config.Passwd, config.Addr, config.DBName))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	host := config.Addr
+
+	// Root can kill connections (has all privileges including CREATE USER for
+	// the probe user).
+	err = canKillConnections(t.Context(), db, host)
+	assert.NoError(t, err)
+
+	// Create a user with CREATE USER privilege (needed to create the probe
+	// user) but no kill privilege — the probe should detect this.
+	_, err = db.ExecContext(t.Context(), "DROP USER IF EXISTS testkillprobe")
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(), "CREATE USER testkillprobe")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "DROP USER IF EXISTS testkillprobe")
+	})
+	// Grant CREATE USER so the probe can create its victim user, but no kill privilege.
+	_, err = db.ExecContext(t.Context(), "GRANT CREATE USER ON *.* TO testkillprobe")
+	require.NoError(t, err)
+
+	unprivDB, err := sql.Open("mysql", fmt.Sprintf("testkillprobe:@tcp(%s)/", host))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(unprivDB)
+
+	err = canKillConnections(t.Context(), unprivDB, host)
+	assert.Error(t, err) // no kill privilege
+
+	// Grant CONNECTION_ADMIN and verify the probe passes.
+	_, err = db.ExecContext(t.Context(), "GRANT CONNECTION_ADMIN ON *.* TO testkillprobe")
+	require.NoError(t, err)
+
+	// Reconnect to pick up the new grant.
+	assert.NoError(t, unprivDB.Close())
+	unprivDB, err = sql.Open("mysql", fmt.Sprintf("testkillprobe:@tcp(%s)/", host))
+	require.NoError(t, err)
+
+	err = canKillConnections(t.Context(), unprivDB, host)
+	assert.NoError(t, err) // has kill privilege now
 }


### PR DESCRIPTION
## Problem

Spirit's preflight privilege check string-matches `SHOW GRANTS` for `CONNECTION_ADMIN`. This fails on managed MySQL services where the capability is granted via roles without exposing the label in `SHOW GRANTS` output.

On **RDS MySQL 8.4**, `CONNECTION_ADMIN` was removed from `rds_superuser_role`. The user *can* kill connections (the capability is inherited through the role), but:

1. `GRANT CONNECTION_ADMIN ON *.*` fails — the RDS admin user lacks `GRANT OPTION` for it
2. Granting `rds_superuser_role` gives the kill capability, but `SHOW GRANTS` only shows the role name, not expanded privileges
3. `SET ROLE ALL` + `SHOW GRANTS` still doesn't surface `CONNECTION_ADMIN` because it's not a standard grant within the role on 8.4

Result: Spirit rejects users who can actually `KILL` connections because the string `CONNECTION_ADMIN` never appears in their grants.

## Fix

Two-layer approach: grant parsing (with role activation) as a fast path, with a direct capability probe as fallback.

### 1. `showGrantsWithRoles()` — role-aware grant parsing

Runs `SET ROLE ALL` on a pinned connection before `SHOW GRANTS`, so role-inherited privileges (like `REPLICATION CLIENT`) are visible. This handles most managed service cases where privileges are assigned via roles that aren't set as `DEFAULT ROLE`.

`CONNECTION_ADMIN` is still parsed from grants as a first-pass check. When visible (normal MySQL, or after `SET ROLE ALL`), the probe is skipped entirely.

### 2. `canKillConnections()` — direct capability probe (fallback)

When `CONNECTION_ADMIN` isn't visible in grants (e.g. RDS 8.4), we test the actual capability by spawning a victim connection:

1. Create a temporary `_spirit_kill_probe` MySQL user
2. Connect as that user to create a victim connection
3. Attempt `KILL <victim_id>` from the caller's connection
4. Clean up the probe user

This works because MySQL only checks kill privileges when the target thread belongs to a **different user** — same-user kills always succeed, and non-existent thread IDs skip the privilege check entirely (returning `ER_NO_SUCH_THREAD` regardless of privilege level). By targeting a real connection from a different user, we get a definitive answer:

- `ER_KILL_DENIED_ERROR` (1095) → caller lacks the privilege
- Success or `ER_NO_SUCH_THREAD` (1094) → caller has the privilege

The victim connection is purpose-built for this test — no risk to active workloads.

### Additional changes

- `PROCESS` is still string-matched from grants rather than capability-tested. Unlike kill capability, `PROCESS` is always directly granted (never hidden behind roles), and there's no cheap side-effect-free probe for it.
- `TestCanKillConnections` — new test covering root (has privilege), unprivileged user with CREATE USER but no kill (lacks privilege), and user after granting `CONNECTION_ADMIN`

## Tested
- Deployed to AWS App Runner + RDS MySQL 8.4 with a user that has kill capability via `rds_superuser_role` — deployment succeeds with force-kill enabled