### PR TITLE
Handles Datum binary type empty byte values

### DIFF
--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -44,7 +44,8 @@ func TestSingleTargetApplierBasic(t *testing.T) {
 		CREATE TABLE test_table (
 			id INT PRIMARY KEY,
 			name VARCHAR(100),
-			value INT
+			value INT,
+			binaryvalue BLOB
 		)
 	`
 
@@ -80,9 +81,10 @@ func TestSingleTargetApplierBasic(t *testing.T) {
 
 	// Prepare test data
 	testRows := [][]any{
-		{int64(1), "Alice", int64(100)},
-		{int64(2), "Bob", int64(200)},
-		{int64(3), "Charlie", int64(300)},
+		{int64(1), "Alice", int64(100), []byte{0x00}},
+		{int64(2), "Bob", int64(200), nil},
+		{int64(3), "Charlie", int64(300), []byte{0x62, 0x72, 0x6F, 0x77, 0x6E}},
+		{int64(4), "Dan", int64(400), []byte{}},
 	}
 
 	// Create a chunk
@@ -117,42 +119,46 @@ func TestSingleTargetApplierBasic(t *testing.T) {
 	callbackErrMu.Lock()
 	assert.NoError(t, callbackErr, "Callback should not have an error")
 	callbackErrMu.Unlock()
-	assert.Equal(t, int64(3), callbackAffectedRows.Load(), "Should have affected 3 rows")
+	assert.Equal(t, int64(4), callbackAffectedRows.Load(), "Should have affected 4 rows")
 
 	// Verify data in target
 	var count int
 	err = targetDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM test_table").Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 3, count, "Should have 3 rows in target")
+	assert.Equal(t, 4, count, "Should have 4 rows in target")
 
 	// Verify specific rows
-	rows, err := targetDB.QueryContext(t.Context(), "SELECT id, name, value FROM test_table ORDER BY id")
+	rows, err := targetDB.QueryContext(t.Context(), "SELECT id, name, value, binaryvalue FROM test_table ORDER BY id")
 	require.NoError(t, err)
 	defer utils.CloseAndLog(rows)
 
 	expected := []struct {
-		id    int64
-		name  string
-		value int64
+		id          int64
+		name        string
+		value       int64
+		binaryvalue []byte
 	}{
-		{1, "Alice", 100},
-		{2, "Bob", 200},
-		{3, "Charlie", 300},
+		{1, "Alice", 100, []byte{0x00}},
+		{2, "Bob", 200, nil},
+		{3, "Charlie", 300, []byte{0x62, 0x72, 0x6F, 0x77, 0x6E}},
+		{4, "Dan", 400, []byte{0x00}},
 	}
 
 	i := 0
 	for rows.Next() {
 		var id, value int64
 		var name string
-		err = rows.Scan(&id, &name, &value)
+		var binaryvalue []byte
+		err = rows.Scan(&id, &name, &value, &binaryvalue)
 		require.NoError(t, err)
 		assert.Equal(t, expected[i].id, id)
 		assert.Equal(t, expected[i].name, name)
 		assert.Equal(t, expected[i].value, value)
+		assert.Equal(t, expected[i].binaryvalue, binaryvalue)
 		i++
 	}
 	require.NoError(t, rows.Err())
-	assert.Equal(t, 3, i, "Should have read 3 rows")
+	assert.Equal(t, 4, i, "Should have read 4 rows")
 }
 
 // TestSingleTargetApplierEmptyRows tests applying empty row set

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -285,7 +285,11 @@ func (d Datum) String() string {
 	}
 	// Check if it should be hex encoded
 	if d.IsBinaryString() {
-		return fmt.Sprintf("0x%x", s)
+		// MySQL binary string needs at least one character
+		if len(s) == 0 {
+			return "0x00"
+		}
+		return fmt.Sprintf("%#x", s)
 	}
 	return "\"" + sqlescape.EscapeString(s) + "\""
 }

--- a/pkg/table/datum_test.go
+++ b/pkg/table/datum_test.go
@@ -278,6 +278,21 @@ func TestNewDatumFromValue(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "0xfffefd", d.String())
 
+	// Test empty binary values - must NOT serialize as "0x" because
+	// MySQL parses that as an identifier, not a hex literal.
+	d, err = NewDatumFromValue([]byte{0x00}, "MEDIUMBLOB")
+	assert.NoError(t, err)
+	assert.Equal(t, "0x00", d.String())
+	d, err = NewDatumFromValue([]byte{}, "VARBINARY(255)")
+	assert.NoError(t, err)
+	assert.Equal(t, "0x00", d.String())
+	d, err = NewDatumFromValue("", "BLOB")
+	assert.NoError(t, err)
+	assert.Equal(t, "0x00", d.String())
+	d, err = NewDatumFromValue(nil, "BLOB")
+	assert.NoError(t, err)
+	assert.Equal(t, "NULL", d.String())
+
 	// Test JSON types - should be quoted like text
 	jsonBytes := []byte(`[1, 2, 3]`)
 	d, err = NewDatumFromValue(jsonBytes, "JSON")


### PR DESCRIPTION
To resolve `Unknown column '0x' in 'field list' errors encountered by copy workers. This occurs for binary type fields with empty byte values.