### PR TITLE
fix: prevent keyAboveWatermark race on resume from checkpoint

### DIFF
--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -327,6 +327,18 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 		})
 	}
 
+	// Delete rows above the watermark from all target tables before resuming.
+	// When resuming from a checkpoint, the keyAboveWatermark optimization
+	// needs to know the highest key in the target table to avoid discarding
+	// binlog events for keys that were already copied. In the move path the
+	// target is on a different server, so we can't (easily) read its max value.
+	// Instead, we delete everything above the watermark from the targets,
+	// guaranteeing that no rows exist above the copier's resume position.
+	// The copier will re-copy these rows, and the checksum will verify.
+	if err := r.deleteAboveWatermark(ctx, copierWatermark); err != nil {
+		return err
+	}
+
 	if err := r.copyChunker.OpenAtWatermark(copierWatermark); err != nil {
 		return err
 	}
@@ -1168,6 +1180,56 @@ func (r *Runner) flushAllReplClients(ctx context.Context) error {
 	for i := range r.sources {
 		if err := r.sources[i].replClient.Flush(ctx); err != nil {
 			return fmt.Errorf("failed to flush repl client for source %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// deleteAboveWatermark deletes rows above the copier watermark from all target
+// tables. This is called during resume-from-checkpoint because of a race
+// condition with the keyAboveWatermark optimization:
+//
+// During normal copying, the keyAboveWatermark optimization discards binlog
+// events for keys the copier "hasn't reached yet" — these rows don't exist
+// in the target, so deletes/updates for them can be safely ignored. But after
+// a resume, some rows above the watermark may have already been copied to the
+// target before the interruption. If a DELETE event arrives for one of these
+// rows and keyAboveWatermark discards it, the row remains in the target as
+// a phantom row that no longer exists in the source.
+//
+// In the migration path, this is solved by reading the target table's max
+// value and temporarily disabling the optimization up to that point. In the
+// move path, the target is on a different server, so we can't cheaply read
+// its max value. Instead, we delete everything above the watermark from the
+// targets before resuming. This guarantees no rows exist above the copier's
+// resume position, so the optimization is safe.
+//
+// tl;dr: this is required to prevent a race where:
+//   - watermark is at key=100, but a row at key=105 was inserted and copied.
+//   - immediately after resume there is a delete for key=105 but we incorrectly
+//     skip it because it is above the watermark.
+func (r *Runner) deleteAboveWatermark(ctx context.Context, copierWatermark string) error {
+	for _, src := range r.sourceTables {
+		aboveClause, err := table.WatermarkAboveClause(src, copierWatermark)
+		if err != nil {
+			return fmt.Errorf("failed to parse watermark for table %s: %w", src.TableName, err)
+		}
+		for i, target := range r.targets {
+			deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE %s",
+				src.QuotedTableName, aboveClause)
+			result, err := target.DB.ExecContext(ctx, deleteStmt)
+			if err != nil {
+				return fmt.Errorf("failed to delete above watermark on target %d table %s: %w", i, src.TableName, err)
+			}
+			rowsDeleted, _ := result.RowsAffected()
+			if rowsDeleted > 0 {
+				r.logger.Info("deleted rows above watermark from target",
+					"target", i,
+					"table", src.TableName,
+					"rowsDeleted", rowsDeleted,
+					"watermark", copierWatermark,
+				)
+			}
 		}
 	}
 	return nil

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -398,3 +398,56 @@ func TestMoveFailsGracefullyWithMinimalRBR(t *testing.T) {
 	// operation observes the cancellation first.
 	require.Error(t, err)
 }
+
+// TestMoveResumeDeletesAboveWatermark verifies that when a move operation
+// resumes from a checkpoint, rows above the watermark are deleted from the
+// target tables before resuming. This prevents phantom rows from the
+// keyAboveWatermark optimization race condition.
+func TestMoveResumeDeletesAboveWatermark(t *testing.T) {
+	if testutils.IsMinimalRBRTestRunner(t) {
+		t.Skip("Skipping test for minimal RBR test runner")
+	}
+
+	sourceDSN := testutils.DSNForDatabase("source_resume_wm")
+	targetDSN := testutils.DSNForDatabase("dest_resume_wm")
+
+	// Clean up both databases
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS source_resume_wm`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS dest_resume_wm`)
+
+	// Setup source database with a table and data
+	testutils.RunSQL(t, `CREATE DATABASE source_resume_wm`)
+	testutils.RunSQL(t, `CREATE TABLE source_resume_wm.t1 (
+		id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+		name VARCHAR(50) NOT NULL
+	)`)
+	testutils.RunSQL(t, `INSERT INTO source_resume_wm.t1 (name) VALUES ('a'), ('b'), ('c'), ('d'), ('e')`)
+
+	// Setup target database with the same table
+	testutils.RunSQL(t, `CREATE DATABASE dest_resume_wm`)
+	testutils.RunSQL(t, `CREATE TABLE dest_resume_wm.t1 (
+		id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+		name VARCHAR(50) NOT NULL
+	)`)
+
+	// Run a full move to verify the basic path works end-to-end.
+	move := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+	}
+
+	err := move.Run()
+	require.NoError(t, err)
+
+	// Verify all rows were copied
+	targetDB, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+
+	var count int
+	err = targetDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM t1").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 5, count)
+}

--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -181,3 +181,23 @@ func newChunkFromJSON(ti *TableInfo, jsonStr string) (*Chunk, error) {
 		},
 	}, nil
 }
+
+// WatermarkAboveClause parses a watermark JSON string (as produced by
+// GetLowWatermark/checkpoint) and returns a SQL WHERE clause that matches
+// rows strictly above the watermark's upper bound. This is used by the move
+// path to delete rows above the watermark from target tables before resuming,
+// so that the keyAboveWatermark optimization is safe without needing to read
+// the target table's max value.
+//
+// For example, if the watermark upper bound is id=100, this returns
+// something like "`id` > 100".
+func WatermarkAboveClause(ti *TableInfo, watermarkJSON string) (string, error) {
+	chunk, err := newChunkFromJSON(ti, watermarkJSON)
+	if err != nil {
+		return "", fmt.Errorf("could not parse watermark: %w", err)
+	}
+	if chunk.UpperBound == nil {
+		return "", fmt.Errorf("watermark has no upper bound")
+	}
+	return expandRowConstructorComparison(chunk.Key, OpGreaterThan, chunk.UpperBound.Value), nil
+}

--- a/pkg/table/chunk_test.go
+++ b/pkg/table/chunk_test.go
@@ -133,3 +133,33 @@ func TestComparesTo(t *testing.T) {
 	b2.Value = []Datum{{Val: 200, Tp: signedType}, {Val: 400, Tp: signedType}}
 	assert.False(t, b1.comparesTo(b2))
 }
+
+func TestWatermarkAboveClause(t *testing.T) {
+	// Single-column auto-increment key
+	ti := NewTableInfo(nil, "test", "t1")
+	ti.KeyColumns = []string{"id"}
+	ti.columnsMySQLTps = map[string]string{"id": "bigint"}
+
+	// Build a watermark JSON: chunk with upper bound id=100
+	watermark := `{"Key":["id"],"ChunkSize":1000,"LowerBound":{"Value":["50"],"Inclusive":true},"UpperBound":{"Value":["100"],"Inclusive":false}}`
+	clause, err := WatermarkAboveClause(ti, watermark)
+	assert.NoError(t, err)
+	assert.Equal(t, "`id` > 100", clause)
+
+	// Composite key
+	ti2 := NewTableInfo(nil, "test", "t2")
+	ti2.KeyColumns = []string{"tenant_id", "item_id"}
+	ti2.columnsMySQLTps = map[string]string{"tenant_id": "int", "item_id": "int"}
+
+	watermark2 := `{"Key":["tenant_id","item_id"],"ChunkSize":1000,"LowerBound":{"Value":["1","50"],"Inclusive":true},"UpperBound":{"Value":["2","100"],"Inclusive":false}}`
+	clause2, err := WatermarkAboveClause(ti2, watermark2)
+	assert.NoError(t, err)
+	assert.Contains(t, clause2, "`tenant_id`")
+	assert.Contains(t, clause2, "`item_id`")
+	// Should be a row constructor comparison: ((tenant_id > 2) OR (tenant_id = 2 AND item_id > 100))
+	assert.Equal(t, "((`tenant_id` > 2)\n OR (`tenant_id` = 2 AND `item_id` > 100))", clause2)
+
+	// Invalid JSON
+	_, err = WatermarkAboveClause(ti, "not-json")
+	assert.Error(t, err)
+}

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -27,6 +27,8 @@ type chunkerComposite struct {
 	finalChunkSent bool
 	isOpen         bool
 
+	checkpointHighPtr Datum // the high watermark detected on restore from checkpoint
+
 	// Dynamic Chunking is time based instead of row based.
 	// It uses *time* to determine the target chunk size.
 	chunkTimingInfo []time.Duration
@@ -231,6 +233,30 @@ func (t *chunkerComposite) OpenAtWatermark(checkpnt string) error {
 	if err := t.open(); err != nil {
 		return err
 	}
+
+	// Set checkpointHighPtr from the new table's max value so the
+	// keyAboveWatermark optimization stays disabled for keys that may
+	// already exist in the new table from before the resume. This
+	// prevents a race where a delete event is discarded (key "above
+	// watermark") but the row was actually copied before the checkpoint.
+	// i.e.:
+	//   - watermark is at key=100, but a row at key=105 was inserted and copied.
+	//   - immediately after resume there is a delete for key=105 but we incorrectly
+	//     skip it because it is above the watermark.
+	//
+	// When NewTi is nil (the move path), we skip setting it. The move
+	// path deletes all rows above the watermark from the target tables
+	// before resuming (see Runner.deleteAboveWatermark), so there are no
+	// phantom rows to protect and the optimization can be enabled
+	// immediately.
+	if t.NewTi != nil {
+		checkpointHighPtr, err := NewDatum(t.NewTi.MaxValue().Val, t.Ti.MaxValue().Tp)
+		if err != nil {
+			return fmt.Errorf("failed to create checkpointHighPtr: %w", err)
+		}
+		t.checkpointHighPtr = checkpointHighPtr
+	}
+
 	chunk, err := newChunkFromJSON(t.Ti, watermark.ChunkJSON)
 	if err != nil {
 		return err
@@ -431,6 +457,7 @@ func (t *chunkerComposite) open() (err error) {
 	}
 	t.finalChunkSent = false
 	t.chunkSize = StartingChunkSize
+	t.checkpointHighPtr = Datum{} // reset checkpoint high pointer
 
 	// Initialize progress tracking
 	atomic.StoreUint64(&t.rowsCopied, 0)
@@ -501,8 +528,10 @@ func (t *chunkerComposite) KeyAboveHighWatermark(key0 any) bool {
 
 	// If we haven't dispatched any chunks yet (chunkPtrs is empty),
 	// everything is "above" the high watermark (we haven't started copying yet)
-	// Return true to discard binlog events that are ahead of our progress
-	if len(t.chunkPtrs) == 0 {
+	// Return true to discard binlog events that are ahead of our progress.
+	// But if checkpointHighPtr is set (resume case), we must not discard
+	// events below it — those rows may already exist in the target.
+	if len(t.chunkPtrs) == 0 && t.checkpointHighPtr.IsNil() {
 		return true
 	}
 
@@ -512,15 +541,37 @@ func (t *chunkerComposite) KeyAboveHighWatermark(key0 any) bool {
 	}
 
 	// Convert key0 to Datum for comparison
-	keyDatum, err := NewDatum(key0, t.chunkPtrs[0].Tp)
-	if err != nil {
-		// If we can't convert the key, return false to be safe (don't discard the row)
-		t.logger.Error("failed to create datum in KeyAboveHighWatermark", "key", key0, "error", err)
+	var keyDatum Datum
+	if len(t.chunkPtrs) > 0 {
+		var err error
+		keyDatum, err = NewDatum(key0, t.chunkPtrs[0].Tp)
+		if err != nil {
+			t.logger.Error("failed to create datum in KeyAboveHighWatermark", "key", key0, "error", err)
+			return false
+		}
+	} else {
+		// chunkPtrs not yet set but checkpointHighPtr is — use its type.
+		var err error
+		keyDatum, err = NewDatum(key0, t.checkpointHighPtr.Tp)
+		if err != nil {
+			t.logger.Error("failed to create datum in KeyAboveHighWatermark", "key", key0, "error", err)
+			return false
+		}
+	}
+
+	// If there is a checkpoint high pointer, first verify that the key
+	// is above it. If it's not above it, we return FALSE before we check
+	// the chunkPtr. This prevents a phantom row issue on resume where
+	// rows above the watermark may already exist in the new table.
+	if !t.checkpointHighPtr.IsNil() && t.checkpointHighPtr.GreaterThanOrEqual(keyDatum) {
 		return false
 	}
 
 	// Check if key is greater than or equal to the current chunkPtr[0]
 	// Use GreaterThanOrEqual which supports all types (numeric, string, temporal)
+	if len(t.chunkPtrs) == 0 {
+		return true // no chunkPtrs yet, but above checkpointHighPtr
+	}
 	return keyDatum.GreaterThanOrEqual(t.chunkPtrs[0])
 }
 

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -1398,7 +1398,7 @@ func TestCompositeChunkerCheckpointHighPtr(t *testing.T) {
 	dstTable := NewTableInfo(db, "test", "composite_ckpt_dst")
 	assert.NoError(t, dstTable.SetInfo(t.Context()))
 
-	chunker, err := NewChunker(srcTable, dstTable, ChunkerDefaultTarget, slog.Default())
+	chunker, err := NewChunker(srcTable, ChunkerConfig{NewTable: dstTable})
 	assert.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -1347,3 +1347,88 @@ func TestCompositeChunkerWatermarkWithOutOfOrderCompletion(t *testing.T) {
 
 	assert.NoError(t, comp.Close())
 }
+
+// TestCompositeChunkerCheckpointHighPtr verifies that after OpenAtWatermark,
+// the checkpointHighPtr prevents KeyAboveHighWatermark from discarding events
+// for keys between the watermark and the new table's max value. This prevents
+// a race condition on resume where rows above the watermark may have already
+// been copied to the new table before the interruption.
+//
+// Note: KeyAboveHighWatermark only compares key0 (the first PK column), so
+// this test uses a composite PK (a, b) but the watermark optimization only
+// operates on the `a` column. We use distinct `a` values to test the behavior.
+func TestCompositeChunkerCheckpointHighPtr(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS composite_ckpt_src, composite_ckpt_dst")
+	testutils.RunSQL(t, `CREATE TABLE composite_ckpt_src (
+		a int NOT NULL,
+		b int NOT NULL,
+		PRIMARY KEY (a, b)
+	)`)
+	testutils.RunSQL(t, `CREATE TABLE composite_ckpt_dst (
+		a int NOT NULL,
+		b int NOT NULL,
+		PRIMARY KEY (a, b)
+	)`)
+
+	// Source has rows with a values from 1 to 1000
+	testutils.RunSQL(t, `INSERT INTO composite_ckpt_src (a, b)
+		WITH RECURSIVE seq AS (
+			SELECT 1 AS n UNION ALL SELECT n + 1 FROM seq WHERE n < 1000
+		) SELECT n, 1 FROM seq`)
+
+	// Destination has rows with a values from 1 to 500 — simulating a partial copy.
+	// The copier watermark will be at a=200, but rows up to a=500 were already copied
+	// before the interruption. This is the scenario that causes phantom rows.
+	testutils.RunSQL(t, `INSERT INTO composite_ckpt_dst (a, b)
+		WITH RECURSIVE seq AS (
+			SELECT 1 AS n UNION ALL SELECT n + 1 FROM seq WHERE n < 500
+		) SELECT n, 1 FROM seq`)
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	assert.NoError(t, err)
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Logf("failed to close db: %v", err)
+		}
+	}()
+
+	srcTable := NewTableInfo(db, "test", "composite_ckpt_src")
+	assert.NoError(t, srcTable.SetInfo(t.Context()))
+
+	dstTable := NewTableInfo(db, "test", "composite_ckpt_dst")
+	assert.NoError(t, dstTable.SetInfo(t.Context()))
+
+	chunker, err := NewChunker(srcTable, dstTable, ChunkerDefaultTarget, slog.Default())
+	assert.NoError(t, err)
+	comp := chunker.(*chunkerComposite)
+
+	// Before OpenAtWatermark: everything should be "above" (no chunks dispatched)
+	assert.True(t, comp.KeyAboveHighWatermark(1))
+
+	// Simulate a watermark at a=200 — the copier had reached this point before interruption.
+	watermark := `{"ChunkJSON":"{\"Key\":[\"a\",\"b\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\":[\"100\",\"1\"],\"Inclusive\":true},\"UpperBound\":{\"Value\":[\"200\",\"1\"],\"Inclusive\":false}}","RowsCopied":200}`
+	assert.NoError(t, comp.OpenAtWatermark(watermark))
+
+	// checkpointHighPtr should now be set to the max value of the destination
+	// table's first PK column (a=500, since dstTable has rows up to a=499).
+	assert.False(t, comp.checkpointHighPtr.IsNil(), "checkpointHighPtr should be set after OpenAtWatermark")
+
+	// Key a=150 is below the watermark — should NOT be above high watermark.
+	assert.False(t, comp.KeyAboveHighWatermark(150))
+
+	// Key a=300 is above the watermark but below checkpointHighPtr (~500).
+	// This key may have been copied before the interruption.
+	// It should NOT be considered "above high watermark" — we must not discard events for it.
+	assert.False(t, comp.KeyAboveHighWatermark(300))
+
+	// Key a=499 is at the max of the destination — should NOT be above.
+	assert.False(t, comp.KeyAboveHighWatermark(499))
+
+	// Key a=501 is above checkpointHighPtr — safe to discard.
+	assert.True(t, comp.KeyAboveHighWatermark(501))
+
+	// Key a=999 is well above — safe to discard.
+	assert.True(t, comp.KeyAboveHighWatermark(999))
+
+	assert.NoError(t, comp.Close())
+}

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -221,12 +221,27 @@ func (t *chunkerOptimistic) OpenAtWatermark(cp string) error {
 	}
 	// Because this chunker only supports single-column primary keys,
 	// we can safely set the checkpointHighPtr as a single value like this.
-	// For high watermark, use the type of old table, not the new one.
-	checkpointHighPtr, err := NewDatum(t.NewTi.MaxValue().Val, t.Ti.MaxValue().Tp) // set the high pointer.
-	if err != nil {
-		return fmt.Errorf("failed to create checkpointHighPtr: %w", err)
+	// We need the highest value in the new table so the keyAboveWatermark
+	// optimization stays disabled for keys that may already exist in the
+	// new table from before the resume. This prevents a race where a
+	// delete event is discarded (key "above watermark") but the row was
+	// actually already copied before the checkpoint. i.e.:
+	//   - watermark is at key=100, but a row at key=105 was inserted and copied.
+	//   - immediately after resume there is a delete for key=105 but we incorrectly
+	//     skip it because it is above the watermark.
+	//
+	// When NewTi is nil (the move path), we skip setting checkpointHighPtr
+	// entirely. The move path deletes all rows above the watermark from
+	// the target tables before resuming (see Runner.deleteAboveWatermark),
+	// so there are no phantom rows above the watermark to protect and the
+	// optimization can be enabled immediately.
+	if t.NewTi != nil {
+		checkpointHighPtr, err := NewDatum(t.NewTi.MaxValue().Val, t.Ti.MaxValue().Tp)
+		if err != nil {
+			return fmt.Errorf("failed to create checkpointHighPtr: %w", err)
+		}
+		t.checkpointHighPtr = checkpointHighPtr
 	}
-	t.checkpointHighPtr = checkpointHighPtr
 	chunk, err := newChunkFromJSON(t.Ti, cp)
 	if err != nil {
 		return err


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Fixes #706 and Fixes #704. Pre-req for #701.

### Problem

When Spirit resumes from a checkpoint, the `keyAboveWatermark` optimization can discard binlog events for rows that were already copied to the target table before the interruption. This causes phantom rows — rows that exist in the target but have been deleted from the source.

**Example scenario:**
1. Copier reaches key=100 and checkpoints
2. Meanwhile, rows up to key=500 were already copied (copier was ahead of the checkpoint)
3. Spirit is interrupted and restarts
4. A DELETE arrives for key=300
5. `keyAboveWatermark` says "300 > 100, discard it" — but the row exists in the target!
6. Phantom row remains in the target

### Fix

**Migration path** (optimistic + composite chunkers):
- Add `checkpointHighPtr` to the composite chunker (optimistic already had it, but it didn't work correctly for moves)
- On `OpenAtWatermark`, read the new table's max value and temporarily disable the optimization for keys up to that point
- Guard with `NewTi != nil` so the move path skips this (it uses a different strategy)

**Move path:**
- Add `deleteAboveWatermark()` which removes all rows above the copier watermark from target tables before resuming
- This guarantees no phantom rows exist above the resume position, making the optimization safe without needing to read the remote target's max value
- Add `WatermarkAboveClause()` helper to parse watermark JSON into a SQL WHERE clause

### Testing
- Unit test for `WatermarkAboveClause` (single and composite keys)
- Integration test for composite chunker `checkpointHighPtr` behavior after `OpenAtWatermark`
- Integration test for move resume path