### PR TITLE
ci: upgrade MySQL 9.6 → 9.7 in CI

### DIFF
--- a/.github/workflows/mysql97-docker.yml
+++ b/.github/workflows/mysql97-docker.yml
@@ -1,4 +1,4 @@
-name: MySQL 9.6 /w docker-compose
+name: MySQL 9.7 /w docker-compose
 on:
   push:
     branches: [ main ]
@@ -18,5 +18,5 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test
-        run: docker compose -f replication-ci.yml -f 9.6.yml up mysql mysql_replica test --abort-on-container-exit
+        run: docker compose -f replication-ci.yml -f 9.7.yml up mysql mysql_replica test --abort-on-container-exit
         working-directory: compose/replication-tls

--- a/compose/9.6.yml
+++ b/compose/9.6.yml
@@ -1,4 +1,0 @@
-services:
-  mysql:
-    image: mysql:9.6
-    ports: [ '9060:3306' ]

--- a/compose/9.7.yml
+++ b/compose/9.7.yml
@@ -1,0 +1,4 @@
+services:
+  mysql:
+    image: mysql:9.7
+    ports: [ '9070:3306' ]

--- a/compose/replication-tls/9.6.yml
+++ b/compose/replication-tls/9.6.yml
@@ -1,8 +1,0 @@
-services:
-  mysql:
-    image: mysql:9.6
-    ports: [ '9060:3306' ]
-
-  mysql_replica:
-    image: mysql:9.6
-    ports: [ '9161:3306' ]

--- a/compose/replication-tls/9.7.yml
+++ b/compose/replication-tls/9.7.yml
@@ -1,0 +1,8 @@
+services:
+  mysql:
+    image: mysql:9.7
+    ports: [ '9070:3306' ]
+
+  mysql_replica:
+    image: mysql:9.7
+    ports: [ '9171:3306' ]


### PR DESCRIPTION
MySQL 9.6 was not an LTS release. Upgrade CI to test against MySQL 9.7 which was released this week.

### Changes
- Rename workflow `mysql96-docker.yml` → `mysql97-docker.yml`
- Update Docker image from `mysql:9.6` to `mysql:9.7`
- Update compose overrides for both standalone and replication-tLS configs
- Adjust host ports (9060→9070, 9161→9171)