### PR TITLE
test: log applier path and copier chunk completions at Debug for #746

### DIFF
--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -210,7 +210,9 @@ func (c *buffered) readWorker(ctx context.Context) error {
 				return
 			}
 
-			c.logger.Debug("applier callback invoked", "chunk", capturedChunk.String(), "affectedRows", affectedRows)
+			c.logger.Debug("applier callback invoked",
+				"table", capturedChunk.Table.TableName, "chunk", capturedChunk.String(),
+				"affected_rows", affectedRows, "duration", time.Since(capturedStartTime))
 
 			// Calculate total time from read start to callback completion (read + write)
 			totalTime := time.Since(capturedStartTime)

--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -2,6 +2,7 @@ package copier
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -20,6 +21,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Tests run at Debug level so diagnostic logs in the copier
+	// (per-chunk affected_rows, applier callback) are captured in CI
+	// output. See issue #746.
+	slog.SetLogLoggerLevel(slog.LevelDebug)
 	goleak.VerifyTestMain(m)
 }
 

--- a/pkg/copier/unbuffered.go
+++ b/pkg/copier/unbuffered.go
@@ -58,6 +58,9 @@ func (c *Unbuffered) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 	if affectedRows, err = dbconn.RetryableTransaction(ctx, c.db, true, c.dbConfig, query); err != nil {
 		return err
 	}
+	c.logger.Debug("CopyChunk completed",
+		"table", chunk.Table.TableName, "chunk", chunk.String(),
+		"affected_rows", affectedRows, "duration", time.Since(startTime))
 	// Send feedback which can be used by the chunker
 	// and infoschema to create a low watermark.
 	chunkProcessingTime := time.Since(startTime)

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -19,6 +20,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Tests run at Debug level so diagnostic logs in the binlog applier
+	// path (HasChanged add/drop, deltaMap.Flush stmt + affected_rows) and
+	// the copier (per-chunk affected_rows) are captured in CI output.
+	// See issue #746.
+	slog.SetLogLoggerLevel(slog.LevelDebug)
 	status.CheckpointDumpInterval = 100 * time.Millisecond
 	status.StatusInterval = 10 * time.Millisecond // the status will be accurate to 1ms
 	sentinelCheckInterval = 100 * time.Millisecond

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -24,6 +24,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Tests run at Debug level so diagnostic logs in the binlog applier
+	// path (HasChanged add/drop, deltaMap.Flush stmt + affected_rows) are
+	// captured in CI output. See issue #746.
+	slog.SetLogLoggerLevel(slog.LevelDebug)
 	maxRecreateAttempts = 3
 	goleak.VerifyTestMain(m)
 }

--- a/pkg/repl/subscription_map.go
+++ b/pkg/repl/subscription_map.go
@@ -55,10 +55,13 @@ func (s *deltaMap) HasChanged(key, _ []any, deleted bool) {
 	// earlier in setup to ensure binary logs are available).
 	// We then disable the optimization after the copier phase has finished.
 	if s.watermarkOptimizationEnabled() && s.chunker.KeyAboveHighWatermark(key[0]) {
-		s.c.logger.Debug("key above watermark", "key", key[0])
+		s.c.logger.Debug("HasChanged dropped above-high-watermark",
+			"table", s.table.TableName, "key", key[0], "deleted", deleted)
 		return
 	}
 	s.changes[utils.HashKey(key)] = mapChange{isDelete: deleted, originalKey: key}
+	s.c.logger.Debug("HasChanged added to delta map",
+		"table", s.table.TableName, "key", key[0], "deleted", deleted, "delta_len", len(s.changes))
 }
 
 func (s *deltaMap) createDeleteStmt(deleteKeys []string) statement {
@@ -116,7 +119,8 @@ func (s *deltaMap) Flush(ctx context.Context, underLock bool, lock *dbconn.Table
 		// When underLock=true (during cutover), we must flush all changes regardless of watermark.
 		// Use originalKey to preserve typed values for watermark comparison
 		if !underLock && s.watermarkOptimizationEnabled() && !s.chunker.KeyBelowLowWatermark(change.originalKey[0]) {
-			s.c.logger.Debug("key not below watermark", "key", change.originalKey[0])
+			s.c.logger.Debug("Flush skipped not-below-low-watermark",
+				"table", s.table.TableName, "key", change.originalKey[0])
 			allChangesFlushed = false
 			continue
 		}
@@ -141,7 +145,10 @@ func (s *deltaMap) Flush(ctx context.Context, underLock bool, lock *dbconn.Table
 		// Execute under lock means it is a final flush
 		// We need to use the lock connection to do this
 		// so there is no parallelism.
-		if err := lock.ExecUnderLock(ctx, extractStmt(stmts)...); err != nil {
+		execStmts := extractStmt(stmts)
+		s.c.logger.Debug("Flush underLock executing",
+			"table", s.table.TableName, "stmt_count", len(execStmts), "keys_flushed", len(keysFlushed))
+		if err := lock.ExecUnderLock(ctx, execStmts...); err != nil {
 			return false, err
 		}
 	} else {
@@ -155,8 +162,13 @@ func (s *deltaMap) Flush(ctx context.Context, underLock bool, lock *dbconn.Table
 			st := stmt
 			g.Go(func() error {
 				startTime := time.Now()
-				_, err := dbconn.RetryableTransaction(errGrpCtx, s.c.db, false, dbconn.NewDBConfig(), st.stmt)
+				affected, err := dbconn.RetryableTransaction(errGrpCtx, s.c.db, false, dbconn.NewDBConfig(), st.stmt)
 				s.c.feedback(st.numKeys, time.Since(startTime))
+				if st.stmt != "" {
+					s.c.logger.Debug("Flush stmt executed",
+						"table", s.table.TableName, "num_keys", st.numKeys,
+						"affected_rows", affected, "err", err, "stmt", st.stmt)
+				}
 				return err
 			})
 		}


### PR DESCRIPTION
## Summary
- Adds Debug-level logs at the decision points in the binlog applier path and the copier that BUG.md (#746) needs to discriminate between the remaining hypotheses.
- Bumps `pkg/{migration,repl,copier}` test log level to Debug in `TestMain` so the new logs reach CI output. Production behavior unchanged — Debug stays filtered there.
- Investigative scaffolding for issue #746 — the log sites should stay useful long-term; the test-level Debug bump can be reverted once root-caused.

## Why
Round one (#750) confirmed `TestCutoverAtomicityWithConcurrentWrites` loses rows mid-keyspace (e.g. id=118 missing while id=157 is present), ruling out the cutover-window race and pointing at the copy-phase delta-map / watermark interaction. The next CI failure needs to answer:

  (a) Did `HasChanged(K)` ever fire? Was it dropped by `KeyAboveHighWatermark`?
  (b) Was K ever in the delta map? Skipped repeatedly by `KeyBelowLowWatermark`?
  (c) When the `REPLACE INTO ... SELECT ...` for K ran, what was its `affected_rows`?
  (d) Which copy chunk's range covered K? What was that chunk's `affected_rows`?

This patch makes (a)-(d) printable in CI logs. Debug is the right level — it's what these decisions would warrant in any case, and there's no reason to filter them in tests.

## What's logged (at Debug)
- `pkg/repl/subscription_map.go`
  - `HasChanged` — every add to the delta map, and every drop by `KeyAboveHighWatermark`.
  - `deltaMap.Flush` — every key skipped by `KeyBelowLowWatermark`; per-statement `affected_rows` on the parallel path; `stmt_count`/`keys_flushed` on the under-lock path.
- `pkg/copier/{unbuffered,buffered}.go`
  - One log per chunk completion with table, range, `affected_rows`, duration.

## Test plan
- [x] `go build ./...` — clean.
- [x] `go vet ./pkg/repl/ ./pkg/copier/ ./pkg/migration/` — clean.
- [x] `go test ./pkg/repl/ ./pkg/copier/` — pass.
- [x] `go test -run TestCutoverAtomicityWithConcurrentWrites ./pkg/migration/` — pass (2.4s) and emits the expected debug lines (`HasChanged added to delta map`, `Flush stmt executed table=... affected_rows=... stmt=...`, `CopyChunk completed chunk=... affected_rows=...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)