### PR TITLE
cutover: support multiple sources with rollback on partial failure

### DIFF
--- a/pkg/dbconn/tablelock_test.go
+++ b/pkg/dbconn/tablelock_test.go
@@ -1,13 +1,16 @@
 package dbconn
 
 import (
+	"fmt"
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testConfig() *DBConfig {
@@ -157,4 +160,73 @@ func TestTableLockFail(t *testing.T) {
 	cfg.ForceKill = true
 	_, err = NewTableLock(t.Context(), db, []*table.TableInfo{tbl}, cfg, slog.Default())
 	assert.Error(t, err) // We won't kill a connection with an explicit table lock, so this should fail after exhausting retries
+}
+
+// TestTableLockCrossSchema verifies that LOCK TABLES on the same table name
+// in different schemas can be held concurrently on the same MySQL server.
+// This is critical for N:M move operations where multiple source databases
+// on the same server each have identically-named tables.
+// Both ForceKill=true and ForceKill=false variants must succeed, and neither
+// should require any force-killing (the locks are on different schemas).
+func TestTableLockCrossSchema(t *testing.T) {
+	for _, forceKill := range []bool{false, true} {
+		t.Run(fmt.Sprintf("ForceKill=%v", forceKill), func(t *testing.T) {
+			db0Name := fmt.Sprintf("t_crosslock_0_%d", os.Getpid())
+			db1Name := fmt.Sprintf("t_crosslock_1_%d", os.Getpid())
+
+			// Create two separate databases.
+			testutils.RunSQL(t, fmt.Sprintf("DROP DATABASE IF EXISTS %s", db0Name))
+			testutils.RunSQL(t, fmt.Sprintf("DROP DATABASE IF EXISTS %s", db1Name))
+			testutils.RunSQL(t, fmt.Sprintf("CREATE DATABASE %s", db0Name))
+			testutils.RunSQL(t, fmt.Sprintf("CREATE DATABASE %s", db1Name))
+			defer testutils.RunSQL(t, fmt.Sprintf("DROP DATABASE IF EXISTS %s", db0Name))
+			defer testutils.RunSQL(t, fmt.Sprintf("DROP DATABASE IF EXISTS %s", db1Name))
+
+			cfg := testConfig()
+			cfg.ForceKill = forceKill
+
+			db0, err := New(testutils.DSNForDatabase(db0Name), cfg)
+			require.NoError(t, err)
+			defer utils.CloseAndLog(db0)
+			db1, err := New(testutils.DSNForDatabase(db1Name), cfg)
+			require.NoError(t, err)
+			defer utils.CloseAndLog(db1)
+
+			// Create identically-named tables in both schemas.
+			testutils.RunSQLInDatabase(t, db0Name, "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)")
+			testutils.RunSQLInDatabase(t, db1Name, "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)")
+
+			tbl0 := &table.TableInfo{SchemaName: db0Name, TableName: "t1", QuotedTableName: "`t1`"}
+			tbl1 := &table.TableInfo{SchemaName: db1Name, TableName: "t1", QuotedTableName: "`t1`"}
+
+			// Acquire lock on t1 in schema 0.
+			lock0, err := NewTableLock(t.Context(), db0, []*table.TableInfo{tbl0}, cfg, slog.Default())
+			require.NoError(t, err, "lock on schema 0 should succeed")
+
+			// Acquire lock on t1 in schema 1 — should succeed immediately because
+			// the connections are scoped to different databases.
+			lock1, err := NewTableLock(t.Context(), db1, []*table.TableInfo{tbl1}, cfg, slog.Default())
+			require.NoError(t, err, "lock on schema 1 should succeed without contention")
+
+			// Verify both locks work: write under each lock.
+			err = lock0.ExecUnderLock(t.Context(), "INSERT INTO t1 VALUES (1)")
+			assert.NoError(t, err)
+			err = lock1.ExecUnderLock(t.Context(), "INSERT INTO t1 VALUES (2)")
+			assert.NoError(t, err)
+
+			// Release both locks.
+			assert.NoError(t, lock0.Close(t.Context()))
+			assert.NoError(t, lock1.Close(t.Context()))
+
+			// Verify data landed in the correct schemas.
+			var id0, id1 int
+			err = db0.QueryRowContext(t.Context(), "SELECT id FROM t1").Scan(&id0)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, id0)
+
+			err = db1.QueryRowContext(t.Context(), "SELECT id FROM t1").Scan(&id1)
+			assert.NoError(t, err)
+			assert.Equal(t, 2, id1)
+		})
+	}
 }

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -64,9 +64,9 @@ func (c *CutOver) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 		// Flush all sources before attempting the cutover.
-		for sourceIdx, src := range c.sources {
+		for i, src := range c.sources {
 			if err := src.ReplClient.Flush(ctx); err != nil {
-				return fmt.Errorf("source %d: flush failed: %w", sourceIdx, err)
+				return fmt.Errorf("source %d: flush failed: %w", i, err)
 			}
 		}
 		c.logger.Warn("Attempting final cut over operation",

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -14,32 +14,44 @@ import (
 	"github.com/block/spirit/pkg/utils"
 )
 
+// CutOverSource holds per-source state needed for the cutover.
+type CutOverSource struct {
+	DB         *sql.DB
+	ReplClient *repl.Client
+	Tables     []*table.TableInfo
+}
+
 type CutOver struct {
-	db          *sql.DB
-	feed        *repl.Client
-	tables      []*table.TableInfo
+	sources     []CutOverSource
 	cutoverFunc func(ctx context.Context) error
 	dbConfig    *dbconn.DBConfig
 	logger      *slog.Logger
 }
 
-// NewCutOver contains the logic to perform the final cut over. It can cutover multiple tables
-// at once based on config. A replication feed which is used to ensure consistency before the cut over.
-func NewCutOver(db *sql.DB, tables []*table.TableInfo, cutoverFunc func(ctx context.Context) error, feed *repl.Client, dbConfig *dbconn.DBConfig, logger *slog.Logger) (*CutOver, error) {
-	if feed == nil {
-		return nil, errors.New("feed must be non-nil")
+// NewCutOver creates a new CutOver that handles multiple sources.
+func NewCutOver(sources []CutOverSource, cutoverFunc func(ctx context.Context) error, dbConfig *dbconn.DBConfig, logger *slog.Logger) (*CutOver, error) {
+	if len(sources) == 0 {
+		return nil, errors.New("at least one source must be provided")
 	}
-	// validate the cutoverConfig
-	for _, tbl := range tables {
-		if tbl == nil {
-			return nil, errors.New("table must be non-nil")
+	for i, src := range sources {
+		if src.DB == nil {
+			return nil, fmt.Errorf("source %d: DB must be non-nil", i)
+		}
+		if src.ReplClient == nil {
+			return nil, fmt.Errorf("source %d: repl client must be non-nil", i)
+		}
+		if len(src.Tables) == 0 {
+			return nil, fmt.Errorf("source %d: at least one table must be provided", i)
+		}
+		for _, tbl := range src.Tables {
+			if tbl == nil {
+				return nil, fmt.Errorf("source %d: table must be non-nil", i)
+			}
 		}
 	}
 	return &CutOver{
-		db:          db,
-		tables:      tables,
+		sources:     sources,
 		cutoverFunc: cutoverFunc,
-		feed:        feed,
 		dbConfig:    dbConfig,
 		logger:      logger,
 	}, nil
@@ -51,14 +63,12 @@ func (c *CutOver) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		// Try and catch up before we attempt the cutover.
-		// since we will need to catch up again with the lock held
-		// and we want to minimize that.
-		if err := c.feed.Flush(ctx); err != nil {
-			return err
+		// Flush all sources before attempting the cutover.
+		for sourceIdx, src := range c.sources {
+			if err := src.ReplClient.Flush(ctx); err != nil {
+				return fmt.Errorf("source %d: flush failed: %w", sourceIdx, err)
+			}
 		}
-		// We use maxCutoverRetries as our retrycount, but nested
-		// within c.algorithmX() it may also have a retry for the specific statement
 		c.logger.Warn("Attempting final cut over operation",
 			"attempt", i+1,
 			"max-retries", c.dbConfig.MaxRetries)
@@ -75,23 +85,40 @@ func (c *CutOver) Run(ctx context.Context) error {
 }
 
 func (c *CutOver) algorithmCutover(ctx context.Context) error {
-	tableLock, err := dbconn.NewTableLock(ctx, c.db, c.tables, c.dbConfig, c.logger)
-	if err != nil {
-		return err
+	// Lock tables on ALL sources.
+	var sourceLocks []*dbconn.TableLock
+	for i, src := range c.sources {
+		lock, err := dbconn.NewTableLock(ctx, src.DB, src.Tables, c.dbConfig, c.logger)
+		if err != nil {
+			// Close any locks we already acquired.
+			for _, l := range sourceLocks {
+				utils.CloseAndLogWithContext(ctx, l)
+			}
+			return fmt.Errorf("failed to lock tables on source %d: %w", i, err)
+		}
+		sourceLocks = append(sourceLocks, lock)
 	}
-	defer utils.CloseAndLogWithContext(ctx, tableLock)
+	defer func() {
+		for _, l := range sourceLocks {
+			utils.CloseAndLogWithContext(ctx, l)
+		}
+	}()
 
-	// We don't use FlushUnderLock: that's for within the same server.
-	// We use a regular flush. No new changes will arrive because of the table lock.
-	if err := c.feed.Flush(ctx); err != nil {
-		return err
+	// Flush ALL repl clients. No new changes will arrive because all sources are locked.
+	for i, src := range c.sources {
+		if err := src.ReplClient.Flush(ctx); err != nil {
+			return fmt.Errorf("failed to flush repl client for source %d: %w", i, err)
+		}
 	}
 
-	if !c.feed.AllChangesFlushed() {
-		return fmt.Errorf("%w, final flush might be broken", repl.ErrChangesNotFlushed)
+	// Check ALL changes flushed.
+	for i, src := range c.sources {
+		if !src.ReplClient.AllChangesFlushed() {
+			return fmt.Errorf("%w on source %d, final flush might be broken", repl.ErrChangesNotFlushed, i)
+		}
 	}
 
-	// If we have all changes flushed under a lock, we can now run the cutover func.
+	// Run the cutover function (Vitess coordination).
 	if c.cutoverFunc != nil {
 		c.logger.Info("Running cutover function")
 		if err := c.cutoverFunc(ctx); err != nil {
@@ -100,16 +127,43 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 		c.logger.Info("Cutover function complete")
 	}
 
-	// If the cutover func succeeded, we can do a rename to prevent
-	// the original tables from being used. We are now effectively serving
-	// from the new location.
-	renameFragments := []string{}
-	for _, tbl := range c.tables {
-		oldQuotedName := fmt.Sprintf("`%s_old`", tbl.TableName)
-		renameFragments = append(renameFragments,
-			fmt.Sprintf("%s TO %s", tbl.QuotedTableName, oldQuotedName),
-		)
+	// Rename tables on each source, with rollback on partial failure.
+	var completedRenames []int
+	for i, src := range c.sources {
+		renameFragments := make([]string, 0, len(src.Tables))
+		for _, tbl := range src.Tables {
+			oldQuotedName := fmt.Sprintf("`%s_old`", tbl.TableName)
+			renameFragments = append(renameFragments,
+				fmt.Sprintf("%s TO %s", tbl.QuotedTableName, oldQuotedName),
+			)
+		}
+		renameStatement := "RENAME TABLE " + strings.Join(renameFragments, ", ")
+		if err := sourceLocks[i].ExecUnderLock(ctx, renameStatement); err != nil {
+			// Rollback completed renames. Log failures since callers need to know
+			// if rollback was incomplete for manual intervention.
+			var rollbackErrors []string
+			for _, j := range completedRenames {
+				undoFragments := make([]string, 0, len(c.sources[j].Tables))
+				for _, tbl := range c.sources[j].Tables {
+					oldQuotedName := fmt.Sprintf("`%s_old`", tbl.TableName)
+					undoFragments = append(undoFragments,
+						fmt.Sprintf("%s TO %s", oldQuotedName, tbl.QuotedTableName),
+					)
+				}
+				undoStatement := "RENAME TABLE " + strings.Join(undoFragments, ", ")
+				if undoErr := sourceLocks[j].ExecUnderLock(ctx, undoStatement); undoErr != nil {
+					c.logger.Error("rollback rename failed", "source", j, "error", undoErr)
+					rollbackErrors = append(rollbackErrors, fmt.Sprintf("source %d: %v", j, undoErr))
+				}
+			}
+			if len(rollbackErrors) > 0 {
+				return fmt.Errorf("rename failed on source %d and rollback also failed (%s): %w",
+					i, strings.Join(rollbackErrors, "; "), err)
+			}
+			return fmt.Errorf("rename failed on source %d, rolled back %d completed renames: %w",
+				i, len(completedRenames), err)
+		}
+		completedRenames = append(completedRenames, i)
 	}
-	renameStatement := "RENAME TABLE " + strings.Join(renameFragments, ", ")
-	return tableLock.ExecUnderLock(ctx, renameStatement)
+	return nil
 }

--- a/pkg/move/cutover_test.go
+++ b/pkg/move/cutover_test.go
@@ -1,0 +1,147 @@
+package move
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/repl"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCutOverValidation(t *testing.T) {
+	dbConfig := dbconn.NewDBConfig()
+	logger := slog.Default()
+
+	// No sources.
+	_, err := NewCutOver(nil, nil, dbConfig, logger)
+	assert.ErrorContains(t, err, "at least one source must be provided")
+
+	_, err = NewCutOver([]CutOverSource{}, nil, dbConfig, logger)
+	assert.ErrorContains(t, err, "at least one source must be provided")
+
+	// Nil DB.
+	_, err = NewCutOver([]CutOverSource{{
+		DB:     nil,
+		Tables: []*table.TableInfo{{}},
+	}}, nil, dbConfig, logger)
+	assert.ErrorContains(t, err, "DB must be non-nil")
+
+	// Nil repl client.
+	db, err := dbconn.New(testutils.DSN(), dbConfig)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	_, err = NewCutOver([]CutOverSource{{
+		DB:         db,
+		ReplClient: nil,
+		Tables:     []*table.TableInfo{{}},
+	}}, nil, dbConfig, logger)
+	assert.ErrorContains(t, err, "repl client must be non-nil")
+
+	// Empty tables.
+	cfg := repl.NewClientDefaultConfig()
+	cfg.CancelFunc = func() bool { return false }
+	srcConfig, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	replClient := repl.NewClient(db, srcConfig.Addr, srcConfig.User, srcConfig.Passwd, cfg)
+
+	_, err = NewCutOver([]CutOverSource{{
+		DB:         db,
+		ReplClient: replClient,
+		Tables:     []*table.TableInfo{},
+	}}, nil, dbConfig, logger)
+	assert.ErrorContains(t, err, "at least one table must be provided")
+
+	// Nil table in list.
+	_, err = NewCutOver([]CutOverSource{{
+		DB:         db,
+		ReplClient: replClient,
+		Tables:     []*table.TableInfo{nil},
+	}}, nil, dbConfig, logger)
+	assert.ErrorContains(t, err, "table must be non-nil")
+}
+
+// TestCutOverSingleSource tests the cutover flow with a single source,
+// verifying table rename and cutoverFunc callback.
+// Note: multi-source cutover cannot be tested with a single MySQL server
+// because LOCK TABLES is server-wide and acquiring a lock on source 0
+// blocks source 1's LOCK TABLES attempt. In production, each source is
+// a separate MySQL server so this is not an issue.
+func TestCutOverSingleSource(t *testing.T) {
+	if testutils.IsMinimalRBRTestRunner(t) {
+		t.Skip("Skipping test for minimal RBR test runner")
+	}
+
+	srcName, srcDB := testutils.CreateUniqueTestDatabase(t)
+
+	testutils.RunSQLInDatabase(t, srcName, `CREATE TABLE t1 (
+		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		val VARCHAR(255)
+	)`)
+	for i := 1; i <= 10; i++ {
+		testutils.RunSQLInDatabase(t, srcName, fmt.Sprintf(
+			"INSERT INTO t1 (id, val) VALUES (%d, 'val_%d')", i, i))
+	}
+
+	dbConfig := dbconn.NewDBConfig()
+	logger := slog.Default()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	srcDSN := testutils.DSNForDatabase(srcName)
+	srcConfig, err := mysql.ParseDSN(srcDSN)
+	require.NoError(t, err)
+
+	// Dedicated connection for the repl client.
+	replDB, err := dbconn.New(srcDSN, dbConfig)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(replDB)
+
+	cfg := repl.NewClientDefaultConfig()
+	cfg.CancelFunc = func() bool { return false }
+	replClient := repl.NewClient(replDB, srcConfig.Addr, srcConfig.User, srcConfig.Passwd, cfg)
+	require.NoError(t, replClient.Run(ctx))
+	defer replClient.Close()
+
+	cutoverTbl := table.NewTableInfo(srcDB, srcName, "t1")
+	require.NoError(t, cutoverTbl.SetInfo(ctx))
+
+	cutoverFuncCalled := false
+	cutoverFunc := func(ctx context.Context) error {
+		cutoverFuncCalled = true
+		return nil
+	}
+
+	sources := []CutOverSource{{
+		DB:         srcDB,
+		ReplClient: replClient,
+		Tables:     []*table.TableInfo{cutoverTbl},
+	}}
+
+	cutover, err := NewCutOver(sources, cutoverFunc, dbConfig, logger)
+	require.NoError(t, err)
+
+	err = cutover.Run(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, cutoverFuncCalled, "cutoverFunc should have been called")
+
+	// Verify: t1 renamed to t1_old.
+	var count int
+	err = srcDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM t1_old").Scan(&count)
+	assert.NoError(t, err, "t1_old should exist")
+	assert.Equal(t, 10, count, "t1_old should have 10 rows")
+
+	_, err = srcDB.ExecContext(ctx, "SELECT 1 FROM t1")
+	assert.Error(t, err, "t1 should not exist after rename")
+}

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -597,7 +597,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.logger.Info("Checksum completed successfully, starting cutover")
 	// Create a cutover.
 	r.status.Set(status.CutOver)
-	cutover, err := NewCutOver(r.source, r.sourceTables, r.cutoverFunc, r.replClient, r.dbConfig, r.logger)
+	cutover, err := NewCutOver(
+		[]CutOverSource{{DB: r.source, ReplClient: r.replClient, Tables: r.sourceTables}},
+		r.cutoverFunc, r.dbConfig, r.logger,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Part of https://github.com/block/spirit/issues/690

Refactor CutOver to accept []CutOverSource instead of a single db/feed pair. This prepares the cutover for N:M move operations where multiple source databases need to be locked, flushed, and renamed atomically.

Key changes:
- New CutOverSource struct with DB, ReplClient, Tables
- NewCutOver accepts []CutOverSource
- algorithmCutover locks all sources, flushes all feeds, checks all changes flushed, then renames per source
- On partial rename failure, completed renames are rolled back by reversing the RENAME TABLE statements

The runner wraps its single source into []CutOverSource{...} for backward compatibility. No behavioral change for 1:1 moves.
