### PR TITLE
Support CREATE INDEX with functional index parts

### DIFF
--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -341,17 +341,15 @@ func convertCreateIndexToAlterTable(stmt ast.StmtNode) (*AbstractStatement, erro
 	if !isCreateIndexStmt {
 		return nil, errors.New("not a CREATE INDEX statement")
 	}
-	var columns []string
+	var parts []string
 	var keyType string
 	for _, part := range ciStmt.IndexPartSpecifications {
-		if part.Column == nil {
-			return nil, errors.New("cannot convert functional index to ALTER TABLE statement; please use ALTER TABLE ADD INDEX … instead")
+		var sb strings.Builder
+		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
+		if err := part.Restore(rCtx); err != nil {
+			return nil, fmt.Errorf("could not restore index part: %w", err)
 		}
-		col := fmt.Sprintf("`%s`", part.Column.Name.String())
-		if part.Length > 0 {
-			col = fmt.Sprintf("%s(%d)", col, part.Length)
-		}
-		columns = append(columns, col)
+		parts = append(parts, sb.String())
 	}
 	switch ciStmt.KeyType { //nolint:exhaustive
 	case ast.IndexKeyTypeUnique:
@@ -363,7 +361,7 @@ func convertCreateIndexToAlterTable(stmt ast.StmtNode) (*AbstractStatement, erro
 	default:
 		keyType = "INDEX"
 	}
-	alterStmt := fmt.Sprintf("ADD %s `%s` (%s)", keyType, ciStmt.IndexName, strings.Join(columns, ", "))
+	alterStmt := fmt.Sprintf("ADD %s `%s` (%s)", keyType, ciStmt.IndexName, strings.Join(parts, ", "))
 	// We hint in the statement that it's been rewritten
 	// and in the stmtNode we reparse from the alterStmt.
 	statement := fmt.Sprintf("/* rewritten from CREATE INDEX */ ALTER TABLE `%s` %s", ciStmt.Table.Name, alterStmt)

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -80,9 +80,16 @@ func TestExtractFromStatement(t *testing.T) {
 	assert.Equal(t, "ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `a table` ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Statement)
 
-	_, err = New("CREATE INDEX idx ON t1 ((`a` IS NULL))")
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "cannot convert functional index to ALTER TABLE statement")
+	// Test functional index is rewritten.
+	abstractStmt, err = New("CREATE INDEX idx ON t1 ((`a` IS NULL))")
+	assert.NoError(t, err)
+	assert.Equal(t, "ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Alter)
+	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Statement)
+
+	// Test mixed functional + plain columns.
+	abstractStmt, err = New("CREATE INDEX idx ON t1 (a, (LOWER(`b`)))")
+	assert.NoError(t, err)
+	assert.Equal(t, "ADD INDEX `idx` (`a`, (LOWER(`b`)))", abstractStmt[0].Alter)
 
 	// Test create index with prefix length.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (name(10))")


### PR DESCRIPTION
## Summary
- `CREATE INDEX idx ON t1 ((`a` IS NULL))` was rejected with "cannot convert functional index to ALTER TABLE statement". The TiDB parser already exposes the expression via `IndexPartSpecification.Expr`, so the rewrite can handle it.
- Replaced the manual column-name building loop in `convertCreateIndexToAlterTable` with `IndexPartSpecification.Restore()`, which uniformly handles plain columns (with prefix lengths) and `(expr)` parts.

Fixes #444.

## Test plan
- [x] `go test ./pkg/statement/` passes, including a new case for `CREATE INDEX idx ON t1 ((`a` IS NULL))` and a mixed `(a, (LOWER(`b`)))` case.
- [x] Existing CREATE INDEX rewrite tests (plain columns, prefix lengths, UNIQUE, quoted identifiers) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)