### PR TITLE
fix: eliminate race conditions in applier completion pipeline

### DIFF
--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -285,11 +285,25 @@ func (a *ShardedApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][
 	}
 	a.pendingMutex.Unlock()
 
-	// Send chunklets to their respective shard buffers
+	// Send chunklets to their respective shard buffers.
+	// If ctx is cancelled mid-send, we must clean up pendingWork before
+	// returning. Otherwise the entry remains with totalChunklets > completedChunklets
+	// forever, hanging Wait(). Chunklets already in shard buffers may still be
+	// processed; their completions arrive at the coordinator after pendingWork
+	// has been deleted and are dropped (logged as "unknown work").
 	for _, chunkletData := range allChunklets {
 		select {
 		case a.shards[chunkletData.shardID].chunkletBuffer <- chunkletData:
 		case <-ctx.Done():
+			a.pendingMutex.Lock()
+			pending, exists := a.pendingWork[workID]
+			if exists {
+				delete(a.pendingWork, workID)
+			}
+			a.pendingMutex.Unlock()
+			if exists {
+				pending.callback(0, ctx.Err())
+			}
 			return ctx.Err()
 		}
 	}

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -368,35 +368,28 @@ func (a *ShardedApplier) writeWorker(ctx context.Context, shard *shardTarget) {
 		}
 	}()
 
-	for {
-		select {
-		case chunkletData, ok := <-shard.chunkletBuffer:
-			if !ok {
-				a.logger.Debug("writeWorker channel closed, exiting", "shardID", shard.shardID, "workerID", workerID)
-				return
-			}
+	// Drain chunkletBuffer until it is closed by Stop(). We deliberately do not
+	// select on ctx.Done() here: every chunklet that made it into the buffer was
+	// already registered in pendingWork by Apply(), so it MUST produce a
+	// completion or Wait() will hang. If ctx is cancelled, writeChunklet returns
+	// quickly with ctx.Err() and we forward that as an error completion — the
+	// feedbackCoordinator then invokes the callback with the error and clears
+	// pendingWork. Stop() is the canonical shutdown path: it cancels ctx (so
+	// in-flight writes abort) and closes chunkletBuffer (so workers exit).
+	for chunkletData := range shard.chunkletBuffer {
+		a.logger.Debug("writeWorker processing chunklet", "shardID", shard.shardID,
+			"workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
 
-			a.logger.Debug("writeWorker processing chunklet", "shardID", shard.shardID,
-				"workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
+		affectedRows, err := a.writeChunklet(ctx, shard, chunkletData)
 
-			// Write chunklet to this shard
-			affectedRows, err := a.writeChunklet(ctx, shard, chunkletData)
-
-			// Send completion — always send after attempting the write so the
-			// feedbackCoordinator can track progress. We must not race this
-			// with ctx.Done(); a lost completion leaves pendingWork stuck and
-			// causes Wait() to hang or report incorrect results.
-			shard.chunkletCompletions <- shardedChunkletCompletion{
-				workID:       chunkletData.workID,
-				shardID:      shard.shardID,
-				affectedRows: affectedRows,
-				err:          err,
-			}
-
-		case <-ctx.Done():
-			return
+		shard.chunkletCompletions <- shardedChunkletCompletion{
+			workID:       chunkletData.workID,
+			shardID:      shard.shardID,
+			affectedRows: affectedRows,
+			err:          err,
 		}
 	}
+	a.logger.Debug("writeWorker channel closed, exiting", "shardID", shard.shardID, "workerID", workerID)
 }
 
 // writeChunklet writes a single chunklet to a specific shard

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -134,8 +134,16 @@ func NewShardedApplier(targets []Target, cfg *ApplierConfig) (*ShardedApplier, e
 	}, nil
 }
 
-// Start initializes all shard workers and begins processing
+// Start initializes all shard workers and begins processing.
 // This method is idempotent and can restart the applier after Stop() is called.
+//
+// Lifecycle: callers MUST call Stop() to terminate the per-shard write workers
+// and the single feedbackCoordinator. Cancelling the ctx passed here does NOT
+// by itself shut down the goroutine pipeline — it only aborts in-flight writes.
+// Workers for a shard exit when its chunkletBuffer is closed (by Stop), and the
+// coordinator exits when every shard's chunkletCompletions has been closed
+// (by the last worker's defer per shard). Failing to call Stop() will leak
+// goroutines.
 func (a *ShardedApplier) Start(ctx context.Context) error {
 	a.Lock()
 	defer a.Unlock()

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -174,7 +174,7 @@ func (a *ShardedApplier) Start(ctx context.Context) error {
 
 	// Start a single feedback coordinator for all shards
 	a.wg.Add(1)
-	go a.feedbackCoordinator(workerCtx)
+	go a.feedbackCoordinator()
 
 	return nil
 }
@@ -382,18 +382,15 @@ func (a *ShardedApplier) writeWorker(ctx context.Context, shard *shardTarget) {
 			// Write chunklet to this shard
 			affectedRows, err := a.writeChunklet(ctx, shard, chunkletData)
 
-			// Send completion
-			completion := shardedChunkletCompletion{
+			// Send completion — always send after attempting the write so the
+			// feedbackCoordinator can track progress. We must not race this
+			// with ctx.Done(); a lost completion leaves pendingWork stuck and
+			// causes Wait() to hang or report incorrect results.
+			shard.chunkletCompletions <- shardedChunkletCompletion{
 				workID:       chunkletData.workID,
 				shardID:      shard.shardID,
 				affectedRows: affectedRows,
 				err:          err,
-			}
-
-			select {
-			case shard.chunkletCompletions <- completion:
-			case <-ctx.Done():
-				return
 			}
 
 		case <-ctx.Done():
@@ -460,25 +457,74 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 }
 
 // feedbackCoordinator tracks chunklet completions from all shards and invokes callbacks when work is done
-func (a *ShardedApplier) feedbackCoordinator(ctx context.Context) {
+func (a *ShardedApplier) feedbackCoordinator() {
 	defer a.wg.Done()
 	a.logger.Debug("feedbackCoordinator started")
+
+	// processCompletion handles a single chunklet completion.
+	processCompletion := func(completion shardedChunkletCompletion) {
+		a.logger.Debug("feedbackCoordinator received chunklet completion",
+			"workID", completion.workID, "shardID", completion.shardID)
+
+		// Update work completion status
+		a.pendingMutex.Lock()
+		pending, exists := a.pendingWork[completion.workID]
+		if !exists {
+			a.pendingMutex.Unlock()
+			a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
+			return
+		}
+
+		// If there was an error, invoke callback immediately
+		if completion.err != nil {
+			callback := pending.callback
+			// Remove the work from pending map before invoking callback
+			delete(a.pendingWork, completion.workID)
+			a.pendingMutex.Unlock()
+			callback(0, completion.err)
+			return
+		}
+
+		// Update completion count and affected rows
+		pending.completedChunklets++
+		pending.totalAffectedRows += completion.affectedRows
+
+		a.logger.Debug("feedbackCoordinator work progress", "workID", completion.workID,
+			"completedChunklets", pending.completedChunklets, "totalChunklets", pending.totalChunklets)
+
+		// Check if all chunklets for this work are complete
+		if pending.completedChunklets == pending.totalChunklets {
+			a.logger.Debug("feedbackCoordinator all chunklets complete, invoking callback", "workID", completion.workID)
+
+			// Invoke the callback
+			callback := pending.callback
+			affectedRows := pending.totalAffectedRows
+
+			// Remove completed work from pending map
+			delete(a.pendingWork, completion.workID)
+			a.pendingMutex.Unlock()
+
+			// Invoke callback outside the lock
+			callback(affectedRows, nil)
+		} else {
+			a.pendingMutex.Unlock()
+		}
+	}
 
 	// Create a merged channel to receive completions from all shards
 	mergedCompletions := make(chan shardedChunkletCompletion, defaultBufferSize)
 
-	// Start goroutines to forward completions from each shard to the merged channel
+	// Start goroutines to forward completions from each shard to the merged channel.
+	// These use a simple range loop (no ctx.Done select) to ensure all completions
+	// are forwarded even during shutdown. The shard channels will be closed once all
+	// write workers for that shard finish, which is the authoritative signal.
 	var forwardWg sync.WaitGroup
 	for _, shard := range a.shards {
 		forwardWg.Add(1)
 		go func(s *shardTarget) {
 			defer forwardWg.Done()
 			for completion := range s.chunkletCompletions {
-				select {
-				case mergedCompletions <- completion:
-				case <-ctx.Done():
-					return
-				}
+				mergedCompletions <- completion
 			}
 		}(shard)
 	}
@@ -489,66 +535,15 @@ func (a *ShardedApplier) feedbackCoordinator(ctx context.Context) {
 		close(mergedCompletions)
 	}()
 
-	// Process completions
-	for {
-		select {
-		case completion, ok := <-mergedCompletions:
-			if !ok {
-				a.logger.Debug("feedbackCoordinator merged completions channel closed, exiting")
-				return
-			}
-
-			a.logger.Debug("feedbackCoordinator received chunklet completion",
-				"workID", completion.workID, "shardID", completion.shardID)
-
-			// Update work completion status
-			a.pendingMutex.Lock()
-			pending, exists := a.pendingWork[completion.workID]
-			if !exists {
-				a.pendingMutex.Unlock()
-				a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
-				continue
-			}
-
-			// If there was an error, invoke callback immediately
-			if completion.err != nil {
-				callback := pending.callback
-				// Remove the work from pending map before invoking callback
-				delete(a.pendingWork, completion.workID)
-				a.pendingMutex.Unlock()
-				callback(0, completion.err)
-				continue
-			}
-
-			// Update completion count and affected rows
-			pending.completedChunklets++
-			pending.totalAffectedRows += completion.affectedRows
-
-			a.logger.Debug("feedbackCoordinator work progress", "workID", completion.workID,
-				"completedChunklets", pending.completedChunklets, "totalChunklets", pending.totalChunklets)
-
-			// Check if all chunklets for this work are complete
-			if pending.completedChunklets == pending.totalChunklets {
-				a.logger.Debug("feedbackCoordinator all chunklets complete, invoking callback", "workID", completion.workID)
-
-				// Invoke the callback
-				callback := pending.callback
-				affectedRows := pending.totalAffectedRows
-
-				// Remove completed work from pending map
-				delete(a.pendingWork, completion.workID)
-				a.pendingMutex.Unlock()
-
-				// Invoke callback outside the lock
-				callback(affectedRows, nil)
-			} else {
-				a.pendingMutex.Unlock()
-			}
-
-		case <-ctx.Done():
-			return
-		}
+	// Main loop: process completions until the merged channel is closed.
+	// We do NOT exit on ctx.Done() here because write workers may still be
+	// sending completions after writing data. Exiting early would leave
+	// entries in pendingWork that are never cleared, causing Wait() to hang
+	// or report incorrect results.
+	for completion := range mergedCompletions {
+		processCompletion(completion)
 	}
+	a.logger.Debug("feedbackCoordinator merged completions channel closed, exiting")
 }
 
 // DeleteKeys deletes rows by their key values synchronously, broadcasting to all shards.

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -87,9 +87,16 @@ func NewSingleTargetApplier(target Target, cfg *ApplierConfig) (*SingleTargetApp
 	}, nil
 }
 
-// Start initializes the applier's async write workers and begins processing
-// This does not control the synchronous methods like UpsertRows/DeleteKeys
+// Start initializes the applier's async write workers and begins processing.
+// This does not control the synchronous methods like UpsertRows/DeleteKeys.
 // This method is idempotent - calling it multiple times is safe.
+//
+// Lifecycle: callers MUST call Stop() to terminate the write workers and
+// feedbackCoordinator. Cancelling the ctx passed here does NOT by itself
+// shut down the goroutine pipeline — it only aborts in-flight writes.
+// Workers exit when chunkletBuffer is closed (by Stop), and the coordinator
+// exits when chunkletCompletions is closed (by the last worker's defer).
+// Failing to call Stop() will leak goroutines.
 func (a *SingleTargetApplier) Start(ctx context.Context) error {
 	a.Lock()
 	defer a.Unlock()

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -124,7 +124,7 @@ func (a *SingleTargetApplier) Start(ctx context.Context) error {
 
 	// Start feedback coordinator
 	a.wg.Add(1)
-	go a.feedbackCoordinator(workerCtx)
+	go a.feedbackCoordinator()
 
 	return nil
 }
@@ -275,17 +275,14 @@ func (a *SingleTargetApplier) writeWorker(ctx context.Context) {
 			// Write chunklet
 			affectedRows, err := a.writeChunklet(ctx, chunkletData)
 
-			// Send completion
-			completion := chunkletCompletion{
+			// Send completion — always send after attempting the write so the
+			// feedbackCoordinator can track progress. We must not race this
+			// with ctx.Done(); a lost completion leaves pendingWork stuck and
+			// causes Wait() to hang or report incorrect results.
+			a.chunkletCompletions <- chunkletCompletion{
 				workID:       chunkletData.workID,
 				affectedRows: affectedRows,
 				err:          err,
-			}
-
-			select {
-			case a.chunkletCompletions <- completion:
-			case <-ctx.Done():
-				return
 			}
 
 		case <-ctx.Done():
@@ -345,68 +342,70 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 }
 
 // feedbackCoordinator tracks chunklet completions and invokes callbacks when work is done
-func (a *SingleTargetApplier) feedbackCoordinator(ctx context.Context) {
+func (a *SingleTargetApplier) feedbackCoordinator() {
 	defer a.wg.Done()
 	a.logger.Debug("feedbackCoordinator started")
 
-	for {
-		select {
-		case completion, ok := <-a.chunkletCompletions:
-			if !ok {
-				a.logger.Debug("feedbackCoordinator chunklet completions channel closed, exiting")
-				return
-			}
+	// processCompletion handles a single chunklet completion.
+	processCompletion := func(completion chunkletCompletion) {
+		a.logger.Debug("feedbackCoordinator received chunklet completion", "workID", completion.workID)
 
-			a.logger.Debug("feedbackCoordinator received chunklet completion", "workID", completion.workID)
-
-			// Update work completion status
-			a.pendingMutex.Lock()
-			pending, exists := a.pendingWork[completion.workID]
-			if !exists {
-				a.pendingMutex.Unlock()
-				a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
-				continue
-			}
-
-			// If there was an error, invoke callback immediately
-			if completion.err != nil {
-				callback := pending.callback
-				// Remove the work from pending map before invoking callback
-				delete(a.pendingWork, completion.workID)
-				a.pendingMutex.Unlock()
-				callback(0, completion.err)
-				continue
-			}
-
-			// Update completion count and affected rows
-			pending.completedChunklets++
-			pending.totalAffectedRows += completion.affectedRows
-
-			a.logger.Debug("feedbackCoordinator work progress", "workID", completion.workID,
-				"completedChunklets", pending.completedChunklets, "totalChunklets", pending.totalChunklets)
-
-			// Check if all chunklets for this work are complete
-			if pending.completedChunklets == pending.totalChunklets {
-				a.logger.Debug("feedbackCoordinator all chunklets complete, invoking callback", "workID", completion.workID)
-
-				// Invoke the callback
-				callback := pending.callback
-				affectedRows := pending.totalAffectedRows
-
-				// Remove completed work from pending map
-				delete(a.pendingWork, completion.workID)
-				a.pendingMutex.Unlock()
-
-				// Invoke callback outside the lock
-				callback(affectedRows, nil)
-			} else {
-				a.pendingMutex.Unlock()
-			}
-
-		case <-ctx.Done():
+		// Update work completion status
+		a.pendingMutex.Lock()
+		pending, exists := a.pendingWork[completion.workID]
+		if !exists {
+			a.pendingMutex.Unlock()
+			a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
 			return
 		}
+
+		// If there was an error, invoke callback immediately
+		if completion.err != nil {
+			callback := pending.callback
+			// Remove the work from pending map before invoking callback
+			delete(a.pendingWork, completion.workID)
+			a.pendingMutex.Unlock()
+			callback(0, completion.err)
+			return
+		}
+
+		// Update completion count and affected rows
+		pending.completedChunklets++
+		pending.totalAffectedRows += completion.affectedRows
+
+		a.logger.Debug("feedbackCoordinator work progress", "workID", completion.workID,
+			"completedChunklets", pending.completedChunklets, "totalChunklets", pending.totalChunklets)
+
+		// Check if all chunklets for this work are complete
+		if pending.completedChunklets == pending.totalChunklets {
+			a.logger.Debug("feedbackCoordinator all chunklets complete, invoking callback", "workID", completion.workID)
+
+			// Invoke the callback
+			callback := pending.callback
+			affectedRows := pending.totalAffectedRows
+
+			// Remove completed work from pending map
+			delete(a.pendingWork, completion.workID)
+			a.pendingMutex.Unlock()
+
+			// Invoke callback outside the lock
+			callback(affectedRows, nil)
+		} else {
+			a.pendingMutex.Unlock()
+		}
 	}
+
+	// Main loop: process completions until the channel is closed.
+	// We do NOT exit on ctx.Done() here because write workers may still be
+	// sending completions after writing data. Exiting early would leave
+	// entries in pendingWork that are never cleared, causing Wait() to hang
+	// or report incorrect results. The channel will be closed once all write
+	// workers finish (including their deferred close logic), which is the
+	// authoritative signal that no more completions will arrive.
+	for completion := range a.chunkletCompletions {
+		processCompletion(completion)
+	}
+	a.logger.Debug("feedbackCoordinator chunklet completions channel closed, exiting")
 }
 
 // DeleteKeys deletes rows by their key values synchronously.

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -175,11 +175,25 @@ func (a *SingleTargetApplier) Apply(ctx context.Context, chunk *table.Chunk, row
 	}
 	a.pendingMutex.Unlock()
 
-	// Send chunklets to buffer
+	// Send chunklets to buffer.
+	// If ctx is cancelled mid-send, we must clean up pendingWork before
+	// returning. Otherwise the entry remains with totalChunklets > completedChunklets
+	// forever, hanging Wait(). Chunklets already in the buffer may still be
+	// processed; their completions arrive at the coordinator after pendingWork
+	// has been deleted and are dropped (logged as "unknown work").
 	for _, chunkletData := range chunklets {
 		select {
 		case a.chunkletBuffer <- chunkletData:
 		case <-ctx.Done():
+			a.pendingMutex.Lock()
+			pending, exists := a.pendingWork[workID]
+			if exists {
+				delete(a.pendingWork, workID)
+			}
+			a.pendingMutex.Unlock()
+			if exists {
+				pending.callback(0, ctx.Err())
+			}
 			return ctx.Err()
 		}
 	}

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -262,33 +262,26 @@ func (a *SingleTargetApplier) writeWorker(ctx context.Context) {
 		}
 	}()
 
-	for {
-		select {
-		case chunkletData, ok := <-a.chunkletBuffer:
-			if !ok {
-				a.logger.Debug("writeWorker channel closed, exiting", "workerID", workerID)
-				return
-			}
+	// Drain chunkletBuffer until it is closed by Stop(). We deliberately do not
+	// select on ctx.Done() here: every chunklet that made it into the buffer was
+	// already registered in pendingWork by Apply(), so it MUST produce a
+	// completion or Wait() will hang. If ctx is cancelled, writeChunklet returns
+	// quickly with ctx.Err() and we forward that as an error completion — the
+	// feedbackCoordinator then invokes the callback with the error and clears
+	// pendingWork. Stop() is the canonical shutdown path: it cancels ctx (so
+	// in-flight writes abort) and closes chunkletBuffer (so workers exit).
+	for chunkletData := range a.chunkletBuffer {
+		a.logger.Debug("writeWorker processing chunklet", "workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
 
-			a.logger.Debug("writeWorker processing chunklet", "workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
+		affectedRows, err := a.writeChunklet(ctx, chunkletData)
 
-			// Write chunklet
-			affectedRows, err := a.writeChunklet(ctx, chunkletData)
-
-			// Send completion — always send after attempting the write so the
-			// feedbackCoordinator can track progress. We must not race this
-			// with ctx.Done(); a lost completion leaves pendingWork stuck and
-			// causes Wait() to hang or report incorrect results.
-			a.chunkletCompletions <- chunkletCompletion{
-				workID:       chunkletData.workID,
-				affectedRows: affectedRows,
-				err:          err,
-			}
-
-		case <-ctx.Done():
-			return
+		a.chunkletCompletions <- chunkletCompletion{
+			workID:       chunkletData.workID,
+			affectedRows: affectedRows,
+			err:          err,
 		}
 	}
+	a.logger.Debug("writeWorker channel closed, exiting", "workerID", workerID)
 }
 
 // writeChunklet writes a single chunklet (up to chunkletMaxRows or chunkletMaxSize)


### PR DESCRIPTION
## Summary

Fix flaky `TestSingleTargetApplierLargeDataset` (#748) caused by race conditions in the writeWorker/feedbackCoordinator pipeline. While addressing the original two races, two related shutdown/cancellation bugs surfaced and are fixed here too.

## Root Causes & Fixes

### Race 1: Lost completions in `writeWorker`

After `writeChunklet()` successfully wrote data to MySQL, the worker used a `select` to send the completion:

```go
select {
case a.chunkletCompletions <- completion:
case <-ctx.Done():
    return  // ← completion lost! Write happened but nobody knows.
}
```

If the context was cancelled at this moment, the `select` could choose `ctx.Done()`, discarding the completion. The data was written to MySQL but the feedbackCoordinator never learned about it, leaving `pendingWork` stuck.

**Fix:** Make the completion send unconditional (blocking). Safe because the channel buffer (128) far exceeds the number of in-flight chunklets.

### Race 2: Early exit in `feedbackCoordinator`

The coordinator had `case <-ctx.Done(): return` in its main select loop. If the context was cancelled while completions were still being sent by workers, the coordinator would exit without processing them — leaving `pendingWork` entries that were never cleared.

**Fix:** Replace the `select` loop with `for completion := range channel`. The coordinator now exits only when the channel is closed (after all write workers finish), guaranteeing all completions are processed.

### Race 3: Skipped completions when `chunkletBuffer` was drained on shutdown

If `Stop()` closed the buffer while chunklets were still queued, the worker would observe the channel close and exit without processing them — every queued chunklet's completion was silently dropped, hanging `Wait()`.

**Fix:** On shutdown, drain the buffer and emit completions for the remaining chunklets so `pendingWork` is always cleared (commit 7179814).

### Race 4: `pendingWork` stuck when `Apply` was cancelled mid-send

If the parent ctx was cancelled while `Apply` was still pushing chunklets onto the buffer, the `pendingWork` entry was registered with `totalChunklets > completedChunklets` and `Wait()` never returned.

**Fix:** On ctx.Done() during `Apply`, delete the `pendingWork` entry and invoke the callback with the cancellation error. The "unknown work" guard in the coordinator harmlessly drops any in-flight completions that arrive after cleanup. A single delete-or-skip step under `pendingMutex` prevents double-callback (commit d7d60ae).

## Lifecycle contract

Because `feedbackCoordinator` and `writeWorker` no longer observe `ctx.Done()` for shutdown, the `Start()` doc comments on both `SingleTargetApplier` and `ShardedApplier` were updated to make the `Stop()` requirement explicit. Cancelling the ctx aborts in-flight writes only; `Stop()` closes the buffers so workers and the coordinator can drain and exit cleanly. All production callers (`pkg/copier/buffered.go`, `pkg/checksum/distributed.go`) already call `Stop()` (commit 8a2a0d6).

All fixes apply to both `SingleTargetApplier` and `ShardedApplier`, which share the same pipeline.

## Testing

- Ran `TestSingleTargetApplierLargeDataset` 50 times with `-race` — all pass
- Full `pkg/applier` test suite passes with `-race`

Fixes #748
