### PR TITLE
Enhance load schema with filtering

### DIFF
--- a/pkg/table/table_schema.go
+++ b/pkg/table/table_schema.go
@@ -16,24 +16,25 @@ type TableSchema struct {
 	Schema string // CREATE TABLE DDL statement
 }
 
-// FilterOptions controls which tables are excluded and which DDL
+// FilterOption controls which tables are excluded and which DDL
 // transformations are applied when loading schema from a database.
-// A zero-value FilterOptions performs no filtering (all tables returned as-is).
-type FilterOptions struct {
-	// TablesStartingWithUnderscore filters out tables whose name begins with "_".
+type FilterOption int
+
+const (
+	// WithoutUnderscoreTables filters out tables whose name begins with "_".
 	// This is commonly used to exclude Spirit's internal shadow/checkpoint tables
 	// and other tool-generated temporary tables.
-	TablesStartingWithUnderscore bool
+	WithoutUnderscoreTables FilterOption = iota + 1
 
-	// ArchiveTables filters out tables matching the archive naming convention:
+	// WithoutArchiveTables filters out tables matching the archive naming convention:
 	// <name>_archive_YYYY, <name>_archive_YYYY_MM, or <name>_archive_YYYY_MM_DD.
-	ArchiveTables bool
+	WithoutArchiveTables
 
-	// StripAutoIncrement removes the AUTO_INCREMENT=N table option from
-	// CREATE TABLE statements. This is useful when comparing schemas to
-	// avoid spurious diffs caused by differing auto-increment counters.
-	StripAutoIncrement bool
-}
+	// WithStrippedAutoIncrement removes the AUTO_INCREMENT=N table option from
+	// CREATE TABLE statements. This is useful when comparing schemas to avoid
+	// spurious diffs caused by differing auto-increment counters.
+	WithStrippedAutoIncrement
+)
 
 // archiveTableRegexp matches table names following the archive convention:
 // <name>_archive_YYYY, <name>_archive_YYYY_MM, or <name>_archive_YYYY_MM_DD.
@@ -42,31 +43,27 @@ var archiveTableRegexp = regexp.MustCompile(`^.*_archive_[0-9]{4}(_[0-9]{2}(_[0-
 // autoIncrementRegexp matches the AUTO_INCREMENT table option in CREATE TABLE output.
 var autoIncrementRegexp = regexp.MustCompile(`(?i)\s*AUTO_INCREMENT\s*=?\s*[0-9]+`)
 
-// isArchiveTable returns true if the table name matches the archive naming
+// IsArchiveTable returns true if the table name matches the archive naming
 // convention: <name>_archive_YYYY, <name>_archive_YYYY_MM, or
 // <name>_archive_YYYY_MM_DD.
-func isArchiveTable(name string) bool {
+func IsArchiveTable(name string) bool {
 	return archiveTableRegexp.MatchString(name)
 }
 
-// stripAutoIncrement removes the AUTO_INCREMENT=N table option from a
+// StripAutoIncrement removes the AUTO_INCREMENT=N table option from a
 // CREATE TABLE statement. This is useful when comparing schemas to avoid
 // spurious diffs caused by differing auto-increment counters.
-func stripAutoIncrement(stmt string) string {
+func StripAutoIncrement(stmt string) string {
 	return autoIncrementRegexp.ReplaceAllString(stmt, "")
 }
 
 // LoadSchemaFromDB retrieves all table schemas from the database using the
-// provided connection. When opts is provided (at most one), tables and DDL
-// are filtered according to the specified options. With no opts or a
-// zero-value FilterOptions, the raw DDL is returned unmodified.
-func LoadSchemaFromDB(ctx context.Context, db *sql.DB, opts ...FilterOptions) ([]TableSchema, error) {
-	if len(opts) > 1 {
-		return nil, fmt.Errorf("at most one FilterOptions may be provided, got %d", len(opts))
-	}
-	var filter FilterOptions
-	if len(opts) == 1 {
-		filter = opts[0]
+// provided connection. The returned tables and DDL are filtered according to
+// the supplied options. With no options the raw DDL is returned unmodified.
+func LoadSchemaFromDB(ctx context.Context, db *sql.DB, opts ...FilterOption) ([]TableSchema, error) {
+	optSet := make(map[FilterOption]bool, len(opts))
+	for _, o := range opts {
+		optSet[o] = true
 	}
 
 	rows, err := db.QueryContext(ctx, "SHOW TABLES")
@@ -87,10 +84,10 @@ func LoadSchemaFromDB(ctx context.Context, db *sql.DB, opts ...FilterOptions) ([
 	}
 	var tables []TableSchema
 	for _, name := range tableNames {
-		if filter.TablesStartingWithUnderscore && strings.HasPrefix(name, "_") {
+		if optSet[WithoutUnderscoreTables] && strings.HasPrefix(name, "_") {
 			continue
 		}
-		if filter.ArchiveTables && isArchiveTable(name) {
+		if optSet[WithoutArchiveTables] && IsArchiveTable(name) {
 			continue
 		}
 		var tbl, createStmt string
@@ -98,8 +95,8 @@ func LoadSchemaFromDB(ctx context.Context, db *sql.DB, opts ...FilterOptions) ([
 		if err != nil {
 			return nil, fmt.Errorf("failed to get CREATE TABLE for %s: %w", name, err)
 		}
-		if filter.StripAutoIncrement {
-			createStmt = stripAutoIncrement(createStmt)
+		if optSet[WithStrippedAutoIncrement] {
+			createStmt = StripAutoIncrement(createStmt)
 		}
 		tables = append(tables, TableSchema{Name: tbl, Schema: createStmt})
 	}

--- a/pkg/table/table_schema_test.go
+++ b/pkg/table/table_schema_test.go
@@ -78,18 +78,6 @@ func TestLoadSchemaFromDB_PreservesAutoIncrement(t *testing.T) {
 	assert.Contains(t, tables[0].Schema, "AUTO_INCREMENT=")
 }
 
-func TestLoadSchemaFromDB_MultipleOptsReturnsError(t *testing.T) {
-	dbName := testutils.CreateUniqueTestDatabase(t)
-
-	db, err := sql.Open("mysql", testutils.DSNForDatabase(dbName))
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	_, err = LoadSchemaFromDB(t.Context(), db, FilterOptions{}, FilterOptions{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "at most one FilterOptions may be provided")
-}
-
 func TestLoadSchemaFromDB_FilterUnderscoreTables(t *testing.T) {
 	dbName := testutils.CreateUniqueTestDatabase(t)
 	testutils.RunSQLInDatabase(t, dbName, `CREATE TABLE users (id bigint NOT NULL, PRIMARY KEY (id)) ENGINE=InnoDB`)
@@ -106,7 +94,7 @@ func TestLoadSchemaFromDB_FilterUnderscoreTables(t *testing.T) {
 	assert.Len(t, all, 3)
 
 	// With underscore filter: only "users" returned.
-	filtered, err := LoadSchemaFromDB(t.Context(), db, FilterOptions{TablesStartingWithUnderscore: true})
+	filtered, err := LoadSchemaFromDB(t.Context(), db, WithoutUnderscoreTables)
 	require.NoError(t, err)
 	require.Len(t, filtered, 1)
 	assert.Equal(t, "users", filtered[0].Name)
@@ -129,7 +117,7 @@ func TestLoadSchemaFromDB_FilterArchiveTables(t *testing.T) {
 	assert.Len(t, all, 4)
 
 	// With archive filter: only "users" returned.
-	filtered, err := LoadSchemaFromDB(t.Context(), db, FilterOptions{ArchiveTables: true})
+	filtered, err := LoadSchemaFromDB(t.Context(), db, WithoutArchiveTables)
 	require.NoError(t, err)
 	require.Len(t, filtered, 1)
 	assert.Equal(t, "users", filtered[0].Name)
@@ -146,7 +134,7 @@ func TestLoadSchemaFromDB_StripAutoIncrement(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	tables, err := LoadSchemaFromDB(t.Context(), db, FilterOptions{StripAutoIncrement: true})
+	tables, err := LoadSchemaFromDB(t.Context(), db, WithStrippedAutoIncrement)
 	require.NoError(t, err)
 	require.Len(t, tables, 1)
 	assert.NotContains(t, tables[0].Schema, "AUTO_INCREMENT=")
@@ -167,11 +155,11 @@ func TestLoadSchemaFromDB_CombinedFilters(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	filtered, err := LoadSchemaFromDB(t.Context(), db, FilterOptions{
-		TablesStartingWithUnderscore: true,
-		ArchiveTables:                true,
-		StripAutoIncrement:           true,
-	})
+	filtered, err := LoadSchemaFromDB(t.Context(), db,
+		WithoutUnderscoreTables,
+		WithoutArchiveTables,
+		WithStrippedAutoIncrement,
+	)
 	require.NoError(t, err)
 	require.Len(t, filtered, 1)
 	assert.Equal(t, "users", filtered[0].Name)


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

This adds optional filtering to the LoadSchemaFromDB API. We are always filtering out the same things in our downstream API usage, so it makes sense to push it into here.