### PR TITLE
refactor: introduce MappedChunker interface and ColumnMapping type

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -66,7 +66,7 @@ type Applier interface {
 	// The rows are LogicalRow structs containing the row images.
 	// If lock is non-nil, the upsert is executed under the table lock.
 	// Returns the number of rows affected and any error.
-	UpsertRows(ctx context.Context, sourceTable, targetTable *table.TableInfo, rows []LogicalRow, lock *dbconn.TableLock) (int64, error)
+	UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []LogicalRow, lock *dbconn.TableLock) (int64, error)
 
 	// Wait blocks until all pending work is complete and all callbacks have been invoked
 	Wait(ctx context.Context) error

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -413,8 +413,8 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 	defer cancel()
 
 	// Get the intersected column names
-	columnNames := utils.IntersectNonGeneratedColumnsAsSlice(chunkletData.chunk.Table, chunkletData.chunk.NewTable)
-	columnList := utils.IntersectNonGeneratedColumns(chunkletData.chunk.Table, chunkletData.chunk.NewTable)
+	columnList, _ := chunkletData.chunk.ColumnMapping.Columns()
+	columnNames, _ := chunkletData.chunk.ColumnMapping.ColumnsSlice()
 
 	// Build VALUES clauses for all rows in the chunklet
 	var valuesClauses []string
@@ -425,7 +425,7 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 		}
 		var values []string
 		for i, value := range row.values {
-			columnType, ok := chunkletData.chunk.NewTable.GetColumnMySQLType(columnNames[i])
+			columnType, ok := chunkletData.chunk.ColumnMapping.TargetTable().GetColumnMySQLType(columnNames[i])
 			if !ok {
 				return 0, fmt.Errorf("column %s not found in table info", columnNames[i])
 			}
@@ -442,13 +442,13 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 	// Note: We use just the table name, not the fully qualified name, because
 	// the database connection (shard.writeDB) already determines which database to write to
 	query := fmt.Sprintf("INSERT IGNORE INTO %s (%s) VALUES %s",
-		chunkletData.chunk.NewTable.QuotedTableName,
+		chunkletData.chunk.ColumnMapping.TargetTable().QuotedTableName,
 		columnList,
 		strings.Join(valuesClauses, ", "),
 	)
 
 	a.logger.Debug("writing chunklet to shard", "shardID", shard.shardID,
-		"rowCount", len(chunkletData.rows), "table", chunkletData.chunk.NewTable.TableName)
+		"rowCount", len(chunkletData.rows), "table", chunkletData.chunk.ColumnMapping.TargetTable().TableName)
 
 	// Execute the batch insert on this shard's database
 	result, err := dbconn.RetryableTransaction(ctx, shard.writeDB, true, shard.dbConfig, query)
@@ -652,7 +652,7 @@ func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.T
 // Note: the sharded applier does not allow any transformations!
 // The targetTable argument is intentionally ignored.
 // This also means that table names between source and target must be the same.
-func (a *ShardedApplier) UpsertRows(ctx context.Context, sourceTable, _ *table.TableInfo, rows []LogicalRow, lock *dbconn.TableLock) (int64, error) {
+func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []LogicalRow, lock *dbconn.TableLock) (int64, error) {
 	if len(rows) == 0 {
 		return 0, nil
 	}
@@ -661,6 +661,7 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, sourceTable, _ *table.T
 	ctx, cancel := context.WithTimeout(ctx, chunkTaskTimeout)
 	defer cancel()
 
+	sourceTable := mapping.SourceTable()
 	if sourceTable.ShardingColumn == "" {
 		return 0, errors.New("ShardingColumn not configured in TableInfo")
 	}
@@ -671,19 +672,9 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, sourceTable, _ *table.T
 	// Find the ordinal position of the sharding column within ALL columns
 	// (since RowImage from binlog contains ALL columns, including generated ones)
 	shardingOrdinal := slices.Index(sourceTable.Columns, sourceTable.ShardingColumn)
+	sourceOrdinal := mapping.SourceOrdinalIndices()
 	if shardingOrdinal == -1 {
 		return 0, fmt.Errorf("sharding column %s not found in columns", sourceTable.ShardingColumn)
-	}
-
-	// Build a map from NonGeneratedColumns to their indices in the full Columns list
-	// This is needed because RowImage contains ALL columns, but we only INSERT non-generated ones
-	var nonGeneratedIndices []int
-	for _, col := range sourceTable.NonGeneratedColumns {
-		idx := slices.Index(sourceTable.Columns, col)
-		if idx == -1 {
-			return 0, fmt.Errorf("non-generated column %s not found in columns", col)
-		}
-		nonGeneratedIndices = append(nonGeneratedIndices, idx)
 	}
 
 	// Group rows by shard
@@ -742,7 +733,7 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, sourceTable, _ *table.T
 			var valuesClauses []string
 			for _, logicalRow := range r {
 				var values []string
-				for i, colIdx := range nonGeneratedIndices {
+				for i, colIdx := range sourceOrdinal {
 					if colIdx >= len(logicalRow.RowImage) {
 						results <- result{err: fmt.Errorf("column index %d exceeds row image length %d", colIdx, len(logicalRow.RowImage))}
 						return

--- a/pkg/applier/sharded_test.go
+++ b/pkg/applier/sharded_test.go
@@ -476,7 +476,7 @@ func TestShardedApplierUpsertRows(t *testing.T) {
 		},
 	}
 
-	affectedRows, err := applier.UpsertRows(t.Context(), sourceTable, target1Table, upsertRows, nil)
+	affectedRows, err := applier.UpsertRows(t.Context(), table.NewColumnMapping(sourceTable, target1Table, nil), upsertRows, nil)
 	require.NoError(t, err)
 	t.Logf("Upserted %d rows total across all shards", affectedRows)
 
@@ -609,7 +609,7 @@ func TestShardedApplierUpsertRowsSkipDeleted(t *testing.T) {
 		},
 	}
 
-	affectedRows, err := applier.UpsertRows(t.Context(), targetTable, targetTable, upsertRows, nil)
+	affectedRows, err := applier.UpsertRows(t.Context(), table.NewColumnMapping(targetTable, targetTable, nil), upsertRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), affectedRows)
 
@@ -776,7 +776,7 @@ func TestShardedApplierUpsertRowsEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	// Upsert with empty rows
-	affectedRows, err := applier.UpsertRows(t.Context(), targetTable, targetTable, []LogicalRow{}, nil)
+	affectedRows, err := applier.UpsertRows(t.Context(), table.NewColumnMapping(targetTable, targetTable, nil), []LogicalRow{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), affectedRows)
 }

--- a/pkg/applier/sharded_test.go
+++ b/pkg/applier/sharded_test.go
@@ -118,8 +118,9 @@ func TestShardedApplierIntegration(t *testing.T) {
 
 	// Create a chunk for the apply operation
 	chunk := &table.Chunk{
-		Table:    sourceTable,
-		NewTable: shard1Table, // Doesn't matter which, both have same structure
+		Table:         sourceTable,
+		NewTable:      shard1Table, // Doesn't matter which, both have same structure
+		ColumnMapping: table.NewColumnMapping(sourceTable, shard1Table, nil),
 	}
 
 	// Apply the rows

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -301,8 +301,8 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 	}
 
 	// Get the intersected column names to match with the values
-	columnNames := utils.IntersectNonGeneratedColumnsAsSlice(chunkletData.chunk.Table, chunkletData.chunk.NewTable)
-	columnList := utils.IntersectNonGeneratedColumns(chunkletData.chunk.Table, chunkletData.chunk.NewTable)
+	columnList, _ := chunkletData.chunk.ColumnMapping.Columns()
+	columnNames, _ := chunkletData.chunk.ColumnMapping.ColumnsSlice()
 
 	// Build VALUES clauses for all rows in the chunklet
 	var valuesClauses []string
@@ -313,7 +313,7 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 		}
 		var values []string
 		for i, value := range row.values {
-			columnType, ok := chunkletData.chunk.NewTable.GetColumnMySQLType(columnNames[i])
+			columnType, ok := chunkletData.chunk.ColumnMapping.TargetTable().GetColumnMySQLType(columnNames[i])
 			if !ok {
 				return 0, fmt.Errorf("column %s not found in table info", columnNames[i])
 			}
@@ -328,12 +328,12 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 
 	// Build the INSERT statement
 	query := fmt.Sprintf("INSERT IGNORE INTO %s (%s) VALUES %s",
-		chunkletData.chunk.NewTable.QuotedTableName,
+		chunkletData.chunk.ColumnMapping.TargetTable().QuotedTableName,
 		columnList,
 		strings.Join(valuesClauses, ", "),
 	)
 
-	a.logger.Debug("writing chunklet", "rowCount", len(chunkletData.rows), "table", chunkletData.chunk.NewTable.TableName)
+	a.logger.Debug("writing chunklet", "rowCount", len(chunkletData.rows), "table", chunkletData.chunk.ColumnMapping.TargetTable().TableName)
 
 	// Execute the batch insert
 	result, err := dbconn.RetryableTransaction(ctx, a.target.DB, true, a.dbConfig, query)
@@ -456,25 +456,13 @@ func (a *SingleTargetApplier) DeleteKeys(ctx context.Context, sourceTable, targe
 // UpsertRows performs an upsert (INSERT ... ON DUPLICATE KEY UPDATE) synchronously.
 // The rows are LogicalRow structs containing the row images.
 // If lock is non-nil, the upsert is executed under the table lock.
-func (a *SingleTargetApplier) UpsertRows(ctx context.Context, sourceTable, targetTable *table.TableInfo, rows []LogicalRow, lock *dbconn.TableLock) (int64, error) {
+func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []LogicalRow, lock *dbconn.TableLock) (int64, error) {
 	if len(rows) == 0 {
 		return 0, nil
 	}
-	// For move operations, targetTable may be nil - use sourceTable for both
-	if targetTable == nil {
-		targetTable = sourceTable
-	}
-	// Get the columns that exist in both source and destination tables
-	columnList := utils.IntersectNonGeneratedColumns(sourceTable, targetTable)
-	columnNames := utils.IntersectNonGeneratedColumnsAsSlice(sourceTable, targetTable)
-
-	// Get the intersected column indices
-	var intersectedColumns []int
-	for i, sourceCol := range sourceTable.NonGeneratedColumns {
-		if slices.Contains(targetTable.NonGeneratedColumns, sourceCol) {
-			intersectedColumns = append(intersectedColumns, i)
-		}
-	}
+	_, targetColumnList := mapping.Columns()
+	sourceColumnNames, targetColumnNames := mapping.ColumnsSlice()
+	intersectedColumns := mapping.SourceColumnIndices()
 
 	// Build the VALUES clause from the row images
 	var valuesClauses []string
@@ -489,21 +477,14 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, sourceTable, targe
 				return 0, fmt.Errorf("column index %d exceeds row image length %d", colIndex, len(logicalRow.RowImage))
 			}
 			// In order to create a datum we need to know the MySQL type,
-			// which we can get from the source table. We just do an initial
-			// safety check to ensure the column index exists in the list
-			// of column names.
-			if i >= len(columnNames) {
-				return 0, fmt.Errorf("column index %d exceeds columnNames length %d", i, len(columnNames))
-			}
-			columnType, ok := sourceTable.GetColumnMySQLType(columnNames[i])
+			// which we can get from the source table.
+			columnType, ok := mapping.SourceTable().GetColumnMySQLType(sourceColumnNames[i])
 			if !ok {
-				return 0, fmt.Errorf("column %s not found in table info", columnNames[i])
+				return 0, fmt.Errorf("column %s not found in table info", sourceColumnNames[i])
 			}
-			// The value appended here will be escaped
-			// by calling String() on the Datum
 			datum, err := table.NewDatumFromValue(logicalRow.RowImage[colIndex], columnType)
 			if err != nil {
-				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", columnNames[i], err)
+				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", sourceColumnNames[i], err)
 			}
 			values = append(values, datum.String())
 		}
@@ -514,26 +495,22 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, sourceTable, targe
 		return 0, nil
 	}
 
-	// Build the ON DUPLICATE KEY UPDATE clause using MySQL 8.0+ syntax
+	// Build the ON DUPLICATE KEY UPDATE clause using target column names.
 	var updateClauses []string
-	for _, col := range targetTable.NonGeneratedColumns {
-		// Skip primary key columns in the UPDATE clause
-		if !slices.Contains(targetTable.KeyColumns, col) {
-			// Check if this column exists in both tables
-			if slices.Contains(sourceTable.NonGeneratedColumns, col) {
-				updateClauses = append(updateClauses, fmt.Sprintf("`%s` = new.`%s`", col, col))
-			}
+	for _, col := range targetColumnNames {
+		if !slices.Contains(mapping.TargetTable().KeyColumns, col) {
+			updateClauses = append(updateClauses, fmt.Sprintf("`%s` = new.`%s`", col, col))
 		}
 	}
 
 	upsertStmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s AS new ON DUPLICATE KEY UPDATE %s",
-		targetTable.QuotedTableName,
-		columnList,
+		mapping.TargetTable().QuotedTableName,
+		targetColumnList,
 		strings.Join(valuesClauses, ", "),
 		strings.Join(updateClauses, ", "),
 	)
 
-	a.logger.Debug("executing upsert", "rowCount", len(valuesClauses), "table", targetTable.TableName)
+	a.logger.Debug("executing upsert", "rowCount", len(valuesClauses), "table", mapping.TargetTable().TableName)
 
 	// Execute under lock if provided
 	if lock != nil {

--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -87,8 +87,9 @@ func TestSingleTargetApplierBasic(t *testing.T) {
 
 	// Create a chunk
 	chunk := &table.Chunk{
-		Table:    sourceTable,
-		NewTable: targetTable,
+		Table:         sourceTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(sourceTable, targetTable, nil),
 	}
 
 	// Apply the rows
@@ -195,8 +196,9 @@ func TestSingleTargetApplierEmptyRows(t *testing.T) {
 
 	// Apply empty rows
 	chunk := &table.Chunk{
-		Table:    targetTable,
-		NewTable: targetTable,
+		Table:         targetTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
 	}
 
 	var callbackInvoked atomic.Bool
@@ -259,8 +261,9 @@ func TestSingleTargetApplierLargeDataset(t *testing.T) {
 	}
 
 	chunk := &table.Chunk{
-		Table:    targetTable,
-		NewTable: targetTable,
+		Table:         targetTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
 	}
 
 	var callbackInvoked atomic.Bool
@@ -345,8 +348,9 @@ func TestSingleTargetApplierConcurrentApplies(t *testing.T) {
 			}
 
 			chunk := &table.Chunk{
-				Table:    targetTable,
-				NewTable: targetTable,
+				Table:         targetTable,
+				NewTable:      targetTable,
+				ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
 			}
 
 			callback := func(affectedRows int64, err error) {
@@ -714,8 +718,9 @@ func TestSingleTargetApplierContextCancellation(t *testing.T) {
 	}
 
 	chunk := &table.Chunk{
-		Table:    targetTable,
-		NewTable: targetTable,
+		Table:         targetTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
 	}
 
 	// Start applying but cancel immediately
@@ -773,8 +778,9 @@ func TestSingleTargetApplierWaitTimeout(t *testing.T) {
 	// Apply some work
 	testRows := [][]any{{int64(1)}, {int64(2)}}
 	chunk := &table.Chunk{
-		Table:    targetTable,
-		NewTable: targetTable,
+		Table:         targetTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
 	}
 
 	callback := func(affectedRows int64, err error) {}
@@ -830,8 +836,9 @@ func TestSingleTargetApplierStartClose(t *testing.T) {
 	// Apply some work
 	testRows := [][]any{{int64(1)}, {int64(2)}}
 	chunk := &table.Chunk{
-		Table:    targetTable,
-		NewTable: targetTable,
+		Table:         targetTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
 	}
 
 	var callbackInvoked atomic.Bool

--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -539,7 +539,7 @@ func TestSingleTargetApplierUpsertRows(t *testing.T) {
 		},
 	}
 
-	affectedRows, err := applier.UpsertRows(t.Context(), targetTable, targetTable, upsertRows, nil)
+	affectedRows, err := applier.UpsertRows(t.Context(), table.NewColumnMapping(targetTable, targetTable, nil), upsertRows, nil)
 	require.NoError(t, err)
 	// MySQL returns 1 for insert, 2 for update in ON DUPLICATE KEY UPDATE
 	// So we expect 1 (update of id=1) + 1 (insert of id=3) = at least 2
@@ -621,7 +621,7 @@ func TestSingleTargetApplierUpsertRowsSkipDeleted(t *testing.T) {
 		},
 	}
 
-	affectedRows, err := applier.UpsertRows(t.Context(), targetTable, targetTable, upsertRows, nil)
+	affectedRows, err := applier.UpsertRows(t.Context(), table.NewColumnMapping(targetTable, targetTable, nil), upsertRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), affectedRows)
 
@@ -663,7 +663,7 @@ func TestSingleTargetApplierUpsertRowsEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	// Upsert with empty rows
-	affectedRows, err := applier.UpsertRows(t.Context(), targetTable, targetTable, []LogicalRow{}, nil)
+	affectedRows, err := applier.UpsertRows(t.Context(), table.NewColumnMapping(targetTable, targetTable, nil), []LogicalRow{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), affectedRows)
 }

--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -60,7 +59,10 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 
 	// Build the checksum query fragment. The same WHERE clause and column list
 	// applies to both sources and targets since all schemas are identical.
-	checksumColumns := c.intersectColumns(chunk)
+	checksumColumns, _, err := chunk.ColumnMapping.ChecksumExprs()
+	if err != nil {
+		return err
+	}
 	whereClause := chunk.String()
 
 	// Query ALL sources and aggregate results.
@@ -538,21 +540,4 @@ func (c *DistributedChecker) runChecksum(ctx context.Context) error {
 		return err1
 	}
 	return nil
-}
-
-// intersectColumns is similar to utils.IntersectColumns, but it
-// wraps an IFNULL(), ISNULL() and cast operation around the columns.
-// The cast is to c.newTable type.
-func (c *DistributedChecker) intersectColumns(chunk *table.Chunk) string {
-	var intersection []string
-	for _, col := range chunk.Table.NonGeneratedColumns {
-		for _, col2 := range chunk.NewTable.NonGeneratedColumns {
-			if col == col2 {
-				// Column exists in both, so we add intersection wrapped in
-				// IFNULL, ISNULL and CAST.
-				intersection = append(intersection, "IFNULL("+chunk.NewTable.WrapCastType(col)+",''), ISNULL(`"+col+"`)")
-			}
-		}
-	}
-	return strings.Join(intersection, ", ")
 }

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -65,11 +65,10 @@ func TestFixCorruptWithApplier(t *testing.T) {
 		Applier:         applier,
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
@@ -170,13 +169,10 @@ func TestDistributedChecksum(t *testing.T) {
 
 	// For distributed checksum, we only add one subscription for the source table
 	// The applier handles distribution to multiple shards
-	require.NoError(t, feed.AddSubscription(sourceTable, sourceTable, nil))
-	require.NoError(t, feed.Run(t.Context()))
-
-	// Create chunker - for distributed checksum, we pass nil for the new table
-	// because the chunker will use the source table for both sides
 	chunker, err := table.NewChunker(sourceTable, table.ChunkerConfig{Logger: logger})
 	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(sourceTable, sourceTable, chunker))
+	require.NoError(t, feed.Run(t.Context()))
 	require.NoError(t, chunker.Open())
 
 	// Create distributed checker config
@@ -298,7 +294,9 @@ func TestDistributedChecksumNtoM(t *testing.T) {
 		Applier:         shardedApplier,
 	})
 	defer feed0.Close()
-	require.NoError(t, feed0.AddSubscription(src0Table, src0Table, nil))
+	chunker0, err := table.NewChunker(src0Table, table.ChunkerConfig{NewTable: src0Table})
+	require.NoError(t, err)
+	require.NoError(t, feed0.AddSubscription(src0Table, src0Table, chunker0))
 	require.NoError(t, feed0.Run(t.Context()))
 
 	feed1 := repl.NewClient(src1DB, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
@@ -309,14 +307,10 @@ func TestDistributedChecksumNtoM(t *testing.T) {
 		Applier:         shardedApplier,
 	})
 	defer feed1.Close()
-	require.NoError(t, feed1.AddSubscription(src1Table, src1Table, nil))
-	require.NoError(t, feed1.Run(t.Context()))
-
-	// Create a chunker per source, then wrap in a MultiChunker.
-	chunker0, err := table.NewChunker(src0Table, table.ChunkerConfig{Logger: logger})
-	require.NoError(t, err)
 	chunker1, err := table.NewChunker(src1Table, table.ChunkerConfig{Logger: logger})
 	require.NoError(t, err)
+	require.NoError(t, feed1.AddSubscription(src1Table, src1Table, chunker1))
+	require.NoError(t, feed1.Run(t.Context()))
 	multiChunker := table.NewMultiChunker(chunker0, chunker1)
 	require.NoError(t, multiChunker.Open())
 

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -53,13 +53,17 @@ func (c *SingleChecker) ChecksumChunk(ctx context.Context, trxPool *dbconn.TrxPo
 	}
 	defer trxPool.Put(trx)
 	c.logger.Debug("checksumming chunk", "chunk", chunk.String())
+	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
+	if err != nil {
+		return err
+	}
 	source := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-		c.intersectColumns(chunk),
+		sourceChecksumCols,
 		chunk.Table.QuotedTableName,
 		chunk.String(),
 	)
 	target := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-		c.intersectColumns(chunk),
+		targetChecksumCols,
 		chunk.NewTable.QuotedTableName,
 		chunk.String(),
 	)
@@ -112,8 +116,12 @@ func (c *SingleChecker) GetProgress() string {
 func (c *SingleChecker) inspectDifferences(ctx context.Context, trx *sql.Tx, chunk *table.Chunk) error {
 	c.logger.Info("inspecting differences for chunk", "chunk", chunk.String())
 
+	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
+	if err != nil {
+		return err
+	}
 	sourceRows, err := trx.QueryContext(ctx, fmt.Sprintf(queryTemplate,
-		c.intersectColumns(chunk),
+		sourceChecksumCols,
 		strings.Join(chunk.Table.KeyColumns, ", "),
 		chunk.Table.QuotedTableName,
 		chunk.String(),
@@ -137,7 +145,7 @@ func (c *SingleChecker) inspectDifferences(ctx context.Context, trx *sql.Tx, chu
 	}
 
 	targetRows, err := trx.QueryContext(ctx, fmt.Sprintf(queryTemplate,
-		c.intersectColumns(chunk),
+		targetChecksumCols,
 		strings.Join(chunk.NewTable.KeyColumns, ", "),
 		chunk.NewTable.QuotedTableName,
 		chunk.String(),
@@ -257,10 +265,11 @@ func (c *SingleChecker) replaceChunk(ctx context.Context, chunk *table.Chunk) er
 	// first so that any since-deleted rows (which wouldn't get removed by replace) are removed first.
 	// By doing this as two transactions we should be able to remove
 	// the opportunity for deadlocks.
+	sourceColumns, targetColumns := chunk.ColumnMapping.Columns()
 	replaceStmt := fmt.Sprintf("REPLACE INTO %s (%s) SELECT %s FROM %s WHERE %s",
 		chunk.NewTable.QuotedTableName,
-		utils.IntersectNonGeneratedColumns(chunk.Table, chunk.NewTable),
-		utils.IntersectNonGeneratedColumns(chunk.Table, chunk.NewTable),
+		targetColumns,
+		sourceColumns,
 		chunk.Table.QuotedTableName,
 		chunk.String(),
 	)
@@ -499,21 +508,4 @@ func (c *SingleChecker) runChecksum(ctx context.Context) error {
 		return err1
 	}
 	return nil
-}
-
-// intersectColumns is similar to utils.IntersectColumns, but it
-// wraps an IFNULL(), ISNULL() and cast operation around the columns.
-// The cast is to c.newTable type.
-func (c *SingleChecker) intersectColumns(chunk *table.Chunk) string {
-	var intersection []string
-	for _, col := range chunk.Table.NonGeneratedColumns {
-		for _, col2 := range chunk.NewTable.NonGeneratedColumns {
-			if col == col2 {
-				// Column exists in both, so we add intersection wrapped in
-				// IFNULL, ISNULL and CAST.
-				intersection = append(intersection, "IFNULL("+chunk.NewTable.WrapCastType(col)+",''), ISNULL(`"+col+"`)")
-			}
-		}
-	}
-	return strings.Join(intersection, ", ")
 }

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -46,12 +46,11 @@ func TestBasicChecksum(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        repl.NewServerID(),
 	})
-	assert.NoError(t, feed.Run(t.Context()))
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
 	assert.NoError(t, err)
@@ -86,11 +85,10 @@ func TestBasicValidation(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 
 	_, err = NewChecker(nil, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig()) // no source DBs
 	assert.EqualError(t, err, "at least one source database must be provided")
@@ -144,11 +142,10 @@ func TestUnfixableUniqueChecksum(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
@@ -187,11 +184,10 @@ func TestFixCorrupt(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
@@ -245,11 +241,10 @@ func TestCorruptChecksum(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
@@ -287,11 +282,10 @@ func TestBoundaryCases(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
@@ -365,11 +359,10 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
@@ -408,11 +401,10 @@ func TestYieldTimeout(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
@@ -461,11 +453,10 @@ func TestFromWatermark(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t2, nil))
-	assert.NoError(t, feed.Run(t.Context()))
-
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	assert.NoError(t, feed.Run(t.Context()))
 	assert.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()

--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -49,7 +49,7 @@ var _ Copier = (*buffered)(nil)
 // readChunkData reads all rows from a chunk into memory
 func (c *buffered) readChunkData(ctx context.Context, chunk *table.Chunk) ([][]any, error) {
 	// Build the SELECT query to read full row data
-	columnList := utils.IntersectNonGeneratedColumns(chunk.Table, chunk.NewTable)
+	columnList, _ := chunk.ColumnMapping.Columns()
 	query := fmt.Sprintf("SELECT %s FROM %s FORCE INDEX (PRIMARY) WHERE %s",
 		columnList,
 		chunk.Table.QuotedTableName,

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -344,8 +344,8 @@ func (d *delayedCallbackApplier) DeleteKeys(ctx context.Context, sourceTable, ta
 	return d.realApplier.DeleteKeys(ctx, sourceTable, targetTable, keys, lock)
 }
 
-func (d *delayedCallbackApplier) UpsertRows(ctx context.Context, sourceTable, targetTable *table.TableInfo, rows []applier.LogicalRow, lock *dbconn.TableLock) (int64, error) {
-	return d.realApplier.UpsertRows(ctx, sourceTable, targetTable, rows, lock)
+func (d *delayedCallbackApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, lock *dbconn.TableLock) (int64, error) {
+	return d.realApplier.UpsertRows(ctx, mapping, rows, lock)
 }
 
 func (d *delayedCallbackApplier) Wait(ctx context.Context) error {

--- a/pkg/copier/unbuffered.go
+++ b/pkg/copier/unbuffered.go
@@ -15,7 +15,6 @@ import (
 	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/throttler"
-	"github.com/block/spirit/pkg/utils"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -45,10 +44,11 @@ func (c *Unbuffered) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 	startTime := time.Now()
 	// INSERT INGORE because we can have duplicate rows in the chunk because in
 	// resuming from checkpoint we will be re-applying some of the previous executed work.
+	sourceColumns, targetColumns := chunk.ColumnMapping.Columns()
 	query := fmt.Sprintf("INSERT IGNORE INTO %s (%s) SELECT %s FROM %s FORCE INDEX (PRIMARY) WHERE %s",
 		chunk.NewTable.QuotedTableName,
-		utils.IntersectNonGeneratedColumns(chunk.Table, chunk.NewTable),
-		utils.IntersectNonGeneratedColumns(chunk.Table, chunk.NewTable),
+		targetColumns,
+		sourceColumns,
 		chunk.Table.QuotedTableName,
 		chunk.String(),
 	)

--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -16,6 +16,12 @@ type change struct {
 	table    *table.TableInfo
 	newTable *table.TableInfo
 
+	// chunker is the MappedChunker specific to this change.
+	// It is set during initChunkers() and used by setupCopierCheckerAndReplClient()
+	// to pass to AddSubscription, which requires a single-table MappedChunker
+	// (not the multi-chunker wrapper stored on the Runner).
+	chunker table.MappedChunker
+
 	// Store a pointer back to the migration runner
 	// (for compatibility, we want to eventually remove this)
 	runner *Runner

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -58,7 +58,9 @@ func TestCutOver(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t1new, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
+	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t1new, chunker))
 	// the feed must be started.
 	assert.NoError(t, feed.Run(t.Context()))
 
@@ -130,7 +132,9 @@ func TestMDLLockFails(t *testing.T) {
 		ServerID:        repl.NewServerID(),
 	})
 	defer feed.Close()
-	assert.NoError(t, feed.AddSubscription(t1, t1new, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
+	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t1new, chunker))
 	// the feed must be started.
 	assert.NoError(t, feed.Run(t.Context()))
 
@@ -193,7 +197,9 @@ func TestInvalidOptions(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        repl.NewServerID(),
 	})
-	assert.NoError(t, feed.AddSubscription(t1, t1new, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
+	assert.NoError(t, err)
+	assert.NoError(t, feed.AddSubscription(t1, t1new, chunker))
 
 	_, err = NewCutOver(db, []*cutoverConfig{{
 		table:        nil,

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -535,7 +535,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 		if err := change.newTable.SetInfo(ctx); err != nil {
 			return err
 		}
-		if err := r.replClient.AddSubscription(change.table, change.newTable, r.copyChunker); err != nil {
+		if err := r.replClient.AddSubscription(change.table, change.newTable, change.chunker); err != nil {
 			return err
 		}
 	}
@@ -1020,12 +1020,15 @@ func (r *Runner) initChunkers() error {
 	copyChunkers := make([]table.Chunker, 0, len(r.changes))
 	checksumChunkers := make([]table.Chunker, 0, len(r.changes))
 	for _, change := range r.changes {
+		columnMapping := table.NewColumnMapping(change.table, change.newTable, nil)
 		chunkerCfg := table.ChunkerConfig{
 			NewTable:        change.newTable,
 			TargetChunkTime: r.migration.TargetChunkTime,
 			Logger:          r.logger,
+			ColumnMapping:   columnMapping,
 		}
-		copyChunker, err := table.NewChunker(change.table, chunkerCfg)
+		var err error
+		change.chunker, err = table.NewChunker(change.table, chunkerCfg)
 		if err != nil {
 			return err
 		}
@@ -1033,7 +1036,7 @@ func (r *Runner) initChunkers() error {
 		if err != nil {
 			return err
 		}
-		copyChunkers = append(copyChunkers, copyChunker)
+		copyChunkers = append(copyChunkers, change.chunker)
 		checksumChunkers = append(checksumChunkers, checksumChunker)
 	}
 	// We can wrap it the multi-chunker regardless.

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -933,7 +933,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	assert.Equal(t, 1, m.replClient.GetDeltaLen())
 
 	testutils.RunSQL(t, `delete from e2et1 where id1 = 1`)
-	assert.False(t, m.copyChunker.KeyAboveHighWatermark(1))
+	assert.False(t, m.changes[0].chunker.KeyAboveHighWatermark(1))
 	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	// id1=1 is below high watermark (1 < 1001), so it's kept
 	assert.Equal(t, 2, m.replClient.GetDeltaLen())
@@ -941,7 +941,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	// Some data is inserted later, even though the last chunk is done.
 	// We still care to pick it up because it could be inserted during checkpoint.
 	testutils.RunSQL(t, `insert into e2et1 (id1, id2) values (5000, 1)`)
-	assert.False(t, m.copyChunker.KeyAboveHighWatermark(int64(math.MaxInt64)))
+	assert.False(t, m.changes[0].chunker.KeyAboveHighWatermark(int64(math.MaxInt64)))
 
 	// Now that copy rows is done, we flush the changeset until trivial.
 	// and perform the optional checksum.
@@ -1615,7 +1615,7 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	// This will be ignored by the binlog subscription.
 	// Because it's ahead of the high watermark.
 	testutils.RunSQL(t, `insert into e2et2 (id) values (4)`)
-	assert.True(t, m.copyChunker.KeyAboveHighWatermark(4))
+	assert.True(t, m.changes[0].chunker.KeyAboveHighWatermark(4))
 	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 0, m.replClient.GetDeltaLen())
 
@@ -1631,8 +1631,8 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	// but until we copy the chunk it is *not* below the low watermark
 	// and can't be flushed.
 	testutils.RunSQL(t, `insert into e2et2 (id) values (5)`)
-	assert.False(t, m.copyChunker.KeyAboveHighWatermark(5))
-	assert.False(t, m.copyChunker.KeyBelowLowWatermark(5))
+	assert.False(t, m.changes[0].chunker.KeyAboveHighWatermark(5))
+	assert.False(t, m.changes[0].chunker.KeyBelowLowWatermark(5))
 	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 1, m.replClient.GetDeltaLen())
 	assert.NoError(t, m.replClient.Flush(t.Context()))
@@ -1642,14 +1642,14 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	// it will mean that the low watermark is advanced and
 	// we can safely flush all changes.
 	assert.NoError(t, ccopier.CopyChunk(t.Context(), chunk))
-	assert.True(t, m.copyChunker.KeyBelowLowWatermark(5))
+	assert.True(t, m.changes[0].chunker.KeyBelowLowWatermark(5))
 	assert.NoError(t, m.replClient.Flush(t.Context()))
 	assert.Equal(t, 0, m.replClient.GetDeltaLen())
 
 	// delete some data.
 	testutils.RunSQL(t, `delete from e2et2 where id = 1`)
-	assert.False(t, m.copyChunker.KeyAboveHighWatermark(1))
-	assert.True(t, m.copyChunker.KeyBelowLowWatermark(1))
+	assert.False(t, m.changes[0].chunker.KeyAboveHighWatermark(1))
+	assert.True(t, m.changes[0].chunker.KeyBelowLowWatermark(1))
 	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 1, m.replClient.GetDeltaLen())
 
@@ -1670,7 +1670,7 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	testutils.RunSQL(t, `insert into e2et2 (id) values (6)`)
 	// the pointer should be at maxint64 for safety. this ensures
 	// that any keyAboveHighWatermark checks return false
-	assert.False(t, m.copyChunker.KeyAboveHighWatermark(int64(math.MaxInt64)))
+	assert.False(t, m.changes[0].chunker.KeyAboveHighWatermark(int64(math.MaxInt64)))
 
 	// Now that copy rows is done, we flush the changeset until trivial.
 	// and perform the optional checksum.
@@ -2054,7 +2054,7 @@ func TestE2ERogueValues(t *testing.T) {
 	// This means the binlog event is discarded (not buffered), and the row will
 	// be copied in later chunks or fixed during checksum.
 	testutils.RunSQL(t, `insert into e2erogue values ("zz'z\"z", 2)`)
-	assert.True(t, m.copyChunker.KeyAboveHighWatermark("zz'z\"z"))
+	assert.True(t, m.changes[0].chunker.KeyAboveHighWatermark("zz'z\"z"))
 
 	// Wait for the binlog event to be processed/discarded
 	assert.NoError(t, m.replClient.BlockWait(t.Context()))
@@ -2070,7 +2070,7 @@ func TestE2ERogueValues(t *testing.T) {
 	// Note: "zz'z\"z" was discarded (KeyAboveHighWatermark=true), not buffered,
 	// so delta count is 1 (only this insert), not 2.
 	testutils.RunSQL(t, `insert into e2erogue values (5, 2)`)
-	assert.False(t, m.copyChunker.KeyAboveHighWatermark(5))
+	assert.False(t, m.changes[0].chunker.KeyAboveHighWatermark(5))
 	assert.NoError(t, m.replClient.BlockWait(t.Context()))
 	assert.Equal(t, 1, m.replClient.GetDeltaLen())
 

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -215,7 +215,7 @@ func NewClientDefaultConfig() *ClientConfig {
 
 // AddSubscription adds a new subscription.
 // Returns an error if a subscription already exists for the given table.
-func (c *Client) AddSubscription(currentTable, newTable *table.TableInfo, chunker table.Chunker) error {
+func (c *Client) AddSubscription(currentTable, newTable *table.TableInfo, chunker table.MappedChunker) error {
 	c.Lock()
 	defer c.Unlock()
 

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -224,6 +224,14 @@ func (c *Client) AddSubscription(currentTable, newTable *table.TableInfo, chunke
 		return fmt.Errorf("subscription already exists for table %s.%s", currentTable.SchemaName, currentTable.TableName)
 	}
 
+	// If no chunker is provided, create a MockChunker with a default ColumnMapping.
+	// This supports test scenarios and cases where watermark optimization is not needed.
+	if chunker == nil {
+		mock := table.NewMockChunker(currentTable.TableName, 0)
+		mock.SetColumnMapping(table.NewColumnMapping(currentTable, newTable, nil))
+		chunker = mock
+	}
+
 	// Decide which subscription type to use. We always prefer deltaMap
 	// But will fall back to deltaQueue if the PK is not memory comparable.
 	if err := currentTable.PrimaryKeyIsMemoryComparable(); err != nil {

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -224,14 +224,6 @@ func (c *Client) AddSubscription(currentTable, newTable *table.TableInfo, chunke
 		return fmt.Errorf("subscription already exists for table %s.%s", currentTable.SchemaName, currentTable.TableName)
 	}
 
-	// If no chunker is provided, create a MockChunker with a default ColumnMapping.
-	// This supports test scenarios and cases where watermark optimization is not needed.
-	if chunker == nil {
-		mock := table.NewMockChunker(currentTable.TableName, 0)
-		mock.SetColumnMapping(table.NewColumnMapping(currentTable, newTable, nil))
-		chunker = mock
-	}
-
 	// Decide which subscription type to use. We always prefer deltaMap
 	// But will fall back to deltaQueue if the PK is not memory comparable.
 	if err := currentTable.PrimaryKeyIsMemoryComparable(); err != nil {

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -51,7 +51,9 @@ func TestReplClient(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        NewServerID(),
 	})
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 	defer client.Close()
 
@@ -181,7 +183,9 @@ func TestReplClientResumeFromImpossible(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        NewServerID(),
 	})
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	client.SetFlushedPos(mysql.Position{
 		Name: "impossible",
 		Pos:  uint32(12345),
@@ -213,7 +217,9 @@ func TestReplClientResumeFromPoint(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        NewServerID(),
 	})
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	pos, err := client.getCurrentBinlogPosition(t.Context())
 	assert.NoError(t, err)
 	pos.Pos = 4
@@ -251,7 +257,9 @@ func TestReplClientOpts(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        NewServerID(),
 	})
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	assert.Equal(t, 0, db.Stats().InUse) // no connections in use.
 	assert.NoError(t, client.Run(t.Context()))
 	defer client.Close()
@@ -371,7 +379,9 @@ func TestFeedback(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, NewClientDefaultConfig())
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 	defer client.Close()
 
@@ -433,7 +443,9 @@ func TestBlockWait(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        NewServerID(),
 	})
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 	defer client.Close()
 
@@ -506,7 +518,9 @@ func TestDDLNotification(t *testing.T) {
 		},
 		ServerID: NewServerID(),
 	})
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 	defer client.Close()
 
@@ -576,7 +590,9 @@ func TestCompositePKUpdate(t *testing.T) {
 	})
 
 	// Add subscription - note that keyAboveWatermark is disabled for composite PKs
-	assert.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(t1, t2, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 	defer client.Close()
 
@@ -737,7 +753,9 @@ func TestMaxRecreateAttemptsError(t *testing.T) {
 		ServerID:        NewServerID(),
 		CancelFunc:      func() bool { cancel(); return true },
 	})
-	require.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
 	require.NoError(t, client.Run(ctx))
 
 	// Ensure we are no longer on the initial binary log.
@@ -922,7 +940,9 @@ func TestProcessRowsEventMinimalRBRWithApplier(t *testing.T) {
 		ServerID:        NewServerID(),
 		Applier:         applierInstance,
 	})
-	require.NoError(t, client.AddSubscription(t1, t2, nil))
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
 
 	err = client.processRowsEvent(binlogEvent, rowsEvent)
 	assert.Error(t, err)
@@ -936,7 +956,9 @@ func TestProcessRowsEventMinimalRBRWithApplier(t *testing.T) {
 		TargetBatchTime: time.Second,
 		ServerID:        NewServerID(),
 	})
-	require.NoError(t, client2.AddSubscription(t1, t2, nil))
+	chunker, err = table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client2.AddSubscription(t1, t2, chunker))
 
 	err = client2.processRowsEvent(binlogEvent, rowsEvent)
 	assert.NoError(t, err)

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -36,7 +36,7 @@ type bufferedMap struct {
 	changes map[string]bufferedChange
 
 	watermarkOptimization bool
-	chunker               table.Chunker
+	chunker               table.MappedChunker
 }
 
 // Assert that bufferedMap implements subscription
@@ -167,7 +167,7 @@ func (s *bufferedMap) flushBatch(ctx context.Context, deleteKeys []string, upser
 
 	// Execute upserts
 	if len(upsertRows) > 0 {
-		affectedRows, err := s.applier.UpsertRows(ctx, s.table, s.newTable, upsertRows, lock)
+		affectedRows, err := s.applier.UpsertRows(ctx, s.chunker.ColumnMapping(), upsertRows, lock)
 		if err != nil {
 			return fmt.Errorf("failed to upsert rows: %w", err)
 		}

--- a/pkg/repl/subscription_buffered_test.go
+++ b/pkg/repl/subscription_buffered_test.go
@@ -252,6 +252,7 @@ func TestBufferedMapFlushUnderLockBypassesWatermark(t *testing.T) {
 	// - Keys >= 5 are NOT below the low watermark (copier is at or hasn't reached them)
 	// - Keys > 5 are above the high watermark (copier hasn't reached them, don't track)
 	mockChunker := table.NewMockChunker("subscription_test", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 	mockChunker.SimulateProgress(0.005) // Current position at 5
 
 	sub := &bufferedMap{
@@ -380,6 +381,7 @@ func TestBufferedMapFlushWithoutLockRespectsWatermark(t *testing.T) {
 
 	// Create mock chunker with current position at 5
 	mockChunker := table.NewMockChunker("subscription_test", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 	mockChunker.SimulateProgress(0.005) // Current position at 5
 
 	sub := &bufferedMap{

--- a/pkg/repl/subscription_buffered_test.go
+++ b/pkg/repl/subscription_buffered_test.go
@@ -107,7 +107,9 @@ func TestBufferedMapVariableColumns(t *testing.T) {
 		ServerID:        NewServerID(),
 		Applier:         applier,
 	})
-	assert.NoError(t, client.AddSubscription(srcTable, dstTable, nil))
+	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 
 	defer client.Close()
@@ -165,7 +167,9 @@ func TestBufferedMapIllegalValues(t *testing.T) {
 		ServerID:        NewServerID(),
 		Applier:         applier,
 	})
-	assert.NoError(t, client.AddSubscription(srcTable, dstTable, nil))
+	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 
 	defer client.Close()

--- a/pkg/repl/subscription_map.go
+++ b/pkg/repl/subscription_map.go
@@ -29,7 +29,7 @@ type deltaMap struct {
 	changes map[string]mapChange // delta map, for memory comparable PKs
 
 	watermarkOptimization bool
-	chunker               table.Chunker
+	chunker               table.MappedChunker
 }
 
 // Assert that deltaMap implements subscription
@@ -79,10 +79,11 @@ func (s *deltaMap) createDeleteStmt(deleteKeys []string) statement {
 func (s *deltaMap) createReplaceStmt(replaceKeys []string) statement {
 	var replaceStmt string
 	if len(replaceKeys) > 0 {
+		sourceColumns, targetColumns := s.chunker.ColumnMapping().Columns()
 		replaceStmt = fmt.Sprintf("REPLACE INTO %s (%s) SELECT %s FROM %s FORCE INDEX (PRIMARY) WHERE (%s) IN (%s)",
 			s.newTable.QuotedTableName,
-			utils.IntersectNonGeneratedColumns(s.table, s.newTable),
-			utils.IntersectNonGeneratedColumns(s.table, s.newTable),
+			targetColumns,
+			sourceColumns,
 			s.table.QuotedTableName,
 			table.QuoteColumns(s.table.KeyColumns),
 			pksToRowValueConstructor(replaceKeys),

--- a/pkg/repl/subscription_map_test.go
+++ b/pkg/repl/subscription_map_test.go
@@ -37,6 +37,7 @@ func TestSubscriptionDeltaMap(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
+		chunker:  table.NewMockChunker("test", 1000),
 	}
 
 	// Test initial state
@@ -91,6 +92,7 @@ func TestFlushWithLock(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
+		chunker:  table.NewMockChunker("test", 1000),
 	}
 
 	// Insert test data
@@ -148,6 +150,7 @@ func TestFlushWithoutLock(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
+		chunker:  table.NewMockChunker("test", 1000),
 	}
 
 	// Insert test data
@@ -198,6 +201,7 @@ func TestConcurrentKeyChanges(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
+		chunker:  table.NewMockChunker("test", 1000),
 	}
 
 	// Run concurrent key changes
@@ -250,6 +254,7 @@ func TestKeyChangedOverwrite(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
+		chunker:  table.NewMockChunker("test", 1000),
 	}
 
 	// Test overwriting the same key multiple times
@@ -355,6 +360,7 @@ func TestKeyChangedNilAndEmpty(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
+		chunker:  table.NewMockChunker("test", 1000),
 	}
 
 	// Test with empty string key

--- a/pkg/repl/subscription_map_test.go
+++ b/pkg/repl/subscription_map_test.go
@@ -37,7 +37,11 @@ func TestSubscriptionDeltaMap(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
-		chunker:  table.NewMockChunker("test", 1000),
+		chunker: func() table.MappedChunker {
+			m := table.NewMockChunker("test", 1000)
+			m.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+			return m
+		}(),
 	}
 
 	// Test initial state
@@ -92,7 +96,11 @@ func TestFlushWithLock(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
-		chunker:  table.NewMockChunker("test", 1000),
+		chunker: func() table.MappedChunker {
+			m := table.NewMockChunker("test", 1000)
+			m.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+			return m
+		}(),
 	}
 
 	// Insert test data
@@ -150,7 +158,11 @@ func TestFlushWithoutLock(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
-		chunker:  table.NewMockChunker("test", 1000),
+		chunker: func() table.MappedChunker {
+			m := table.NewMockChunker("test", 1000)
+			m.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+			return m
+		}(),
 	}
 
 	// Insert test data
@@ -201,7 +213,11 @@ func TestConcurrentKeyChanges(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
-		chunker:  table.NewMockChunker("test", 1000),
+		chunker: func() table.MappedChunker {
+			m := table.NewMockChunker("test", 1000)
+			m.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+			return m
+		}(),
 	}
 
 	// Run concurrent key changes
@@ -254,7 +270,11 @@ func TestKeyChangedOverwrite(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
-		chunker:  table.NewMockChunker("test", 1000),
+		chunker: func() table.MappedChunker {
+			m := table.NewMockChunker("test", 1000)
+			m.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+			return m
+		}(),
 	}
 
 	// Test overwriting the same key multiple times
@@ -301,6 +321,7 @@ func TestKeyChangedEdgeCases(t *testing.T) {
 
 	// Create mock chunker with watermark behavior
 	mockChunker := table.NewMockChunker("test_table", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 	// Set current position to 5, so keys above 5 will be above watermark
 	mockChunker.SimulateProgress(0.005) // 5/1000 = 0.005
 
@@ -360,7 +381,11 @@ func TestKeyChangedNilAndEmpty(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make(map[string]mapChange),
-		chunker:  table.NewMockChunker("test", 1000),
+		chunker: func() table.MappedChunker {
+			m := table.NewMockChunker("test", 1000)
+			m.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+			return m
+		}(),
 	}
 
 	// Test with empty string key
@@ -398,6 +423,7 @@ func TestKeyAboveWatermark(t *testing.T) {
 	}
 
 	mockChunker := table.NewMockChunker("test_table", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 	// Set current position to 5, so keys above 5 will be above watermark
 	mockChunker.SimulateProgress(0.005) // 5/1000 = 0.005
 
@@ -448,6 +474,7 @@ func TestKeyBelowWatermarkMock(t *testing.T) {
 
 	// Create mock chunker with low watermark behavior
 	mockChunker := table.NewMockChunker("test_table", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 	// Set current position to 5, so keys below 5 will be below watermark
 	mockChunker.SimulateProgress(0.005) // 5/1000 = 0.005
 
@@ -519,6 +546,7 @@ func TestFlushUnderLockBypassesWatermark(t *testing.T) {
 	// - Keys >= 5 are NOT below the low watermark (copier is at or hasn't reached them)
 	// - Keys > 5 are above the high watermark (copier hasn't reached them, don't track)
 	mockChunker := table.NewMockChunker("subscription_test", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 	mockChunker.SimulateProgress(0.005) // Current position at 5
 
 	sub := &deltaMap{
@@ -622,6 +650,7 @@ func TestFlushWithoutLockRespectsWatermark(t *testing.T) {
 
 	// Create mock chunker with current position at 5
 	mockChunker := table.NewMockChunker("subscription_test", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 	mockChunker.SimulateProgress(0.005) // Current position at 5
 
 	sub := &deltaMap{

--- a/pkg/repl/subscription_queue.go
+++ b/pkg/repl/subscription_queue.go
@@ -27,7 +27,7 @@ type deltaQueue struct {
 	changes []queuedChange
 
 	watermarkOptimization bool
-	chunker               table.Chunker
+	chunker               table.MappedChunker
 }
 
 // Assert that deltaQueue implements subscription
@@ -77,10 +77,11 @@ func (s *deltaQueue) createDeleteStmt(deleteKeys []string) statement {
 func (s *deltaQueue) createReplaceStmt(replaceKeys []string) statement {
 	var replaceStmt string
 	if len(replaceKeys) > 0 {
+		sourceColumns, targetColumns := s.chunker.ColumnMapping().Columns()
 		replaceStmt = fmt.Sprintf("REPLACE INTO %s (%s) SELECT %s FROM %s FORCE INDEX (PRIMARY) WHERE (%s) IN (%s)",
 			s.newTable.QuotedTableName,
-			utils.IntersectNonGeneratedColumns(s.table, s.newTable),
-			utils.IntersectNonGeneratedColumns(s.table, s.newTable),
+			targetColumns,
+			sourceColumns,
 			s.table.QuotedTableName,
 			table.QuoteColumns(s.table.KeyColumns),
 			pksToRowValueConstructor(replaceKeys),

--- a/pkg/repl/subscription_queue_test.go
+++ b/pkg/repl/subscription_queue_test.go
@@ -25,6 +25,8 @@ func TestSubscriptionDeltaQueue(t *testing.T) {
 		PRIMARY KEY (id)
 	)`
 	srcTable, dstTable := setupTestTables(t, t1, t2)
+	mockChunker := table.NewMockChunker("test", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
 		db:              nil,
@@ -39,6 +41,7 @@ func TestSubscriptionDeltaQueue(t *testing.T) {
 		table:    srcTable,
 		newTable: dstTable,
 		changes:  make([]queuedChange, 0),
+		chunker:  mockChunker,
 	}
 
 	// Test initial state
@@ -71,6 +74,8 @@ func TestFlushDeltaQueue(t *testing.T) {
 		PRIMARY KEY (id)
 	)`
 	srcTable, dstTable := setupTestTables(t, t1, t2)
+	mockChunker := table.NewMockChunker("test", 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	dbConfig := dbconn.NewDBConfig()
 	dbConfig.MaxOpenConnections = 32
@@ -92,6 +97,7 @@ func TestFlushDeltaQueue(t *testing.T) {
 			table:    srcTable,
 			newTable: dstTable,
 			changes:  make([]queuedChange, 0),
+			chunker:  mockChunker,
 		}
 
 		allFlushed, err := sub.Flush(t.Context(), false, nil)
@@ -112,6 +118,7 @@ func TestFlushDeltaQueue(t *testing.T) {
 			table:    srcTable,
 			newTable: dstTable,
 			changes:  make([]queuedChange, 0),
+			chunker:  mockChunker,
 		}
 
 		// Clear the source and destination table
@@ -171,6 +178,7 @@ func TestFlushDeltaQueue(t *testing.T) {
 			table:    srcTable,
 			newTable: dstTable,
 			changes:  make([]queuedChange, 0),
+			chunker:  mockChunker,
 		}
 
 		// Clear the source and destination table
@@ -210,6 +218,7 @@ func TestFlushDeltaQueue(t *testing.T) {
 			table:    srcTable,
 			newTable: dstTable,
 			changes:  make([]queuedChange, 0),
+			chunker:  mockChunker,
 		}
 
 		// Clear the source and destination table
@@ -254,6 +263,7 @@ func TestFlushDeltaQueue(t *testing.T) {
 			table:    srcTable,
 			newTable: dstTable,
 			changes:  make([]queuedChange, 0),
+			chunker:  mockChunker,
 		}
 
 		// Clear the source and destination table
@@ -309,6 +319,7 @@ func TestFlushDeltaQueue(t *testing.T) {
 			table:    srcTable,
 			newTable: dstTable,
 			changes:  make([]queuedChange, 0),
+			chunker:  mockChunker,
 		}
 
 		// Clear the source and destination table

--- a/pkg/repl/subscription_test.go
+++ b/pkg/repl/subscription_test.go
@@ -66,7 +66,9 @@ func setupBufferedTest(t *testing.T) (*sql.DB, *Client) {
 		ServerID:        NewServerID(),
 		Applier:         applier,
 	})
-	assert.NoError(t, client.AddSubscription(srcTable, dstTable, nil))
+	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
+	assert.NoError(t, err)
+	assert.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
 	assert.NoError(t, client.Run(t.Context()))
 	return db, client
 }

--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -14,8 +14,9 @@ type Chunk struct {
 	LowerBound           *Boundary
 	UpperBound           *Boundary
 	AdditionalConditions string
-	Table                *TableInfo // Source table information for this chunk
-	NewTable             *TableInfo // Destination table information for this chunk
+	Table                *TableInfo     // Source table information for this chunk
+	NewTable             *TableInfo     // Destination table information for this chunk
+	ColumnMapping        *ColumnMapping // Column relationship between source and target, including renames
 }
 
 // Boundary is used by chunk for lower or upper boundary

--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -27,14 +27,12 @@ const (
 	ChunkerDefaultTarget = 100 * time.Millisecond
 )
 
-type Chunker interface { //nolint: interfacebloat
+type Chunker interface {
 	Open() error
 	IsRead() bool
 	Close() error
 	Next() (*Chunk, error)
 	Feedback(chunk *Chunk, duration time.Duration, actualRows uint64)
-	KeyAboveHighWatermark(key0 any) bool
-	KeyBelowLowWatermark(key0 any) bool
 	Progress() (rowsRead uint64, chunksCopied uint64, totalRowsExpected uint64)
 	OpenAtWatermark(watermark string) error
 	GetLowWatermark() (watermark string, err error)
@@ -49,6 +47,19 @@ type Chunker interface { //nolint: interfacebloat
 	Tables() []*TableInfo
 }
 
+// MappedChunker is a Chunker that operates on a single source→target table pair
+// and carries a ColumnMapping describing the column relationship between them.
+// The multiChunker does not implement this interface because it wraps multiple
+// independent table pairs, each with their own mapping.
+type MappedChunker interface {
+	Chunker
+	// ColumnMapping returns the column mapping between source and target tables,
+	// including any column renames.
+	ColumnMapping() *ColumnMapping
+	KeyAboveHighWatermark(key0 any) bool
+	KeyBelowLowWatermark(key0 any) bool
+}
+
 // ChunkerConfig holds optional configuration for creating a Chunker.
 // Only the source table (passed as the first argument to NewChunker) is required;
 // all other fields have sensible defaults.
@@ -60,6 +71,9 @@ type ChunkerConfig struct {
 	TargetChunkTime time.Duration
 	// Logger is the structured logger. Defaults to slog.Default().
 	Logger *slog.Logger
+	// ColumnMapping describes the column relationship between source and target tables,
+	// including any renames. If nil, a default mapping with no renames is created.
+	ColumnMapping *ColumnMapping
 	// Key and Where are used for composite chunkers to specify a non-primary key index.
 	// When Key is set, the composite chunker is always used regardless of whether the
 	// table has an auto-increment primary key.
@@ -67,15 +81,18 @@ type ChunkerConfig struct {
 	Where string
 }
 
-// NewChunker creates a new Chunker for the given source table.
+// NewChunker creates a new MappedChunker for the given source table.
 // It selects the optimistic chunker for single-column auto-increment primary keys
 // (unless Key/Where overrides are specified), and the composite chunker otherwise.
-func NewChunker(t *TableInfo, config ChunkerConfig) (Chunker, error) {
+func NewChunker(t *TableInfo, config ChunkerConfig) (MappedChunker, error) {
 	if config.TargetChunkTime == 0 {
 		config.TargetChunkTime = ChunkerDefaultTarget
 	}
 	if config.Logger == nil {
 		config.Logger = slog.Default()
+	}
+	if config.ColumnMapping == nil {
+		config.ColumnMapping = NewColumnMapping(t, config.NewTable, nil)
 	}
 	newTable := config.NewTable
 	if newTable == nil {
@@ -91,6 +108,7 @@ func NewChunker(t *TableInfo, config ChunkerConfig) (Chunker, error) {
 			Ti:                     t,
 			NewTi:                  newTable,
 			ChunkerTarget:          config.TargetChunkTime,
+			columnMapping:          config.ColumnMapping,
 			lowerBoundWatermarkMap: make(map[string]*Chunk, 0),
 			logger:                 config.Logger,
 		}, nil
@@ -99,6 +117,7 @@ func NewChunker(t *TableInfo, config ChunkerConfig) (Chunker, error) {
 		Ti:                     t,
 		NewTi:                  newTable,
 		ChunkerTarget:          config.TargetChunkTime,
+		columnMapping:          config.ColumnMapping,
 		keyName:                config.Key,
 		where:                  config.Where,
 		lowerBoundWatermarkMap: make(map[string]*Chunk, 0),

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -27,6 +27,8 @@ type chunkerComposite struct {
 	finalChunkSent bool
 	isOpen         bool
 
+	columnMapping *ColumnMapping
+
 	checkpointHighPtr Datum // the high watermark detected on restore from checkpoint
 
 	// Dynamic Chunking is time based instead of row based.
@@ -55,7 +57,7 @@ type compositeWatermark struct {
 	RowsCopied uint64
 }
 
-var _ Chunker = &chunkerComposite{}
+var _ MappedChunker = &chunkerComposite{}
 
 func (t *chunkerComposite) additionalConditionsSQL(whereSent bool) string {
 	if t.where == "" {
@@ -119,6 +121,7 @@ func (t *chunkerComposite) Next() (*Chunk, error) {
 				AdditionalConditions: t.where,
 				Table:                t.Ti,
 				NewTable:             t.NewTi,
+				ColumnMapping:        t.columnMapping,
 			}, nil
 		}
 		// Else, it's just the last chunk.
@@ -129,6 +132,7 @@ func (t *chunkerComposite) Next() (*Chunk, error) {
 			AdditionalConditions: t.where,
 			Table:                t.Ti,
 			NewTable:             t.NewTi,
+			ColumnMapping:        t.columnMapping,
 		}, nil
 	}
 	// Else, there were rows found.
@@ -146,6 +150,7 @@ func (t *chunkerComposite) Next() (*Chunk, error) {
 		AdditionalConditions: t.where,
 		Table:                t.Ti,
 		NewTable:             t.NewTi,
+		ColumnMapping:        t.columnMapping,
 	}, nil
 }
 
@@ -654,4 +659,8 @@ func (t *chunkerComposite) Tables() []*TableInfo {
 		return []*TableInfo{t.Ti, t.NewTi}
 	}
 	return []*TableInfo{t.Ti}
+}
+
+func (t *chunkerComposite) ColumnMapping() *ColumnMapping {
+	return t.columnMapping
 }

--- a/pkg/table/chunker_mock.go
+++ b/pkg/table/chunker_mock.go
@@ -12,10 +12,11 @@ type MockChunker struct {
 	mu sync.Mutex
 
 	// Configuration
-	tableName string
-	totalRows uint64
-	chunkSize uint64
-	tableInfo *TableInfo
+	tableName     string
+	totalRows     uint64
+	chunkSize     uint64
+	tableInfo     *TableInfo
+	columnMapping *ColumnMapping
 
 	// State
 	isOpen          bool
@@ -41,7 +42,7 @@ type FeedbackCall struct {
 	Timestamp  time.Time
 }
 
-var _ Chunker = &MockChunker{}
+var _ MappedChunker = &MockChunker{}
 
 // NewMockChunker creates a new mock chunker for testing
 func NewMockChunker(tableName string, totalRows uint64) *MockChunker {
@@ -354,4 +355,19 @@ func (m *MockChunker) Tables() []*TableInfo {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return []*TableInfo{m.tableInfo}
+}
+
+func (m *MockChunker) SetColumnMapping(mapping *ColumnMapping) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.columnMapping = mapping
+}
+
+func (m *MockChunker) ColumnMapping() *ColumnMapping {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.columnMapping != nil {
+		return m.columnMapping
+	}
+	return NewColumnMapping(m.tableInfo, m.tableInfo, nil)
 }

--- a/pkg/table/chunker_multi.go
+++ b/pkg/table/chunker_multi.go
@@ -183,19 +183,6 @@ func (m *multiChunker) Feedback(chunk *Chunk, duration time.Duration, actualRows
 	}
 }
 
-// KeyAboveHighWatermark currently not supported for multi-chunker
-// The interface would need to be changed to accept (table, key) to route properly
-// We work around this by using the child chunkers in repl.AddSubscription() directly.
-func (m *multiChunker) KeyAboveHighWatermark(_ any) bool {
-	return false
-}
-
-// KeyBelowLowWatermark currently not supported for multi-chunker
-// We need to return true so callers don't block flushing.
-func (m *multiChunker) KeyBelowLowWatermark(_ any) bool {
-	return true
-}
-
 // Progress returns aggregate progress across all chunkers
 func (m *multiChunker) Progress() (uint64, uint64, uint64) {
 	m.Lock()

--- a/pkg/table/chunker_multi_test.go
+++ b/pkg/table/chunker_multi_test.go
@@ -314,16 +314,6 @@ func TestMultiChunkerTables(t *testing.T) {
 	assert.Contains(t, tableNames, "table2")
 }
 
-func TestMultiChunkerKeyAboveHighWatermark(t *testing.T) {
-	mock1 := NewMockChunker("table1", 1000)
-	mock2 := NewMockChunker("table2", 1000)
-	chunker := NewMultiChunker(mock1, mock2).(*multiChunker)
-
-	// Should always return false (not supported)
-	result := chunker.KeyAboveHighWatermark("any_key")
-	assert.False(t, result)
-}
-
 func TestMultiChunkerErrorHandling(t *testing.T) {
 	t.Run("NextOnClosedChunker", func(t *testing.T) {
 		mock1 := NewMockChunker("table1", 1000)

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -21,6 +21,7 @@ type chunkerOptimistic struct {
 	checkpointHighPtr Datum // the high watermark detected on restore
 	finalChunkSent    bool
 	isOpen            bool
+	columnMapping     *ColumnMapping
 
 	// Dynamic Chunking is time based instead of row based.
 	// It uses *time* to determine the target chunk size.
@@ -49,7 +50,7 @@ type chunkerOptimistic struct {
 	logger *slog.Logger
 }
 
-var _ Chunker = &chunkerOptimistic{}
+var _ MappedChunker = &chunkerOptimistic{}
 
 // nextChunkByPrefetching uses prefetching instead of feedback to determine the chunk size.
 // It is used when the chunker detects that there are very large gaps in the sequence.
@@ -101,6 +102,8 @@ func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
 			UpperBound: &Boundary{[]Datum{maxVal}, false},
 			Table:      t.Ti,
 			NewTable:   t.NewTi,
+
+			ColumnMapping: t.columnMapping,
 		}, nil
 	}
 	if rows.Err() != nil {
@@ -116,6 +119,8 @@ func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
 		LowerBound: &Boundary{[]Datum{t.chunkPtr}, true},
 		Table:      t.Ti,
 		NewTable:   t.NewTi,
+
+		ColumnMapping: t.columnMapping,
 	}, nil
 }
 
@@ -139,6 +144,8 @@ func (t *chunkerOptimistic) Next() (*Chunk, error) {
 			UpperBound: &Boundary{[]Datum{t.chunkPtr}, false},
 			Table:      t.Ti,
 			NewTable:   t.NewTi,
+
+			ColumnMapping: t.columnMapping,
 		}, nil
 	}
 	if t.chunkPrefetchingEnabled {
@@ -167,6 +174,8 @@ func (t *chunkerOptimistic) Next() (*Chunk, error) {
 			LowerBound: &Boundary{[]Datum{t.chunkPtr}, true},
 			Table:      t.Ti,
 			NewTable:   t.NewTi,
+
+			ColumnMapping: t.columnMapping,
 		}, nil
 	}
 
@@ -184,6 +193,8 @@ func (t *chunkerOptimistic) Next() (*Chunk, error) {
 		UpperBound: &Boundary{[]Datum{maxVal}, false},
 		Table:      t.Ti,
 		NewTable:   t.NewTi,
+
+		ColumnMapping: t.columnMapping,
 	}, nil
 }
 
@@ -608,4 +619,8 @@ func (t *chunkerOptimistic) Tables() []*TableInfo {
 		return []*TableInfo{t.Ti, t.NewTi}
 	}
 	return []*TableInfo{t.Ti}
+}
+
+func (t *chunkerOptimistic) ColumnMapping() *ColumnMapping {
+	return t.columnMapping
 }

--- a/pkg/table/column_mapping.go
+++ b/pkg/table/column_mapping.go
@@ -1,0 +1,163 @@
+package table
+
+import (
+	"strings"
+)
+
+// ColumnMapping represents the column relationship between a source and target table,
+// including any column renames. It is computed once and shared across chunker,
+// copier, applier, checksum, and repl subscription.
+//
+// A nil *ColumnMapping is safe to use — all methods return sensible defaults
+// (empty columns, nil renames).
+type ColumnMapping struct {
+	sourceTable *TableInfo
+	targetTable *TableInfo
+	renames     map[string]string // old→new, may be nil
+
+	// Pre-computed intersection results
+	sourceColumns []string // non-generated source columns that exist in target
+	targetColumns []string // corresponding target column names (renamed where applicable)
+}
+
+// NewColumnMapping creates a ColumnMapping between source and target tables,
+// with an optional rename map (old→new). The column intersection is computed
+// immediately. If target is nil, source is used as the target.
+func NewColumnMapping(source, target *TableInfo, renames map[string]string) *ColumnMapping {
+	if target == nil {
+		target = source
+	}
+	m := &ColumnMapping{
+		sourceTable: source,
+		targetTable: target,
+		renames:     renames,
+	}
+	m.sourceColumns, m.targetColumns = m.computeIntersection()
+	return m
+}
+
+// computeIntersection calculates the column intersection between source and target.
+func (m *ColumnMapping) computeIntersection() ([]string, []string) {
+	// Build a set of target column names for fast lookup
+	t2Set := make(map[string]struct{}, len(m.targetTable.NonGeneratedColumns))
+	for _, col := range m.targetTable.NonGeneratedColumns {
+		t2Set[col] = struct{}{}
+	}
+
+	// Build a set of target columns that are "claimed" by renames.
+	// These cannot be used for identity matching by other source columns.
+	claimedTargets := make(map[string]struct{}, len(m.renames))
+	for _, newName := range m.renames {
+		claimedTargets[newName] = struct{}{}
+	}
+
+	var srcCols, tgtCols []string
+	for _, srcCol := range m.sourceTable.NonGeneratedColumns {
+		// Check if this column was renamed
+		if newName, ok := m.renames[srcCol]; ok {
+			if _, exists := t2Set[newName]; exists {
+				srcCols = append(srcCols, srcCol)
+				tgtCols = append(tgtCols, newName)
+				continue
+			}
+		}
+		// Identity match (same name in both tables), but only if the target
+		// column is not already claimed by a rename from another source column.
+		if _, exists := t2Set[srcCol]; exists {
+			if _, claimed := claimedTargets[srcCol]; !claimed {
+				srcCols = append(srcCols, srcCol)
+				tgtCols = append(tgtCols, srcCol)
+			}
+		}
+	}
+	return srcCols, tgtCols
+}
+
+// Columns returns two comma-separated, backtick-quoted column lists
+// for source and target. When there are no renames, both strings are identical.
+func (m *ColumnMapping) Columns() (source, target string) {
+	srcQuoted := make([]string, len(m.sourceColumns))
+	tgtQuoted := make([]string, len(m.targetColumns))
+	for i := range m.sourceColumns {
+		srcQuoted[i] = "`" + m.sourceColumns[i] + "`"
+		tgtQuoted[i] = "`" + m.targetColumns[i] + "`"
+	}
+	return strings.Join(srcQuoted, ", "), strings.Join(tgtQuoted, ", ")
+}
+
+// ColumnsSlice returns parallel slices of source and target column names.
+// sourceColumns[i] corresponds to targetColumns[i].
+func (m *ColumnMapping) ColumnsSlice() (sourceColumns, targetColumns []string) {
+	return m.sourceColumns, m.targetColumns
+}
+
+// ChecksumExprs returns two comma-separated checksum column expressions for
+// source and target, wrapping each column in IFNULL(), ISNULL() and CAST.
+// The CAST type always comes from the target table's type definition.
+// When there are no renames, both expressions are identical.
+func (m *ColumnMapping) ChecksumExprs() (source, target string, err error) {
+	sourceExprs := make([]string, len(m.sourceColumns))
+	targetExprs := make([]string, len(m.targetColumns))
+	for i := range m.sourceColumns {
+		// CAST type comes from the target table for both source and target
+		// so that type conversions (e.g. INT→BIGINT) are applied consistently.
+		// For source: SQL references the old column name, type from target's new column name.
+		// For target: both SQL reference and type lookup use the new column name.
+		srcCast, err := m.targetTable.wrapCastTypeAs(m.sourceColumns[i], m.targetColumns[i])
+		if err != nil {
+			return "", "", err
+		}
+		tgtCast, err := m.targetTable.wrapCastType(m.targetColumns[i])
+		if err != nil {
+			return "", "", err
+		}
+		sourceExprs[i] = "IFNULL(" + srcCast + ",''), ISNULL(`" + m.sourceColumns[i] + "`)"
+		targetExprs[i] = "IFNULL(" + tgtCast + ",''), ISNULL(`" + m.targetColumns[i] + "`)"
+	}
+	return strings.Join(sourceExprs, ", "), strings.Join(targetExprs, ", "), nil
+}
+
+// SourceColumnIndices returns the indices into sourceTable.NonGeneratedColumns
+// for each intersected column. This is used when row data only contains
+// non-generated columns (e.g., from SELECT statements).
+func (m *ColumnMapping) SourceColumnIndices() []int {
+	indexMap := make(map[string]int, len(m.sourceTable.NonGeneratedColumns))
+	for i, col := range m.sourceTable.NonGeneratedColumns {
+		indexMap[col] = i
+	}
+	indices := make([]int, len(m.sourceColumns))
+	for i, col := range m.sourceColumns {
+		indices[i] = indexMap[col]
+	}
+	return indices
+}
+
+// SourceOrdinalIndices returns the indices into sourceTable.Columns (all columns,
+// including generated) for each intersected column. This is needed when working
+// with binlog row images, which contain ALL columns including generated ones.
+func (m *ColumnMapping) SourceOrdinalIndices() []int {
+	indexMap := make(map[string]int, len(m.sourceTable.Columns))
+	for i, col := range m.sourceTable.Columns {
+		indexMap[col] = i
+	}
+	indices := make([]int, len(m.sourceColumns))
+	for i, col := range m.sourceColumns {
+		indices[i] = indexMap[col]
+	}
+	return indices
+}
+
+// Renames returns the column rename mapping (old→new), or nil if there are none.
+func (m *ColumnMapping) Renames() map[string]string {
+	return m.renames
+}
+
+// TargetTable returns the target table.
+func (m *ColumnMapping) TargetTable() *TableInfo {
+	return m.targetTable
+}
+
+// SourceTable returns the source table.
+func (m *ColumnMapping) SourceTable() *TableInfo {
+	return m.sourceTable
+}

--- a/pkg/table/column_mapping_test.go
+++ b/pkg/table/column_mapping_test.go
@@ -1,0 +1,152 @@
+package table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColumnMappingColumns(t *testing.T) {
+	t1 := NewTableInfo(nil, "test", "t1")
+	t1new := NewTableInfo(nil, "test", "t1_new")
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"a", "b", "c"}
+	m := NewColumnMapping(t1, t1new, nil)
+	src, _ := m.Columns()
+	assert.Equal(t, "`a`, `b`, `c`", src)
+
+	t1new.NonGeneratedColumns = []string{"a", "c"}
+	m = NewColumnMapping(t1, t1new, nil)
+	src, _ = m.Columns()
+	assert.Equal(t, "`a`, `c`", src)
+
+	t1new.NonGeneratedColumns = []string{"a", "c", "d"}
+	m = NewColumnMapping(t1, t1new, nil)
+	src, _ = m.Columns()
+	assert.Equal(t, "`a`, `c`", src)
+}
+
+func TestColumnMappingColumnsSlice(t *testing.T) {
+	t1 := NewTableInfo(nil, "test", "t1")
+	t1new := NewTableInfo(nil, "test", "t1_new")
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"a", "b", "c"}
+	m := NewColumnMapping(t1, t1new, nil)
+	cols, _ := m.ColumnsSlice()
+	assert.Equal(t, []string{"a", "b", "c"}, cols)
+
+	t1new.NonGeneratedColumns = []string{"a", "c"}
+	m = NewColumnMapping(t1, t1new, nil)
+	cols, _ = m.ColumnsSlice()
+	assert.Equal(t, []string{"a", "c"}, cols)
+
+	t1new.NonGeneratedColumns = []string{"a", "c", "d"}
+	m = NewColumnMapping(t1, t1new, nil)
+	cols, _ = m.ColumnsSlice()
+	assert.Equal(t, []string{"a", "c"}, cols)
+}
+
+func TestColumnMappingWithRenames(t *testing.T) {
+	t1 := NewTableInfo(nil, "test", "t1")
+	t1new := NewTableInfo(nil, "test", "t1_new")
+
+	// Simple rename: a→x
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"x", "b", "c"}
+	renames := map[string]string{"a": "x"}
+
+	m := NewColumnMapping(t1, t1new, renames)
+	srcStr, tgtStr := m.Columns()
+	assert.Equal(t, "`a`, `b`, `c`", srcStr)
+	assert.Equal(t, "`x`, `b`, `c`", tgtStr)
+
+	srcSlice, tgtSlice := m.ColumnsSlice()
+	assert.Equal(t, []string{"a", "b", "c"}, srcSlice)
+	assert.Equal(t, []string{"x", "b", "c"}, tgtSlice)
+
+	// Multiple renames: a→x, c→z
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"x", "b", "z"}
+	renames = map[string]string{"a": "x", "c": "z"}
+
+	m = NewColumnMapping(t1, t1new, renames)
+	srcStr, tgtStr = m.Columns()
+	assert.Equal(t, "`a`, `b`, `c`", srcStr)
+	assert.Equal(t, "`x`, `b`, `z`", tgtStr)
+
+	// No renames (nil map) - should behave like original
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"a", "b", "c"}
+
+	m = NewColumnMapping(t1, t1new, nil)
+	srcStr, tgtStr = m.Columns()
+	assert.Equal(t, "`a`, `b`, `c`", srcStr)
+	assert.Equal(t, "`a`, `b`, `c`", tgtStr)
+
+	// Empty renames map - should behave like original
+	m = NewColumnMapping(t1, t1new, map[string]string{})
+	srcStr, tgtStr = m.Columns()
+	assert.Equal(t, "`a`, `b`, `c`", srcStr)
+	assert.Equal(t, "`a`, `b`, `c`", tgtStr)
+
+	// Rename with column added in new table (d is new, not in source)
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"x", "b", "c", "d"}
+	renames = map[string]string{"a": "x"}
+
+	m = NewColumnMapping(t1, t1new, renames)
+	srcSlice, tgtSlice = m.ColumnsSlice()
+	assert.Equal(t, []string{"a", "b", "c"}, srcSlice)
+	assert.Equal(t, []string{"x", "b", "c"}, tgtSlice)
+
+	// Rename with column dropped from new table (c dropped)
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+	t1new.NonGeneratedColumns = []string{"x", "b"}
+	renames = map[string]string{"a": "x"}
+
+	m = NewColumnMapping(t1, t1new, renames)
+	srcSlice, tgtSlice = m.ColumnsSlice()
+	assert.Equal(t, []string{"a", "b"}, srcSlice)
+	assert.Equal(t, []string{"x", "b"}, tgtSlice)
+
+	// Dangerous pattern: RENAME COLUMN c1 TO n1, ADD COLUMN c1 varchar(100)
+	// The old name "c1" now exists in BOTH the source table AND the target table
+	// (as a new column). The rename must take priority: source c1 → target n1.
+	// The new c1 in the target must NOT get matched to the old c1 in the source.
+	t1.NonGeneratedColumns = []string{"id", "c1"}
+	t1new.NonGeneratedColumns = []string{"id", "n1", "c1"} // n1 is renamed from c1; c1 is brand new
+	renames = map[string]string{"c1": "n1"}
+
+	m = NewColumnMapping(t1, t1new, renames)
+	srcSlice, tgtSlice = m.ColumnsSlice()
+	// Source c1 must map to target n1 (via rename), NOT to target c1 (identity match).
+	// The new target c1 has no source counterpart — it should get its DEFAULT value.
+	assert.Equal(t, []string{"id", "c1"}, srcSlice)
+	assert.Equal(t, []string{"id", "n1"}, tgtSlice)
+
+	// Reverse dangerous pattern: RENAME COLUMN a TO c (where c already existed)
+	// Source: [id, a, c], Target: [id, c] where a→c is the rename
+	// source.a → target.c (rename). source.c must NOT identity-match target.c
+	// because target.c is already claimed by the rename from source.a.
+	t1.NonGeneratedColumns = []string{"id", "a", "c"}
+	t1new.NonGeneratedColumns = []string{"id", "c"} // c is renamed from a; old c is dropped
+	renames = map[string]string{"a": "c"}
+
+	m = NewColumnMapping(t1, t1new, renames)
+	srcSlice, tgtSlice = m.ColumnsSlice()
+	// source.a → target.c (rename), source.c is excluded (target.c is claimed)
+	assert.Equal(t, []string{"id", "a"}, srcSlice)
+	assert.Equal(t, []string{"id", "c"}, tgtSlice)
+}
+
+func TestColumnMappingTargetNil(t *testing.T) {
+	// When target is nil, source is used as target
+	t1 := NewTableInfo(nil, "test", "t1")
+	t1.NonGeneratedColumns = []string{"a", "b", "c"}
+
+	m := NewColumnMapping(t1, nil, nil)
+	src, tgt := m.Columns()
+	assert.Equal(t, "`a`, `b`, `c`", src)
+	assert.Equal(t, "`a`, `b`, `c`", tgt)
+	assert.Equal(t, t1, m.TargetTable())
+}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -385,12 +385,25 @@ func (t *TableInfo) MaxValue() Datum {
 	return t.maxValue
 }
 
-func (t *TableInfo) WrapCastType(col string) string {
+func (t *TableInfo) wrapCastType(col string) (string, error) {
 	tp, ok := t.columnsMySQLTps[col] // the tp keeps the width in this context.
 	if !ok {
-		panic("column not found")
+		return "", fmt.Errorf("column %q not found in table %s", col, t.TableName)
 	}
-	return fmt.Sprintf("CAST(`%s` AS %s)", col, castableTp(tp))
+	return fmt.Sprintf("CAST(`%s` AS %s)", col, castableTp(tp)), nil
+}
+
+// wrapCastTypeAs generates a CAST expression using sqlCol as the column reference
+// in the SQL, but looks up the cast type from typeCol in this table's column types.
+// This is used for column renames where the SQL column name differs from the
+// type-lookup column name (e.g., source table uses old name, but cast type
+// comes from the target table's new name).
+func (t *TableInfo) wrapCastTypeAs(sqlCol, typeCol string) (string, error) {
+	tp, ok := t.columnsMySQLTps[typeCol]
+	if !ok {
+		return "", fmt.Errorf("column %q not found for type lookup in table %s", typeCol, t.TableName)
+	}
+	return fmt.Sprintf("CAST(`%s` AS %s)", sqlCol, castableTp(tp)), nil
 }
 
 func (t *TableInfo) datumTp(col string) datumTp {

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -90,8 +90,12 @@ func TestDiscovery(t *testing.T) {
 
 	// normalize for mysql 5.7 and 8.0
 	assert.Equal(t, "int", removeWidth(t1.columnsMySQLTps["id"]))
-	assert.Equal(t, "CAST(`id` AS signed)", t1.WrapCastType("id"))
-	assert.Equal(t, "CAST(`name` AS char CHARACTER SET utf8mb4)", t1.WrapCastType("name"))
+	castID, err := t1.wrapCastType("id")
+	assert.NoError(t, err)
+	assert.Equal(t, "CAST(`id` AS signed)", castID)
+	castName, err := t1.wrapCastType("name")
+	assert.NoError(t, err)
+	assert.Equal(t, "CAST(`name` AS char CHARACTER SET utf8mb4)", castName)
 
 	assert.Equal(t, "1", t1.minValue.String())
 	assert.Equal(t, "3", t1.maxValue.String())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
-	"github.com/block/spirit/pkg/table"
 )
 
 const (
@@ -21,33 +20,6 @@ func HashKey(key []any) string {
 		pk = append(pk, fmt.Sprintf("%v", v))
 	}
 	return strings.Join(pk, PrimaryKeySeparator)
-}
-
-// IntersectNonGeneratedColumns returns a string of columns that are in both tables
-// The column names are in backticks and comma separated.
-func IntersectNonGeneratedColumns(t1, t2 *table.TableInfo) string {
-	var intersection []string
-	for _, col := range t1.NonGeneratedColumns {
-		for _, col2 := range t2.NonGeneratedColumns {
-			if col == col2 {
-				intersection = append(intersection, "`"+col+"`")
-			}
-		}
-	}
-	return strings.Join(intersection, ", ")
-}
-
-// IntersectNonGeneratedColumnsAsSlice returns a slice of column names that are in both tables
-func IntersectNonGeneratedColumnsAsSlice(t1, t2 *table.TableInfo) []string {
-	var intersection []string
-	for _, col := range t1.NonGeneratedColumns {
-		for _, col2 := range t2.NonGeneratedColumns {
-			if col == col2 {
-				intersection = append(intersection, col)
-			}
-		}
-	}
-	return intersection
 }
 
 // UnhashKeyToString converts a hashed key to a string that can be used in a query.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -3,47 +3,12 @@ package utils
 import (
 	"testing"
 
-	"github.com/block/spirit/pkg/table"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
-}
-
-func TestIntersectColumns(t *testing.T) {
-	t1 := table.NewTableInfo(nil, "test", "t1")
-	t1new := table.NewTableInfo(nil, "test", "t1_new")
-	t1.NonGeneratedColumns = []string{"a", "b", "c"}
-	t1new.NonGeneratedColumns = []string{"a", "b", "c"}
-	str := IntersectNonGeneratedColumns(t1, t1new)
-	assert.Equal(t, "`a`, `b`, `c`", str)
-
-	t1new.NonGeneratedColumns = []string{"a", "c"}
-	str = IntersectNonGeneratedColumns(t1, t1new)
-	assert.Equal(t, "`a`, `c`", str)
-
-	t1new.NonGeneratedColumns = []string{"a", "c", "d"}
-	str = IntersectNonGeneratedColumns(t1, t1new)
-	assert.Equal(t, "`a`, `c`", str)
-}
-
-func TestGetIntersectingColumns(t *testing.T) {
-	t1 := table.NewTableInfo(nil, "test", "t1")
-	t1new := table.NewTableInfo(nil, "test", "t1_new")
-	t1.NonGeneratedColumns = []string{"a", "b", "c"}
-	t1new.NonGeneratedColumns = []string{"a", "b", "c"}
-	cols := IntersectNonGeneratedColumnsAsSlice(t1, t1new)
-	assert.Equal(t, []string{"a", "b", "c"}, cols)
-
-	t1new.NonGeneratedColumns = []string{"a", "c"}
-	cols = IntersectNonGeneratedColumnsAsSlice(t1, t1new)
-	assert.Equal(t, []string{"a", "c"}, cols)
-
-	t1new.NonGeneratedColumns = []string{"a", "c", "d"}
-	cols = IntersectNonGeneratedColumnsAsSlice(t1, t1new)
-	assert.Equal(t, []string{"a", "c"}, cols)
 }
 
 func TestHashAndUnhashKey(t *testing.T) {


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

This PR is part of https://github.com/block/spirit/issues/701 (pre-req for rename column support).

### Summary

Split the `Chunker` interface into `Chunker` (base) and `MappedChunker` (single-table pair with column mapping and watermark optimization). The `multiChunker` remains a plain `Chunker`.

Introduce `ColumnMapping` as a first-class type that replaces `utils.IntersectNonGeneratedColumns` everywhere:

| Package | Before | After |
|---------|--------|-------|
| copier | `utils.IntersectNonGeneratedColumns(chunk.Table, chunk.NewTable)` | `chunk.ColumnMapping.Columns()` |
| checksum | `c.intersectColumns(chunk)` (private method with CAST/IFNULL wrapping) | `chunk.ColumnMapping.ChecksumExprs()` |
| repl subscriptions | `utils.IntersectNonGeneratedColumns(s.table, s.newTable)` | `s.chunker.ColumnMapping().Columns()` |
| applier | `UpsertRows(ctx, sourceTable, targetTable, rows, lock)` | `UpsertRows(ctx, mapping, rows, lock)` |

`ColumnMapping` supports column renames (old→new map) with correct handling of dangerous overlap patterns. Without renames, it produces identical output to the old intersection logic.

### Key changes

- **`MappedChunker` interface**: extends `Chunker` with `ColumnMapping()`, `KeyAboveHighWatermark()`, `KeyBelowLowWatermark()`
- **`ColumnMapping` type**: pre-computed column intersection with rename support, `Columns()`, `ColumnsSlice()`, `ChecksumExprs()`, `SourceColumnIndices()`, `SourceOrdinalIndices()`
- **`ChunkerConfig.ColumnMapping`**: optional field; defaults to identity mapping
- **`WrapCastType` → `wrapCastType`**: unexported, returns error instead of panicking; added `wrapCastTypeAs` for rename support
- **Deleted**: `utils.IntersectNonGeneratedColumns`, `utils.IntersectNonGeneratedColumnsAsSlice`, `multiChunker.KeyAboveHighWatermark`, `multiChunker.KeyBelowLowWatermark`
- **`migration/change.go`**: stores per-change `MappedChunker` for `AddSubscription`

### This is a pure refactor

No behavior change — without renames wired in, `ColumnMapping` produces identical SQL to the old intersection logic. The rename feature will be wired in a follow-up PR.

### Depends on

- [x] #705 (ChunkerConfig refactor)
- [x] #708 (keyAboveWatermark resume fix)