### PR TITLE
docs: fix outdated information in AGENTS.md, DEVELOPMENT.md, and lint README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ cd cmd/spirit && go build
 ./spirit move --help
 ./spirit lint --help
 ./spirit diff --help
+./spirit fmt --help
 ```
 
 Spirit uses [Kong](https://github.com/alecthomas/kong) for CLI argument parsing with subcommands. The CLI structs are defined in `pkg/migration/`, `pkg/move/`, and `pkg/lint/` respectively.
@@ -132,7 +133,7 @@ m.Alter = "ENGINE=InnoDB"
 require.NoError(t, m.Run())
 ```
 
-Available options: `WithThreads(n)`, `WithTargetChunkTime(d)`, `WithBuffered(b)`, `WithTable(name)`, `WithAlter(stmt)`, `WithStatement(sql)`, `WithTestThrottler()`, `WithDeferCutOver()`, `WithSkipDropAfterCutover()`, `WithStrict()`, `WithDBName(name)`, `WithRespectSentinel()`.
+Available options: `WithThreads(n)`, `WithTargetChunkTime(d)`, `WithBuffered(b)`, `WithTable(name)`, `WithAlter(stmt)`, `WithStatement(sql)`, `WithTestThrottler()`, `WithDeferCutOver()`, `WithSkipDropAfterCutover()`, `WithStrict()`, `WithDBName(name)`, `WithRespectSentinel()`, `WithLint()`, `WithLintOnly()`, `WithHost(host)`, `WithReplicaDSN(dsn)`, `WithReplicaMaxLag(d)`, `WithConfFile(t, content)`.
 
 **General test patterns:**
 - Integration tests connect to real MySQL — there are no mocked database tests for core logic
@@ -154,7 +155,7 @@ The project uses golangci-lint v2 with `gofmt` and `goimports` formatters enable
 
 ```
 cmd/
-  spirit/     → Single CLI entry point with subcommands: migrate, move, lint, diff
+  spirit/     → Single CLI entry point with subcommands: migrate, move, lint, diff, fmt
 
 pkg/
   migration/  → Orchestrator for single-table schema changes (main entry point)
@@ -166,10 +167,12 @@ pkg/
   checksum/   → Post-copy data verification (CRC32 + BIT_XOR)
   dbconn/     → MySQL connection management, TLS, retries, locking, kill logic
   statement/  → SQL parsing via TiDB parser (ALTER, CREATE, DROP, RENAME)
-  lint/       → Static analysis framework for schemas and DDL (12 built-in linters)
+  lint/       → Static analysis framework for schemas and DDL (15 built-in linters)
+  fmt/        → Schema file formatter (canonicalize CREATE TABLE .sql files)
   throttler/  → Rate limiting interface (noop, mock, replica-lag based)
   status/     → State machine and progress reporting
   metrics/    → Metric types for observability
+  buildinfo/  → Build version and metadata
   utils/      → General utilities
   testutils/  → Test helpers (DSN, database creation, SQL execution)
 
@@ -221,7 +224,7 @@ Three chunker implementations:
 Uses the [TiDB parser](https://github.com/pingcap/tidb/tree/master/pkg/parser) for SQL parsing. If a DDL cannot be parsed by TiDB, Spirit cannot execute it. `parse_create_table.go` provides structured `CREATE TABLE` parsing.
 
 ### `pkg/lint`
-12 built-in linters that auto-register via `init()`. Each linter is in its own file (`lint_<name>.go`). To add a new linter, create a new file following the existing pattern and implement the `Linter` interface from `linter.go`.
+15 built-in linters that auto-register via `init()`. Each linter is in its own file (`lint_<name>.go`). To add a new linter, create a new file following the existing pattern and implement the `Linter` interface from `linter.go`.
 
 ### `pkg/dbconn`
 Handles connection management including:
@@ -272,8 +275,11 @@ Spirit is designed to fail safely. When in doubt:
 
 GitHub Actions workflows (`.github/workflows/`):
 - **linter.yml** — runs `golangci-lint` v2.11.4 on Go 1.26 (push to main + PRs)
-- **mysql8-docker.yml** — integration tests against MySQL 8.0.33 with replication/TLS
+- **mysql8-docker.yml** — integration tests against MySQL 8.0.45 with replication/TLS
 - **mysql8.0.28-docker.yml** — integration tests against MySQL 8.0.28
+- **mysql8.0.42-docker.yml** — integration tests against MySQL 8.0.42
 - **mysql84-docker.yml** — integration tests against MySQL 8.4
+- **mysql97-docker.yml** — integration tests against MySQL 9.7
 - **mysql8_rbr_minimal-docker.yml** — tests with minimal `binlog_row_image`
 - **buildandrun-docker.yml** — build and run smoke test
+- **release.yml** — release automation

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 ## Minimum Requirements
 
-Spirit requires go 1.25 or higher. MySQL version 8.0 and higher is required for performing schema changes.
+Spirit requires go 1.26 or higher. MySQL version 8.0 and higher is required for performing schema changes.
 
 ## Running tests
 

--- a/pkg/lint/README.md
+++ b/pkg/lint/README.md
@@ -29,9 +29,8 @@ if lint.HasErrors(violations) {
     // Handle errors
 }
 
-// Filter violations
-errors := lint.FilterBySeverity(violations, lint.SeverityError)
-warnings := lint.FilterBySeverity(violations, lint.SeverityWarning)
+// Filter violations by linter
+flagViolations := lint.FilterByLinter(violations, "has_fk")
 ```
 
 ### Creating a Custom Linter
@@ -58,7 +57,6 @@ func init() {
 type MyCustomLinter struct{}
 
 func (l *MyCustomLinter) Name() string        { return "my_custom" }
-func (l *MyCustomLinter) Category() string    { return "naming" }
 func (l *MyCustomLinter) Description() string { return "Checks naming conventions" }
 func (l *MyCustomLinter) String() string      { return l.Name() }
 
@@ -159,7 +157,6 @@ type Location struct {
 - `Enable(name string)` - Enable a linter by name
 - `Disable(name string)` - Disable a linter by name
 - `List()` - Get all registered linter names
-- `ListByCategory(category string)` - Get linters in a category
 - `Get(name string)` - Get a linter by name
 
 ### Execution
@@ -167,12 +164,11 @@ type Location struct {
 - `RunLinters(createTables, alterStatements, config) ([]Violation, error)` - Run all enabled linters, returns violations and any configuration errors
 - `HasErrors(violations)` - Check if any violations are errors
 - `HasWarnings(violations)` - Check if any violations are warnings
-- `FilterBySeverity(violations, severity)` - Filter by severity level
 - `FilterByLinter(violations, name)` - Filter by linter name
 
 ## Built-in Linters
 
-The `lint` package includes 11 built-in linters covering schema design, data types, and safety best practices.
+The `lint` package includes 15 built-in linters covering schema design, data types, and safety best practices.
 
 ### allow_charset
 
@@ -616,6 +612,30 @@ CREATE TABLE users (
 ALTER TABLE users ADD COLUMN legacy_date DATETIME DEFAULT '0000-00-00 00:00:00';
 ```
 
+### has_timestamp
+
+**Severity**: Warning  
+**Configurable**: No  
+**Checks**: CREATE TABLE, ALTER TABLE (ADD/MODIFY/CHANGE COLUMN)
+
+Detects TIMESTAMP columns, which have problematic behavior in MySQL (automatic initialization, timezone conversion, limited range to 2038). Recommends using DATETIME instead.
+
+### redundant_indexes
+
+**Severity**: Warning  
+**Configurable**: No  
+**Checks**: CREATE TABLE
+
+Detects redundant indexes where one index is a prefix of another (e.g., INDEX(a) is redundant if INDEX(a, b) exists). Also detects duplicate indexes with the same column list.
+
+### rename_column
+
+**Severity**: Warning  
+**Configurable**: No  
+**Checks**: ALTER TABLE
+
+Detects column renames via RENAME COLUMN or CHANGE COLUMN. Column renames cannot be done atomically across application pods and break ORMs that generate column names at compile time. Recommends using ADD COLUMN + DROP COLUMN instead.
+
 ---
 
 ## Linter Summary Table
@@ -627,10 +647,13 @@ ALTER TABLE users ADD COLUMN legacy_date DATETIME DEFAULT '0000-00-00 00:00:00';
 | `auto_inc_capacity` | ✅ | ✅ | ❌ | Warning |
 | `has_fk` | ❌ | ✅ | ✅ | Warning |
 | `has_float` | ❌ | ✅ | ✅ | Warning |
+| `has_timestamp` | ❌ | ✅ | ✅ | Warning |
 | `invisible_index_before_drop` | ✅ | ❌ | ✅ | Warning |
 | `multiple_alter_table` | ❌ | ❌ | ✅ | Warning |
 | `name_case` | ❌ | ✅ | ✅ | Warning |
 | `primary_key` | ✅ | ✅ | ❌ | Warning |
+| `redundant_indexes` | ❌ | ✅ | ❌ | Warning |
+| `rename_column` | ❌ | ❌ | ✅ | Warning |
 | `reserved_words` | ❌ | ✅ | ✅ | Warning |
 | `unsafe` | ✅ | ❌ | ✅ | Warning |
 | `zero_date` | ❌ | ✅ | ✅ | Warning |


### PR DESCRIPTION
## Summary

Fixes various stale/incorrect documentation across the project.

### AGENTS.md
- Fix linter count: 12 → 15 (3 linters were added without updating the count)
- Add missing `fmt` subcommand to architecture and CLI sections
- Add missing `pkg/fmt/` and `pkg/buildinfo/` to architecture diagram
- Fix MySQL version in CI section: 8.0.33 → 8.0.45
- Add missing CI workflows: `mysql8.0.42-docker.yml`, `mysql97-docker.yml`, `release.yml`
- Add missing test helper options: `WithLint()`, `WithLintOnly()`, `WithHost()`, `WithReplicaDSN()`, `WithReplicaMaxLag()`, `WithConfFile()`

### DEVELOPMENT.md
- Fix Go version requirement: 1.25 → 1.26 (matches go.mod)

### pkg/lint/README.md
- Fix linter count: 11 → 15
- Remove non-existent `Category()` method from example linter code
- Remove non-existent `FilterBySeverity()` and `ListByCategory()` from API docs
- Add missing linter documentation: `has_timestamp`, `redundant_indexes`, `rename_column`
- Add missing linters to summary table