### PR TITLE
Propagate applier threads config to SingleTargetApplier

### DIFF
--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -498,6 +498,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 			&applier.ApplierConfig{
 				Logger:   r.logger,
 				DBConfig: r.dbConfig,
+				Threads:  r.migration.Threads,
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
Set SingleTargetApplier worker count = migration thread count.