### PR TITLE
statement: order DeclarativeToImperative output as CREATE → ALTER → DROP

### DIFF
--- a/pkg/statement/declarative.go
+++ b/pkg/statement/declarative.go
@@ -17,11 +17,12 @@ import (
 // definitions, compute the minimal set of changes. It is used by spirit's diff
 // subcommand, strata, and GAP.
 //
-// The returned statements are ordered by table name, with CREATE/ALTER
-// statements before DROP statements. This ordering is a correctness property:
-// it ensures the output is safe to execute sequentially (e.g. a table
-// referenced by a foreign key will not be dropped before the referencing
-// ALTER runs).
+// The returned statements are ordered as CREATE → ALTER → DROP (within each
+// group, tables are sorted alphabetically). This ordering is a correctness
+// property: it ensures the output is safe to execute sequentially (e.g. an
+// ALTER that adds a foreign key referencing a newly-created table will run
+// after the CREATE, and a table referenced by a FK won't be dropped before
+// the referencing ALTER runs).
 //
 // If opts is nil, NewDiffOptions() defaults are used for table diffs.
 func DeclarativeToImperative(current, desired []table.TableSchema, opts *DiffOptions) ([]*AbstractStatement, error) {
@@ -41,7 +42,8 @@ func DeclarativeToImperative(current, desired []table.TableSchema, opts *DiffOpt
 	}
 	sort.Strings(desiredNames)
 
-	var changes []*AbstractStatement
+	var creates []*AbstractStatement
+	var alters []*AbstractStatement
 	var drops []*AbstractStatement
 
 	// Tables in desired: create if new, diff if existing.
@@ -54,7 +56,7 @@ func DeclarativeToImperative(current, desired []table.TableSchema, opts *DiffOpt
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse CREATE TABLE for new table %q: %w", name, err)
 			}
-			changes = append(changes, stmts...)
+			creates = append(creates, stmts...)
 			continue
 		}
 
@@ -63,7 +65,7 @@ func DeclarativeToImperative(current, desired []table.TableSchema, opts *DiffOpt
 		if err != nil {
 			return nil, err
 		}
-		changes = append(changes, diffs...)
+		alters = append(alters, diffs...)
 	}
 
 	// Tables in current but not in desired — emit DROP TABLE.
@@ -83,9 +85,12 @@ func DeclarativeToImperative(current, desired []table.TableSchema, opts *DiffOpt
 		drops = append(drops, stmts...)
 	}
 
-	// CREATE/ALTER first, then DROP.
-	changes = append(changes, drops...)
-	return changes, nil
+	// Order: CREATE first, then ALTER, then DROP.
+	result := make([]*AbstractStatement, 0, len(creates)+len(alters)+len(drops))
+	result = append(result, creates...)
+	result = append(result, alters...)
+	result = append(result, drops...)
+	return result, nil
 }
 
 // diffTable computes the ALTER TABLE diff for a single table, recovering from

--- a/pkg/statement/declarative_test.go
+++ b/pkg/statement/declarative_test.go
@@ -180,10 +180,11 @@ func TestDeclarativeToImperativeWithOptions(t *testing.T) {
 }
 
 func TestDeclarativeToImperative_OrderingCreateAlterBeforeDrop(t *testing.T) {
-	// Verify the correctness property: CREATE/ALTER statements always come
-	// before DROP statements. This ensures safe sequential execution (e.g.
-	// a table referenced by a FK won't be dropped before the referencing
-	// ALTER runs).
+	// Verify the correctness property: statements are ordered as
+	// CREATE → ALTER → DROP. This ensures safe sequential execution (e.g.
+	// an ALTER adding a FK to a newly-created table runs after the CREATE,
+	// and a table referenced by a FK won't be dropped before the
+	// referencing ALTER runs).
 	current := []table.TableSchema{
 		{Name: "a_table", Schema: "CREATE TABLE a_table (id INT PRIMARY KEY)"},
 		{Name: "b_table", Schema: "CREATE TABLE b_table (id INT PRIMARY KEY)"},
@@ -199,23 +200,39 @@ func TestDeclarativeToImperative_OrderingCreateAlterBeforeDrop(t *testing.T) {
 	changes, err := DeclarativeToImperative(current, desired, nil)
 	require.NoError(t, err)
 
-	// We expect: ALTER a_table, CREATE e_new, DROP c_drop_me, DROP d_drop_me
+	// We expect: CREATE e_new, ALTER a_table, DROP c_drop_me, DROP d_drop_me
 	require.Len(t, changes, 4)
 
-	// Find the boundary: all DROPs must come after all non-DROPs.
-	firstDropIdx := -1
+	// Classify each statement and verify strict CREATE → ALTER → DROP ordering.
+	const (
+		phaseCreate = iota
+		phaseAlter
+		phaseDrop
+	)
+	phase := phaseCreate
 	for i, ch := range changes {
-		if strings.Contains(ch.Statement, "DROP TABLE") {
-			if firstDropIdx == -1 {
-				firstDropIdx = i
-			}
-		} else {
-			// Any non-DROP after a DROP is a violation of the ordering invariant.
-			if firstDropIdx != -1 {
-				t.Fatalf("non-DROP statement at index %d after DROP at index %d: %s", i, firstDropIdx, ch.Statement)
-			}
+		var stmtPhase int
+		switch {
+		case strings.Contains(ch.Statement, "CREATE TABLE"):
+			stmtPhase = phaseCreate
+		case strings.Contains(ch.Statement, "ALTER TABLE"):
+			stmtPhase = phaseAlter
+		case strings.Contains(ch.Statement, "DROP TABLE"):
+			stmtPhase = phaseDrop
+		default:
+			t.Fatalf("unexpected statement at index %d: %s", i, ch.Statement)
 		}
+		if stmtPhase < phase {
+			t.Fatalf("ordering violation at index %d: got %s after phase %d", i, ch.Statement, phase)
+		}
+		phase = stmtPhase
 	}
+
+	// Additionally verify the exact order of statement types.
+	assert.Contains(t, changes[0].Statement, "CREATE TABLE")
+	assert.Contains(t, changes[1].Statement, "ALTER TABLE")
+	assert.Contains(t, changes[2].Statement, "DROP TABLE")
+	assert.Contains(t, changes[3].Statement, "DROP TABLE")
 }
 
 func TestToTableSchema(t *testing.T) {


### PR DESCRIPTION
## Summary

Orders the output of `DeclarativeToImperative` as CREATE → ALTER → DROP instead of the previous behavior where CREATEs and ALTERs were interleaved alphabetically.

## Motivation

When a diff produces both CREATE TABLE and ALTER TABLE statements, the ALTER may reference the newly-created table (e.g., adding a foreign key to a new table). By ensuring CREATEs come first, the output is safe to execute sequentially without dependency issues.

## Changes

- Split the single `changes` slice into separate `creates` and `alters` slices
- Combined them as `creates + alters + drops` at the end
- Updated the existing ordering test to verify the three-phase ordering

Fixes #671