### PR TITLE
Fix expression defaults being quoted as string literals

### DIFF
--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -1054,12 +1054,13 @@ func formatColumnDefinition(col *Column) string {
 	// Default value
 	if col.Default != nil {
 		defaultVal := *col.Default
-		if col.DefaultIsExpr {
+		switch {
+		case col.DefaultIsExpr:
 			// Expression defaults must be wrapped in parentheses, e.g. DEFAULT (json_object())
 			parts = append(parts, fmt.Sprintf("DEFAULT (%s)", defaultVal))
-		} else if needsQuotes(defaultVal) {
+		case needsQuotes(defaultVal):
 			parts = append(parts, fmt.Sprintf("DEFAULT '%s'", sqlescape.EscapeString(defaultVal)))
-		} else {
+		default:
 			parts = append(parts, fmt.Sprintf("DEFAULT %s", defaultVal))
 		}
 	}

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -738,6 +738,9 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	if !stringPtrEqual(sourceDefault, targetDefault) {
 		return false
 	}
+	if a.DefaultIsExpr != b.DefaultIsExpr {
+		return false
+	}
 	if a.AutoInc != b.AutoInc {
 		return false
 	}
@@ -832,6 +835,9 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 		}
 	}
 	if !stringPtrEqual(sourceDefault, targetDefault) {
+		return false
+	}
+	if a.DefaultIsExpr != b.DefaultIsExpr {
 		return false
 	}
 	if a.AutoInc != b.AutoInc {
@@ -1047,9 +1053,11 @@ func formatColumnDefinition(col *Column) string {
 
 	// Default value
 	if col.Default != nil {
-		// Check if it's a function/expression (no quotes) or a literal value (needs quotes)
 		defaultVal := *col.Default
-		if needsQuotes(defaultVal) {
+		if col.DefaultIsExpr {
+			// Expression defaults must be wrapped in parentheses, e.g. DEFAULT (json_object())
+			parts = append(parts, fmt.Sprintf("DEFAULT (%s)", defaultVal))
+		} else if needsQuotes(defaultVal) {
 			parts = append(parts, fmt.Sprintf("DEFAULT '%s'", sqlescape.EscapeString(defaultVal)))
 		} else {
 			parts = append(parts, fmt.Sprintf("DEFAULT %s", defaultVal))

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -865,6 +865,25 @@ func TestDiff(t *testing.T) {
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, metadata JSON NOT NULL DEFAULT (json_object()))",
 			expected: "ALTER TABLE `t1` MODIFY COLUMN `metadata` json NOT NULL DEFAULT (json_object())",
 		},
+		{
+			name: "AddJSONColumnWithExpressionDefaultToExistingTable",
+			source: `CREATE TABLE t1 (
+				id bigint PRIMARY KEY AUTO_INCREMENT,
+				name varchar(255) NOT NULL,
+				details json,
+				customer_id bigint NOT NULL,
+				UNIQUE KEY unq_name (name)
+			) ENGINE InnoDB DEFAULT CHARSET utf8mb4`,
+			target: `CREATE TABLE t1 (
+				id bigint PRIMARY KEY AUTO_INCREMENT,
+				name varchar(255) NOT NULL,
+				details json,
+				customer_id bigint NOT NULL,
+				extra json NOT NULL DEFAULT (json_object()),
+				UNIQUE KEY unq_name (name)
+			) ENGINE InnoDB DEFAULT CHARSET utf8mb4`,
+			expected: "ALTER TABLE `t1` ADD COLUMN `extra` json NOT NULL DEFAULT (json_object())",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -209,7 +209,7 @@ func TestDiff(t *testing.T) {
 			name:     "DefaultValueFunction_UUID",
 			source:   "CREATE TABLE t1 (id VARCHAR(36) PRIMARY KEY, name VARCHAR(100))",
 			target:   "CREATE TABLE t1 (id VARCHAR(36) PRIMARY KEY DEFAULT (UUID()), name VARCHAR(100))",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` varchar(36) NOT NULL DEFAULT 'uuid'",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` varchar(36) NOT NULL DEFAULT (uuid())",
 		},
 		{
 			name: "MultipleChangesComplex",
@@ -840,6 +840,30 @@ func TestDiff(t *testing.T) {
 			source:   "CREATE TABLE `t1` (\n  `version` varchar(50) NOT NULL,\n  PRIMARY KEY (`version`)\n)",
 			target:   "CREATE TABLE `t1` (\n  `version` varchar(50) NOT NULL,\n  PRIMARY KEY `version` (`version`)\n)",
 			expected: "",
+		},
+		{
+			name:     "AddJSONColumnWithExpressionDefault",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, metadata JSON NOT NULL DEFAULT (json_object()))",
+			expected: "ALTER TABLE `t1` ADD COLUMN `metadata` json NOT NULL DEFAULT (json_object())",
+		},
+		{
+			name:     "AddJSONColumnWithJsonArrayDefault",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, tags JSON NOT NULL DEFAULT (json_array()))",
+			expected: "ALTER TABLE `t1` ADD COLUMN `tags` json NOT NULL DEFAULT (json_array())",
+		},
+		{
+			name:     "NoChanges_JSONColumnWithExpressionDefault",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, metadata JSON NOT NULL DEFAULT (json_object()))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, metadata JSON NOT NULL DEFAULT (json_object()))",
+			expected: "",
+		},
+		{
+			name:     "ModifyColumnToAddJSONExpressionDefault",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, metadata JSON NULL)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, metadata JSON NOT NULL DEFAULT (json_object()))",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `metadata` json NOT NULL DEFAULT (json_object())",
 		},
 	}
 

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -31,24 +31,25 @@ type CreateTable struct {
 
 // Column represents a table column definition
 type Column struct {
-	Raw        *ast.ColumnDef    `json:"-"`
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	Length     *int              `json:"length,omitempty"`
-	Precision  *int              `json:"precision,omitempty"`
-	Scale      *int              `json:"scale,omitempty"`
-	Unsigned   *bool             `json:"unsigned,omitempty"`
-	EnumValues []string          `json:"enum_values,omitempty"` // Permitted values for ENUM type
-	SetValues  []string          `json:"set_values,omitempty"`  // Permitted values for SET type
-	Nullable   bool              `json:"nullable"`
-	Default    *string           `json:"default,omitempty"`
-	AutoInc    bool              `json:"auto_increment"`
-	PrimaryKey bool              `json:"primary_key"`
-	Unique     bool              `json:"unique"`
-	Comment    *string           `json:"comment,omitempty"`
-	Charset    *string           `json:"charset,omitempty"`
-	Collation  *string           `json:"collation,omitempty"`
-	Options    map[string]string `json:"options,omitempty"`
+	Raw           *ast.ColumnDef    `json:"-"`
+	Name          string            `json:"name"`
+	Type          string            `json:"type"`
+	Length        *int              `json:"length,omitempty"`
+	Precision     *int              `json:"precision,omitempty"`
+	Scale         *int              `json:"scale,omitempty"`
+	Unsigned      *bool             `json:"unsigned,omitempty"`
+	EnumValues    []string          `json:"enum_values,omitempty"` // Permitted values for ENUM type
+	SetValues     []string          `json:"set_values,omitempty"`  // Permitted values for SET type
+	Nullable      bool              `json:"nullable"`
+	Default       *string           `json:"default,omitempty"`
+	DefaultIsExpr bool              `json:"default_is_expr,omitempty"` // true when default is an expression (needs parens), e.g. DEFAULT (json_object())
+	AutoInc       bool              `json:"auto_increment"`
+	PrimaryKey    bool              `json:"primary_key"`
+	Unique        bool              `json:"unique"`
+	Comment       *string           `json:"comment,omitempty"`
+	Charset       *string           `json:"charset,omitempty"`
+	Collation     *string           `json:"collation,omitempty"`
+	Options       map[string]string `json:"options,omitempty"`
 }
 
 // IndexColumn represents a column or expression in an index
@@ -513,6 +514,11 @@ func (ct *CreateTable) parseColumn(col *ast.ColumnDef) Column {
 			column.Unique = true
 		case ast.ColumnOptionDefaultValue:
 			if opt.Expr != nil {
+				// Detect expression defaults: the TiDB parser wraps non-CURRENT_TIMESTAMP
+				// function calls in outer parentheses (e.g., DEFAULT (json_object())).
+				// We track this so we can reproduce the correct syntax when generating ALTERs.
+				column.DefaultIsExpr = isExpressionDefault(opt.Expr)
+
 				defaultVal := ct.parseExpression(opt.Expr)
 				if defaultStr, ok := defaultVal.(string); ok && defaultStr != "" {
 					// Remove surrounding quotes if present for string literals
@@ -1031,6 +1037,31 @@ func (ct *CreateTable) parseSubPartitionDefinition(sub *ast.SubPartitionDefiniti
 	return subDef
 }
 
+// isExpressionDefault returns true when the default value expression should be
+// wrapped in parentheses in the generated DDL. MySQL requires expression defaults
+// (as opposed to literal defaults) to be enclosed in parens, e.g. DEFAULT (json_object()).
+// This mirrors the logic in the TiDB parser's ColumnOption.Restore for ColumnOptionDefaultValue:
+// non-CURRENT_TIMESTAMP function calls and column name expressions get outer parentheses.
+func isExpressionDefault(expr ast.ExprNode) bool {
+	if expr == nil {
+		return false
+	}
+	switch e := expr.(type) {
+	case *ast.FuncCallExpr:
+		// CURRENT_TIMESTAMP (and aliases NOW, LOCALTIME, etc.) are literal-style defaults
+		// that don't need parens. Everything else is an expression default.
+		switch e.FnName.L {
+		case "current_timestamp", "now", "localtime", "localtimestamp", "utc_timestamp":
+			return false
+		}
+		return true
+	case *ast.ColumnNameExpr:
+		return true
+	default:
+		return false
+	}
+}
+
 // parseExpression converts an expression to a string representation
 func (ct *CreateTable) parseExpression(expr ast.ExprNode) any {
 	if expr == nil {
@@ -1042,8 +1073,6 @@ func (ct *CreateTable) parseExpression(expr ast.ExprNode) any {
 	case *ast.FuncCallExpr:
 		// Handle function calls like CURRENT_TIMESTAMP, CURRENT_TIMESTAMP(3), UUID(), etc.
 		// We use Restore to preserve function arguments (e.g. precision in CURRENT_TIMESTAMP(3)).
-		// For CURRENT_TIMESTAMP with no args, Restore produces "CURRENT_TIMESTAMP()" but
-		// MySQL's canonical form (SHOW CREATE TABLE) omits the parens, so we normalize it.
 		var sb strings.Builder
 		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreStringWithoutCharset, &sb)
 		if err := e.Restore(rCtx); err != nil {
@@ -1052,7 +1081,12 @@ func (ct *CreateTable) parseExpression(expr ast.ExprNode) any {
 		restored := sb.String()
 		// Normalize: MySQL's canonical SHOW CREATE TABLE uses "CURRENT_TIMESTAMP" (no parens)
 		// when there is no fractional seconds precision, but the parser's Restore always adds "()".
-		if len(e.Args) == 0 && strings.HasSuffix(restored, "()") {
+		// We only strip parens for timestamp-family functions; other functions like json_object()
+		// need to keep their parens as they represent actual function calls.
+		name := strings.ToUpper(e.FnName.L)
+		isTimestampFunc := name == "CURRENT_TIMESTAMP" || name == "NOW" ||
+			name == "LOCALTIME" || name == "LOCALTIMESTAMP" || name == "UTC_TIMESTAMP"
+		if isTimestampFunc && len(e.Args) == 0 && strings.HasSuffix(restored, "()") {
 			restored = strings.TrimSuffix(restored, "()")
 		}
 		return strings.ToLower(restored)

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -1843,6 +1843,67 @@ func TestCurrentTimestampPrecision(t *testing.T) {
 	}
 }
 
+// TestExpressionDefaultParsing tests that expression defaults (e.g., DEFAULT (json_object()))
+// are correctly parsed with DefaultIsExpr=true, while literal defaults remain DefaultIsExpr=false.
+func TestExpressionDefaultParsing(t *testing.T) {
+	testCases := []struct {
+		name            string
+		sql             string
+		columnName      string
+		expectedDefault string
+		expectedIsExpr  bool
+	}{
+		{
+			name:            "json_object expression default",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, metadata JSON NOT NULL DEFAULT (json_object()))",
+			columnName:      "metadata",
+			expectedDefault: "json_object()",
+			expectedIsExpr:  true,
+		},
+		{
+			name:            "json_array expression default",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, tags JSON NOT NULL DEFAULT (json_array()))",
+			columnName:      "tags",
+			expectedDefault: "json_array()",
+			expectedIsExpr:  true,
+		},
+		{
+			name:            "CURRENT_TIMESTAMP is not an expression default",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
+			columnName:      "created_at",
+			expectedDefault: "current_timestamp",
+			expectedIsExpr:  false,
+		},
+		{
+			name:            "string literal is not an expression default",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100) DEFAULT 'hello')",
+			columnName:      "name",
+			expectedDefault: "hello",
+			expectedIsExpr:  false,
+		},
+		{
+			name:            "UUID expression default",
+			sql:             "CREATE TABLE t1 (id INT PRIMARY KEY, uid VARCHAR(36) NOT NULL DEFAULT (uuid()))",
+			columnName:      "uid",
+			expectedDefault: "uuid()",
+			expectedIsExpr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct, err := ParseCreateTable(tc.sql)
+			require.NoError(t, err)
+
+			col := ct.Columns.ByName(tc.columnName)
+			require.NotNil(t, col, "column %q not found", tc.columnName)
+			require.NotNil(t, col.Default, "column %q has no default", tc.columnName)
+			assert.Equal(t, tc.expectedDefault, *col.Default)
+			assert.Equal(t, tc.expectedIsExpr, col.DefaultIsExpr, "DefaultIsExpr mismatch for %q", tc.columnName)
+		})
+	}
+}
+
 // TestBinaryTypeDetection tests that binary types are correctly detected and converted
 // from their text equivalents when the binary flag is set
 func TestBinaryTypeDetection(t *testing.T) {


### PR DESCRIPTION
## What's this?

Fixes expression defaults like `json_object()`, `json_array()`, and `uuid()` being incorrectly quoted as string literals in generated ALTER statements.

Before: `ALTER TABLE t1 ADD COLUMN metadata json NOT NULL DEFAULT 'json_object()'` (errno 1101)
After: `ALTER TABLE t1 ADD COLUMN metadata json NOT NULL DEFAULT (json_object())`

## How it works

- Adds `DefaultIsExpr` bool to the `Column` struct to track whether a default is an expression vs literal
- During parsing, inspects the TiDB AST node: non-timestamp `FuncCallExpr` nodes (json_object, json_array, uuid, etc.) are flagged as expression defaults
- `formatColumnDefinition` uses `DEFAULT (expr)` for expression defaults instead of `DEFAULT 'expr'`
- Also fixes `parseExpression` stripping `()` from all zero-arg functions — now only strips for timestamp-family functions where MySQL's canonical form omits parens
---
_Most of this was written by Claude Code — I just provided direction._