### PR TITLE
Replace PlannedChange string slices with structured Violations field

### DIFF
--- a/pkg/lint/cmd_diff.go
+++ b/pkg/lint/cmd_diff.go
@@ -144,16 +144,8 @@ func printPlan(plan *Plan) {
 	// Collect all violations across changes for the comment header.
 	var hasViolations bool
 	for _, ch := range plan.Changes {
-		for _, e := range ch.Errors {
-			fmt.Printf("-- %s\n", e)
-			hasViolations = true
-		}
-		for _, w := range ch.Warnings {
-			fmt.Printf("-- %s\n", w)
-			hasViolations = true
-		}
-		for _, info := range ch.Infos {
-			fmt.Printf("-- %s\n", info)
+		for _, v := range ch.Violations {
+			fmt.Printf("-- %s\n", v.String())
 			hasViolations = true
 		}
 	}

--- a/pkg/lint/cmd_diff_test.go
+++ b/pkg/lint/cmd_diff_test.go
@@ -234,7 +234,7 @@ func TestDiff_DirToDirIntegration(t *testing.T) {
 		}
 	}
 	require.NotNil(t, ordersChange, "expected a change for orders table")
-	assert.NotEmpty(t, ordersChange.Warnings, "expected warnings for orders table (has_float, has_fk)")
+	assert.NotEmpty(t, ordersChange.Warnings(), "expected warnings for orders table (has_float, has_fk)")
 
 	// Should NOT have changes for users (unchanged)
 	for _, ch := range plan.Changes {

--- a/pkg/lint/declarative.go
+++ b/pkg/lint/declarative.go
@@ -17,20 +17,36 @@ type PlannedChange struct {
 	// TableName is the table affected by this change.
 	TableName string
 
-	// Warnings contains lint violations with WARNING severity for this table.
+	// Violations contains lint violations for this table.
 	// Linters operate at the table level. When a diff produces multiple
 	// statements for the same table, violations are attached only to the
 	// last statement to avoid duplication.
-	Warnings []string
+	Violations []Violation
+}
 
-	// Errors contains lint violations with ERROR severity for this table.
-	// See Warnings for multi-statement behavior.
-	Errors []string
+// Errors returns lint violations with ERROR severity.
+func (c *PlannedChange) Errors() []Violation {
+	return c.filterBySeverity(SeverityError)
+}
 
-	// Infos contains lint violations with INFO severity for this table.
-	// These are suggestions or style preferences that callers may choose to ignore.
-	// See Warnings for multi-statement behavior.
-	Infos []string
+// Warnings returns lint violations with WARNING severity.
+func (c *PlannedChange) Warnings() []Violation {
+	return c.filterBySeverity(SeverityWarning)
+}
+
+// Infos returns lint violations with INFO severity.
+func (c *PlannedChange) Infos() []Violation {
+	return c.filterBySeverity(SeverityInfo)
+}
+
+func (c *PlannedChange) filterBySeverity(severity Severity) []Violation {
+	var result []Violation
+	for _, v := range c.Violations {
+		if v.Severity == severity {
+			result = append(result, v)
+		}
+	}
+	return result
 }
 
 // Plan holds the complete result of a declarative-to-imperative diff with linting.
@@ -47,7 +63,7 @@ func (p *Plan) HasChanges() bool {
 // HasErrors returns true if any change has lint errors.
 func (p *Plan) HasErrors() bool {
 	for i := range p.Changes {
-		if len(p.Changes[i].Errors) > 0 {
+		if len(p.Changes[i].Errors()) > 0 {
 			return true
 		}
 	}
@@ -57,7 +73,7 @@ func (p *Plan) HasErrors() bool {
 // HasWarnings returns true if any change has lint warnings.
 func (p *Plan) HasWarnings() bool {
 	for i := range p.Changes {
-		if len(p.Changes[i].Warnings) > 0 {
+		if len(p.Changes[i].Warnings()) > 0 {
 			return true
 		}
 	}
@@ -67,7 +83,7 @@ func (p *Plan) HasWarnings() bool {
 // HasInfos returns true if any change has lint infos.
 func (p *Plan) HasInfos() bool {
 	for i := range p.Changes {
-		if len(p.Changes[i].Infos) > 0 {
+		if len(p.Changes[i].Infos()) > 0 {
 			return true
 		}
 	}
@@ -132,30 +148,13 @@ func PlanChanges(current, desired []table.TableSchema, diffOpts *statement.DiffO
 	//
 	// Violations are sorted first to ensure deterministic output, since
 	// RunLinters iterates over a map of registered linters.
-	type tableViolations struct {
-		warnings []string
-		errors   []string
-		infos    []string
-	}
-	violationsByTable := make(map[string]*tableViolations)
+	violationsByTable := make(map[string][]Violation)
 	for _, v := range sortViolations(violations) {
 		tableName := ""
 		if v.Location != nil {
 			tableName = v.Location.Table
 		}
-		tv, ok := violationsByTable[tableName]
-		if !ok {
-			tv = &tableViolations{}
-			violationsByTable[tableName] = tv
-		}
-		switch v.Severity {
-		case SeverityError:
-			tv.errors = append(tv.errors, v.String())
-		case SeverityWarning:
-			tv.warnings = append(tv.warnings, v.String())
-		case SeverityInfo:
-			tv.infos = append(tv.infos, v.String())
-		}
+		violationsByTable[tableName] = append(violationsByTable[tableName], v)
 	}
 
 	// 5. Build the plan, attaching violations to the last statement per table.
@@ -172,14 +171,12 @@ func PlanChanges(current, desired []table.TableSchema, diffOpts *statement.DiffO
 		})
 		lastIndexByTable[ch.Table] = i
 	}
-	for tableName, tv := range violationsByTable {
+	for tableName, vs := range violationsByTable {
 		idx, ok := lastIndexByTable[tableName]
 		if !ok {
 			continue
 		}
-		plan.Changes[idx].Warnings = tv.warnings
-		plan.Changes[idx].Errors = tv.errors
-		plan.Changes[idx].Infos = tv.infos
+		plan.Changes[idx].Violations = vs
 	}
 
 	return plan, nil

--- a/pkg/lint/declarative_test.go
+++ b/pkg/lint/declarative_test.go
@@ -129,7 +129,44 @@ func TestPlanChanges_WithLintViolations(t *testing.T) {
 	assert.Equal(t, "child", plan.Changes[0].TableName)
 	// The has_fk linter should produce a warning for the child table
 	assert.True(t, plan.HasWarnings(), "expected lint warnings for table with FK")
-	assert.NotEmpty(t, plan.Changes[0].Warnings)
+	assert.NotEmpty(t, plan.Changes[0].Warnings())
+}
+
+func TestPlanChanges_StructuredViolations(t *testing.T) {
+	current := []table.TableSchema{
+		{Name: "parent", Schema: "CREATE TABLE parent (id BIGINT PRIMARY KEY)"},
+		{Name: "child", Schema: `CREATE TABLE child (
+			id BIGINT PRIMARY KEY,
+			parent_id BIGINT,
+			CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent(id)
+		)`},
+	}
+	desired := []table.TableSchema{
+		{Name: "parent", Schema: "CREATE TABLE parent (id BIGINT PRIMARY KEY)"},
+		{Name: "child", Schema: `CREATE TABLE child (
+			id BIGINT PRIMARY KEY,
+			parent_id BIGINT,
+			name VARCHAR(100),
+			CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent(id)
+		)`},
+	}
+	plan, err := PlanChanges(current, desired, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+
+	change := plan.Changes[0]
+	require.NotEmpty(t, change.Violations, "expected structured Violations to be populated")
+
+	// Verify structured fields are accessible
+	v := change.Violations[0]
+	assert.Equal(t, "child", v.Location.Table)
+	assert.NotEmpty(t, v.Message)
+	assert.Equal(t, SeverityWarning, v.Severity)
+	assert.Equal(t, "has_foreign_key", v.Linter.Name())
+
+	// Severity methods filter correctly
+	assert.Len(t, change.Warnings(), 1)
+	assert.Empty(t, change.Errors())
 }
 
 func TestPlanChanges_WithLintConfig(t *testing.T) {
@@ -161,7 +198,7 @@ func TestPlanChanges_WithLintConfig(t *testing.T) {
 	// on this schema, so there should be no warnings at all.
 	assert.False(t, plan.HasWarnings(), "expected no warnings when has_foreign_key is disabled")
 	for _, ch := range plan.Changes {
-		assert.Empty(t, ch.Warnings, "expected no warnings on any change")
+		assert.Empty(t, ch.Warnings(), "expected no warnings on any change")
 	}
 }
 
@@ -195,12 +232,12 @@ func TestPlanChanges_WithInfos(t *testing.T) {
 
 	// The test_info linter should produce an info for the ALTER TABLE change.
 	assert.True(t, plan.HasInfos(), "expected lint infos from test_info linter")
-	require.NotEmpty(t, plan.Changes[0].Infos)
-	assert.Contains(t, plan.Changes[0].Infos[0], "test_info")
-	assert.Contains(t, plan.Changes[0].Infos[0], "informational suggestion")
+	require.NotEmpty(t, plan.Changes[0].Infos())
+	assert.Equal(t, "test_info", plan.Changes[0].Infos()[0].Linter.Name())
+	assert.Contains(t, plan.Changes[0].Infos()[0].Message, "informational suggestion")
 
 	// Infos should not appear as warnings or errors.
-	assert.Empty(t, plan.Changes[0].Errors)
+	assert.Empty(t, plan.Changes[0].Errors())
 }
 
 func TestPlanChanges_HasInfosFalseWhenNone(t *testing.T) {
@@ -215,7 +252,7 @@ func TestPlanChanges_HasInfosFalseWhenNone(t *testing.T) {
 	assert.True(t, plan.HasChanges())
 	// No info-producing linter is registered, so HasInfos should be false.
 	assert.False(t, plan.HasInfos())
-	assert.Empty(t, plan.Changes[0].Infos)
+	assert.Empty(t, plan.Changes[0].Infos())
 }
 
 func TestPlanChanges_InfosNotOnNonAlter(t *testing.T) {
@@ -242,7 +279,7 @@ func TestPlanChanges_InfosNotOnNonAlter(t *testing.T) {
 	assert.Contains(t, plan.Changes[0].Statement, "CREATE TABLE")
 	// The info linter only fires on ALTER, so no infos here.
 	assert.False(t, plan.HasInfos())
-	assert.Empty(t, plan.Changes[0].Infos)
+	assert.Empty(t, plan.Changes[0].Infos())
 }
 
 func TestPlanChanges_MultiStatementSameTable(t *testing.T) {
@@ -283,10 +320,10 @@ func TestPlanChanges_MultiStatementSameTable(t *testing.T) {
 	assert.Contains(t, t1Changes[1].Statement, "PARTITION BY")
 
 	// Violations should only be on the last statement.
-	assert.Empty(t, t1Changes[0].Warnings, "first statement should have no violations")
-	assert.Empty(t, t1Changes[0].Errors, "first statement should have no violations")
-	assert.Empty(t, t1Changes[0].Infos, "first statement should have no violations")
-	assert.NotEmpty(t, t1Changes[1].Warnings, "last statement should carry the FK warning")
+	assert.Empty(t, t1Changes[0].Warnings(), "first statement should have no violations")
+	assert.Empty(t, t1Changes[0].Errors(), "first statement should have no violations")
+	assert.Empty(t, t1Changes[0].Infos(), "first statement should have no violations")
+	assert.NotEmpty(t, t1Changes[1].Warnings(), "last statement should carry the FK warning")
 	assert.True(t, plan.HasWarnings())
 }
 


### PR DESCRIPTION
PlannedChange now carries a single `Violations []Violation` field instead of separate `Errors`/`Warnings`/`Infos` `[]string` slices. `Errors()`, `Warnings()`, and `Infos()` are methods that filter by severity, returning `[]Violation`. Consumers that need the formatted string can call `v.String()`.

This is a breaking change for consumers that access the old string fields directly. The migration is straightforward:
- `change.Errors` → `change.Errors()` (returns `[]Violation` instead of `[]string`)
- `change.Warnings` → `change.Warnings()`
- `change.Infos` → `change.Infos()`
- To get the old string format: `v.String()` on each violation

Closes #688