### PR TITLE
fix(lint): serialize Configure() and isolate test registry mutations

### DIFF
--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -121,8 +121,11 @@ func (c *Config) IsEnabled(linterName string) bool {
 func RunLinters(existingSchema []*statement.CreateTable, changes []*statement.AbstractStatement, config Config) ([]Violation, error) {
 	var errs []error
 
-	lock.RLock()
-	defer lock.RUnlock()
+	// Acquired as a writer (not a reader) because Configure() mutates the
+	// globally-registered linter singletons. Concurrent RunLinters calls
+	// would otherwise race on those fields — see issue #747.
+	lock.Lock()
+	defer lock.Unlock()
 
 	var violations []Violation
 

--- a/pkg/lint/lint_has_fk_test.go
+++ b/pkg/lint/lint_has_fk_test.go
@@ -367,7 +367,7 @@ func TestHasFKLinter_ForeignKeyWithNoAction(t *testing.T) {
 }
 
 func TestHasFKLinter_Integration(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&HasFKLinter{})
 
 	sql := `CREATE TABLE orders (
@@ -393,7 +393,7 @@ func TestHasFKLinter_Integration(t *testing.T) {
 }
 
 func TestHasFKLinter_IntegrationDisabled(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&HasFKLinter{})
 
 	sql := `CREATE TABLE orders (

--- a/pkg/lint/lint_has_float_test.go
+++ b/pkg/lint/lint_has_float_test.go
@@ -264,7 +264,7 @@ func TestHasFloatLinter_SimilarTypeNames(t *testing.T) {
 }
 
 func TestHasFloatLinter_Integration(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&HasFloatLinter{})
 
 	sql := `CREATE TABLE measurements (
@@ -289,7 +289,7 @@ func TestHasFloatLinter_Integration(t *testing.T) {
 }
 
 func TestHasFloatLinter_IntegrationDisabled(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&HasFloatLinter{})
 
 	sql := `CREATE TABLE measurements (

--- a/pkg/lint/lint_has_timestamp_test.go
+++ b/pkg/lint/lint_has_timestamp_test.go
@@ -795,7 +795,7 @@ func TestHasTimestampLinter_String(t *testing.T) {
 // --- Registration ---
 
 func TestHasTimestampLinter_Registered(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&HasTimestampLinter{})
 
 	names := List()

--- a/pkg/lint/lint_invisible_index_test.go
+++ b/pkg/lint/lint_invisible_index_test.go
@@ -145,7 +145,7 @@ func TestInvisibleIndexBeforeDropLinter_AlterWithoutDrop(t *testing.T) {
 
 func TestInvisibleIndexBeforeDropLinter_Integration(t *testing.T) {
 	// Reset registry and register linter
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -161,7 +161,7 @@ func TestInvisibleIndexBeforeDropLinter_Integration(t *testing.T) {
 
 func TestInvisibleIndexBeforeDropLinter_IntegrationDisabled(t *testing.T) {
 	// Reset registry and register linter
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -340,7 +340,7 @@ func TestInvisibleIndexBeforeDropLinter_DefaultBehavior(t *testing.T) {
 // Integration Tests with RunLinters
 
 func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_RaiseErrorTrue(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -361,7 +361,7 @@ func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_RaiseErrorTrue(t *
 }
 
 func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_RaiseErrorFalse(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -382,7 +382,7 @@ func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_RaiseErrorFalse(t 
 }
 
 func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_InvalidConfig(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -404,7 +404,7 @@ func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_InvalidConfig(t *t
 }
 
 func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_DisabledLinter(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -427,7 +427,7 @@ func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_DisabledLinter(t *
 }
 
 func TestInvisibleIndexBeforeDropLinter_IntegrationWithConfig_EnabledWithConfig(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"

--- a/pkg/lint/lint_multiple_alter_test.go
+++ b/pkg/lint/lint_multiple_alter_test.go
@@ -194,7 +194,7 @@ func TestMultipleAlterTableLinter_EmptyStatements(t *testing.T) {
 }
 
 func TestMultipleAlterTableLinter_Integration(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&MultipleAlterTableLinter{})
 
 	sql := `ALTER TABLE users ADD COLUMN age INT;
@@ -210,7 +210,7 @@ func TestMultipleAlterTableLinter_Integration(t *testing.T) {
 }
 
 func TestMultipleAlterTableLinter_IntegrationDisabled(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&MultipleAlterTableLinter{})
 
 	sql := `ALTER TABLE users ADD COLUMN age INT;

--- a/pkg/lint/lint_primary_key_type_test.go
+++ b/pkg/lint/lint_primary_key_type_test.go
@@ -282,7 +282,7 @@ func TestPrimaryKeyLinter_EmptyInput(t *testing.T) {
 }
 
 func TestPrimaryKeyLinter_Integration(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&PrimaryKeyLinter{})
 
 	sql := `CREATE TABLE users (
@@ -300,7 +300,7 @@ func TestPrimaryKeyLinter_Integration(t *testing.T) {
 }
 
 func TestPrimaryKeyLinter_IntegrationDisabled(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&PrimaryKeyLinter{})
 
 	sql := `CREATE TABLE users (
@@ -897,7 +897,7 @@ func TestPrimaryKeyLinter_ConfigureSignedWarningStillWorks(t *testing.T) {
 }
 
 func TestPrimaryKeyLinter_IntegrationWithConfig(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&PrimaryKeyLinter{})
 
 	sql := `CREATE TABLE users (

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -54,7 +54,7 @@ func (m *mockConfigurableLinter) DefaultConfig() map[string]string {
 
 func TestRegister(t *testing.T) {
 	// Reset registry before test
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{
 		name:        "test_linter",
@@ -74,7 +74,7 @@ func TestRegister(t *testing.T) {
 }
 
 func TestRegisterMultiple(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter1 := &mockLinter{name: "linter1"}
 	linter2 := &mockLinter{name: "linter2"}
@@ -92,7 +92,7 @@ func TestRegisterMultiple(t *testing.T) {
 }
 
 func TestEnableDisable(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	Register(linter)
@@ -112,7 +112,7 @@ func TestEnableDisable(t *testing.T) {
 }
 
 func TestEnableDisableNonexistent(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	err := Enable("nonexistent")
 	assert.Error(t, err)
@@ -124,7 +124,7 @@ func TestEnableDisableNonexistent(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{
 		name:        "test_linter",
@@ -139,7 +139,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetNonexistent(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	_, err := Get("nonexistent")
 	assert.Error(t, err)
@@ -147,7 +147,7 @@ func TestGetNonexistent(t *testing.T) {
 }
 
 func TestRunLinters_Empty(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	violations, err := RunLinters(nil, nil, Config{})
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestRunLinters_Empty(t *testing.T) {
 }
 
 func TestRunLinters_SingleLinter(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{
 		name: "test_linter",
@@ -181,7 +181,7 @@ func TestRunLinters_SingleLinter(t *testing.T) {
 }
 
 func TestRunLinters_MultipleLinters(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter1 := &mockLinter{
 		name: "linter1",
@@ -207,7 +207,7 @@ func TestRunLinters_MultipleLinters(t *testing.T) {
 }
 
 func TestRunLinters_WithConfig_Disabled(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{
 		name: "test_linter",
@@ -229,7 +229,7 @@ func TestRunLinters_WithConfig_Disabled(t *testing.T) {
 }
 
 func TestRunLinters_WithConfig_Enabled(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{
 		name: "test_linter",
@@ -255,7 +255,7 @@ func TestRunLinters_WithConfig_Enabled(t *testing.T) {
 }
 
 func TestRunLinters_ConfigurableLinter(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockConfigurableLinter{}
 	linter.name = "configurable_linter"
@@ -283,7 +283,7 @@ func TestRunLinters_ConfigurableLinter(t *testing.T) {
 }
 
 func TestRunLinters_ConfigurableLinter_NoConfig(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockConfigurableLinter{}
 	linter.name = "configurable_linter"
@@ -351,7 +351,7 @@ func TestFilterByLinter(t *testing.T) {
 }
 
 func TestListSorted(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	// Register in non-alphabetical order
 	Register(&mockLinter{name: "zebra"})
@@ -363,6 +363,8 @@ func TestListSorted(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
+	captureInitialLintRegistry()
+	t.Cleanup(restoreInitialLintRegistry)
 	Reset()
 
 	Register(&mockLinter{name: "linter1"})
@@ -486,7 +488,7 @@ func TestConfigBool_Invalid(t *testing.T) {
 // DefaultConfig tests
 
 func TestRunLinters_AppliesDefaultConfig(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -503,7 +505,7 @@ func TestRunLinters_AppliesDefaultConfig(t *testing.T) {
 }
 
 func TestRunLinters_UserConfigOverridesDefault(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&InvisibleIndexBeforeDropLinter{})
 
 	sql := "ALTER TABLE users DROP INDEX idx_email"
@@ -528,7 +530,7 @@ func TestRunLinters_UserConfigOverridesDefault(t *testing.T) {
 // LintOnlyChanges tests
 
 func TestRunLinters_LintOnlyChanges_False(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -571,7 +573,7 @@ func TestRunLinters_LintOnlyChanges_False(t *testing.T) {
 }
 
 func TestRunLinters_LintOnlyChanges_True(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -613,7 +615,7 @@ func TestRunLinters_LintOnlyChanges_True(t *testing.T) {
 }
 
 func TestRunLinters_LintOnlyChanges_MultipleChangedTables(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -665,7 +667,7 @@ func TestRunLinters_LintOnlyChanges_MultipleChangedTables(t *testing.T) {
 }
 
 func TestRunLinters_LintOnlyChanges_NoChanges(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -689,7 +691,7 @@ func TestRunLinters_LintOnlyChanges_NoChanges(t *testing.T) {
 }
 
 func TestRunLinters_LintOnlyChanges_ViolationWithoutLocation(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -725,7 +727,7 @@ func TestRunLinters_LintOnlyChanges_ViolationWithoutLocation(t *testing.T) {
 // IgnoreTables tests
 
 func TestRunLinters_IgnoreTables_Empty(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -754,7 +756,7 @@ func TestRunLinters_IgnoreTables_Empty(t *testing.T) {
 }
 
 func TestRunLinters_IgnoreTables_SingleTable(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -787,7 +789,7 @@ func TestRunLinters_IgnoreTables_SingleTable(t *testing.T) {
 }
 
 func TestRunLinters_IgnoreTables_MultipleTables(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -827,7 +829,7 @@ func TestRunLinters_IgnoreTables_MultipleTables(t *testing.T) {
 }
 
 func TestRunLinters_IgnoreTables_AllTables(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -859,7 +861,7 @@ func TestRunLinters_IgnoreTables_AllTables(t *testing.T) {
 }
 
 func TestRunLinters_IgnoreTables_ViolationWithoutLocation(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -893,7 +895,7 @@ func TestRunLinters_IgnoreTables_ViolationWithoutLocation(t *testing.T) {
 }
 
 func TestRunLinters_IgnoreTables_FalseValue(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -927,7 +929,7 @@ func TestRunLinters_IgnoreTables_FalseValue(t *testing.T) {
 // Combined tests for LintOnlyChanges and IgnoreTables
 
 func TestRunLinters_LintOnlyChanges_And_IgnoreTables(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{
@@ -977,7 +979,7 @@ func TestRunLinters_LintOnlyChanges_And_IgnoreTables(t *testing.T) {
 }
 
 func TestRunLinters_LintOnlyChanges_And_IgnoreTables_NoResults(t *testing.T) {
-	Reset()
+	resetForTest(t)
 
 	linter := &mockLinter{name: "test_linter"}
 	linter.violations = []Violation{

--- a/pkg/lint/lint_unsafe_test.go
+++ b/pkg/lint/lint_unsafe_test.go
@@ -365,7 +365,7 @@ func TestUnsafeLinter_CreateIndex(t *testing.T) {
 }
 
 func TestUnsafeLinter_Integration(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&UnsafeLinter{})
 
 	sql := `DROP TABLE users`
@@ -387,7 +387,7 @@ func TestUnsafeLinter_Integration(t *testing.T) {
 }
 
 func TestUnsafeLinter_IntegrationDisabled(t *testing.T) {
-	Reset()
+	resetForTest(t)
 	Register(&UnsafeLinter{})
 
 	sql := `DROP TABLE users`

--- a/pkg/lint/registry_helpers_test.go
+++ b/pkg/lint/registry_helpers_test.go
@@ -1,0 +1,47 @@
+package lint
+
+import (
+	"sync"
+	"testing"
+)
+
+// initialLintRegistry holds a snapshot of the linters registered by init()
+// functions, captured once on first use. Tests that wipe the registry use this
+// snapshot to restore it on cleanup so they don't pollute later tests.
+var (
+	initialLintRegistry map[string]*linter
+	initialCaptureOnce  sync.Once
+)
+
+func captureInitialLintRegistry() {
+	initialCaptureOnce.Do(func() {
+		lock.RLock()
+		defer lock.RUnlock()
+		initialLintRegistry = make(map[string]*linter, len(linters))
+		for k, v := range linters {
+			cp := *v
+			initialLintRegistry[k] = &cp
+		}
+	})
+}
+
+func restoreInitialLintRegistry() {
+	lock.Lock()
+	defer lock.Unlock()
+	linters = make(map[string]*linter, len(initialLintRegistry))
+	for k, v := range initialLintRegistry {
+		cp := *v
+		linters[k] = &cp
+	}
+}
+
+// resetForTest wipes the linter registry like Reset() does, but also registers
+// a t.Cleanup that restores the init() snapshot when the test ends. Use this
+// instead of bare Reset() in tests so that subsequent tests in the same binary
+// see the full set of linters their init() functions registered.
+func resetForTest(t *testing.T) {
+	t.Helper()
+	captureInitialLintRegistry()
+	Reset()
+	t.Cleanup(restoreInitialLintRegistry)
+}


### PR DESCRIPTION
## Summary

Two related global-state issues in `pkg/lint`:

1. **Race in `RunLinters()` (fixes #747)** — held the registry as a reader while calling `Configure()` on globally-registered linter singletons, which mutates fields like `raiseError`, `allowedTypes`, `charsets`. Concurrent callers (parallel migration tests) raced on those fields under `-race`. Promoted to a writer lock so `Configure()`+`Lint()` are serialized; in production `RunLinters` has no concurrent callers, so the extra serialization is free.

2. **Test pollution from bare `Reset()`** — tests called `Reset()` to wipe the registry for isolation but never restored the init() snapshot, so subsequent tests in the same binary saw a partial registry. With `-count=2`, `TestPlanChanges_MultiStatementSameTable` failed because `HasFKLinter` was no longer registered. Added a `resetForTest(t)` helper that captures the init() snapshot once and restores it via `t.Cleanup`. Migrated existing call sites; `TestReset` itself still uses bare `Reset()` since it directly tests the wipe semantics.

## Test plan

- [x] `go test -race ./pkg/lint/ -count=5` — passes
- [x] `go test -race -run "TestLintOnly|TestLintNoViolations" -count=20 ./pkg/migration/` — passes (was the racing pair from #747)
- [x] `go test -race -run "TestLint" ./pkg/migration/ -count=3` — passes
- [x] `go test ./pkg/lint/ -count=2` — passes (was failing on main due to test pollution)
- [x] `golangci-lint run ./pkg/lint/...` — clean

Fixes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)