### PR TITLE
refactor: consolidate chunker constructors into NewChunker with ChunkerConfig

### DIFF
--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -68,7 +68,7 @@ func TestFixCorruptWithApplier(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 
@@ -175,7 +175,7 @@ func TestDistributedChecksum(t *testing.T) {
 
 	// Create chunker - for distributed checksum, we pass nil for the new table
 	// because the chunker will use the source table for both sides
-	chunker, err := table.NewChunker(sourceTable, nil, 0, logger)
+	chunker, err := table.NewChunker(sourceTable, table.ChunkerConfig{Logger: logger})
 	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 
@@ -313,9 +313,9 @@ func TestDistributedChecksumNtoM(t *testing.T) {
 	require.NoError(t, feed1.Run(t.Context()))
 
 	// Create a chunker per source, then wrap in a MultiChunker.
-	chunker0, err := table.NewChunker(src0Table, nil, 0, logger)
+	chunker0, err := table.NewChunker(src0Table, table.ChunkerConfig{Logger: logger})
 	require.NoError(t, err)
-	chunker1, err := table.NewChunker(src1Table, nil, 0, logger)
+	chunker1, err := table.NewChunker(src1Table, table.ChunkerConfig{Logger: logger})
 	require.NoError(t, err)
 	multiChunker := table.NewMultiChunker(chunker0, chunker1)
 	require.NoError(t, multiChunker.Open())

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -50,7 +50,7 @@ func TestBasicChecksum(t *testing.T) {
 	defer feed.Close()
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
@@ -89,7 +89,7 @@ func TestBasicValidation(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 
 	_, err = NewChecker(nil, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig()) // no source DBs
@@ -147,7 +147,7 @@ func TestUnfixableUniqueChecksum(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 
@@ -190,7 +190,7 @@ func TestFixCorrupt(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 
@@ -248,7 +248,7 @@ func TestCorruptChecksum(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 
@@ -290,7 +290,7 @@ func TestBoundaryCases(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 
@@ -368,7 +368,7 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 
@@ -411,7 +411,7 @@ func TestYieldTimeout(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 
@@ -464,7 +464,7 @@ func TestFromWatermark(t *testing.T) {
 	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
 	assert.NoError(t, feed.Run(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, 0, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -41,7 +41,7 @@ func TestBufferedCopier(t *testing.T) {
 	}
 	cfg.Applier, err = applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
-	chunker, err := table.NewChunker(t1, t2, cfg.TargetChunkTime, cfg.Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
 	assert.NoError(t, err)
 
 	assert.NoError(t, chunker.Open())
@@ -98,7 +98,7 @@ func TestBufferedCopierCharsetConversion(t *testing.T) {
 	cfg := NewCopierDefaultConfig()
 	cfg.Applier, err = applier.NewSingleTargetApplier(applier.Target{DB: db}, applier.NewApplierDefaultConfig())
 	assert.NoError(t, err)
-	chunker, err := table.NewChunker(t1, t2, cfg.TargetChunkTime, cfg.Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
 	assert.NoError(t, err)
 
 	assert.NoError(t, chunker.Open())
@@ -114,7 +114,7 @@ func TestBufferedCopierCharsetConversion(t *testing.T) {
 	// Reverse the copy to show the other direction works too
 	// Start by emptying the "src" table, which is our intended destination.
 	testutils.RunSQL(t, "TRUNCATE TABLE charsetsrc")
-	chunker, err = table.NewChunker(t2, t1, cfg.TargetChunkTime, cfg.Logger)
+	chunker, err = table.NewChunker(t2, table.ChunkerConfig{NewTable: t1, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
 	assert.NoError(t, err)
 	copier, err = NewCopier(db, chunker, cfg)
 	assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestBufferedCopierDataTypeConversionError(t *testing.T) {
 	cfg.TargetChunkTime = 10 // Small chunk time to create more chunks
 	cfg.Applier, err = applier.NewSingleTargetApplier(applier.Target{DB: db}, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
-	chunker, err := table.NewChunker(t1, t2, cfg.TargetChunkTime, cfg.Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
 	assert.NoError(t, err)
 
 	assert.NoError(t, chunker.Open())
@@ -210,7 +210,7 @@ func TestBufferedCopierChunkTimingIncludesCallbackDelay(t *testing.T) {
 	cfg := NewCopierDefaultConfig()
 
 	// Create a real chunker (we need real chunk metadata for the copier)
-	realChunker, err := table.NewChunker(t1, t2, 1000*time.Millisecond, cfg.Logger)
+	realChunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: 1000 * time.Millisecond, Logger: cfg.Logger})
 	require.NoError(t, err)
 	assert.NoError(t, realChunker.Open())
 

--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -55,7 +55,7 @@ func TestCopier(t *testing.T) {
 	copierConfig := NewCopierDefaultConfig()
 	testMetricsSink := &TestMetricsSink{}
 	copierConfig.MetricsSink = testMetricsSink
-	chunker, err := table.NewChunker(t1, t2, copierConfig.TargetChunkTime, copierConfig.Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: copierConfig.TargetChunkTime, Logger: copierConfig.Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, copierConfig)
@@ -89,7 +89,7 @@ func TestThrottler(t *testing.T) {
 	t2 := table.NewTableInfo(db, "test", "throttlert2")
 	assert.NoError(t, t2.SetInfo(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t2, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
 	assert.NoError(t, err)
@@ -131,7 +131,7 @@ func TestCopierUniqueDestination(t *testing.T) {
 	assert.NoError(t, t1.SetInfo(t.Context()))
 	t2 = table.NewTableInfo(db, "test", "copieruniqt2")
 	assert.NoError(t, t2.SetInfo(t.Context()))
-	chunker, err := table.NewChunker(t1, t2, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
@@ -157,7 +157,7 @@ func TestCopierLossyDataTypeConversion(t *testing.T) {
 	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
-	chunker, err := table.NewChunker(t1, t2, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
@@ -184,7 +184,7 @@ func TestCopierNullToNotNullConversion(t *testing.T) {
 	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
-	chunker, err := table.NewChunker(t1, t2, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
@@ -210,7 +210,7 @@ func TestSQLModeAllowZeroInvalidDates(t *testing.T) {
 	assert.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
-	chunker, err := table.NewChunker(t1, t2, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
@@ -253,7 +253,7 @@ func TestLockWaitTimeoutIsRetyable(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	wg1.Wait()
-	chunker, err := table.NewChunker(t1, t2, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
@@ -301,7 +301,7 @@ func TestLockWaitTimeoutRetryExceeded(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	wg1.Wait() // Wait only for the lock to be acquired.
-	chunker, err := table.NewChunker(t1, t2, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
 	assert.NoError(t, err)
@@ -339,7 +339,7 @@ func TestCopierFromCheckpoint(t *testing.T) {
 	lowWatermark := `{"Key":["a"],"ChunkSize":1,"LowerBound":{"Value":["3"],"Inclusive":true},"UpperBound":{"Value":["4"],"Inclusive":false}}`
 
 	// Create chunker first and open at the checkpoint watermark
-	chunker, err := table.NewChunker(t1, t1new, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 
 	// Open chunker at the specified watermark
@@ -382,7 +382,7 @@ func TestRangeOptimizationMustApply(t *testing.T) {
 	t1new := table.NewTableInfo(db, "test", "_rangeoptimizertest_new")
 	assert.NoError(t, t1new.SetInfo(t.Context()))
 
-	chunker, err := table.NewChunker(t1, t1new, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
@@ -395,7 +395,7 @@ func TestRangeOptimizationMustApply(t *testing.T) {
 	assert.NoError(t, err)
 	defer utils.CloseAndLog(db2)
 	testutils.RunSQL(t, "TRUNCATE _rangeoptimizertest_new")
-	chunker2, err := table.NewChunker(t1, t1new, NewCopierDefaultConfig().TargetChunkTime, NewCopierDefaultConfig().Logger)
+	chunker2, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
 	assert.NoError(t, err)
 	require.NoError(t, chunker2.Open())
 	copier, err = NewCopier(db2, chunker2, NewCopierDefaultConfig())

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -1020,11 +1020,16 @@ func (r *Runner) initChunkers() error {
 	copyChunkers := make([]table.Chunker, 0, len(r.changes))
 	checksumChunkers := make([]table.Chunker, 0, len(r.changes))
 	for _, change := range r.changes {
-		copyChunker, err := table.NewChunker(change.table, change.newTable, r.migration.TargetChunkTime, r.logger)
+		chunkerCfg := table.ChunkerConfig{
+			NewTable:        change.newTable,
+			TargetChunkTime: r.migration.TargetChunkTime,
+			Logger:          r.logger,
+		}
+		copyChunker, err := table.NewChunker(change.table, chunkerCfg)
 		if err != nil {
 			return err
 		}
-		checksumChunker, err := table.NewChunker(change.table, change.newTable, r.migration.TargetChunkTime, r.logger)
+		checksumChunker, err := table.NewChunker(change.table, chunkerCfg)
 		if err != nil {
 			return err
 		}

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -252,14 +252,18 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	// to that source's repl client.
 	for i := range r.sources {
 		for _, tbl := range r.sources[i].tables {
-			copyChunker, err := table.NewChunker(tbl, nil, r.move.TargetChunkTime, r.logger)
+			chunkerCfg := table.ChunkerConfig{
+				TargetChunkTime: r.move.TargetChunkTime,
+				Logger:          r.logger,
+			}
+			copyChunker, err := table.NewChunker(tbl, chunkerCfg)
 			if err != nil {
 				return err
 			}
 			if err := r.sources[i].replClient.AddSubscription(tbl, nil, copyChunker); err != nil {
 				return err
 			}
-			checksumChunker, err := table.NewChunker(tbl, nil, r.move.TargetChunkTime, r.logger)
+			checksumChunker, err := table.NewChunker(tbl, chunkerCfg)
 			if err != nil {
 				return err
 			}
@@ -443,14 +447,18 @@ func (r *Runner) newCopy(ctx context.Context) error {
 	// to that source's repl client.
 	for i := range r.sources {
 		for _, tbl := range r.sources[i].tables {
-			copyChunker, err := table.NewChunker(tbl, nil, r.move.TargetChunkTime, r.logger)
+			chunkerCfg := table.ChunkerConfig{
+				TargetChunkTime: r.move.TargetChunkTime,
+				Logger:          r.logger,
+			}
+			copyChunker, err := table.NewChunker(tbl, chunkerCfg)
 			if err != nil {
 				return err
 			}
 			if err := r.sources[i].replClient.AddSubscription(tbl, nil, copyChunker); err != nil {
 				return err
 			}
-			checksumChunker, err := table.NewChunker(tbl, nil, r.move.TargetChunkTime, r.logger)
+			checksumChunker, err := table.NewChunker(tbl, chunkerCfg)
 			if err != nil {
 				return err
 			}

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -95,7 +95,7 @@ func TestReplClientComplex(t *testing.T) {
 
 	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, NewClientDefaultConfig())
 
-	chunker, err := table.NewChunker(t1, t2, time.Second, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: time.Second})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 	_, err = copier.NewCopier(db, chunker, copier.NewCopierDefaultConfig())
@@ -307,7 +307,7 @@ func TestReplClientQueue(t *testing.T) {
 
 	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, NewClientDefaultConfig())
 
-	chunker, err := table.NewChunker(t1, t2, 1000, slog.Default())
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: 1000})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 	_, err = copier.NewCopier(db, chunker, copier.NewCopierDefaultConfig())

--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -49,53 +49,59 @@ type Chunker interface { //nolint: interfacebloat
 	Tables() []*TableInfo
 }
 
-func newChunker(t *TableInfo, chunkerTarget time.Duration, logger *slog.Logger) (Chunker, error) {
-	return NewChunker(t, nil, chunkerTarget, logger)
+// ChunkerConfig holds optional configuration for creating a Chunker.
+// Only the source table (passed as the first argument to NewChunker) is required;
+// all other fields have sensible defaults.
+type ChunkerConfig struct {
+	// NewTable is the destination table. If nil, defaults to the source table
+	// (for move operations where there is no distinct new table).
+	NewTable *TableInfo
+	// TargetChunkTime is the target duration for each chunk. Defaults to ChunkerDefaultTarget.
+	TargetChunkTime time.Duration
+	// Logger is the structured logger. Defaults to slog.Default().
+	Logger *slog.Logger
+	// Key and Where are used for composite chunkers to specify a non-primary key index.
+	// When Key is set, the composite chunker is always used regardless of whether the
+	// table has an auto-increment primary key.
+	Key   string
+	Where string
 }
 
-func NewChunker(t *TableInfo, newTable *TableInfo, chunkerTarget time.Duration, logger *slog.Logger) (Chunker, error) {
-	if chunkerTarget == 0 {
-		chunkerTarget = ChunkerDefaultTarget
+// NewChunker creates a new Chunker for the given source table.
+// It selects the optimistic chunker for single-column auto-increment primary keys
+// (unless Key/Where overrides are specified), and the composite chunker otherwise.
+func NewChunker(t *TableInfo, config ChunkerConfig) (Chunker, error) {
+	if config.TargetChunkTime == 0 {
+		config.TargetChunkTime = ChunkerDefaultTarget
 	}
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+	newTable := config.NewTable
 	if newTable == nil {
 		// This supports moveTable cases where there is no new table per-se.
 		// But the chunker needs a non-nil newTable for some operations,
 		// like resuming from a checkpoint.
 		newTable = t
 	}
-	// Use the optimistic chunker for auto_increment
-	// tables with a single column key.
-	if len(t.KeyColumns) == 1 && t.KeyIsAutoInc {
+	// Use the optimistic chunker for auto_increment tables with a single
+	// column key, unless a specific key/where is requested.
+	if len(t.KeyColumns) == 1 && t.KeyIsAutoInc && config.Key == "" && config.Where == "" {
 		return &chunkerOptimistic{
 			Ti:                     t,
 			NewTi:                  newTable,
-			ChunkerTarget:          chunkerTarget,
+			ChunkerTarget:          config.TargetChunkTime,
 			lowerBoundWatermarkMap: make(map[string]*Chunk, 0),
-			logger:                 logger,
+			logger:                 config.Logger,
 		}, nil
 	}
-	return newCompositeChunkerWithDestination(t, newTable, chunkerTarget, logger, "", "")
-}
-
-// NewCompositeChunker returns a chunkerComposite ,
-// setting its Key if keyName and where conditions are provided
-func NewCompositeChunker(t *TableInfo, chunkerTarget time.Duration, logger *slog.Logger, keyName string, whereCondition string) (Chunker, error) {
-	return newCompositeChunkerWithDestination(t, nil, chunkerTarget, logger, keyName, whereCondition)
-}
-
-// NewCompositeChunkerWithDestination returns a chunkerComposite with destination table info,
-// setting its Key if keyName and where conditions are provided
-func newCompositeChunkerWithDestination(t *TableInfo, newTable *TableInfo, chunkerTarget time.Duration, logger *slog.Logger, keyName string, whereCondition string) (Chunker, error) {
-	c := chunkerComposite{
+	return &chunkerComposite{
 		Ti:                     t,
 		NewTi:                  newTable,
-		ChunkerTarget:          chunkerTarget,
+		ChunkerTarget:          config.TargetChunkTime,
+		keyName:                config.Key,
+		where:                  config.Where,
 		lowerBoundWatermarkMap: make(map[string]*Chunk, 0),
-		logger:                 logger,
-	}
-	var err error
-	if keyName != "" && whereCondition != "" {
-		err = c.SetKey(keyName, whereCondition)
-	}
-	return &c, err
+		logger:                 config.Logger,
+	}, nil
 }

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -422,10 +422,14 @@ func (t *chunkerComposite) open() (err error) {
 		return ErrChunkerAlreadyOpen
 	}
 	t.isOpen = true
+	if len(t.chunkKeys) == 0 && t.keyName != "" {
+		// A key name was provided at construction time but not yet resolved.
+		if err := t.resolveKey(); err != nil {
+			return err
+		}
+	}
 	if len(t.chunkKeys) == 0 {
-		// SetKey has not been called.
-		// chunk on all keys in the PK.
-		// default to primary key.
+		// No key specified; default to primary key.
 		t.chunkKeys = t.Ti.KeyColumns
 		t.keyName = "PRIMARY"
 	}
@@ -568,7 +572,14 @@ func (t *chunkerComposite) SetKey(keyName string, where string) error {
 	if t.isOpen {
 		return errors.New("cannot set key after table is open")
 	}
-	keyCols, err := t.Ti.DescIndex(keyName)
+	t.keyName = keyName
+	t.where = where
+	return t.resolveKey()
+}
+
+// resolveKey resolves keyName to its index columns and merges in PK columns.
+func (t *chunkerComposite) resolveKey() error {
+	keyCols, err := t.Ti.DescIndex(t.keyName)
 	if err != nil {
 		return err // index is not valid.
 	}
@@ -584,8 +595,6 @@ func (t *chunkerComposite) SetKey(keyName string, where string) error {
 		}
 	}
 	t.chunkKeys = keyCols
-	t.keyName = keyName
-	t.where = where
 	return nil
 }
 

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -45,7 +45,7 @@ func TestCompositeChunkerCompositeBinary(t *testing.T) {
 	assert.Equal(t, binaryType, t1.keyDatums[0])
 	assert.Equal(t, binaryType, t1.keyDatums[1])
 
-	chunker, err := newChunker(t1, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{})
 	assert.NoError(t, err)
 	assert.IsType(t, &chunkerComposite{}, chunker)
 
@@ -149,7 +149,7 @@ func TestCompositeChunkerBinary(t *testing.T) {
 	assert.Equal(t, []string{"varbinary"}, t1.keyColumnsMySQLTp)
 	assert.Equal(t, binaryType, t1.keyDatums[0])
 
-	chunker, err := newChunker(t1, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{})
 	assert.NoError(t, err)
 	assert.IsType(t, &chunkerComposite{}, chunker)
 
@@ -229,7 +229,7 @@ func TestCompositeChunkerInt(t *testing.T) {
 	assert.Equal(t, []string{"int"}, t1.keyColumnsMySQLTp)
 	assert.Equal(t, signedType, t1.keyDatums[0])
 
-	chunker, err := newChunker(t1, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{})
 	assert.NoError(t, err)
 	assert.IsType(t, &chunkerComposite{}, chunker)
 
@@ -420,7 +420,7 @@ func TestCompositeSmallTable(t *testing.T) {
 	t1 := NewTableInfo(db, "test", "compositesmall_t1")
 	assert.NoError(t, t1.SetInfo(t.Context()))
 
-	chunker, err := newChunker(t1, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{})
 	assert.NoError(t, err)
 	assert.IsType(t, &chunkerComposite{}, chunker)
 
@@ -829,7 +829,7 @@ func TestCompositeChunkerWatermarkOptimizations(t *testing.T) {
 	tbl := NewTableInfo(db, "test", "compositewatermarkopt_t1")
 	assert.NoError(t, tbl.SetInfo(t.Context()))
 
-	chunker, err := newChunker(tbl, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(tbl, ChunkerConfig{})
 	assert.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 
@@ -976,7 +976,7 @@ func TestCompositeChunkerWatermarkNonNumeric(t *testing.T) {
 	tbl := NewTableInfo(db, "test", "compositewatermarknn_t1")
 	assert.NoError(t, tbl.SetInfo(t.Context()))
 
-	chunker, err := newChunker(tbl, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(tbl, ChunkerConfig{})
 	assert.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 
@@ -1055,7 +1055,7 @@ func TestCompositeChunkerWatermarkDateTime(t *testing.T) {
 	tbl := NewTableInfo(db, "test", "compositewatermarkdt_t1")
 	assert.NoError(t, tbl.SetInfo(t.Context()))
 
-	chunker, err := newChunker(tbl, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(tbl, ChunkerConfig{})
 	assert.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 
@@ -1165,7 +1165,7 @@ func TestCompositeChunkerCollationDifference(t *testing.T) {
 	tbl := NewTableInfo(db, "test", "compositecollation_t1")
 	assert.NoError(t, tbl.SetInfo(t.Context()))
 
-	chunker, err := newChunker(tbl, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(tbl, ChunkerConfig{})
 	assert.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 
@@ -1284,7 +1284,7 @@ func TestCompositeChunkerWatermarkWithOutOfOrderCompletion(t *testing.T) {
 	tbl := NewTableInfo(db, "test", "compositewatermarkooo_t1")
 	assert.NoError(t, tbl.SetInfo(t.Context()))
 
-	chunker, err := newChunker(tbl, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(tbl, ChunkerConfig{})
 	assert.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -194,7 +194,7 @@ func TestOptimisticDynamicChunking(t *testing.T) {
 	t1.columnsMySQLTps = make(map[string]string)
 	t1.columnsMySQLTps["id"] = "bigint"
 
-	chunker, err := newChunker(t1, 100*time.Millisecond, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{TargetChunkTime: 100 * time.Millisecond})
 	assert.NoError(t, err)
 
 	assert.NoError(t, chunker.Open())
@@ -261,7 +261,7 @@ func TestOptimisticDynamicChunking(t *testing.T) {
 	t2.columnsMySQLTps = make(map[string]string)
 	t2.columnsMySQLTps["id"] = "bigint"
 
-	chunker2, err := NewChunker(t2, t2, 100, slog.Default())
+	chunker2, err := NewChunker(t2, ChunkerConfig{NewTable: t2, TargetChunkTime: 100})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker2.OpenAtWatermark(watermark))
 

--- a/pkg/table/chunker_test.go
+++ b/pkg/table/chunker_test.go
@@ -2,7 +2,6 @@ package table
 
 import (
 	"database/sql"
-	"log/slog"
 	"testing"
 
 	"github.com/block/spirit/pkg/testutils"
@@ -29,7 +28,7 @@ func TestCompositeChunker(t *testing.T) {
 	t1 := NewTableInfo(db, "test", "composite")
 	assert.NoError(t, t1.SetInfo(t.Context()))
 
-	chunker, err := newChunker(t1, 0, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{})
 	assert.NoError(t, err)
 	assert.IsType(t, &chunkerComposite{}, chunker)
 }
@@ -53,12 +52,12 @@ func TestOptimisticChunker(t *testing.T) {
 	t1 := NewTableInfo(db, "test", "optimistic")
 	assert.NoError(t, t1.SetInfo(t.Context()))
 
-	chunker, err := newChunker(t1, 0, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{})
 	assert.NoError(t, err)
 	assert.IsType(t, &chunkerOptimistic{}, chunker)
 }
 
-func TestNewCompositeChunker(t *testing.T) {
+func TestNewCompositeChunkerWithKeyAndWhere(t *testing.T) {
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS composite`)
 	table := `CREATE TABLE composite (
 		id bigint NOT NULL AUTO_INCREMENT,
@@ -79,7 +78,12 @@ func TestNewCompositeChunker(t *testing.T) {
 	t1 := NewTableInfo(db, "test", "composite")
 	assert.NoError(t, t1.SetInfo(t.Context()))
 
-	chunker, err := NewCompositeChunker(t1, 0, slog.Default(), "age_idx", "age > 50")
+	// When Key and Where are specified, NewChunker should always return a
+	// composite chunker even though this table has a single-column auto-inc PK.
+	chunker, err := NewChunker(t1, ChunkerConfig{
+		Key:   "age_idx",
+		Where: "age > 50",
+	})
 	assert.NoError(t, err)
 	assert.IsType(t, &chunkerComposite{}, chunker)
 	assert.Equal(t, "age_idx", chunker.(*chunkerComposite).keyName)

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -24,7 +24,7 @@ func TestOpenOnBinaryType(t *testing.T) {
 	t1.keyDatums = []datumTp{binaryType}
 	t1.KeyIsAutoInc = true
 	t1.Columns = []string{"id", "name"}
-	chunker, err := newChunker(t1, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 }
@@ -37,7 +37,7 @@ func TestOpenOnNoMinMax(t *testing.T) {
 	t1.keyDatums = []datumTp{binaryType}
 	t1.KeyIsAutoInc = true
 	t1.Columns = []string{"id", "name"}
-	chunker, err := newChunker(t1, 100, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{TargetChunkTime: 100})
 	assert.NoError(t, err)
 	assert.NoError(t, chunker.Open())
 }
@@ -50,7 +50,7 @@ func TestCallingNextChunkWithoutOpen(t *testing.T) {
 	t1.keyDatums = []datumTp{binaryType}
 	t1.KeyIsAutoInc = true
 	t1.Columns = []string{"id", "name"}
-	chunker, err := newChunker(t1, 100, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{TargetChunkTime: 100})
 	assert.NoError(t, err)
 
 	_, err = chunker.Next()
@@ -200,7 +200,7 @@ func TestDiscoveryBalancesTable(t *testing.T) {
 	assert.Equal(t, "0", t1.minValue.String())
 	assert.Equal(t, "0", t1.maxValue.String())
 
-	chunker, err := newChunker(t1, 100, slog.Default())
+	chunker, err := NewChunker(t1, ChunkerConfig{TargetChunkTime: 100})
 	assert.NoError(t, err)
 
 	assert.NoError(t, chunker.Open())


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Related: https://github.com/block/spirit/issues/701 (pre-requisite refactor)

## Summary

Replaces the four chunker constructor functions (`newChunker`, `NewChunker`, `NewCompositeChunker`, `newCompositeChunkerWithDestination`) with a single unified constructor:

```go
func NewChunker(t *TableInfo, config ChunkerConfig) (Chunker, error)
```

`ChunkerConfig` is a struct with optional fields that all have sensible defaults:
- **NewTable** — destination table (defaults to source table for move operations)
- **TargetChunkTime** — target duration per chunk (defaults to `ChunkerDefaultTarget`)
- **Logger** — structured logger (defaults to `slog.Default()`)
- **Key / Where** — force composite chunker on a specific secondary index

## Changes

- **`pkg/table/chunker.go`** — Introduce `ChunkerConfig` struct and collapse four constructors into one. When `Key` is set, the composite chunker is always selected regardless of whether the table has a single-column auto-increment PK.
- **`pkg/table/chunker_composite.go`** — Extract `resolveKey()` from `SetKey()` so that key resolution can be deferred to `open()` when key/where are provided via config at construction time. `SetKey()` still works as before for direct callers.
- **All callers updated** — `pkg/migration/runner.go`, `pkg/move/runner.go`, and all test files in `pkg/table`, `pkg/copier`, `pkg/checksum`, and `pkg/repl`.

## Why

This is a pure refactor with no behavior change. It prepares the constructor for upcoming features (ColumnMapping, MappedChunker interface) that need to pass additional configuration at chunker creation time, as part of the work to support column rename operations (#701).