### PR TITLE
docs: recommend against --strict in migrate documentation

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -274,10 +274,10 @@ There are some restrictions to `--statement`:
 
 By default, Spirit will automatically clean up old checkpoints before starting the schema change. This allows schema changes to always proceed forward, at the cost of potentially lost progress from a previous incomplete run.
 
-When set to `true`, if Spirit encounters a checkpoint belonging to a previous migration, it will validate that the alter statement matches the `--alter` parameter. If the validation fails (e.g., the ALTER was changed between runs, or the binlog position is no longer available), Spirit will exit with an error rather than silently restarting from scratch.
+When set to `true`, if Spirit encounters a checkpoint belonging to a previous migration, it will validate that the statement being executed matches the statement from the previous run (whether provided via `--alter` or `--statement`). If the validation fails (e.g., the statement was changed between runs, or the binlog position is no longer available), Spirit will exit with an error rather than silently restarting from scratch.
 
 The scenarios where `--strict` causes Spirit to fail rather than restart are:
-- The `--alter` statement changed between runs (checkpoint has a different ALTER)
+- The migration statement changed between runs (checkpoint has a different statement)
 - The binlog file referenced by the checkpoint has been purged from the server
 - The checkpoint is too old to safely resume (replaying binlogs would be slower than restarting)
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -270,9 +270,18 @@ There are some restrictions to `--statement`:
 - Type: Boolean
 - Default value: `false`
 
-By default, Spirit will automatically clean up these old checkpoints before starting the schema change. This allows schema changes to always be possible to proceed forward, at the risk of lost progress.
+> **⚠️ Not recommended.** In most cases, the default behavior (idempotent restart) is safer and more convenient. `--strict` was added for a specific internal use case and is generally the wrong choice for new deployments. If a previous migration was interrupted, the default behavior will safely clean up and restart, which is almost always what you want.
 
-When set to `true`, if Spirit encounters a checkpoint belonging to a previous migration, it will validate that the alter statement matches the `--alter` parameter. If the validation fails, Spirit will exit and prevent the schema change process from proceeding.
+By default, Spirit will automatically clean up old checkpoints before starting the schema change. This allows schema changes to always proceed forward, at the cost of potentially lost progress from a previous incomplete run.
+
+When set to `true`, if Spirit encounters a checkpoint belonging to a previous migration, it will validate that the alter statement matches the `--alter` parameter. If the validation fails (e.g., the ALTER was changed between runs, or the binlog position is no longer available), Spirit will exit with an error rather than silently restarting from scratch.
+
+The scenarios where `--strict` causes Spirit to fail rather than restart are:
+- The `--alter` statement changed between runs (checkpoint has a different ALTER)
+- The binlog file referenced by the checkpoint has been purged from the server
+- The checkpoint is too old to safely resume (replaying binlogs would be slower than restarting)
+
+In all of these cases, the default (non-strict) behavior is to log a warning and start fresh, which is usually the correct action.
 
 ### table
 

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -41,7 +41,7 @@ type Migration struct {
 	SkipDropAfterCutover bool          `name:"skip-drop-after-cutover" help:"Keep old table after completing cutover" optional:"" default:"false"`
 	DeferCutOver         bool          `name:"defer-cutover" help:"Defer cutover (and checksum) until sentinel table is dropped" optional:"" default:"false"`
 	SkipForceKill        bool          `name:"skip-force-kill" help:"Disable killing long-running transactions in order to acquire metadata lock (MDL) at checksum and cutover time" optional:"" default:"false"`
-	Strict               bool          `name:"strict" help:"Exit on --alter mismatch when incomplete migration is detected" optional:"" default:"false"`
+	Strict               bool          `name:"strict" help:"Exit on --alter mismatch when incomplete migration is detected. Not recommended for most users; the default idempotent restart behavior is safer." optional:"" default:"false"`
 	Statement            string        `name:"statement" help:"The SQL statement to run (replaces --table and --alter)" optional:"" default:""`
 	Lint                 bool          `name:"lint" help:"Run lint checks before running migration" optional:""`
 	LintOnly             bool          `name:"lint-only" help:"Run lint checks and exit without performing migration" optional:""`

--- a/pkg/migration/resume-from-checkpoint.md
+++ b/pkg/migration/resume-from-checkpoint.md
@@ -56,12 +56,14 @@ What happens next depends on whether strict mode is enabled:
 The tradeoff of falling back to `newMigration()` is that all copy progress is lost. For a large table this could mean hours of wasted work. To avoid this:
 
 - **Keep binlog retention longer than your longest expected migration pause.** If you expect to pause migrations for up to a week, make sure `binlog_expire_logs_seconds` is set to at least 7 days. The MySQL 8.0 default is 30 days (`2592000`), which is usually sufficient.
-- **Use `--strict` mode if losing progress silently is unacceptable.** In strict mode, Spirit surfaces both DDL mismatches (`status.ErrMismatchedAlter`) and binlog expiry (`status.ErrBinlogNotFound`) as errors. Callers can use `errors.Is()` to handle each case.
+- **Consider `--strict` mode only if you have automation that handles the errors it produces.** In strict mode, Spirit surfaces both DDL mismatches (`status.ErrMismatchedAlter`) and binlog expiry (`status.ErrBinlogNotFound`) as errors instead of restarting. This is generally not recommended for most users — the default behavior of discarding stale checkpoints and restarting is safer and simpler. See [strict](../docs/migrate.md#strict) for more details.
 - **Be aware of your binlog retention window.** If Spirit is paused longer than the retention period, the checkpoint's binlog file will be purged and resume will fail. Some managed MySQL services disable retention by default.
 
 ## Strict mode
 
-By default, Spirit treats checkpoint resume as best-effort. If the checkpoint is invalid for any reason — mismatched DDL statement, expired binlog, corrupt checkpoint data — Spirit discards it and starts a new migration.
+> **Note:** `--strict` is not recommended for most users. The default idempotent restart behavior (discard stale checkpoint, restart from scratch) is safer and requires no special error handling. Only use `--strict` if you have automation that can programmatically handle the specific errors it produces.
+
+By default, Spirit treats checkpoint resume as best-effort. If the checkpoint is invalid for any reason — mismatched DDL statement, expired binlog, corrupt checkpoint data — Spirit discards it and starts a new migration. This is the recommended behavior.
 
 With `Strict: true`, Spirit returns a hard error for two specific resume failures:
 


### PR DESCRIPTION
The default idempotent restart behavior is safer and more convenient for most users. `--strict` was added for a specific internal use case and can cause unexpected failures when checkpoints become stale.

This updates the `docs/migrate.md` to:
- Add a prominent warning recommending against `--strict`
- Explain the specific failure scenarios where strict mode causes errors
- Clarify that the default behavior (clean up and restart) is usually correct

Fixes #736