### PR TITLE
throttler: add MultiThrottler and support multiple replica DSNs

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -192,8 +192,11 @@ The password to use when connecting to MySQL. To connect to MySQL without any pa
 - Type: String
 - Default value: ``
 - Example: `root:mypassword@tcp(localhost:3307)/test`
+- Multiple replicas: `root:pass@tcp(replica1:3306)/db,root:pass@tcp(replica2:3306)/db`
 
-Used in combination with [replica-max-lag](#replica-max-lag). This is the host which Spirit will connect to to determine if the copy should be throttled to ensure replica health.
+Used in combination with [replica-max-lag](#replica-max-lag). This is the host (or hosts) which Spirit will connect to to determine if the copy should be throttled to ensure replica health.
+
+Multiple replica DSNs can be specified as a comma-separated list. When multiple replicas are configured, Spirit monitors all of them and throttles based on the **slowest** replica (i.e., the one with the highest lag). This is useful for environments with multiple read replicas where you want to ensure none of them fall too far behind.
 
 #### Replica TLS Behavior
 

--- a/pkg/migration/check/check.go
+++ b/pkg/migration/check/check.go
@@ -29,7 +29,7 @@ const (
 
 type Resources struct {
 	DB                   *sql.DB
-	Replica              *sql.DB
+	Replicas             []*sql.DB
 	Table                *table.TableInfo
 	Statement            *statement.AbstractStatement
 	TargetChunkTime      time.Duration

--- a/pkg/migration/check/replicahealth.go
+++ b/pkg/migration/check/replicahealth.go
@@ -13,23 +13,25 @@ func init() {
 	registerCheck("replicahealth", replicaHealth, ScopePostSetup|ScopeCutover)
 }
 
-// replicaHealth checks SHOW REPLICA STATUS for Yes and Yes.
-// It should be run at various stages of the migration if a replica is present.
+// replicaHealth checks SHOW REPLICA STATUS for Yes and Yes on all replicas.
+// It should be run at various stages of the migration if replicas are present.
 func replicaHealth(ctx context.Context, r Resources, logger *slog.Logger) error {
-	if r.Replica == nil {
+	if len(r.Replicas) == 0 {
 		return nil // The user is not using the replica DSN feature.
 	}
-	rows, err := r.Replica.QueryContext(ctx, "SHOW REPLICA STATUS")
-	if err != nil {
-		return err
-	}
-	defer utils.CloseAndLog(rows)
-	status, err := scanToMap(rows)
-	if err != nil {
-		return err
-	}
-	if status["Replica_IO_Running"].String != "Yes" || status["Replica_SQL_Running"].String != "Yes" {
-		return errors.New("replica is not healthy")
+	for _, replica := range r.Replicas {
+		rows, err := replica.QueryContext(ctx, "SHOW REPLICA STATUS")
+		if err != nil {
+			return err
+		}
+		status, err := scanToMap(rows)
+		utils.CloseAndLog(rows)
+		if err != nil {
+			return err
+		}
+		if status["Replica_IO_Running"].String != "Yes" || status["Replica_SQL_Running"].String != "Yes" {
+			return errors.New("replica is not healthy")
+		}
 	}
 	return nil
 }

--- a/pkg/migration/check/replicahealth.go
+++ b/pkg/migration/check/replicahealth.go
@@ -32,6 +32,10 @@ func replicaHealth(ctx context.Context, r Resources, logger *slog.Logger) error 
 		if err != nil {
 			return err
 		}
+		if status == nil {
+			host := replicaHost(ctx, replica)
+			return fmt.Errorf("%w: SHOW REPLICA STATUS returned no rows on %s (not a replica?)", ErrReplicaNotHealthy, host)
+		}
 
 		ioRunning := status["Replica_IO_Running"].String
 		sqlRunning := status["Replica_SQL_Running"].String

--- a/pkg/migration/check/replicahealth.go
+++ b/pkg/migration/check/replicahealth.go
@@ -3,11 +3,14 @@ package check
 import (
 	"context"
 	"database/sql"
-	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/block/spirit/pkg/utils"
 )
+
+// ErrReplicaNotHealthy is returned when a replica's IO or SQL thread is not running.
+var ErrReplicaNotHealthy = fmt.Errorf("replica is not healthy")
 
 func init() {
 	registerCheck("replicahealth", replicaHealth, ScopePostSetup|ScopeCutover)
@@ -29,11 +32,33 @@ func replicaHealth(ctx context.Context, r Resources, logger *slog.Logger) error 
 		if err != nil {
 			return err
 		}
-		if status["Replica_IO_Running"].String != "Yes" || status["Replica_SQL_Running"].String != "Yes" {
-			return errors.New("replica is not healthy")
+
+		ioRunning := status["Replica_IO_Running"].String
+		sqlRunning := status["Replica_SQL_Running"].String
+
+		if ioRunning != "Yes" {
+			ioState := status["Replica_IO_State"].String
+			host := replicaHost(ctx, replica)
+			return fmt.Errorf("%w: IO thread not running on %s (Replica_IO_State: %s)", ErrReplicaNotHealthy, host, ioState)
+		}
+		if sqlRunning != "Yes" {
+			sqlState := status["Replica_SQL_Running_State"].String
+			host := replicaHost(ctx, replica)
+			return fmt.Errorf("%w: SQL thread not running on %s (Replica_SQL_Running_State: %s)", ErrReplicaNotHealthy, host, sqlState)
 		}
 	}
 	return nil
+}
+
+// replicaHost attempts to identify the replica by querying @@hostname and @@port.
+// Falls back to "unknown" if the query fails.
+func replicaHost(ctx context.Context, db *sql.DB) string {
+	var hostname string
+	var port int
+	if err := db.QueryRowContext(ctx, "SELECT @@hostname, @@port").Scan(&hostname, &port); err != nil {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s:%d", hostname, port)
 }
 
 func scanToMap(rows *sql.Rows) (map[string]sql.NullString, error) {

--- a/pkg/migration/check/replicahealth_test.go
+++ b/pkg/migration/check/replicahealth_test.go
@@ -20,13 +20,15 @@ func TestReplicaHealth(t *testing.T) {
 	err := replicaHealth(t.Context(), r, slog.Default())
 	assert.NoError(t, err) // if no replicas, it returns no error.
 
-	// use a non-replica. this will return an error.
+	// use a non-replica. this will return an error identifying which thread
+	// is not running and on which host.
 	nonReplica, err := sql.Open("mysql", testutils.DSN())
 	assert.NoError(t, err)
 	r.Replicas = []*sql.DB{nonReplica}
 	err = replicaHealth(t.Context(), r, slog.Default())
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "replica is not healthy")
+	assert.ErrorIs(t, err, ErrReplicaNotHealthy)
+	assert.Contains(t, err.Error(), "IO thread not running") // specific thread identified
 
 	// use an actual replica
 	replicaDSN := os.Getenv("REPLICA_DSN")

--- a/pkg/migration/check/replicahealth_test.go
+++ b/pkg/migration/check/replicahealth_test.go
@@ -28,7 +28,6 @@ func TestReplicaHealth(t *testing.T) {
 	err = replicaHealth(t.Context(), r, slog.Default())
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrReplicaNotHealthy)
-	assert.Contains(t, err.Error(), "IO thread not running") // specific thread identified
 
 	// use an actual replica
 	replicaDSN := os.Getenv("REPLICA_DSN")

--- a/pkg/migration/check/replicahealth_test.go
+++ b/pkg/migration/check/replicahealth_test.go
@@ -18,11 +18,12 @@ func TestReplicaHealth(t *testing.T) {
 		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename")[0],
 	}
 	err := replicaHealth(t.Context(), r, slog.Default())
-	assert.NoError(t, err) // if no replica, it returns no error.
+	assert.NoError(t, err) // if no replicas, it returns no error.
 
 	// use a non-replica. this will return an error.
-	r.Replica, err = sql.Open("mysql", testutils.DSN())
+	nonReplica, err := sql.Open("mysql", testutils.DSN())
 	assert.NoError(t, err)
+	r.Replicas = []*sql.DB{nonReplica}
 	err = replicaHealth(t.Context(), r, slog.Default())
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "replica is not healthy")
@@ -32,15 +33,17 @@ func TestReplicaHealth(t *testing.T) {
 	if replicaDSN == "" {
 		t.Skip("skipping test because REPLICA_DSN not set")
 	}
-	r.Replica, err = sql.Open("mysql", replicaDSN)
+	replicaDB, err := sql.Open("mysql", replicaDSN)
 	assert.NoError(t, err)
+	r.Replicas = []*sql.DB{replicaDB}
 	err = replicaHealth(t.Context(), r, slog.Default())
 	assert.NoError(t, err) // all looks good of course.
 
 	// use a completely invalid DSN.
 	// golang sql.Open lazy loads, so this is possible.
-	r.Replica, err = sql.Open("mysql", "msandbox:msandbox@tcp(127.0.0.1:22)/test")
+	invalidDB, err := sql.Open("mysql", "msandbox:msandbox@tcp(127.0.0.1:22)/test")
 	assert.NoError(t, err)
+	r.Replicas = []*sql.DB{invalidDB}
 	err = replicaHealth(t.Context(), r, slog.Default())
 	assert.Error(t, err) // invalid
 }

--- a/pkg/migration/check/replicaprivileges.go
+++ b/pkg/migration/check/replicaprivileges.go
@@ -13,19 +13,25 @@ func init() {
 }
 
 // Check that there is permission to run perfschema queries for replication (8.0)
+// on all configured replicas.
 func replicaPrivilegeCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
-	if r.Replica == nil {
+	if len(r.Replicas) == 0 {
 		return nil // The user is not using the replica DSN feature.
 	}
-	var version string
-	if err := r.Replica.QueryRowContext(ctx, "select substr(version(), 1, 1)").Scan(&version); err != nil {
-		return err //  can not get version
+	for _, replica := range r.Replicas {
+		var version string
+		if err := replica.QueryRowContext(ctx, "select substr(version(), 1, 1)").Scan(&version); err != nil {
+			return err //  can not get version
+		}
+		rows, err := replica.QueryContext(ctx, throttler.MySQL8LagQuery)
+		if err != nil {
+			return err
+		}
+		_, err = scanToMap(rows)
+		utils.CloseAndLog(rows)
+		if err != nil {
+			return err
+		}
 	}
-	rows, err := r.Replica.QueryContext(ctx, throttler.MySQL8LagQuery)
-	if err != nil {
-		return err
-	}
-	defer utils.CloseAndLog(rows)
-	_, err = scanToMap(rows)
-	return err
+	return nil
 }

--- a/pkg/migration/check/replicaprivileges_test.go
+++ b/pkg/migration/check/replicaprivileges_test.go
@@ -22,10 +22,11 @@ func TestReplicaPrivileges(t *testing.T) {
 		Statement: statement.MustNew("ALTER TABLE test RENAME TO newtablename")[0],
 	}
 	err := replicaPrivilegeCheck(t.Context(), r, slog.Default())
-	assert.NoError(t, err) // if no replica, it returns no error.
+	assert.NoError(t, err) // if no replicas, it returns no error.
 
-	r.Replica, err = sql.Open("mysql", replicaDSN)
+	replicaDB, err := sql.Open("mysql", replicaDSN)
 	assert.NoError(t, err) // no error
+	r.Replicas = []*sql.DB{replicaDB}
 	err = replicaPrivilegeCheck(t.Context(), r, slog.Default())
 	assert.NoError(t, err) // user has privileges
 }

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -35,7 +35,7 @@ type Migration struct {
 	Alter                string        `name:"alter" help:"The alter statement to run on the table" optional:""`
 	Threads              int           `name:"threads" help:"Number of concurrent threads for copy and checksum tasks" optional:"" default:"4"`
 	TargetChunkTime      time.Duration `name:"target-chunk-time" help:"The target copy time for each chunk" optional:"" default:"500ms"`
-	ReplicaDSN           string        `name:"replica-dsn" help:"A DSN for a replica which (if specified) will be used for lag checking." optional:""`
+	ReplicaDSN           string        `name:"replica-dsn" help:"DSN(s) for replica(s) used for lag checking. Multiple replicas can be comma-separated; Spirit throttles on the slowest." optional:""`
 	ReplicaMaxLag        time.Duration `name:"replica-max-lag" help:"The maximum lag allowed on the replica before the migration throttles." optional:"" default:"120s"`
 	LockWaitTimeout      time.Duration `name:"lock-wait-timeout" help:"The DDL lock_wait_timeout required for checksum and cutover" optional:"" default:"30s"`
 	SkipDropAfterCutover bool          `name:"skip-drop-after-cutover" help:"Keep old table after completing cutover" optional:"" default:"false"`

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -991,6 +991,11 @@ func TestSplitReplicaDSNs(t *testing.T) {
 			input:    "root:pass@tcp(localhost:3306)/db,",
 			expected: []string{"root:pass@tcp(localhost:3306)/db"},
 		},
+		{
+			name:     "only commas and spaces",
+			input:    " , , , ",
+			expected: []string{},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -951,3 +951,52 @@ func TestDSN(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitReplicaDSNs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "single DSN",
+			input:    "root:pass@tcp(localhost:3307)/test",
+			expected: []string{"root:pass@tcp(localhost:3307)/test"},
+		},
+		{
+			name:  "two DSNs",
+			input: "root:pass@tcp(replica1:3306)/db,root:pass@tcp(replica2:3306)/db",
+			expected: []string{
+				"root:pass@tcp(replica1:3306)/db",
+				"root:pass@tcp(replica2:3306)/db",
+			},
+		},
+		{
+			name:  "three DSNs with spaces",
+			input: "root:pass@tcp(r1:3306)/db, root:pass@tcp(r2:3306)/db , root:pass@tcp(r3:3306)/db",
+			expected: []string{
+				"root:pass@tcp(r1:3306)/db",
+				"root:pass@tcp(r2:3306)/db",
+				"root:pass@tcp(r3:3306)/db",
+			},
+		},
+		{
+			name:     "trailing comma",
+			input:    "root:pass@tcp(localhost:3306)/db,",
+			expected: []string{"root:pass@tcp(localhost:3306)/db"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := splitReplicaDSNs(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -623,6 +623,17 @@ func (r *Runner) newMigration(ctx context.Context) error {
 	return nil
 }
 
+// closeReplicas closes all open replica database connections.
+func (r *Runner) closeReplicas() error {
+	for _, replica := range r.replicas {
+		if err := replica.Close(); err != nil {
+			return err
+		}
+	}
+	r.replicas = nil
+	return nil
+}
+
 // setupThrottler sets up the replication throttler if a replica DSN is configured.
 // Multiple replica DSNs can be specified as a comma-separated list; Spirit will
 // monitor all of them and throttle on the slowest one.
@@ -640,6 +651,9 @@ func (r *Runner) setupThrottler(ctx context.Context) error {
 
 	// Split comma-separated DSNs to support multiple replicas.
 	dsns := splitReplicaDSNs(r.migration.ReplicaDSN)
+	if len(dsns) == 0 {
+		return fmt.Errorf("--replica-dsn was specified but contains no valid DSNs: %q", r.migration.ReplicaDSN)
+	}
 
 	// Create a separate DB config for replica connections
 	replicaDBConfig := dbconn.NewDBConfig()
@@ -666,12 +680,14 @@ func (r *Runner) setupThrottler(ctx context.Context) error {
 
 		replicaDB, err := dbconn.NewWithConnectionType(enhancedDSN, replicaDBConfig, "replica database")
 		if err != nil {
+			_ = r.closeReplicas()
 			return fmt.Errorf("failed to connect to replica database (DSN: %s): %w", maskPasswordInDSN(dsn), err)
 		}
 		r.replicas = append(r.replicas, replicaDB)
 
 		replicaThrottler, err := throttler.NewReplicationThrottler(replicaDB, r.migration.ReplicaMaxLag, r.logger)
 		if err != nil {
+			_ = r.closeReplicas()
 			return fmt.Errorf("could not create replication throttler (DSN: %s): %w", maskPasswordInDSN(dsn), err)
 		}
 		throttlers = append(throttlers, replicaThrottler)
@@ -883,10 +899,8 @@ func (r *Runner) Close() error {
 			return err
 		}
 	}
-	for _, replica := range r.replicas {
-		if err := replica.Close(); err != nil {
-			return err
-		}
+	if err := r.closeReplicas(); err != nil {
+		return err
 	}
 	if r.db != nil {
 		err := r.db.Close()

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -415,13 +415,9 @@ func (r *Runner) prepareForCutover(ctx context.Context) error {
 // We redundantly run checks, once per change.
 func (r *Runner) runChecks(ctx context.Context, scope check.ScopeFlag) error {
 	for _, change := range r.changes {
-		var firstReplica *sql.DB
-		if len(r.replicas) > 0 {
-			firstReplica = r.replicas[0]
-		}
 		if err := check.RunChecks(ctx, check.Resources{
 			DB:              r.db,
-			Replica:         firstReplica,
+			Replicas:        r.replicas,
 			Table:           change.table,
 			Statement:       change.stmt,
 			TargetChunkTime: r.migration.TargetChunkTime,

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -39,7 +39,7 @@ type Runner struct {
 	migration       *Migration
 	db              *sql.DB
 	dbConfig        *dbconn.DBConfig
-	replica         *sql.DB
+	replicas        []*sql.DB
 	checkpointTable *table.TableInfo
 
 	// Changes enccapsulates all changes
@@ -415,9 +415,13 @@ func (r *Runner) prepareForCutover(ctx context.Context) error {
 // We redundantly run checks, once per change.
 func (r *Runner) runChecks(ctx context.Context, scope check.ScopeFlag) error {
 	for _, change := range r.changes {
+		var firstReplica *sql.DB
+		if len(r.replicas) > 0 {
+			firstReplica = r.replicas[0]
+		}
 		if err := check.RunChecks(ctx, check.Resources{
 			DB:              r.db,
-			Replica:         r.replica,
+			Replica:         firstReplica,
 			Table:           change.table,
 			Statement:       change.stmt,
 			TargetChunkTime: r.migration.TargetChunkTime,
@@ -448,6 +452,23 @@ func (r *Runner) dsn() string {
 	cfg.Addr = r.migration.Host
 	cfg.DBName = r.changes[0].stmt.Schema
 	return cfg.FormatDSN()
+}
+
+// splitReplicaDSNs splits a comma-separated list of replica DSNs.
+// A single DSN returns a single-element slice. Empty string returns nil.
+func splitReplicaDSNs(dsnList string) []string {
+	if dsnList == "" {
+		return nil
+	}
+	parts := strings.Split(dsnList, ",")
+	dsns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			dsns = append(dsns, trimmed)
+		}
+	}
+	return dsns
 }
 
 // maskPasswordInDSN masks the password in any DSN string for safe logging
@@ -607,6 +628,8 @@ func (r *Runner) newMigration(ctx context.Context) error {
 }
 
 // setupThrottler sets up the replication throttler if a replica DSN is configured.
+// Multiple replica DSNs can be specified as a comma-separated list; Spirit will
+// monitor all of them and throttle on the slowest one.
 // This is common logic shared between resume and new migration paths.
 func (r *Runner) setupThrottler(ctx context.Context) error {
 	if r.migration.useTestThrottler {
@@ -619,8 +642,10 @@ func (r *Runner) setupThrottler(ctx context.Context) error {
 		return nil // No replica DSN specified, use default NOOP throttler
 	}
 
-	var err error
-	// Create a separate DB config for replica connection
+	// Split comma-separated DSNs to support multiple replicas.
+	dsns := splitReplicaDSNs(r.migration.ReplicaDSN)
+
+	// Create a separate DB config for replica connections
 	replicaDBConfig := dbconn.NewDBConfig()
 	replicaDBConfig.LockWaitTimeout = r.dbConfig.LockWaitTimeout
 	replicaDBConfig.InterpolateParams = r.dbConfig.InterpolateParams
@@ -628,38 +653,35 @@ func (r *Runner) setupThrottler(ctx context.Context) error {
 	replicaDBConfig.MaxOpenConnections = r.dbConfig.MaxOpenConnections
 
 	// Copy TLS settings from main DB config to replica config
-	// This allows the DSN enhancement to use the correct TLS settings
 	replicaDBConfig.TLSMode = r.dbConfig.TLSMode
 	replicaDBConfig.TLSCertificatePath = r.dbConfig.TLSCertificatePath
 
-	// Enhance replica DSN with TLS settings if not already present
-	// This preserves any explicit TLS configuration in the replica DSN
-	// while providing sensible defaults from the main DB configuration
-	enhancedReplicaDSN, err := dbconn.EnhanceDSNWithTLS(r.migration.ReplicaDSN, replicaDBConfig)
-	if err != nil {
-		r.logger.Warn("could not enhance replica DSN with TLS settings",
-			"error", err,
-		)
-		// Continue with original DSN if enhancement fails
-		enhancedReplicaDSN = r.migration.ReplicaDSN
+	var throttlers []throttler.Throttler
+	for _, dsn := range dsns {
+		// Enhance replica DSN with TLS settings if not already present
+		enhancedDSN, err := dbconn.EnhanceDSNWithTLS(dsn, replicaDBConfig)
+		if err != nil {
+			r.logger.Warn("could not enhance replica DSN with TLS settings",
+				"dsn", maskPasswordInDSN(dsn),
+				"error", err,
+			)
+			enhancedDSN = dsn
+		}
+
+		replicaDB, err := dbconn.NewWithConnectionType(enhancedDSN, replicaDBConfig, "replica database")
+		if err != nil {
+			return fmt.Errorf("failed to connect to replica database (DSN: %s): %w", maskPasswordInDSN(dsn), err)
+		}
+		r.replicas = append(r.replicas, replicaDB)
+
+		replicaThrottler, err := throttler.NewReplicationThrottler(replicaDB, r.migration.ReplicaMaxLag, r.logger)
+		if err != nil {
+			return fmt.Errorf("could not create replication throttler (DSN: %s): %w", maskPasswordInDSN(dsn), err)
+		}
+		throttlers = append(throttlers, replicaThrottler)
 	}
 
-	r.replica, err = dbconn.NewWithConnectionType(enhancedReplicaDSN, replicaDBConfig, "replica database")
-	if err != nil {
-		return fmt.Errorf("failed to connect to replica database (DSN: %s): %w", maskPasswordInDSN(r.migration.ReplicaDSN), err)
-	}
-
-	// An error here means the connection to the replica is not valid, or it can't be detected
-	// This is fatal because if a user specifies a replica throttler, and it can't be used,
-	// we should not proceed.
-	r.throttler, err = throttler.NewReplicationThrottler(r.replica, r.migration.ReplicaMaxLag, r.logger)
-	if err != nil {
-		r.logger.Warn("could not create replication throttler",
-			"error", err,
-		)
-		return err
-	}
-
+	r.throttler = throttler.NewMultiThrottler(throttlers...)
 	r.copier.SetThrottler(r.throttler)
 	return r.throttler.Open(ctx)
 }
@@ -865,9 +887,8 @@ func (r *Runner) Close() error {
 			return err
 		}
 	}
-	if r.replica != nil {
-		err := r.replica.Close()
-		if err != nil {
+	for _, replica := range r.replicas {
+		if err := replica.Close(); err != nil {
 			return err
 		}
 	}

--- a/pkg/throttler/multi.go
+++ b/pkg/throttler/multi.go
@@ -1,0 +1,81 @@
+package throttler
+
+import (
+	"context"
+	"errors"
+)
+
+// multiThrottler wraps multiple throttlers and throttles if any child is throttled.
+// It is used to support multiple replica endpoints or combining different
+// throttling strategies (e.g., replica lag + commit latency).
+type multiThrottler struct {
+	throttlers []Throttler
+}
+
+var _ Throttler = &multiThrottler{}
+
+// NewMultiThrottler creates a throttler that wraps multiple child throttlers.
+// If zero throttlers are provided, it returns a Noop. If one is provided,
+// it is returned directly without wrapping.
+func NewMultiThrottler(throttlers ...Throttler) Throttler {
+	switch len(throttlers) {
+	case 0:
+		return &Noop{}
+	case 1:
+		return throttlers[0]
+	default:
+		return &multiThrottler{throttlers: throttlers}
+	}
+}
+
+func (m *multiThrottler) Open(ctx context.Context) error {
+	for _, t := range m.throttlers {
+		if err := t.Open(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *multiThrottler) Close() error {
+	var errs []error
+	for _, t := range m.throttlers {
+		if err := t.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// IsThrottled returns true if any child throttler is throttled.
+func (m *multiThrottler) IsThrottled() bool {
+	for _, t := range m.throttlers {
+		if t.IsThrottled() {
+			return true
+		}
+	}
+	return false
+}
+
+// BlockWait blocks until all child throttlers are unthrottled.
+// It delegates to the slowest child — once the slowest is done waiting,
+// all others should already be unthrottled.
+func (m *multiThrottler) BlockWait(ctx context.Context) {
+	for _, t := range m.throttlers {
+		if t.IsThrottled() {
+			t.BlockWait(ctx)
+		}
+	}
+}
+
+// UpdateLag updates lag on all child throttlers.
+// Returns the first error encountered but continues updating all.
+func (m *multiThrottler) UpdateLag(ctx context.Context) error {
+	var firstErr error
+	for _, t := range m.throttlers {
+		if err := t.UpdateLag(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/pkg/throttler/multi.go
+++ b/pkg/throttler/multi.go
@@ -3,6 +3,7 @@ package throttler
 import (
 	"context"
 	"errors"
+	"sync"
 )
 
 // multiThrottler wraps multiple throttlers and throttles if any child is throttled.
@@ -29,10 +30,16 @@ func NewMultiThrottler(throttlers ...Throttler) Throttler {
 }
 
 func (m *multiThrottler) Open(ctx context.Context) error {
+	var opened []Throttler
 	for _, t := range m.throttlers {
 		if err := t.Open(ctx); err != nil {
+			// Close any already-opened throttlers to avoid resource leaks.
+			for i := len(opened) - 1; i >= 0; i-- {
+				_ = opened[i].Close()
+			}
 			return err
 		}
+		opened = append(opened, t)
 	}
 	return nil
 }
@@ -58,14 +65,18 @@ func (m *multiThrottler) IsThrottled() bool {
 }
 
 // BlockWait blocks until all child throttlers are unthrottled.
-// It delegates to the slowest child — once the slowest is done waiting,
-// all others should already be unthrottled.
+// It waits on all throttled children concurrently so the total wait time
+// is bounded by the slowest replica, not the sum of all replicas.
 func (m *multiThrottler) BlockWait(ctx context.Context) {
+	var wg sync.WaitGroup
 	for _, t := range m.throttlers {
 		if t.IsThrottled() {
-			t.BlockWait(ctx)
+			wg.Go(func() {
+				t.BlockWait(ctx)
+			})
 		}
 	}
+	wg.Wait()
 }
 
 // UpdateLag updates lag on all child throttlers.

--- a/pkg/throttler/multi_test.go
+++ b/pkg/throttler/multi_test.go
@@ -1,0 +1,185 @@
+package throttler
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMultiThrottler_Zero(t *testing.T) {
+	throttler := NewMultiThrottler()
+	assert.IsType(t, &Noop{}, throttler)
+}
+
+func TestNewMultiThrottler_One(t *testing.T) {
+	single := &Noop{}
+	throttler := NewMultiThrottler(single)
+	assert.Same(t, single, throttler)
+}
+
+func TestNewMultiThrottler_Multiple(t *testing.T) {
+	throttler := NewMultiThrottler(&Noop{}, &Noop{})
+	assert.IsType(t, &multiThrottler{}, throttler)
+}
+
+// testThrottler is a configurable throttler for testing.
+type testThrottler struct {
+	throttled    atomic.Bool
+	openErr      error
+	closeErr     error
+	updateLagErr error
+	opened       atomic.Bool
+	closed       atomic.Bool
+	blockWaited  atomic.Bool
+}
+
+func (t *testThrottler) Open(_ context.Context) error {
+	t.opened.Store(true)
+	return t.openErr
+}
+
+func (t *testThrottler) Close() error {
+	t.closed.Store(true)
+	return t.closeErr
+}
+
+func (t *testThrottler) IsThrottled() bool {
+	return t.throttled.Load()
+}
+
+func (t *testThrottler) BlockWait(ctx context.Context) {
+	t.blockWaited.Store(true)
+	// Simulate waiting then becoming unthrottled
+	timer := time.NewTimer(10 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+	t.throttled.Store(false)
+}
+
+func (t *testThrottler) UpdateLag(_ context.Context) error {
+	return t.updateLagErr
+}
+
+func TestMultiThrottler_Open(t *testing.T) {
+	t1 := &testThrottler{}
+	t2 := &testThrottler{}
+	multi := NewMultiThrottler(t1, t2)
+
+	require.NoError(t, multi.Open(t.Context()))
+	assert.True(t, t1.opened.Load())
+	assert.True(t, t2.opened.Load())
+}
+
+func TestMultiThrottler_Open_Error(t *testing.T) {
+	t1 := &testThrottler{openErr: errors.New("connection refused")}
+	t2 := &testThrottler{}
+	multi := NewMultiThrottler(t1, t2)
+
+	err := multi.Open(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	// Second throttler should not have been opened
+	assert.False(t, t2.opened.Load())
+}
+
+func TestMultiThrottler_Close(t *testing.T) {
+	t1 := &testThrottler{}
+	t2 := &testThrottler{}
+	multi := NewMultiThrottler(t1, t2)
+
+	require.NoError(t, multi.Close())
+	assert.True(t, t1.closed.Load())
+	assert.True(t, t2.closed.Load())
+}
+
+func TestMultiThrottler_Close_CollectsErrors(t *testing.T) {
+	t1 := &testThrottler{closeErr: errors.New("err1")}
+	t2 := &testThrottler{closeErr: errors.New("err2")}
+	multi := NewMultiThrottler(t1, t2)
+
+	err := multi.Close()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "err1")
+	assert.Contains(t, err.Error(), "err2")
+	// Both should still be closed
+	assert.True(t, t1.closed.Load())
+	assert.True(t, t2.closed.Load())
+}
+
+func TestMultiThrottler_IsThrottled_NoneThrottled(t *testing.T) {
+	t1 := &testThrottler{}
+	t2 := &testThrottler{}
+	multi := NewMultiThrottler(t1, t2)
+
+	assert.False(t, multi.IsThrottled())
+}
+
+func TestMultiThrottler_IsThrottled_OneThrottled(t *testing.T) {
+	t1 := &testThrottler{}
+	t2 := &testThrottler{}
+	t2.throttled.Store(true)
+	multi := NewMultiThrottler(t1, t2)
+
+	assert.True(t, multi.IsThrottled())
+}
+
+func TestMultiThrottler_IsThrottled_AllThrottled(t *testing.T) {
+	t1 := &testThrottler{}
+	t2 := &testThrottler{}
+	t1.throttled.Store(true)
+	t2.throttled.Store(true)
+	multi := NewMultiThrottler(t1, t2)
+
+	assert.True(t, multi.IsThrottled())
+}
+
+func TestMultiThrottler_BlockWait_OnlyBlocksThrottled(t *testing.T) {
+	t1 := &testThrottler{}
+	t2 := &testThrottler{}
+	t2.throttled.Store(true)
+	multi := NewMultiThrottler(t1, t2)
+
+	multi.BlockWait(t.Context())
+
+	// Only t2 should have been waited on
+	assert.False(t, t1.blockWaited.Load())
+	assert.True(t, t2.blockWaited.Load())
+}
+
+func TestMultiThrottler_BlockWait_RespectsContext(t *testing.T) {
+	t1 := &testThrottler{}
+	t1.throttled.Store(true)
+	multi := NewMultiThrottler(t1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately
+
+	// Should return quickly without hanging
+	multi.BlockWait(ctx)
+}
+
+func TestMultiThrottler_UpdateLag(t *testing.T) {
+	t1 := &testThrottler{}
+	t2 := &testThrottler{}
+	multi := NewMultiThrottler(t1, t2)
+
+	require.NoError(t, multi.UpdateLag(t.Context()))
+}
+
+func TestMultiThrottler_UpdateLag_ReturnsFirstError(t *testing.T) {
+	t1 := &testThrottler{updateLagErr: errors.New("lag error")}
+	t2 := &testThrottler{}
+	multi := NewMultiThrottler(t1, t2)
+
+	err := multi.UpdateLag(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lag error")
+}

--- a/pkg/throttler/multi_test.go
+++ b/pkg/throttler/multi_test.go
@@ -90,6 +90,23 @@ func TestMultiThrottler_Open_Error(t *testing.T) {
 	assert.False(t, t2.opened.Load())
 }
 
+func TestMultiThrottler_Open_PartialFailure_CleansUp(t *testing.T) {
+	// First throttler opens successfully, second fails.
+	// The first should be closed on cleanup.
+	t1 := &testThrottler{}
+	t2 := &testThrottler{openErr: errors.New("connection refused")}
+	multi := NewMultiThrottler(t1, t2)
+
+	err := multi.Open(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	// First throttler was opened successfully and should have been closed during cleanup
+	assert.True(t, t1.opened.Load())
+	assert.True(t, t1.closed.Load())
+	// Second throttler's Open was attempted but failed
+	assert.False(t, t2.closed.Load(), "failed throttler should not be closed")
+}
+
 func TestMultiThrottler_Close(t *testing.T) {
 	t1 := &testThrottler{}
 	t2 := &testThrottler{}


### PR DESCRIPTION
## Summary

Add a `MultiThrottler` that wraps multiple child throttlers and throttles based on the slowest one (any child throttled = throttled). This follows the same pattern as `MultiChunker` in `pkg/table`.

This is not so useful to us directly, but unlocks having multiple throttlers, which is desirable (we want to introduce an innodb commit latency throttler..)

## Changes

- **`pkg/throttler/multi.go`**: New `multiThrottler` type implementing the `Throttler` interface. `NewMultiThrottler()` constructor optimizes for 0 (returns Noop) and 1 (returns directly) throttlers. `Open()` cleans up already-opened children on partial failure; `BlockWait()` waits on throttled children concurrently so the total wait is bounded by the slowest replica, not the sum.
- **`pkg/migration/runner.go`**: `setupThrottler()` now splits `--replica-dsn` on commas and creates a throttler per replica, wrapped in a `MultiThrottler`. The `Runner.replica` field is replaced with `Runner.replicas []*sql.DB` for proper cleanup. Returns an explicit error for inputs like `",,,"` that parse to zero valid DSNs, and cleans up already-opened replica connections on per-replica setup failures via a `closeReplicas()` helper.
- **`pkg/migration/check/replicahealth.go`**: Iterates all replicas, identifies the offending host on failure, and handles the nil-status case (`SHOW REPLICA STATUS` returns no rows on a non-replica) with a clear `ErrReplicaNotHealthy` instead of panicking.
- **`pkg/migration/check/check.go`** and **`replicaprivileges.go`**: `Resources.Replica` becomes `Resources.Replicas []*sql.DB`; checks run across all replicas.
- **`pkg/migration/migration.go`**: Updated help text for `--replica-dsn` to document comma-separated support.
- **`docs/migrate.md`**: Updated documentation with multiple replica DSN examples.

## Behavior

- **Backward compatible**: A single DSN works exactly as before (no wrapping overhead due to the `len == 1` optimization).
- **Throttles on slowest**: `IsThrottled()` returns true if *any* child is throttled. `BlockWait()` blocks until *all* children are unthrottled, waiting concurrently.
- **Enables future composition**: Different throttling strategies (replica lag, commit latency, etc.) can be combined via `NewMultiThrottler()` without changing the Copier interface.

## Example

```bash
./spirit migrate --replica-dsn="user:pass@tcp(replica1:3306)/db,user:pass@tcp(replica2:3306)/db" ...
```

Fixes #220