### PR TITLE
support multi-target buffered copies

### DIFF
--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -710,6 +710,60 @@ func TestLargeNumberOfMultiChanges(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestBufferedMultiTableMigration(t *testing.T) {
+	if testutils.IsMinimalRBRTestRunner(t) {
+		t.Skip("Skipping buffered copy test because binlog_row_image is not FULL or binlog_row_value_options is not empty")
+	}
+	// Create two tables with data
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS bmt_t1, _bmt_t1_new, _bmt_t1_old`)
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS bmt_t2, _bmt_t2_new, _bmt_t2_old`)
+	testutils.RunSQL(t, `CREATE TABLE bmt_t1 (
+		id int not null primary key auto_increment,
+		name varchar(100) not null,
+		val int not null
+	)`)
+	testutils.RunSQL(t, `CREATE TABLE bmt_t2 (
+		id int not null primary key auto_increment,
+		description varchar(200) not null,
+		amount decimal(10,2) not null
+	)`)
+	// Insert enough rows to trigger multiple chunks
+	for i := range 100 {
+		testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO bmt_t1 (name, val) VALUES ('row_%d', %d)`, i, i*10))
+		testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO bmt_t2 (description, amount) VALUES ('item_%d', %d.%d)`, i, i, i%100))
+	}
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+	migration := &Migration{
+		Host:            cfg.Addr,
+		Username:        cfg.User,
+		Password:        &cfg.Passwd,
+		Database:        cfg.DBName,
+		Threads:         2,
+		TargetChunkTime: 100 * time.Millisecond,
+		Buffered:        true,
+		Statement:       "ALTER TABLE bmt_t1 ADD COLUMN extra int DEFAULT 0; ALTER TABLE bmt_t2 ADD COLUMN extra int DEFAULT 0",
+	}
+	err = migration.Run()
+	assert.NoError(t, err)
+
+	// Verify both tables were altered correctly
+	db, err := sql.Open("mysql", testutils.DSN())
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, db.Close()) }()
+
+	var count1 int
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM bmt_t1 WHERE extra = 0`).Scan(&count1)
+	assert.NoError(t, err)
+	assert.Equal(t, 100, count1)
+
+	var count2 int
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM bmt_t2 WHERE extra = 0`).Scan(&count2)
+	assert.NoError(t, err)
+	assert.Equal(t, 100, count2)
+}
+
 func TestMigrationParamsDefaultsUsed(t *testing.T) {
 	migration := &Migration{Table: "test_table", Alter: "ENGINE=INNODB"}
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -488,11 +488,9 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	// Create an applier if using buffered copy or buffered replication
 	var appl applier.Applier
 	if r.migration.Buffered {
-		// For now, we only support single-table migrations with buffered copy
-		if len(r.changes) > 1 {
-			return errors.New("buffered copy is not yet supported for multi-table migrations")
-		}
-		// Create a SingleTargetApplier for the buffered copier
+		// Create a SingleTargetApplier for the buffered copier.
+		// The applier is table-aware: each chunk/operation carries its own
+		// table info, so a single applier handles multi-table migrations correctly.
 		appl, err = applier.NewSingleTargetApplier(
 			applier.Target{DB: r.db},
 			&applier.ApplierConfig{


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

This unblocks using buffered copies for atomic (multi-target) schema changes.

I believe I added this limitation initially just to limit testing scope, so with tests we can un-restrict it.