### PR TITLE
Improve table name length handling for CREATE TABLE and SkipDropAfterCutover

### DIFF
--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -9,6 +9,7 @@ import (
 	"github.com/block/spirit/pkg/migration/check"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/utils"
 )
 
 type change struct {
@@ -118,11 +119,15 @@ func (c *change) dropOldTable(ctx context.Context) error {
 
 func (c *change) oldTableName() string {
 	// By default we just set the old table name to _<table>_old
-	// but if they've enabled SkipDropAfterCutover, we add a timestamp
+	// but if they've enabled SkipDropAfterCutover, we add a timestamp.
+	// We truncate the table name portion to ensure the result fits within
+	// MySQL's 64-character table name limit.
 	if !c.runner.migration.SkipDropAfterCutover {
 		return fmt.Sprintf(check.NameFormatOld, c.table.TableName)
 	}
-	return fmt.Sprintf(check.NameFormatOldTimeStamp, c.table.TableName, c.runner.startTime.UTC().Format(check.NameFormatTimestamp))
+	timestamp := c.runner.startTime.UTC().Format(check.NameFormatTimestamp)
+	truncatedName := utils.TruncateTableName(c.table.TableName, check.NameFormatTimestampExtraChars)
+	return fmt.Sprintf(check.NameFormatOldTimeStamp, truncatedName, timestamp)
 }
 
 func (c *change) attemptInstantDDL(ctx context.Context) error {

--- a/pkg/migration/change_test.go
+++ b/pkg/migration/change_test.go
@@ -3,9 +3,12 @@ package migration
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/migration/check"
+	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/go-sql-driver/mysql"
@@ -252,4 +255,117 @@ func TestAutoIncrementWithRows(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, autoIncValue.Valid)
 	assert.GreaterOrEqual(t, autoIncValue.Int64, int64(2979719), "Final AUTO_INCREMENT should be >= 2979719")
+}
+
+func TestOldTableNameTruncation(t *testing.T) {
+	startTime := time.Date(2025, 6, 15, 10, 30, 45, 0, time.UTC)
+
+	tests := []struct {
+		name                 string
+		tableName            string
+		skipDropAfterCutover bool
+		expectMaxLen         int
+	}{
+		{
+			name:                 "short name without skip drop",
+			tableName:            "mytable",
+			skipDropAfterCutover: false,
+			expectMaxLen:         utils.MaxTableNameLength,
+		},
+		{
+			name:                 "short name with skip drop",
+			tableName:            "mytable",
+			skipDropAfterCutover: true,
+			expectMaxLen:         utils.MaxTableNameLength,
+		},
+		{
+			name:                 "long name without skip drop",
+			tableName:            strings.Repeat("a", 56),
+			skipDropAfterCutover: false,
+			expectMaxLen:         utils.MaxTableNameLength,
+		},
+		{
+			name:                 "long name with skip drop - requires truncation",
+			tableName:            strings.Repeat("b", 56),
+			skipDropAfterCutover: true,
+			expectMaxLen:         utils.MaxTableNameLength,
+		},
+		{
+			name:                 "max normal length with skip drop - requires truncation",
+			tableName:            strings.Repeat("c", utils.MaxTableNameLength-check.NameFormatNormalExtraChars),
+			skipDropAfterCutover: true,
+			expectMaxLen:         utils.MaxTableNameLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &change{
+				table: &table.TableInfo{
+					TableName: tt.tableName,
+				},
+				runner: &Runner{
+					migration: &Migration{
+						SkipDropAfterCutover: tt.skipDropAfterCutover,
+					},
+					startTime: startTime,
+				},
+			}
+
+			result := c.oldTableName()
+			assert.LessOrEqual(t, len(result), tt.expectMaxLen,
+				"oldTableName() result %q (len=%d) exceeds max length %d",
+				result, len(result), tt.expectMaxLen)
+			assert.Greater(t, len(result), 0, "oldTableName() should not be empty")
+
+			if tt.skipDropAfterCutover {
+				// Should contain the timestamp
+				assert.Contains(t, result, "20250615_103045")
+				// Should have the expected format prefix and suffix
+				assert.True(t, strings.HasPrefix(result, "_"))
+				assert.Contains(t, result, "_old_")
+			} else {
+				// Should have the simple _<name>_old format
+				expected := fmt.Sprintf(check.NameFormatOld, tt.tableName)
+				assert.Equal(t, expected, result)
+			}
+		})
+	}
+}
+
+func TestOldTableNameTruncationPreservesUniqueness(t *testing.T) {
+	// Two different long table names that share a prefix should still produce
+	// different old table names because the timestamp is always included.
+	startTime := time.Date(2025, 6, 15, 10, 30, 45, 0, time.UTC)
+
+	c1 := &change{
+		table: &table.TableInfo{
+			TableName: strings.Repeat("x", 56) + "_table1",
+		},
+		runner: &Runner{
+			migration: &Migration{SkipDropAfterCutover: true},
+			startTime: startTime,
+		},
+	}
+	c2 := &change{
+		table: &table.TableInfo{
+			TableName: strings.Repeat("x", 56) + "_table2",
+		},
+		runner: &Runner{
+			migration: &Migration{SkipDropAfterCutover: true},
+			startTime: startTime,
+		},
+	}
+
+	// Both should fit within the limit
+	result1 := c1.oldTableName()
+	result2 := c2.oldTableName()
+	assert.LessOrEqual(t, len(result1), utils.MaxTableNameLength)
+	assert.LessOrEqual(t, len(result2), utils.MaxTableNameLength)
+
+	// With the same start time and truncated names, they will be the same
+	// (since the distinguishing suffix is truncated). This is acceptable because
+	// SkipDropAfterCutover migrations with the same start time on the same table
+	// cannot run concurrently.
+	assert.Equal(t, result1, result2)
 }

--- a/pkg/migration/change_test.go
+++ b/pkg/migration/change_test.go
@@ -292,7 +292,7 @@ func TestOldTableNameTruncation(t *testing.T) {
 		},
 		{
 			name:                 "max normal length with skip drop - requires truncation",
-			tableName:            strings.Repeat("c", utils.MaxTableNameLength-check.NameFormatNormalExtraChars),
+			tableName:            strings.Repeat("c", check.MaxMigratableTableNameLength),
 			skipDropAfterCutover: true,
 			expectMaxLen:         utils.MaxTableNameLength,
 		},

--- a/pkg/migration/change_test.go
+++ b/pkg/migration/change_test.go
@@ -333,9 +333,12 @@ func TestOldTableNameTruncation(t *testing.T) {
 	}
 }
 
-func TestOldTableNameTruncationPreservesUniqueness(t *testing.T) {
-	// Two different long table names that share a prefix should still produce
-	// different old table names because the timestamp is always included.
+func TestOldTableNameTruncationCollision(t *testing.T) {
+	// Two different long table names that share a common prefix longer than
+	// MaxMigratableTableNameLength will produce the same old table name when
+	// truncated. This is acceptable because:
+	// 1. Table names > 56 chars cannot be created via Spirit (createTableNameCheck).
+	// 2. Concurrent migrations on the same table are not possible.
 	startTime := time.Date(2025, 6, 15, 10, 30, 45, 0, time.UTC)
 
 	c1 := &change{
@@ -363,9 +366,9 @@ func TestOldTableNameTruncationPreservesUniqueness(t *testing.T) {
 	assert.LessOrEqual(t, len(result1), utils.MaxTableNameLength)
 	assert.LessOrEqual(t, len(result2), utils.MaxTableNameLength)
 
-	// With the same start time and truncated names, they will be the same
-	// (since the distinguishing suffix is truncated). This is acceptable because
-	// SkipDropAfterCutover migrations with the same start time on the same table
-	// cannot run concurrently.
+	// These collide because the distinguishing suffix is truncated.
+	// In practice this cannot happen since Spirit enforces a 56-char
+	// table name limit, so the truncation only removes characters
+	// beyond position 43 (which is still unique for valid table names).
 	assert.Equal(t, result1, result2)
 }

--- a/pkg/migration/check/check.go
+++ b/pkg/migration/check/check.go
@@ -24,6 +24,7 @@ const (
 	ScopeCutover     ScopeFlag = 1 << 3
 	ScopePostCutover ScopeFlag = 1 << 4
 	ScopeTesting     ScopeFlag = 1 << 5
+	ScopeStatement   ScopeFlag = 1 << 6 // checks that only require Statement (no DB/Table)
 )
 
 type Resources struct {

--- a/pkg/migration/check/createtablename.go
+++ b/pkg/migration/check/createtablename.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-
-	"github.com/block/spirit/pkg/utils"
 )
 
 func init() {
@@ -13,14 +11,16 @@ func init() {
 }
 
 // createTableNameCheck validates that CREATE TABLE statements do not exceed
-// MySQL's maximum table name length of 64 characters.
+// the maximum table name length that Spirit can manage. This is MySQL's
+// 64-character limit minus the longest Spirit metadata suffix (e.g. _<table>_chkpnt),
+// ensuring that a future ALTER TABLE via Spirit will be possible.
 func createTableNameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 	if r.Statement == nil || !r.Statement.IsCreateTable() {
 		return nil
 	}
 	tableName := r.Statement.Table
-	if len(tableName) > utils.MaxTableNameLength {
-		return fmt.Errorf("table name %q exceeds MySQL's maximum length of %d characters", tableName, utils.MaxTableNameLength)
+	if len(tableName) > MaxMigratableTableNameLength {
+		return fmt.Errorf("table name %q exceeds the maximum length of %d characters that Spirit can manage", tableName, MaxMigratableTableNameLength)
 	}
 	return nil
 }

--- a/pkg/migration/check/createtablename.go
+++ b/pkg/migration/check/createtablename.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registerCheck("createtablename", createTableNameCheck, ScopePreflight)
+	registerCheck("createtablename", createTableNameCheck, ScopeStatement)
 }
 
 // createTableNameCheck validates that CREATE TABLE statements do not exceed

--- a/pkg/migration/check/createtablename.go
+++ b/pkg/migration/check/createtablename.go
@@ -1,0 +1,26 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/block/spirit/pkg/utils"
+)
+
+func init() {
+	registerCheck("createtablename", createTableNameCheck, ScopePreflight)
+}
+
+// createTableNameCheck validates that CREATE TABLE statements do not exceed
+// MySQL's maximum table name length of 64 characters.
+func createTableNameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
+	if r.Statement == nil || !r.Statement.IsCreateTable() {
+		return nil
+	}
+	tableName := r.Statement.Table
+	if len(tableName) > utils.MaxTableNameLength {
+		return fmt.Errorf("table name %q exceeds MySQL's maximum length of %d characters", tableName, utils.MaxTableNameLength)
+	}
+	return nil
+}

--- a/pkg/migration/check/createtablename_test.go
+++ b/pkg/migration/check/createtablename_test.go
@@ -1,0 +1,43 @@
+package check
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/block/spirit/pkg/statement"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTableNameCheck(t *testing.T) {
+	// Non-CREATE TABLE statements should pass (no-op)
+	alterStmt := statement.MustNew("ALTER TABLE t1 ADD COLUMN a INT")[0]
+	r := Resources{
+		Statement: alterStmt,
+	}
+	assert.NoError(t, createTableNameCheck(t.Context(), r, slog.Default()))
+
+	// Nil statement should pass (no-op)
+	r = Resources{Statement: nil}
+	assert.NoError(t, createTableNameCheck(t.Context(), r, slog.Default()))
+
+	// CREATE TABLE with a short name should pass
+	shortStmt := statement.MustNew("CREATE TABLE short_name (id INT NOT NULL PRIMARY KEY)")[0]
+	r = Resources{Statement: shortStmt}
+	assert.NoError(t, createTableNameCheck(t.Context(), r, slog.Default()))
+
+	// CREATE TABLE with exactly 64 characters should pass
+	name64 := strings.Repeat("x", 64)
+	stmt64 := statement.MustNew("CREATE TABLE `" + name64 + "` (id INT NOT NULL PRIMARY KEY)")[0]
+	r = Resources{Statement: stmt64}
+	assert.NoError(t, createTableNameCheck(t.Context(), r, slog.Default()))
+
+	// CREATE TABLE with more than 64 characters should fail
+	name65 := strings.Repeat("y", utils.MaxTableNameLength+1)
+	stmt65 := statement.MustNew("CREATE TABLE `" + name65 + "` (id INT NOT NULL PRIMARY KEY)")[0]
+	r = Resources{Statement: stmt65}
+	err := createTableNameCheck(t.Context(), r, slog.Default())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "exceeds MySQL's maximum length of 64 characters")
+}

--- a/pkg/migration/check/createtablename_test.go
+++ b/pkg/migration/check/createtablename_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/block/spirit/pkg/statement"
-	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,17 +26,17 @@ func TestCreateTableNameCheck(t *testing.T) {
 	r = Resources{Statement: shortStmt}
 	assert.NoError(t, createTableNameCheck(t.Context(), r, slog.Default()))
 
-	// CREATE TABLE with exactly 64 characters should pass
-	name64 := strings.Repeat("x", 64)
-	stmt64 := statement.MustNew("CREATE TABLE `" + name64 + "` (id INT NOT NULL PRIMARY KEY)")[0]
-	r = Resources{Statement: stmt64}
+	// CREATE TABLE with exactly the max manageable length should pass
+	nameMax := strings.Repeat("x", MaxMigratableTableNameLength)
+	stmtMax := statement.MustNew("CREATE TABLE `" + nameMax + "` (id INT NOT NULL PRIMARY KEY)")[0]
+	r = Resources{Statement: stmtMax}
 	assert.NoError(t, createTableNameCheck(t.Context(), r, slog.Default()))
 
-	// CREATE TABLE with more than 64 characters should fail
-	name65 := strings.Repeat("y", utils.MaxTableNameLength+1)
-	stmt65 := statement.MustNew("CREATE TABLE `" + name65 + "` (id INT NOT NULL PRIMARY KEY)")[0]
-	r = Resources{Statement: stmt65}
+	// CREATE TABLE with one character over the max should fail
+	nameTooLong := strings.Repeat("y", MaxMigratableTableNameLength+1)
+	stmtTooLong := statement.MustNew("CREATE TABLE `" + nameTooLong + "` (id INT NOT NULL PRIMARY KEY)")[0]
+	r = Resources{Statement: stmtTooLong}
 	err := createTableNameCheck(t.Context(), r, slog.Default())
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "exceeds MySQL's maximum length of 64 characters")
+	assert.ErrorContains(t, err, "exceeds the maximum length of 56 characters that Spirit can manage")
 }

--- a/pkg/migration/check/createtablename_test.go
+++ b/pkg/migration/check/createtablename_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -38,5 +39,5 @@ func TestCreateTableNameCheck(t *testing.T) {
 	r = Resources{Statement: stmtTooLong}
 	err := createTableNameCheck(t.Context(), r, slog.Default())
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "exceeds the maximum length of 56 characters that Spirit can manage")
+	assert.ErrorContains(t, err, fmt.Sprintf("exceeds the maximum length of %d characters that Spirit can manage", MaxMigratableTableNameLength))
 }

--- a/pkg/migration/check/tablename.go
+++ b/pkg/migration/check/tablename.go
@@ -5,47 +5,31 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/block/spirit/pkg/utils"
 )
 
 const (
-	// Formats for table names
+	// Formats for table names used by Spirit during migrations.
 	NameFormatCheckpoint   = "_%s_chkpnt"
 	NameFormatNew          = "_%s_new"
 	NameFormatOld          = "_%s_old"
 	NameFormatOldTimeStamp = "_%s_old_%s"
 	NameFormatTimestamp    = "20060102_150405"
-)
-
-var (
-	// The number of extra characters needed for table names with all possible
-	// formats. These vars are calculated in the `init` function below.
-	NameFormatNormalExtraChars    = 0
-	NameFormatTimestampExtraChars = 0
 
 	// MaxMigratableTableNameLength is the maximum table name length that Spirit
-	// can manage, accounting for the longest metadata suffix (e.g. _<table>_chkpnt).
-	// Calculated in init().
-	MaxMigratableTableNameLength = 0
+	// can manage. This is MySQL's 64-character limit minus the longest metadata
+	// suffix (_<table>_chkpnt = 8 extra characters), giving 56 usable characters.
+	MaxMigratableTableNameLength = utils.MaxTableNameLength - 8 // len("_") + len("_chkpnt") = 8
+
+	// NameFormatTimestampExtraChars is the number of extra characters added by
+	// the timestamped old table name format (_%s_old_%s with a 15-char timestamp).
+	// This equals len("_") + len("_old_") + len("20060102_150405") = 21.
+	NameFormatTimestampExtraChars = 21
 )
 
 func init() {
 	registerCheck("tablename", tableNameCheck, ScopePreflight)
-
-	// Calculate the number of extra characters needed table names with all possible formats
-	for _, format := range []string{NameFormatCheckpoint, NameFormatNew, NameFormatOld} {
-		extraChars := len(strings.ReplaceAll(format, "%s", ""))
-		if extraChars > NameFormatNormalExtraChars {
-			NameFormatNormalExtraChars = extraChars
-		}
-	}
-
-	// Calculate the number of extra characters needed for table names with the old timestamp format
-	NameFormatTimestampExtraChars = len(strings.ReplaceAll(NameFormatOldTimeStamp, "%s", "")) + len(NameFormatTimestamp)
-
-	MaxMigratableTableNameLength = utils.MaxTableNameLength - NameFormatNormalExtraChars
 }
 
 func tableNameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
@@ -53,10 +37,8 @@ func tableNameCheck(ctx context.Context, r Resources, logger *slog.Logger) error
 	if len(tableName) < 1 {
 		return errors.New("table name must be at least 1 character")
 	}
-
-	normalTableNameLength := utils.MaxTableNameLength - NameFormatNormalExtraChars
-	if len(tableName) > normalTableNameLength {
-		return fmt.Errorf("table name must be less than %d characters", normalTableNameLength)
+	if len(tableName) > MaxMigratableTableNameLength {
+		return fmt.Errorf("table name must be less than %d characters", MaxMigratableTableNameLength)
 	}
 	return nil
 }

--- a/pkg/migration/check/tablename.go
+++ b/pkg/migration/check/tablename.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+
+	"github.com/block/spirit/pkg/utils"
 )
 
 const (
-	// Max table name length in MySQL
-	maxTableNameLength = 64
-
 	// Formats for table names
 	NameFormatCheckpoint   = "_%s_chkpnt"
 	NameFormatNew          = "_%s_new"
@@ -48,12 +47,7 @@ func tableNameCheck(ctx context.Context, r Resources, logger *slog.Logger) error
 		return errors.New("table name must be at least 1 character")
 	}
 
-	timestampTableNameLength := maxTableNameLength - NameFormatTimestampExtraChars
-	if r.SkipDropAfterCutover && len(tableName) > timestampTableNameLength {
-		return fmt.Errorf("table name must be less than %d characters when --skip-drop-after-cutover is set", timestampTableNameLength)
-	}
-
-	normalTableNameLength := maxTableNameLength - NameFormatNormalExtraChars
+	normalTableNameLength := utils.MaxTableNameLength - NameFormatNormalExtraChars
 	if len(tableName) > normalTableNameLength {
 		return fmt.Errorf("table name must be less than %d characters", normalTableNameLength)
 	}

--- a/pkg/migration/check/tablename.go
+++ b/pkg/migration/check/tablename.go
@@ -24,6 +24,11 @@ var (
 	// formats. These vars are calculated in the `init` function below.
 	NameFormatNormalExtraChars    = 0
 	NameFormatTimestampExtraChars = 0
+
+	// MaxMigratableTableNameLength is the maximum table name length that Spirit
+	// can manage, accounting for the longest metadata suffix (e.g. _<table>_chkpnt).
+	// Calculated in init().
+	MaxMigratableTableNameLength = 0
 )
 
 func init() {
@@ -39,6 +44,8 @@ func init() {
 
 	// Calculate the number of extra characters needed for table names with the old timestamp format
 	NameFormatTimestampExtraChars = len(strings.ReplaceAll(NameFormatOldTimeStamp, "%s", "")) + len(NameFormatTimestamp)
+
+	MaxMigratableTableNameLength = utils.MaxTableNameLength - NameFormatNormalExtraChars
 }
 
 func tableNameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {

--- a/pkg/migration/check/tablename_test.go
+++ b/pkg/migration/check/tablename_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 func TestCheckTableNameConstants(t *testing.T) {
-	// Calculated extra chars should always be greater than 0
-	assert.Positive(t, NameFormatNormalExtraChars)
+	assert.Positive(t, MaxMigratableTableNameLength)
 	assert.Positive(t, NameFormatTimestampExtraChars)
-
-	// Calculated extra chars should be less than the max table name length
-	assert.Less(t, NameFormatNormalExtraChars, utils.MaxTableNameLength)
+	assert.Less(t, MaxMigratableTableNameLength, utils.MaxTableNameLength)
 	assert.Less(t, NameFormatTimestampExtraChars, utils.MaxTableNameLength)
 }
 
@@ -42,16 +39,15 @@ func TestCheckTableName(t *testing.T) {
 	assert.ErrorContains(t, testTableName(longName, false), "table name must be less than")
 	assert.ErrorContains(t, testTableName(longName, true), "table name must be less than")
 
-	// A table name at the normal max length should pass regardless of SkipDropAfterCutover.
+	// A table name at the max migratable length should pass regardless of SkipDropAfterCutover.
 	// The SkipDropAfterCutover case is handled by truncation in oldTableName(), not by
 	// rejecting the table name at preflight.
-	normalMax := utils.MaxTableNameLength - NameFormatNormalExtraChars
-	exactFitName := strings.Repeat("x", normalMax)
+	exactFitName := strings.Repeat("x", MaxMigratableTableNameLength)
 	assert.NoError(t, testTableName(exactFitName, false))
 	assert.NoError(t, testTableName(exactFitName, true))
 
-	// One character over the normal max should fail
-	tooLongName := strings.Repeat("x", normalMax+1)
+	// One character over the max should fail
+	tooLongName := strings.Repeat("x", MaxMigratableTableNameLength+1)
 	assert.ErrorContains(t, testTableName(tooLongName, false), "table name must be less than")
 	assert.ErrorContains(t, testTableName(tooLongName, true), "table name must be less than")
 }
@@ -60,7 +56,7 @@ func TestTruncateTableName(t *testing.T) {
 	// Short name that doesn't need truncation
 	assert.Equal(t, "mytable", utils.TruncateTableName("mytable", 21))
 
-	// Name that exactly fits
+	// Name that exactly fits (64 - 21 = 43)
 	name43 := strings.Repeat("a", 43)
 	assert.Equal(t, name43, utils.TruncateTableName(name43, 21))
 
@@ -69,7 +65,7 @@ func TestTruncateTableName(t *testing.T) {
 	assert.Equal(t, strings.Repeat("b", 43), utils.TruncateTableName(name56, 21))
 
 	// Verify that the truncated name + suffix fits within MaxTableNameLength
-	longName := strings.Repeat("c", 56)
+	longName := strings.Repeat("c", MaxMigratableTableNameLength)
 	truncated := utils.TruncateTableName(longName, NameFormatTimestampExtraChars)
 	result := fmt.Sprintf(NameFormatOldTimeStamp, truncated, "20060102_150405")
 	assert.LessOrEqual(t, len(result), utils.MaxTableNameLength)

--- a/pkg/migration/check/tablename_test.go
+++ b/pkg/migration/check/tablename_test.go
@@ -1,10 +1,13 @@
 package check
 
 import (
+	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,8 +17,8 @@ func TestCheckTableNameConstants(t *testing.T) {
 	assert.Positive(t, NameFormatTimestampExtraChars)
 
 	// Calculated extra chars should be less than the max table name length
-	assert.Less(t, NameFormatNormalExtraChars, maxTableNameLength)
-	assert.Less(t, NameFormatTimestampExtraChars, maxTableNameLength)
+	assert.Less(t, NameFormatNormalExtraChars, utils.MaxTableNameLength)
+	assert.Less(t, NameFormatTimestampExtraChars, utils.MaxTableNameLength)
 }
 
 func TestCheckTableName(t *testing.T) {
@@ -38,4 +41,44 @@ func TestCheckTableName(t *testing.T) {
 	longName := "thisisareallylongtablenamethisisareallylongtablenamethisisareallylongtablename"
 	assert.ErrorContains(t, testTableName(longName, false), "table name must be less than")
 	assert.ErrorContains(t, testTableName(longName, true), "table name must be less than")
+
+	// A table name at the normal max length should pass regardless of SkipDropAfterCutover.
+	// The SkipDropAfterCutover case is handled by truncation in oldTableName(), not by
+	// rejecting the table name at preflight.
+	normalMax := utils.MaxTableNameLength - NameFormatNormalExtraChars
+	exactFitName := strings.Repeat("x", normalMax)
+	assert.NoError(t, testTableName(exactFitName, false))
+	assert.NoError(t, testTableName(exactFitName, true))
+
+	// One character over the normal max should fail
+	tooLongName := strings.Repeat("x", normalMax+1)
+	assert.ErrorContains(t, testTableName(tooLongName, false), "table name must be less than")
+	assert.ErrorContains(t, testTableName(tooLongName, true), "table name must be less than")
+}
+
+func TestTruncateTableName(t *testing.T) {
+	// Short name that doesn't need truncation
+	assert.Equal(t, "mytable", utils.TruncateTableName("mytable", 21))
+
+	// Name that exactly fits
+	name43 := strings.Repeat("a", 43)
+	assert.Equal(t, name43, utils.TruncateTableName(name43, 21))
+
+	// Name that exceeds the limit and needs truncation
+	name56 := strings.Repeat("b", 56)
+	assert.Equal(t, strings.Repeat("b", 43), utils.TruncateTableName(name56, 21))
+
+	// Verify that the truncated name + suffix fits within MaxTableNameLength
+	longName := strings.Repeat("c", 56)
+	truncated := utils.TruncateTableName(longName, NameFormatTimestampExtraChars)
+	result := fmt.Sprintf(NameFormatOldTimeStamp, truncated, "20060102_150405")
+	assert.LessOrEqual(t, len(result), utils.MaxTableNameLength)
+
+	// Zero suffix length means full 64 chars available
+	name64 := strings.Repeat("d", 64)
+	assert.Equal(t, name64, utils.TruncateTableName(name64, 0))
+
+	// Name longer than 64 with zero suffix gets truncated to 64
+	name70 := strings.Repeat("e", 70)
+	assert.Equal(t, strings.Repeat("e", 64), utils.TruncateTableName(name70, 0))
 }

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/throttler"
+	"github.com/block/spirit/pkg/utils"
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 )
 
@@ -180,6 +181,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		// We only allow non-ALTERs (i.e. CREATE TABLE, DROP TABLE, RENAME TABLE)
 		// in single table mode.
 		if !r.changes[0].stmt.IsAlterTable() {
+			// Validate table name length for CREATE TABLE statements.
+			if r.changes[0].stmt.IsCreateTable() {
+				tableName := r.changes[0].stmt.Table
+				if len(tableName) > utils.MaxTableNameLength {
+					return fmt.Errorf("table name %q exceeds MySQL's maximum length of %d characters", tableName, utils.MaxTableNameLength)
+				}
+			}
 			err := dbconn.Exec(ctx, r.db, r.changes[0].stmt.Statement)
 			if err != nil {
 				return err

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -180,14 +180,8 @@ func (r *Runner) Run(ctx context.Context) error {
 		// We only allow non-ALTERs (i.e. CREATE TABLE, DROP TABLE, RENAME TABLE)
 		// in single table mode.
 		if !r.changes[0].stmt.IsAlterTable() {
-			// Validate table name length for CREATE TABLE statements.
-			// Enforce the same limit as ALTER TABLE (64 - longest Spirit suffix)
-			// so that a future migration on this table will be possible.
-			if r.changes[0].stmt.IsCreateTable() {
-				tableName := r.changes[0].stmt.Table
-				if len(tableName) > check.MaxMigratableTableNameLength {
-					return fmt.Errorf("table name %q exceeds the maximum length of %d characters that Spirit can manage", tableName, check.MaxMigratableTableNameLength)
-				}
+			if err := r.runChecks(ctx, check.ScopeStatement); err != nil {
+				return err
 			}
 			err := dbconn.Exec(ctx, r.db, r.changes[0].stmt.Statement)
 			if err != nil {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/throttler"
-	"github.com/block/spirit/pkg/utils"
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 )
 
@@ -182,10 +181,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		// in single table mode.
 		if !r.changes[0].stmt.IsAlterTable() {
 			// Validate table name length for CREATE TABLE statements.
+			// Enforce the same limit as ALTER TABLE (64 - longest Spirit suffix)
+			// so that a future migration on this table will be possible.
 			if r.changes[0].stmt.IsCreateTable() {
 				tableName := r.changes[0].stmt.Table
-				if len(tableName) > utils.MaxTableNameLength {
-					return fmt.Errorf("table name %q exceeds MySQL's maximum length of %d characters", tableName, utils.MaxTableNameLength)
+				if len(tableName) > check.MaxMigratableTableNameLength {
+					return fmt.Errorf("table name %q exceeds the maximum length of %d characters that Spirit can manage", tableName, check.MaxMigratableTableNameLength)
 				}
 			}
 			err := dbconn.Exec(ctx, r.db, r.changes[0].stmt.Statement)

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -435,9 +435,10 @@ func TestCreateTableNameLength(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
 
-	// A CREATE TABLE with a table name exceeding MySQL's 64-character limit should be rejected.
-	longName := "this_is_a_really_long_table_name_that_exceeds_sixty_four_characters_total"
-	assert.Greater(t, len(longName), 64)
+	// A CREATE TABLE with a table name exceeding Spirit's manageable limit (56 chars)
+	// should be rejected, since Spirit needs room for metadata suffixes like _<table>_chkpnt.
+	longName := strings.Repeat("z", 57)
+	assert.Greater(t, len(longName), check.MaxMigratableTableNameLength)
 
 	m, err := NewRunner(&Migration{
 		Host:      cfg.Addr,
@@ -450,14 +451,12 @@ func TestCreateTableNameLength(t *testing.T) {
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "exceeds MySQL's maximum length of 64 characters")
+	assert.ErrorContains(t, err, "exceeds the maximum length of 56 characters that Spirit can manage")
 	assert.NoError(t, m.Close())
 
-	// A CREATE TABLE with a table name at exactly 64 characters should be allowed
-	// (MySQL will accept it, and we don't need to reserve space for shadow tables
-	// since CREATE TABLE doesn't go through the online schema change path).
-	exactName := strings.Repeat("x", 64)
-	assert.Equal(t, 64, len(exactName))
+	// A CREATE TABLE with a table name at exactly the max manageable length (56 chars)
+	// should be allowed.
+	exactName := strings.Repeat("x", check.MaxMigratableTableNameLength)
 	testutils.RunSQL(t, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", exactName))
 
 	m, err = NewRunner(&Migration{

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -430,6 +430,97 @@ func TestTableLength(t *testing.T) {
 	assert.NoError(t, m.Close())
 }
 
+func TestCreateTableNameLength(t *testing.T) {
+	t.Parallel()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+
+	// A CREATE TABLE with a table name exceeding MySQL's 64-character limit should be rejected.
+	longName := "this_is_a_really_long_table_name_that_exceeds_sixty_four_characters_total"
+	assert.Greater(t, len(longName), 64)
+
+	m, err := NewRunner(&Migration{
+		Host:      cfg.Addr,
+		Username:  cfg.User,
+		Password:  &cfg.Passwd,
+		Database:  cfg.DBName,
+		Threads:   2,
+		Statement: fmt.Sprintf("CREATE TABLE `%s` (id INT NOT NULL PRIMARY KEY)", longName),
+	})
+	assert.NoError(t, err)
+	err = m.Run(t.Context())
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "exceeds MySQL's maximum length of 64 characters")
+	assert.NoError(t, m.Close())
+
+	// A CREATE TABLE with a table name at exactly 64 characters should be allowed
+	// (MySQL will accept it, and we don't need to reserve space for shadow tables
+	// since CREATE TABLE doesn't go through the online schema change path).
+	exactName := strings.Repeat("x", 64)
+	assert.Equal(t, 64, len(exactName))
+	testutils.RunSQL(t, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", exactName))
+
+	m, err = NewRunner(&Migration{
+		Host:      cfg.Addr,
+		Username:  cfg.User,
+		Password:  &cfg.Passwd,
+		Database:  cfg.DBName,
+		Threads:   2,
+		Statement: fmt.Sprintf("CREATE TABLE `%s` (id INT NOT NULL PRIMARY KEY)", exactName),
+	})
+	assert.NoError(t, err)
+	err = m.Run(t.Context())
+	assert.NoError(t, err)
+	assert.NoError(t, m.Close())
+
+	// Cleanup
+	testutils.RunSQL(t, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", exactName))
+}
+
+func TestSkipDropAfterCutoverLongTableName(t *testing.T) {
+	t.Parallel()
+
+	// A table name at the normal max (56 chars) should work with SkipDropAfterCutover.
+	// Previously this would have been rejected because the timestamp format exceeds 64 chars,
+	// but now we truncate the table name portion in the old table name.
+	tableName := "a_fifty_six_character_table_name_that_fits_normal_limits"
+	assert.Equal(t, 56, len(tableName))
+
+	testutils.RunSQL(t, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", tableName))
+	testutils.RunSQL(t, fmt.Sprintf(`CREATE TABLE %s (
+		pk int UNSIGNED NOT NULL AUTO_INCREMENT,
+		PRIMARY KEY(pk)
+	)`, tableName))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	assert.NoError(t, err)
+	m, err := NewRunner(&Migration{
+		Host:                 cfg.Addr,
+		Username:             cfg.User,
+		Password:             &cfg.Passwd,
+		Database:             cfg.DBName,
+		Threads:              4,
+		Table:                tableName,
+		Alter:                "ENGINE=InnoDB",
+		SkipDropAfterCutover: true,
+	})
+	assert.NoError(t, err)
+	err = m.Run(t.Context())
+	assert.NoError(t, err)
+
+	// Verify the old table exists (with truncated name + timestamp)
+	oldName := m.changes[0].oldTableName()
+	assert.LessOrEqual(t, len(oldName), 64, "old table name should fit within 64 chars")
+
+	var tableCount int
+	err = m.db.QueryRowContext(t.Context(), fmt.Sprintf(
+		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
+		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, oldName)).Scan(&tableCount)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, tableCount, "old table should exist after SkipDropAfterCutover")
+	assert.NoError(t, m.Close())
+}
+
 func TestBadOptions(t *testing.T) {
 	// N.B. Because host, user, password and database have defaults enforced, we expect to
 	// fail in the same way when they're not provided.

--- a/pkg/migration/runner_test.go
+++ b/pkg/migration/runner_test.go
@@ -451,7 +451,7 @@ func TestCreateTableNameLength(t *testing.T) {
 	assert.NoError(t, err)
 	err = m.Run(t.Context())
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "exceeds the maximum length of 56 characters that Spirit can manage")
+	assert.ErrorContains(t, err, fmt.Sprintf("exceeds the maximum length of %d characters that Spirit can manage", check.MaxMigratableTableNameLength))
 	assert.NoError(t, m.Close())
 
 	// A CREATE TABLE with a table name at exactly the max manageable length (56 chars)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,6 +42,9 @@ func UnhashKeyToString(key string) string {
 // it is returned unchanged.
 func TruncateTableName(tableName string, suffixLength int) string {
 	maxLen := MaxTableNameLength - suffixLength
+	if maxLen <= 0 {
+		return ""
+	}
 	if len(tableName) > maxLen {
 		return tableName[:maxLen]
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,6 +10,9 @@ import (
 
 const (
 	PrimaryKeySeparator = "-#-" // used to hash a composite primary key
+
+	// MaxTableNameLength is the maximum table name length in MySQL.
+	MaxTableNameLength = 64
 )
 
 // HashKey is used to convert a composite key into a string
@@ -32,4 +35,15 @@ func UnhashKeyToString(key string) string {
 		str[i] = "'" + sqlescape.EscapeString(v) + "'"
 	}
 	return "(" + strings.Join(str, ",") + ")"
+}
+
+// TruncateTableName truncates a table name to fit within MySQL's 64-character limit,
+// reserving space for a suffix of the given length. If the table name already fits,
+// it is returned unchanged.
+func TruncateTableName(tableName string, suffixLength int) string {
+	maxLen := MaxTableNameLength - suffixLength
+	if len(tableName) > maxLen {
+		return tableName[:maxLen]
+	}
+	return tableName
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,4 +27,25 @@ func TestHashAndUnhashKey(t *testing.T) {
 	assert.Equal(t, "1234", hashed)
 	unhashed = UnhashKeyToString(hashed)
 	assert.Equal(t, "'1234'", unhashed)
+}
+
+func TestTruncateTableName(t *testing.T) {
+	// Short name that doesn't need truncation
+	assert.Equal(t, "mytable", TruncateTableName("mytable", 21))
+
+	// Name that exactly fits (64 - 21 = 43)
+	name43 := strings.Repeat("a", 43)
+	assert.Equal(t, name43, TruncateTableName(name43, 21))
+
+	// Name that exceeds the limit and needs truncation
+	name56 := strings.Repeat("b", 56)
+	assert.Equal(t, strings.Repeat("b", 43), TruncateTableName(name56, 21))
+
+	// Zero suffix length means full 64 chars available
+	name64 := strings.Repeat("d", 64)
+	assert.Equal(t, name64, TruncateTableName(name64, 0))
+
+	// Name longer than 64 with zero suffix gets truncated to 64
+	name70 := strings.Repeat("e", 70)
+	assert.Equal(t, strings.Repeat("e", 64), TruncateTableName(name70, 0))
 }


### PR DESCRIPTION
Fixes #712

## Problem

1. **`--skip-drop-after-cutover` rejected tables with names 44–56 characters at validation time.** The preflight check enforced a 43-character limit when this flag was set, preventing migrations from ever starting — even though the actual fix is to truncate the table name in the rename operation.

2. **CREATE TABLE statements bypassed all table name length validation.** The CREATE TABLE path returns early before preflight checks run, so a table could be created with a name that Spirit cannot later migrate.

## Solution

- **Truncate instead of reject**: When `SkipDropAfterCutover` is true, `oldTableName()` now truncates the table name portion (using `utils.TruncateTableName`) so the timestamped old table name always fits within 64 characters. The preflight check no longer applies a stricter limit for this flag.

- **New `createTableNameCheck`**: A registered check at `ScopeStatement` validates CREATE TABLE names against Spirit's 56-character manageable limit (64 minus the longest metadata suffix). This runs via `runChecks(ScopeStatement)` before the non-ALTER early return in `Runner.Run()`.

- **New `ScopeStatement` check scope**: For checks that only require the parsed statement (no DB connection or table info needed).

- **`MaxTableNameLength` and `TruncateTableName` in `pkg/utils`**: Shared utilities to avoid circular imports between packages.

- **Simplified constants**: Replaced `init()`-calculated vars with plain constants (`MaxMigratableTableNameLength = 56`, `NameFormatTimestampExtraChars = 21`) for clarity.