### PR TITLE
fix: explicitly RELEASE_LOCK before closing metadata lock connection

### DIFF
--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -100,10 +100,20 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 		for {
 			select {
 			case <-ctx.Done():
-				// Close the dedicated connection to release all locks
+				// Explicitly release the locks before closing the connection.
+				// Relying on connection close alone leaves a small window where
+				// MySQL has not yet finished tearing down the session, so a
+				// rapid reacquire on a new connection can see the lock as still
+				// held. RELEASE_LOCK on the same session avoids that race.
+				releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				for _, lockName := range mdl.lockNames {
 					logger.Info("releasing metadata lock", "lock_name", lockName)
+					stmt := sqlescape.MustEscapeSQL("DO RELEASE_LOCK(%?)", lockName)
+					if _, err := mdl.db.ExecContext(releaseCtx, stmt); err != nil {
+						logger.Warn("could not release metadata lock", "lock_name", lockName, "error", err)
+					}
 				}
+				releaseCancel()
 				// Use select with default to avoid blocking if Close() isn't called
 				select {
 				case mdl.closeCh <- mdl.db.Close():

--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -108,8 +108,9 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 				releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				for _, lockName := range mdl.lockNames {
 					logger.Info("releasing metadata lock", "lock_name", lockName)
-					stmt := sqlescape.MustEscapeSQL("DO RELEASE_LOCK(%?)", lockName)
-					if _, err := mdl.db.ExecContext(releaseCtx, stmt); err != nil {
+					var released sql.NullInt64
+					stmt := sqlescape.MustEscapeSQL("SELECT RELEASE_LOCK(%?)", lockName)
+					if err := mdl.db.QueryRowContext(releaseCtx, stmt).Scan(&released); err != nil {
 						logger.Warn("could not release metadata lock", "lock_name", lockName, "error", err)
 					}
 				}


### PR DESCRIPTION
## Summary

Fixes #761: `MetadataLock.Close()` was relying on connection close (`COM_QUIT`) alone to release `GET_LOCK`, which leaves a small window where MySQL has not yet finished tearing down the session. A fresh connection arriving in that window sees the lock as still held by another connection.

This PR calls `RELEASE_LOCK` on the same session before closing the connection. `RELEASE_LOCK` is synchronous within the session, so by the time `MetadataLock.Close()` returns, MySQL guarantees the named locks are no longer held — eliminating the race.

The query uses `SELECT RELEASE_LOCK(?)` (rather than `DO RELEASE_LOCK(?)`) so it's familiar to readers and handled correctly by routing layers / proxies that may not understand `DO`.

## Relationship to #742

#742 (the flaky `TestResumeFromCheckpointStrictTooOld` test) was originally reported with the `lock is held by another connection` symptom, which is exactly the race this PR eliminates. However, after this fix lands, the test still has a *separate* failure mode — m2 sometimes succeeds at acquiring the lock and reading the checkpoint, but doesn't detect it as too old, so it resumes when it should error. That second mode is unrelated to lock release and will be addressed in a follow-up PR. #742 stays open until that's done.

## Test plan

- [ ] CI passes on the resume-test matrix.
- [ ] Stress-loop `TestMetadataLock` / `TestMetadataLockContextCancel` — close-then-reacquire should now be deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)