### PR TITLE
check: refactor Resources to support multiple sources

### DIFF
--- a/pkg/move/check/check.go
+++ b/pkg/move/check/check.go
@@ -24,16 +24,19 @@ const (
 	ScopeResume
 )
 
+// SourceResource holds per-source connection state for checks.
+type SourceResource struct {
+	DB     *sql.DB
+	Config *mysql.Config
+	DSN    string
+}
+
 // Resources contains the resources needed for move checks
 type Resources struct {
-	SourceDB       *sql.DB
-	SourceConfig   *mysql.Config
+	Sources        []SourceResource
 	Targets        []applier.Target
 	SourceTables   []*table.TableInfo
 	CreateSentinel bool
-	// For PreRun checks (before DB connections established)
-	SourceDSN string
-	TargetDSN string
 }
 
 type check struct {

--- a/pkg/move/check/configuration.go
+++ b/pkg/move/check/configuration.go
@@ -3,6 +3,7 @@ package check
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 )
 
@@ -10,60 +11,51 @@ func init() {
 	registerCheck("configuration", configurationCheck, ScopePreflight)
 }
 
-// configurationCheck verifies the MySQL configuration on the source database
-// is suitable for move operations. Move operations require:
-// - ROW binlog format for reading changes
-// - Binary logging enabled
-// - log_slave_updates enabled (unless we verify no replication)
-// - FULL binlog_row_image (for buffered copy which is always used in move)
+// configurationCheck verifies the MySQL configuration on all source databases.
 func configurationCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
-	var binlogFormat, binlogRowImage, logBin, logSlaveUpdates, binlogRowValueOptions, performanceSchema string
-	err := r.SourceDB.QueryRowContext(ctx,
-		`SELECT @@global.binlog_format,
-		@@global.binlog_row_image,
-		@@global.log_bin,
-		@@global.log_slave_updates,
-		@@global.binlog_row_value_options,
-		@@global.performance_schema`).Scan(
-		&binlogFormat,
-		&binlogRowImage,
-		&logBin,
-		&logSlaveUpdates,
-		&binlogRowValueOptions,
-		&performanceSchema,
-	)
-	if err != nil {
-		return err
+	if len(r.Sources) == 0 {
+		return errors.New("no sources configured")
 	}
-
-	if binlogFormat != "ROW" {
-		return errors.New("binlog_format must be ROW")
+	for i, src := range r.Sources {
+		if src.DB == nil {
+			return fmt.Errorf("source %d: database connection is not initialized", i)
+		}
+		var binlogFormat, binlogRowImage, logBin, logSlaveUpdates, binlogRowValueOptions, performanceSchema string
+		err := src.DB.QueryRowContext(ctx,
+			`SELECT @@global.binlog_format,
+			@@global.binlog_row_image,
+			@@global.log_bin,
+			@@global.log_slave_updates,
+			@@global.binlog_row_value_options,
+			@@global.performance_schema`).Scan(
+			&binlogFormat,
+			&binlogRowImage,
+			&logBin,
+			&logSlaveUpdates,
+			&binlogRowValueOptions,
+			&performanceSchema,
+		)
+		if err != nil {
+			return fmt.Errorf("source %d: %w", i, err)
+		}
+		if binlogFormat != "ROW" {
+			return fmt.Errorf("source %d: binlog_format must be ROW", i)
+		}
+		if binlogRowImage != "FULL" {
+			return fmt.Errorf("source %d: binlog_row_image must be FULL for move operations", i)
+		}
+		if binlogRowValueOptions != "" {
+			return fmt.Errorf("source %d: binlog_row_value_options must be empty for move operations", i)
+		}
+		if logBin != "1" {
+			return fmt.Errorf("source %d: log_bin must be enabled", i)
+		}
+		if logSlaveUpdates != "1" {
+			return fmt.Errorf("source %d: log_slave_updates must be enabled", i)
+		}
+		if performanceSchema != "1" {
+			return fmt.Errorf("source %d: performance_schema must be enabled for move operations", i)
+		}
 	}
-
-	// Move always uses buffered copy, which requires FULL binlog_row_image
-	if binlogRowImage != "FULL" {
-		return errors.New("binlog_row_image must be FULL for move operations (buffered copy requires reading all columns from binlog)")
-	}
-
-	if binlogRowValueOptions != "" {
-		return errors.New("binlog_row_value_options must be empty for move operations (buffered copy requires reading all columns from binlog)")
-	}
-
-	if logBin != "1" {
-		return errors.New("log_bin must be enabled")
-	}
-
-	if logSlaveUpdates != "1" {
-		// This is a hard requirement unless we enhance this to confirm
-		// it's not receiving any updates via the replication stream.
-		return errors.New("log_slave_updates must be enabled")
-	}
-
-	if performanceSchema != "1" {
-		// Move operations use force-kill by default, which requires performance_schema
-		// to find and kill locking transactions via metadata_locks and threads tables.
-		return errors.New("performance_schema must be enabled for move operations")
-	}
-
 	return nil
 }

--- a/pkg/move/check/configuration_test.go
+++ b/pkg/move/check/configuration_test.go
@@ -22,7 +22,7 @@ func TestConfigurationCheck(t *testing.T) {
 
 	// Test with valid configuration
 	r := Resources{
-		SourceDB: db,
+		Sources: []SourceResource{{DB: db}},
 	}
 	err = configurationCheck(context.Background(), r, slog.Default())
 	assert.NoError(t, err)

--- a/pkg/move/check/privileges.go
+++ b/pkg/move/check/privileges.go
@@ -35,7 +35,16 @@ var grantedRolesRegexp = regexp.MustCompile("`([^`]+)`@`[^`]+`")
 // active on every connection, so we tolerate its presence as a substitute for
 // CONNECTION_ADMIN and PROCESS.
 func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
-	if r.SourceDB == nil {
+	for i, src := range r.Sources {
+		if err := checkSourcePrivileges(ctx, src, r, logger); err != nil {
+			return fmt.Errorf("source %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func checkSourcePrivileges(ctx context.Context, src SourceResource, r Resources, logger *slog.Logger) error {
+	if src.DB == nil {
 		return nil // skip if no source DB connection yet (pre-run phase)
 	}
 
@@ -43,11 +52,11 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 	var grantedRoles []string
 
 	schemaName := ""
-	if r.SourceConfig != nil {
-		schemaName = r.SourceConfig.DBName
+	if src.Config != nil {
+		schemaName = src.Config.DBName
 	}
 
-	rows, err := r.SourceDB.QueryContext(ctx, `SHOW GRANTS`)
+	rows, err := src.DB.QueryContext(ctx, `SHOW GRANTS`)
 	if err != nil {
 		return err
 	}
@@ -110,7 +119,7 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 	// opaque rds_superuser_role. When activate_all_roles_on_login=ON, this role
 	// is automatically active on every connection, so we can skip checking for
 	// those privileges directly.
-	skipRolePrivilegeCheck := hasRole(grantedRoles, "rds_superuser_role") && activateAllRolesOnLogin(ctx, r.SourceDB, logger)
+	skipRolePrivilegeCheck := hasRole(grantedRoles, "rds_superuser_role") && activateAllRolesOnLogin(ctx, src.DB, logger)
 
 	// Move operations always use force-kill (it's enabled by default in DBConfig).
 	// Check the force-kill related privileges.
@@ -118,10 +127,10 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 
 	// Verify SELECT access on performance_schema.*, which is required for the
 	// queries used by force-kill during cutover.
-	if _, err := dbconn.GetTableLocks(ctx, r.SourceDB, r.SourceTables, logger, nil); err != nil {
+	if _, err := dbconn.GetTableLocks(ctx, src.DB, r.SourceTables, logger, nil); err != nil {
 		errs = append(errs, err)
 	}
-	if _, err := dbconn.GetLockingTransactions(ctx, r.SourceDB, r.SourceTables, nil, logger, nil); err != nil {
+	if _, err := dbconn.GetLockingTransactions(ctx, src.DB, r.SourceTables, nil, logger, nil); err != nil {
 		errs = append(errs, err)
 	}
 	if !skipRolePrivilegeCheck {

--- a/pkg/move/check/privileges.go
+++ b/pkg/move/check/privileges.go
@@ -45,7 +45,7 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 
 func checkSourcePrivileges(ctx context.Context, src SourceResource, r Resources, logger *slog.Logger) error {
 	if src.DB == nil {
-		return nil // skip if no source DB connection yet (pre-run phase)
+		return errors.New("database connection is not initialized")
 	}
 
 	var foundAll, foundSuper, foundReplicationClient, foundReplicationSlave, foundDBAll, foundReload, foundConnectionAdmin, foundProcess bool

--- a/pkg/move/check/privileges_test.go
+++ b/pkg/move/check/privileges_test.go
@@ -43,8 +43,7 @@ func TestMovePrivileges(t *testing.T) {
 	defer utils.CloseAndLog(lowPrivDB)
 
 	r := Resources{
-		SourceDB:     lowPrivDB,
-		SourceConfig: sourceConfig,
+		Sources: []SourceResource{{DB: lowPrivDB, Config: sourceConfig}},
 	}
 	err = privilegesCheck(t.Context(), r, slog.Default())
 	assert.Error(t, err) // privileges fail, since user has nothing granted.
@@ -82,15 +81,14 @@ func TestMovePrivileges(t *testing.T) {
 	lowPrivDB, err = sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s", config.User, config.Passwd, config.Addr, config.DBName))
 	assert.NoError(t, err)
 	defer utils.CloseAndLog(lowPrivDB)
-	r.SourceDB = lowPrivDB
+	r.Sources = []SourceResource{{DB: lowPrivDB, Config: sourceConfig}}
 
 	err = privilegesCheck(t.Context(), r, slog.Default())
 	assert.NoError(t, err) // all privileges granted, should pass now
 
 	// Test the root user
 	r = Resources{
-		SourceDB:     db,
-		SourceConfig: sourceConfig,
+		Sources: []SourceResource{{DB: db, Config: sourceConfig}},
 	}
 	err = privilegesCheck(t.Context(), r, slog.Default())
 	assert.NoError(t, err) // root privileges work fine
@@ -163,8 +161,7 @@ func TestMovePrivilegesWithRDSSuperuserRole(t *testing.T) {
 	defer utils.CloseAndLog(lowPrivDB)
 
 	r := Resources{
-		SourceDB:     lowPrivDB,
-		SourceConfig: sourceConfig,
+		Sources: []SourceResource{{DB: lowPrivDB, Config: sourceConfig}},
 	}
 
 	err = privilegesCheck(t.Context(), r, slog.Default())
@@ -180,7 +177,7 @@ func TestMovePrivilegesWithRDSSuperuserRole(t *testing.T) {
 	require.NoError(t, lowPrivDB.Close())
 	lowPrivDB, err = sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s", config.User, config.Passwd, config.Addr, config.DBName))
 	require.NoError(t, err)
-	r.SourceDB = lowPrivDB
+	r.Sources = []SourceResource{{DB: lowPrivDB, Config: sourceConfig}}
 
 	err = privilegesCheck(t.Context(), r, slog.Default())
 	assert.NoError(t, err, "should pass when activate_all_roles_on_login=ON and rds_superuser_role is granted")

--- a/pkg/move/check/resume_state.go
+++ b/pkg/move/check/resume_state.go
@@ -29,21 +29,29 @@ func resumeStateCheck(ctx context.Context, r Resources, logger *slog.Logger) err
 		return errors.New("no source tables available for resume validation")
 	}
 
-	// Check 1: Verify checkpoint table exists on source
+	if len(r.Sources) == 0 {
+		return errors.New("no sources configured for resume validation")
+	}
+
+	// Check 1: Verify checkpoint table exists on sources[0] (by convention).
+	src0 := r.Sources[0]
+	if src0.DB == nil || src0.Config == nil {
+		return errors.New("source[0] database connection or config is not initialized")
+	}
 	checkpointTableName := "_spirit_checkpoint"
 	var checkpointExists int
-	err := r.SourceDB.QueryRowContext(ctx,
+	err := src0.DB.QueryRowContext(ctx,
 		"SELECT 1 FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?",
-		r.SourceConfig.DBName, checkpointTableName).Scan(&checkpointExists)
+		src0.Config.DBName, checkpointTableName).Scan(&checkpointExists)
 	if err == sql.ErrNoRows {
-		return fmt.Errorf("checkpoint table '%s.%s' does not exist; cannot resume", r.SourceConfig.DBName, checkpointTableName)
+		return fmt.Errorf("checkpoint table '%s.%s' does not exist; cannot resume", src0.Config.DBName, checkpointTableName)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to check for checkpoint table: %w", err)
 	}
 
 	logger.Info("checkpoint table exists, validating target tables for resume",
-		"checkpoint_table", fmt.Sprintf("%s.%s", r.SourceConfig.DBName, checkpointTableName))
+		"checkpoint_table", fmt.Sprintf("%s.%s", src0.Config.DBName, checkpointTableName))
 
 	// Check 2: Verify all source tables have corresponding target tables with matching schema
 	for _, sourceTable := range r.SourceTables {

--- a/pkg/move/check/resume_state_test.go
+++ b/pkg/move/check/resume_state_test.go
@@ -53,8 +53,7 @@ func TestResumeStateCheck(t *testing.T) {
 	// Test 1: No checkpoint table should fail
 	t.Run("no checkpoint table fails", func(t *testing.T) {
 		r := Resources{
-			SourceDB:     sourceDB,
-			SourceConfig: sourceConfig,
+			Sources: []SourceResource{{DB: sourceDB, Config: sourceConfig}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -85,8 +84,7 @@ func TestResumeStateCheck(t *testing.T) {
 	// Test 2: Checkpoint exists but no target tables should fail
 	t.Run("checkpoint exists but no target tables fails", func(t *testing.T) {
 		r := Resources{
-			SourceDB:     sourceDB,
-			SourceConfig: sourceConfig,
+			Sources: []SourceResource{{DB: sourceDB, Config: sourceConfig}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -111,8 +109,7 @@ func TestResumeStateCheck(t *testing.T) {
 	// Test 3: Checkpoint and matching target tables should pass
 	t.Run("checkpoint and matching target tables pass", func(t *testing.T) {
 		r := Resources{
-			SourceDB:     sourceDB,
-			SourceConfig: sourceConfig,
+			Sources: []SourceResource{{DB: sourceDB, Config: sourceConfig}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -136,8 +133,7 @@ func TestResumeStateCheck(t *testing.T) {
 			_, _ = targetDB.ExecContext(t.Context(), "DROP TABLE IF EXISTS resume_tgt.test_table")
 		}()
 		r := Resources{
-			SourceDB:     sourceDB,
-			SourceConfig: sourceConfig,
+			Sources: []SourceResource{{DB: sourceDB, Config: sourceConfig}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -155,8 +151,7 @@ func TestResumeStateCheck(t *testing.T) {
 	// Test 5: No source tables should fail
 	t.Run("no source tables fails", func(t *testing.T) {
 		r := Resources{
-			SourceDB:     sourceDB,
-			SourceConfig: sourceConfig,
+			Sources: []SourceResource{{DB: sourceDB, Config: sourceConfig}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -198,8 +193,7 @@ func TestResumeStateCheck(t *testing.T) {
 		}
 
 		r := Resources{
-			SourceDB:     sourceDB,
-			SourceConfig: sourceConfig,
+			Sources: []SourceResource{{DB: sourceDB, Config: sourceConfig}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -231,8 +225,7 @@ func TestResumeStateCheck(t *testing.T) {
 		}
 
 		r := Resources{
-			SourceDB:     sourceDB,
-			SourceConfig: sourceConfig,
+			Sources: []SourceResource{{DB: sourceDB, Config: sourceConfig}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,

--- a/pkg/move/check/target_state_test.go
+++ b/pkg/move/check/target_state_test.go
@@ -49,7 +49,7 @@ func TestTargetStateCheck(t *testing.T) {
 	// Test 1: Empty target should pass
 	t.Run("empty target passes", func(t *testing.T) {
 		r := Resources{
-			SourceDB: sourceDB,
+			Sources: []SourceResource{{DB: sourceDB}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -71,7 +71,7 @@ func TestTargetStateCheck(t *testing.T) {
 		}()
 
 		r := Resources{
-			SourceDB: sourceDB,
+			Sources: []SourceResource{{DB: sourceDB}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -97,7 +97,7 @@ func TestTargetStateCheck(t *testing.T) {
 		}()
 
 		r := Resources{
-			SourceDB: sourceDB,
+			Sources: []SourceResource{{DB: sourceDB}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,
@@ -122,7 +122,7 @@ func TestTargetStateCheck(t *testing.T) {
 		}()
 
 		r := Resources{
-			SourceDB: sourceDB,
+			Sources: []SourceResource{{DB: sourceDB}},
 			Targets: []applier.Target{
 				{
 					DB:     targetDB,

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -719,13 +719,14 @@ func (r *Runner) SetLogger(logger *slog.Logger) {
 // runChecks wraps around check.RunChecks and adds the context of this move operation
 func (r *Runner) runChecks(ctx context.Context, scope check.ScopeFlag) error {
 	return check.RunChecks(ctx, check.Resources{
-		SourceDB:       r.source,
-		SourceConfig:   r.sourceConfig,
+		Sources: []check.SourceResource{{
+			DB:     r.source,
+			Config: r.sourceConfig,
+			DSN:    r.move.SourceDSN,
+		}},
 		Targets:        r.targets,
 		SourceTables:   r.sourceTables,
 		CreateSentinel: r.move.CreateSentinel,
-		SourceDSN:      r.move.SourceDSN,
-		TargetDSN:      r.move.TargetDSN,
 	}, r.logger, scope)
 }
 


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Part of https://github.com/block/spirit/issues/690

Replace individual SourceDB/SourceConfig/SourceDSN/TargetDSN fields with Sources []SourceResource slice in the Resources struct. This prepares the check package for N:M move operations where multiple source databases need to be validated.

All checks updated to iterate over Sources:
- configuration: validates MySQL config on all sources
- privileges: checks privileges on all sources via checkSourcePrivileges helper
- resume_state: uses Sources[0] for checkpoint validation
- target_state/table_compatibility: unchanged (use SourceTables only)

The runner wraps its single source into []SourceResource{...} for backward compatibility. No behavioral change for 1:1 moves.