### PR TITLE
fix: explicitly set AllowNativePasswords=true in newDSN

### DIFF
--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -284,6 +284,7 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	// Allow cleartext password authentication only when TLS is configured
 	// (required for AWS RDS IAM auth, safe because the connection uses TLS).
 	cfg.AllowCleartextPasswords = cfg.TLSConfig != ""
+	cfg.AllowNativePasswords = true
 
 	return cfg.FormatDSN(), nil
 }

--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -86,6 +86,31 @@ func TestNewDSN(t *testing.T) {
 	assert.Empty(t, resp)
 }
 
+func TestNewDSNAllowNativePasswords(t *testing.T) {
+	// Verify AllowNativePasswords is true for both TLS-enabled and TLS-disabled DSNs.
+	// This is important because Spirit's PREFERRED TLS mode falls back to a DISABLED
+	// DSN when TLS is unavailable, and both paths must support mysql_native_password.
+	dsn := "root:password@tcp(127.0.0.1:3306)/test"
+
+	// Default (PREFERRED) mode — TLS enabled
+	resp, err := newDSN(dsn, NewDBConfig())
+	assert.NoError(t, err)
+	cfg, err := mysql.ParseDSN(resp)
+	assert.NoError(t, err)
+	assert.True(t, cfg.AllowNativePasswords, "AllowNativePasswords must be true with TLS enabled")
+
+	// DISABLED mode — the fallback path used when TLS is unavailable
+	config := NewDBConfig()
+	config.TLSMode = "DISABLED"
+	resp, err = newDSN(dsn, config)
+	assert.NoError(t, err)
+	cfg, err = mysql.ParseDSN(resp)
+	assert.NoError(t, err)
+	assert.True(t, cfg.AllowNativePasswords, "AllowNativePasswords must be true with TLS disabled (fallback path)")
+	assert.NotContains(t, resp, "allowNativePasswords=false",
+		"DSN must not contain allowNativePasswords=false")
+}
+
 func TestNewDSNAllowCleartextPasswords(t *testing.T) {
 	// With TLS enabled (default PREFERRED mode), AllowCleartextPasswords should be true
 	dsn := "root:password@tcp(127.0.0.1:3306)/test"


### PR DESCRIPTION
Fixes #666

## Problem

Spirit rejects connections to MySQL servers that use `mysql_native_password` authentication:

```
[mysql] could not use requested auth plugin 'mysql_native_password': this user requires mysql native password authentication
spirit: error: [MAIN-DATABASE-CONNECTION-FALLBACK] ping failed: this user requires mysql native password authentication
```

## Root Cause

In `newDSN()` (`pkg/dbconn/conn.go`), Spirit explicitly sets several driver config options (`RejectReadOnly`, `InterpolateParams`, `AllowCleartextPasswords`) but does not explicitly set `AllowNativePasswords`. While `NewConfig()` defaults it to `true`, `FormatDSN()` omits default-true values from the DSN string, making the setting fragile across DSN serialization/deserialization cycles.

## Fix

Explicitly set `cfg.AllowNativePasswords = true` in `newDSN()`, consistent with how other driver options are already configured.

## Test

Added `TestNewDSNAllowNativePasswords` which validates `AllowNativePasswords` is true for both TLS-enabled (default PREFERRED mode) and TLS-disabled (fallback path) DSNs, and asserts the DSN never contains `allowNativePasswords=false`.

Also verified with integration test against a MySQL server using `mysql_native_password`:
- **Baseline (no fix)**: `could not use requested auth plugin 'mysql_native_password'`
- **Fixed**: Connects successfully, proceeds to migration