### PR TITLE
fix parse timestamp precision

### DIFF
--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -22,6 +22,12 @@ func TestDiff(t *testing.T) {
 			expected: "",
 		},
 		{
+			name:     "NoChanges_DatetimeWithPrecision",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
+			expected: "",
+		},
+		{
 			name:     "AddColumn",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT)",
@@ -192,6 +198,12 @@ func TestDiff(t *testing.T) {
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME DEFAULT NOW())",
 			expected: "ALTER TABLE `t1` MODIFY COLUMN `created_at` datetime NULL DEFAULT current_timestamp",
+		},
+		{
+			name:     "DefaultValueFunction_CurrentTimestampWithPrecision",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME(3))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `created_at` datetime(3) NOT NULL DEFAULT current_timestamp(3)",
 		},
 		{
 			name:     "DefaultValueFunction_UUID",

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -1040,8 +1040,22 @@ func (ct *CreateTable) parseExpression(expr ast.ExprNode) any {
 	// Handle different expression types
 	switch e := expr.(type) {
 	case *ast.FuncCallExpr:
-		// Handle function calls like CURRENT_TIMESTAMP
-		return e.FnName.L
+		// Handle function calls like CURRENT_TIMESTAMP, CURRENT_TIMESTAMP(3), UUID(), etc.
+		// We use Restore to preserve function arguments (e.g. precision in CURRENT_TIMESTAMP(3)).
+		// For CURRENT_TIMESTAMP with no args, Restore produces "CURRENT_TIMESTAMP()" but
+		// MySQL's canonical form (SHOW CREATE TABLE) omits the parens, so we normalize it.
+		var sb strings.Builder
+		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreStringWithoutCharset, &sb)
+		if err := e.Restore(rCtx); err != nil {
+			return e.FnName.L // fallback to function name on error
+		}
+		restored := sb.String()
+		// Normalize: MySQL's canonical SHOW CREATE TABLE uses "CURRENT_TIMESTAMP" (no parens)
+		// when there is no fractional seconds precision, but the parser's Restore always adds "()".
+		if len(e.Args) == 0 && strings.HasSuffix(restored, "()") {
+			restored = strings.TrimSuffix(restored, "()")
+		}
+		return strings.ToLower(restored)
 	default:
 		// For other types, fall back to text representation
 		var sb strings.Builder

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -1792,6 +1792,57 @@ func TestRemoveSecondaryIndexes_ErrorCases(t *testing.T) {
 	}
 }
 
+// TestCurrentTimestampPrecision tests that CURRENT_TIMESTAMP with fractional seconds
+// precision (e.g. CURRENT_TIMESTAMP(3)) is correctly preserved during parsing.
+// This is critical for DATETIME(3)/TIMESTAMP(3) columns where MySQL requires the
+// precision to match between the column type and the default value.
+// See: https://github.com/block/spirit/issues/XXX
+func TestCurrentTimestampPrecision(t *testing.T) {
+	testCases := []struct {
+		name            string
+		sql             string
+		columnName      string
+		expectedDefault string
+	}{
+		{
+			name:            "CURRENT_TIMESTAMP without precision",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
+			columnName:      "created_at",
+			expectedDefault: "current_timestamp",
+		},
+		{
+			name:            "CURRENT_TIMESTAMP(3) with millisecond precision",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
+			columnName:      "created_at",
+			expectedDefault: "current_timestamp(3)",
+		},
+		{
+			name:            "CURRENT_TIMESTAMP(6) with microsecond precision",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6))",
+			columnName:      "created_at",
+			expectedDefault: "current_timestamp(6)",
+		},
+		{
+			name:            "NOW() normalized to CURRENT_TIMESTAMP",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, created_at TIMESTAMP DEFAULT NOW())",
+			columnName:      "created_at",
+			expectedDefault: "current_timestamp",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct, err := ParseCreateTable(tc.sql)
+			require.NoError(t, err)
+
+			col := ct.Columns.ByName(tc.columnName)
+			require.NotNil(t, col, "column %q not found", tc.columnName)
+			require.NotNil(t, col.Default, "column %q has no default", tc.columnName)
+			assert.Equal(t, tc.expectedDefault, *col.Default)
+		})
+	}
+}
+
 // TestBinaryTypeDetection tests that binary types are correctly detected and converted
 // from their text equivalents when the binary flag is set
 func TestBinaryTypeDetection(t *testing.T) {


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Fix restore of DATETIME default with precision