### PR TITLE
status: write checkpoint immediately when WatchTask starts

### DIFF
--- a/pkg/status/task.go
+++ b/pkg/status/task.go
@@ -45,6 +45,27 @@ func continuallyDumpStatus(ctx context.Context, task Task, logger *slog.Logger) 
 }
 
 func continuallyDumpCheckpoint(ctx context.Context, task Task, logger *slog.Logger) {
+	// Attempt an immediate checkpoint write so that even short-lived
+	// migrations have a recovery point. If the watermark isn't ready
+	// yet (e.g. copier hasn't started), we just fall through to the
+	// periodic loop which will retry.
+	if err := task.DumpCheckpoint(ctx); err != nil {
+		switch {
+		case errors.Is(err, ErrWatermarkNotReady):
+			// Non-fatal: watermark not ready yet, fall through to periodic loop.
+		case errors.Is(err, context.Canceled):
+			// Context already canceled, no point entering the loop.
+			return
+		default:
+			if task.Progress().CurrentState >= CutOver {
+				return
+			}
+			logger.Error("error writing checkpoint", "error", err)
+			task.Cancel()
+			return
+		}
+	}
+
 	ticker := time.NewTicker(CheckpointDumpInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/status/task_test.go
+++ b/pkg/status/task_test.go
@@ -1,0 +1,142 @@
+package status
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockTask implements Task for testing checkpoint behavior.
+type mockTask struct {
+	mu               sync.Mutex
+	checkpointCalls  atomic.Int32
+	progress         Progress
+	dumpCheckpointFn func(ctx context.Context) error
+	cancelled        atomic.Bool
+}
+
+func (m *mockTask) Progress() Progress {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.progress
+}
+
+func (m *mockTask) Status() string {
+	return "mock status"
+}
+
+func (m *mockTask) DumpCheckpoint(ctx context.Context) error {
+	m.checkpointCalls.Add(1)
+	if m.dumpCheckpointFn != nil {
+		return m.dumpCheckpointFn(ctx)
+	}
+	return nil
+}
+
+func (m *mockTask) Cancel() {
+	m.cancelled.Store(true)
+}
+
+func TestContinuallyDumpCheckpoint_ImmediateWrite(t *testing.T) {
+	// Verify that DumpCheckpoint is called immediately when the routine starts,
+	// without waiting for the ticker interval.
+	mock := &mockTask{
+		progress: Progress{CurrentState: CopyRows},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	logger := slog.Default()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(ctx, mock, logger)
+	}()
+
+	// Wait briefly for the immediate checkpoint to be written.
+	// This should happen almost instantly, well before the 50s ticker.
+	assert.Eventually(t, func() bool {
+		return mock.checkpointCalls.Load() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "expected immediate checkpoint write")
+
+	cancel()
+	<-done // Wait for goroutine to exit
+}
+
+func TestContinuallyDumpCheckpoint_ImmediateWatermarkNotReady(t *testing.T) {
+	// When the immediate checkpoint returns ErrWatermarkNotReady,
+	// the routine should continue to the ticker loop (not cancel).
+	var calls atomic.Int32
+	mock := &mockTask{
+		progress: Progress{CurrentState: CopyRows},
+		dumpCheckpointFn: func(ctx context.Context) error {
+			n := calls.Add(1)
+			if n == 1 {
+				return ErrWatermarkNotReady
+			}
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	logger := slog.Default()
+
+	// Use a short checkpoint interval for the test.
+	origInterval := CheckpointDumpInterval
+	CheckpointDumpInterval = 50 * time.Millisecond
+	defer func() { CheckpointDumpInterval = origInterval }()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(ctx, mock, logger)
+	}()
+
+	// The first call should fail with ErrWatermarkNotReady, but the routine
+	// should continue and succeed on the next ticker-driven call.
+	assert.Eventually(t, func() bool {
+		return calls.Load() >= 2
+	}, 2*time.Second, 10*time.Millisecond, "expected retry after watermark not ready")
+
+	assert.False(t, mock.cancelled.Load(), "task should not be cancelled for ErrWatermarkNotReady")
+
+	cancel()
+	<-done // Wait for goroutine to exit
+}
+
+func TestContinuallyDumpCheckpoint_ContextCanceled_ReturnsImmediately(t *testing.T) {
+	// When the context is already canceled, the routine should return immediately
+	// without entering the ticker loop.
+	mock := &mockTask{
+		progress: Progress{CurrentState: CopyRows},
+		dumpCheckpointFn: func(ctx context.Context) error {
+			return context.Canceled
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel before starting
+
+	logger := slog.Default()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(ctx, mock, logger)
+	}()
+
+	// Should exit quickly
+	select {
+	case <-done:
+		// Good — exited promptly
+	case <-time.After(2 * time.Second):
+		t.Fatal("continuallyDumpCheckpoint did not exit after context canceled")
+	}
+
+	assert.False(t, mock.cancelled.Load(), "task should not be cancelled for context.Canceled")
+}


### PR DESCRIPTION
## Summary

Writes the first checkpoint immediately when the periodic checkpoint routine starts, rather than waiting for the first 50-second ticker interval.

## Motivation

Previously, if a migration crashed in the first 50 seconds of copying, no checkpoint existed and all progress was lost. This is particularly painful for large migrations where even a few seconds of progress represents meaningful work.

## Changes

- **`pkg/status/task.go`**: Added an immediate `DumpCheckpoint()` call at the start of `continuallyDumpCheckpoint()`, before entering the ticker loop. The immediate attempt gracefully handles `ErrWatermarkNotReady` (falls through to the periodic loop) since the watermark might not be ready at the very start.

- **`pkg/status/task_test.go`** (new file): Added tests verifying:
  - `DumpCheckpoint` is called immediately without waiting for the ticker
  - The routine continues normally when the immediate attempt returns `ErrWatermarkNotReady`

Fixes #298