### PR TITLE
feat(migration): add checkpoint max age to prevent resuming stale checkpoints

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -54,6 +54,8 @@ type Migration struct {
 	// using INSERT IGNORE .. SELECT. This is also required for cross-server moves.
 	Buffered bool `name:"buffered" help:"Use the buffered copier based on the lock-free DBLog algorithm" optional:"" default:"false"`
 
+	CheckpointMaxAge time.Duration `name:"checkpoint-max-age" help:"Maximum age of a checkpoint before refusing to resume from it" optional:"" default:"168h"`
+
 	// Hidden options for now (supports more obscure cash/sq usecases)
 	InterpolateParams bool `name:"interpolate-params" help:"Enable interpolate params for DSN" optional:"" default:"false" hidden:""`
 	// Used for tests so we can concurrently execute without issues even though
@@ -103,6 +105,9 @@ func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, er
 	}
 	if m.ReplicaMaxLag == 0 {
 		m.ReplicaMaxLag = 120 * time.Second
+	}
+	if m.CheckpointMaxAge == 0 {
+		m.CheckpointMaxAge = 7 * 24 * time.Hour // 7 days
 	}
 
 	if err := m.normalizeConnectionOptions(); err != nil {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -915,20 +915,18 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 
 	// Check if the checkpoint is too old to safely resume.
 	// Replaying many days of binary logs can be slower than starting fresh.
-	if r.migration.CheckpointMaxAge > 0 {
-		// The connection uses time_zone="+00:00", so timestamps are in UTC.
-		createdAt, parseErr := time.Parse("2006-01-02 15:04:05", createdAtStr)
-		if parseErr != nil {
-			return fmt.Errorf("could not parse checkpoint created_at timestamp: %w", parseErr)
-		}
-		checkpointAge := time.Since(createdAt)
-		if checkpointAge >= r.migration.CheckpointMaxAge {
-			return fmt.Errorf("%w: checkpoint is %s old (max allowed: %s)",
-				status.ErrCheckpointTooOld,
-				checkpointAge.Round(time.Second),
-				r.migration.CheckpointMaxAge,
-			)
-		}
+	// The connection uses time_zone="+00:00", so timestamps are in UTC.
+	createdAt, parseErr := time.Parse("2006-01-02 15:04:05", createdAtStr)
+	if parseErr != nil {
+		return fmt.Errorf("could not parse checkpoint created_at timestamp: %w", parseErr)
+	}
+	checkpointAge := time.Since(createdAt)
+	if checkpointAge >= r.migration.CheckpointMaxAge {
+		return fmt.Errorf("%w: checkpoint is %s old (max allowed: %s)",
+			status.ErrCheckpointTooOld,
+			checkpointAge.Round(time.Second),
+			r.migration.CheckpointMaxAge,
+		)
 	}
 
 	// Initialize and call SetInfo on all the new tables, since we need the column info

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -694,9 +694,11 @@ func (r *Runner) setup(ctx context.Context) error {
 		// A mismatched alter means the user changed the DDL between runs.
 		// An expired binlog means the checkpoint can't be used because
 		// changes would be lost in the replication gap.
-		// In both cases, strict mode surfaces the error rather than
+		// A checkpoint that is too old means replaying binlogs would be
+		// slower than starting fresh.
+		// In all cases, strict mode surfaces the error rather than
 		// silently restarting from scratch.
-		if r.migration.Strict && (errors.Is(err, status.ErrMismatchedAlter) || errors.Is(err, status.ErrBinlogNotFound)) {
+		if r.migration.Strict && (errors.Is(err, status.ErrMismatchedAlter) || errors.Is(err, status.ErrBinlogNotFound) || errors.Is(err, status.ErrCheckpointTooOld)) {
 			return err
 		}
 
@@ -766,7 +768,8 @@ func (r *Runner) createCheckpointTable(ctx context.Context) error {
 	checksum_watermark TEXT,
 	binlog_name VARCHAR(255),
 	binlog_pos INT,
-	statement TEXT
+	statement TEXT,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`,
 		r.changes[0].table.SchemaName, cpName); err != nil {
 		return err
@@ -889,7 +892,8 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 		r.changes[0].stmt.Schema, r.checkpointTableName())
 	var copierWatermark, binlogName, statement, checksumWatermark string
 	var id, binlogPos int
-	err := r.db.QueryRowContext(ctx, query).Scan(&id, &copierWatermark, &checksumWatermark, &binlogName, &binlogPos, &statement)
+	var createdAtStr string
+	err := r.db.QueryRowContext(ctx, query).Scan(&id, &copierWatermark, &checksumWatermark, &binlogName, &binlogPos, &statement, &createdAtStr)
 	if err != nil {
 		return fmt.Errorf("could not read from table '%s', err:%w", r.checkpointTableName(), err)
 	}
@@ -907,6 +911,24 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	// This avoids partial initialization that would need cleanup on failure.
 	if !r.binlogFileExists(ctx, binlogName) {
 		return fmt.Errorf("%w: %s has been purged, cannot resume", status.ErrBinlogNotFound, binlogName)
+	}
+
+	// Check if the checkpoint is too old to safely resume.
+	// Replaying many days of binary logs can be slower than starting fresh.
+	if r.migration.CheckpointMaxAge > 0 {
+		// The connection uses time_zone="+00:00", so timestamps are in UTC.
+		createdAt, parseErr := time.Parse("2006-01-02 15:04:05", createdAtStr)
+		if parseErr != nil {
+			return fmt.Errorf("could not parse checkpoint created_at timestamp: %w", parseErr)
+		}
+		checkpointAge := time.Since(createdAt)
+		if checkpointAge >= r.migration.CheckpointMaxAge {
+			return fmt.Errorf("%w: checkpoint is %s old (max allowed: %s)",
+				status.ErrCheckpointTooOld,
+				checkpointAge.Round(time.Second),
+				r.migration.CheckpointMaxAge,
+			)
+		}
 	}
 
 	// Initialize and call SetInfo on all the new tables, since we need the column info

--- a/pkg/migration/runner_resume_test.go
+++ b/pkg/migration/runner_resume_test.go
@@ -1213,3 +1213,188 @@ func TestResumeFromCheckpointStrictBinlogExpired(t *testing.T) {
 	assert.ErrorIs(t, err, status.ErrBinlogNotFound)
 	assert.NoError(t, r2.Close())
 }
+
+// TestResumeFromCheckpointTooOld tests that when a checkpoint's created_at timestamp
+// exceeds CheckpointMaxAge, the migration falls back to a fresh start instead of
+// resuming from the stale checkpoint. This prevents the slow replay of many days
+// of binary logs when starting fresh would be faster.
+func TestResumeFromCheckpointTooOld(t *testing.T) {
+	t.Parallel()
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS chkpttooold, _chkpttooold_new, _chkpttooold_chkpnt, _chkpttooold_old`)
+	testutils.RunSQL(t, `CREATE TABLE chkpttooold (
+		id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255) NOT NULL,
+		pad VARCHAR(1000) NOT NULL default 'x')`)
+	testutils.RunSQL(t, "INSERT INTO chkpttooold (name, pad) VALUES ('a', REPEAT('x', 1000))")
+	testutils.RunSQL(t, `INSERT INTO chkpttooold (name, pad) SELECT a.name, a.pad FROM chkpttooold a, chkpttooold b, chkpttooold c LIMIT 10`)
+	testutils.RunSQL(t, `INSERT INTO chkpttooold (name, pad) SELECT a.name, a.pad FROM chkpttooold a, chkpttooold b, chkpttooold c LIMIT 100`)
+	testutils.RunSQL(t, `INSERT INTO chkpttooold (name, pad) SELECT a.name, a.pad FROM chkpttooold a, chkpttooold b LIMIT 1000`)
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+
+	// First run: create a checkpoint
+	r, err := NewRunner(&Migration{
+		Host:             cfg.Addr,
+		Username:         cfg.User,
+		Password:         &cfg.Passwd,
+		Database:         cfg.DBName,
+		Threads:          1,
+		TargetChunkTime:  100 * time.Millisecond,
+		Table:            "chkpttooold",
+		Alter:            "ENGINE=InnoDB",
+		useTestThrottler: true,
+	})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		_ = r.Run(ctx)
+	}()
+
+	waitForCheckpoint(t, r)
+	assert.NoError(t, r.Close())
+	cancel()
+
+	// Backdate the checkpoint's created_at to simulate an old checkpoint (8 days ago).
+	testutils.RunSQL(t, `UPDATE _chkpttooold_chkpnt SET created_at = DATE_SUB(NOW(), INTERVAL 8 DAY)`)
+
+	// Without strict mode: falls back to newMigration and completes successfully.
+	r2, err := NewRunner(&Migration{
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: &cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  2,
+		Table:    "chkpttooold",
+		Alter:    "ENGINE=InnoDB",
+	})
+	assert.NoError(t, err)
+
+	err = r2.Run(t.Context())
+	assert.NoError(t, err)                       // Should succeed - falls back to newMigration
+	assert.False(t, r2.usedResumeFromCheckpoint) // Should NOT have resumed because checkpoint was too old
+	assert.NoError(t, r2.Close())
+}
+
+// TestResumeFromCheckpointStrictTooOld tests that when strict mode is enabled
+// and a checkpoint exceeds CheckpointMaxAge, the migration fails with
+// ErrCheckpointTooOld rather than silently starting fresh.
+func TestResumeFromCheckpointStrictTooOld(t *testing.T) {
+	t.Parallel()
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS strictoldtest, _strictoldtest_new, _strictoldtest_chkpnt, _strictoldtest_old`)
+	testutils.RunSQL(t, `CREATE TABLE strictoldtest (
+		id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255) NOT NULL,
+		pad VARCHAR(1000) NOT NULL default 'x')`)
+	testutils.RunSQL(t, "INSERT INTO strictoldtest (name, pad) VALUES ('a', REPEAT('x', 1000))")
+	testutils.RunSQL(t, `INSERT INTO strictoldtest (name, pad) SELECT a.name, a.pad FROM strictoldtest a, strictoldtest b, strictoldtest c LIMIT 10`)
+	testutils.RunSQL(t, `INSERT INTO strictoldtest (name, pad) SELECT a.name, a.pad FROM strictoldtest a, strictoldtest b, strictoldtest c LIMIT 100`)
+	testutils.RunSQL(t, `INSERT INTO strictoldtest (name, pad) SELECT a.name, a.pad FROM strictoldtest a, strictoldtest b LIMIT 1000`)
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+
+	// First run: create a checkpoint
+	r, err := NewRunner(&Migration{
+		Host:             cfg.Addr,
+		Username:         cfg.User,
+		Password:         &cfg.Passwd,
+		Database:         cfg.DBName,
+		Threads:          1,
+		TargetChunkTime:  100 * time.Millisecond,
+		Table:            "strictoldtest",
+		Alter:            "ENGINE=InnoDB",
+		useTestThrottler: true,
+	})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		_ = r.Run(ctx)
+	}()
+
+	waitForCheckpoint(t, r)
+	assert.NoError(t, r.Close())
+	cancel()
+
+	// Backdate the checkpoint's created_at to simulate an old checkpoint (8 days ago).
+	testutils.RunSQL(t, `UPDATE _strictoldtest_chkpnt SET created_at = DATE_SUB(NOW(), INTERVAL 8 DAY)`)
+
+	// With strict mode: should error with ErrCheckpointTooOld instead of silently restarting.
+	r2, err := NewRunner(&Migration{
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: &cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  2,
+		Table:    "strictoldtest",
+		Alter:    "ENGINE=InnoDB",
+		Strict:   true,
+	})
+	assert.NoError(t, err)
+
+	err = r2.Run(t.Context())
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, status.ErrCheckpointTooOld)
+	assert.NoError(t, r2.Close())
+}
+
+// TestResumeFromCheckpointNotTooOld tests that a recent checkpoint (within
+// CheckpointMaxAge) is still used for resume as expected.
+func TestResumeFromCheckpointNotTooOld(t *testing.T) {
+	t.Parallel()
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS chkptnotold, _chkptnotold_new, _chkptnotold_chkpnt, _chkptnotold_old`)
+	testutils.RunSQL(t, `CREATE TABLE chkptnotold (
+		id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255) NOT NULL,
+		pad VARCHAR(1000) NOT NULL default 'x')`)
+	testutils.RunSQL(t, "INSERT INTO chkptnotold (name, pad) VALUES ('a', REPEAT('x', 1000))")
+	testutils.RunSQL(t, `INSERT INTO chkptnotold (name, pad) SELECT a.name, a.pad FROM chkptnotold a, chkptnotold b, chkptnotold c LIMIT 10`)
+	testutils.RunSQL(t, `INSERT INTO chkptnotold (name, pad) SELECT a.name, a.pad FROM chkptnotold a, chkptnotold b, chkptnotold c LIMIT 100`)
+	testutils.RunSQL(t, `INSERT INTO chkptnotold (name, pad) SELECT a.name, a.pad FROM chkptnotold a, chkptnotold b LIMIT 1000`)
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+
+	// First run: create a checkpoint
+	r, err := NewRunner(&Migration{
+		Host:             cfg.Addr,
+		Username:         cfg.User,
+		Password:         &cfg.Passwd,
+		Database:         cfg.DBName,
+		Threads:          1,
+		TargetChunkTime:  100 * time.Millisecond,
+		Table:            "chkptnotold",
+		Alter:            "ENGINE=InnoDB",
+		useTestThrottler: true,
+	})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		_ = r.Run(ctx)
+	}()
+
+	waitForCheckpoint(t, r)
+	assert.NoError(t, r.Close())
+	cancel()
+
+	// Do NOT backdate the checkpoint - it was just created, so it's fresh.
+	// The migration should resume from checkpoint successfully.
+	r2, err := NewRunner(&Migration{
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: &cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  2,
+		Table:    "chkptnotold",
+		Alter:    "ENGINE=InnoDB",
+	})
+	assert.NoError(t, err)
+
+	err = r2.Run(t.Context())
+	assert.NoError(t, err)
+	assert.True(t, r2.usedResumeFromCheckpoint) // Should have resumed because checkpoint is fresh
+	assert.NoError(t, r2.Close())
+}

--- a/pkg/status/state.go
+++ b/pkg/status/state.go
@@ -11,6 +11,7 @@ type State int32
 var (
 	ErrMismatchedAlter         = errors.New("alter statement in checkpoint table does not match the alter statement specified here")
 	ErrBinlogNotFound          = errors.New("checkpoint binlog file not found on server")
+	ErrCheckpointTooOld        = errors.New("checkpoint is too old to safely resume")
 	ErrCouldNotWriteCheckpoint = errors.New("could not write checkpoint")
 	ErrWatermarkNotReady       = errors.New("watermark not ready")
 )


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Closes https://github.com/block/spirit/issues/485

## Summary

Adds a `--checkpoint-max-age` option (default 7 days) that prevents resuming from checkpoints that are too old. Replaying many days of binary logs can be slower than starting a fresh migration from scratch.

## Changes

- **`pkg/status/state.go`**: Added `ErrCheckpointTooOld` sentinel error
- **`pkg/migration/migration.go`**: Added `CheckpointMaxAge` field to `Migration` struct with CLI flag `--checkpoint-max-age` (default `168h`). Default is also applied in `normalizeOptions()` for programmatic construction.
- **`pkg/migration/runner.go`**:
  - Added `created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP` column to the checkpoint table schema
  - In `resumeFromCheckpoint()`, reads the `created_at` column and compares its age against `CheckpointMaxAge`. Returns `ErrCheckpointTooOld` if exceeded.
  - Added `ErrCheckpointTooOld` to the strict mode check in `setup()`
- **`pkg/migration/runner_resume_test.go`**: Three new tests:
  - `TestResumeFromCheckpointTooOld` — old checkpoint falls back to fresh migration
  - `TestResumeFromCheckpointStrictTooOld` — strict mode returns `ErrCheckpointTooOld`
  - `TestResumeFromCheckpointNotTooOld` — fresh checkpoint still resumes normally

## Design Notes

- Uses `DATETIME` (not `TIMESTAMP`) to avoid the Y2038 problem
- Old checkpoint tables without the `created_at` column will gracefully fail the `SELECT *` scan and fall back to a fresh migration — this is the existing intentional behavior for checkpoint schema changes
- The check is always active. Following Spirit's "decisions, not options" philosophy, there is no way to disable it. Users can set a very large value (e.g. `--checkpoint-max-age=87600h`) to effectively bypass it if needed.