### PR TITLE
repl: fix flaky TestBlockWait by requiring consecutive stalls before flush

### DIFF
--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -1028,6 +1028,7 @@ func (c *Client) BlockWait(ctx context.Context) error {
 
 	prevPos := c.getBufferedPos()
 	first := true
+	stallCount := 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -1037,13 +1038,21 @@ func (c *Client) BlockWait(ctx context.Context) error {
 		default:
 			currPos := c.getBufferedPos()
 			if currPos.Compare(prevPos) <= 0 && !first {
-				// we skip flushing on the first iteration because c.getCurrentBinlogPosition already flushes the binary log
-
-				c.logger.Debug("buffered position has not advanced, flushing binary logs")
-				if err := dbconn.Exec(ctx, c.db, "FLUSH BINARY LOGS"); err != nil {
-					return err // it could be context cancelled, return it
+				// Position hasn't advanced. Only flush after multiple consecutive
+				// stalls to avoid unnecessary flushes when the binlog syncer is
+				// just slightly behind (e.g., under CI load). getCurrentBinlogPosition
+				// already flushes once at the start, so a brief stall is expected.
+				stallCount++
+				if stallCount >= 3 {
+					c.logger.Debug("buffered position has not advanced, flushing binary logs")
+					if err := dbconn.Exec(ctx, c.db, "FLUSH BINARY LOGS"); err != nil {
+						return err // it could be context cancelled, return it
+					}
+					c.flushedBinlogs.Add(1)
+					stallCount = 0
 				}
-				c.flushedBinlogs.Add(1)
+			} else {
+				stallCount = 0
 			}
 			prevPos = currPos
 			first = false

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -54,6 +54,11 @@ const (
 	backoffMultiplier = 2
 	// Sleep time between position checks in BlockWait
 	blockWaitSleep = 100 * time.Millisecond
+	// Number of consecutive blockWaitSleep intervals where the buffered position
+	// hasn't advanced before BlockWait flushes binary logs to nudge the syncer.
+	// 3 * blockWaitSleep (~300ms) tolerates brief syncer lag (e.g. CI load) while
+	// remaining negligible relative to DefaultTimeout.
+	blockWaitStallThreshold = 3
 )
 
 var (
@@ -1043,7 +1048,7 @@ func (c *Client) BlockWait(ctx context.Context) error {
 				// just slightly behind (e.g., under CI load). getCurrentBinlogPosition
 				// already flushes once at the start, so a brief stall is expected.
 				stallCount++
-				if stallCount >= 3 {
+				if stallCount >= blockWaitStallThreshold {
 					c.logger.Debug("buffered position has not advanced, flushing binary logs")
 					if err := dbconn.Exec(ctx, c.db, "FLUSH BINARY LOGS"); err != nil {
 						return err // it could be context cancelled, return it


### PR DESCRIPTION
## Problem

`TestBlockWait` is flaky in CI (see #743). The test asserts that `flushedBinlogs == 0` after `BlockWait` returns, verifying that the binlog position advanced naturally without needing a flush. However, under CI load, this assertion fails intermittently with values of 1 or 2.

## Root Cause

`BlockWait` flushes binary logs after a **single** 100ms interval where the buffered position doesn't advance. Under CI load, the binlog syncer may not deliver events to the client within a single 100ms window, even when the server is actively receiving writes. This causes a spurious flush that increments `flushedBinlogs`.

The sequence:
1. `BlockWait` calls `getCurrentBinlogPosition()` which already does a `FLUSH BINARY LOGS`
2. First loop iteration: position may not have caught up yet (skip flush because `first=true`)
3. Second iteration (100ms later): if the syncer hasn't delivered events yet, `currPos <= prevPos` triggers a flush

## Fix

Require **3 consecutive stalls** (300ms of no progress) before flushing binary logs. This gives the binlog syncer adequate time to deliver events while still ensuring correctness:
- `DefaultTimeout` is 30s, so a 300ms delay before the first kick is negligible
- `getCurrentBinlogPosition` already flushes once at the start
- `stallCount` resets whenever the position advances, so genuine stalls still trigger flushes promptly
- The threshold lives in a named constant (`blockWaitStallThreshold`) so the "N intervals × `blockWaitSleep`" relationship stays explicit if either knob is retuned later

## Testing

- Ran `TestBlockWait` 5× locally with `-count=5`: all pass
- Ran with `-race -count=3`: no data races detected

Fixes #743