### PR TITLE
test: fix flaky TestCheckpoint chunker shrink under CI load

### DIFF
--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -103,12 +103,15 @@ func TestCheckpoint(t *testing.T) {
 
 	preSetup := func() *Runner {
 		r, err := NewRunner(&Migration{
-			Host:             cfg.Addr,
-			Username:         cfg.User,
-			Password:         &cfg.Passwd,
-			Database:         cfg.DBName,
-			Threads:          1,
-			TargetChunkTime:  100 * time.Millisecond,
+			Host:     cfg.Addr,
+			Username: cfg.User,
+			Password: &cfg.Passwd,
+			Database: cfg.DBName,
+			Threads:  1,
+			// Large TargetChunkTime so the optimistic chunker does not
+			// shrink ChunkSize under CI load — this test asserts an exact
+			// ChunkSize=1000 watermark, so dynamic resizing must not kick in.
+			TargetChunkTime:  time.Hour,
 			Table:            "cpt1",
 			Alter:            "ENGINE=InnoDB",
 			useTestThrottler: true,

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -103,15 +103,12 @@ func TestCheckpoint(t *testing.T) {
 
 	preSetup := func() *Runner {
 		r, err := NewRunner(&Migration{
-			Host:     cfg.Addr,
-			Username: cfg.User,
-			Password: &cfg.Passwd,
-			Database: cfg.DBName,
-			Threads:  1,
-			// Large TargetChunkTime so the optimistic chunker does not
-			// shrink ChunkSize under CI load — this test asserts an exact
-			// ChunkSize=1000 watermark, so dynamic resizing must not kick in.
-			TargetChunkTime:  time.Hour,
+			Host:             cfg.Addr,
+			Username:         cfg.User,
+			Password:         &cfg.Passwd,
+			Database:         cfg.DBName,
+			Threads:          1,
+			TargetChunkTime:  100 * time.Millisecond,
 			Table:            "cpt1",
 			Alter:            "ENGINE=InnoDB",
 			useTestThrottler: true,
@@ -130,6 +127,17 @@ func TestCheckpoint(t *testing.T) {
 		require.NoError(t, r.changes[0].dropOldTable(t.Context()))
 		return r
 	}
+	// disableDynamicChunking turns off the optimistic chunker's adaptive
+	// resizing so this test sees a stable ChunkSize=1000 regardless of
+	// per-chunk timing under CI load. The test asserts watermark contents,
+	// not chunker auto-sizing behavior.
+	disableDynamicChunking := func(c table.Chunker) {
+		t.Helper()
+		setter, ok := c.(interface{ SetDynamicChunking(bool) })
+		require.True(t, ok, "copyChunker does not expose SetDynamicChunking")
+		setter.SetDynamicChunking(false)
+	}
+
 	r := preSetup()
 	// migrationRunner.Run usually calls r.Setup() here.
 	// Which first checks if the table can be restored from checkpoint.
@@ -137,6 +145,7 @@ func TestCheckpoint(t *testing.T) {
 	require.Error(t, r.resumeFromCheckpoint(t.Context()))
 	// So we proceed with the initial steps.
 	require.NoError(t, r.newMigration(t.Context()))
+	disableDynamicChunking(r.copyChunker)
 
 	// Now we are ready to start copying rows.
 	// Instead of calling r.copyRows() we will step through it manually.
@@ -196,6 +205,7 @@ func TestCheckpoint(t *testing.T) {
 	// Start the binary log feed just before copy rows starts.
 	// replClient.Run() is already called in resumeFromCheckpoint.
 	require.NoError(t, r.resumeFromCheckpoint(t.Context()))
+	disableDynamicChunking(r.copyChunker)
 	// This opens the table at the checkpoint (table.OpenAtWatermark())
 	// which sets the chunkPtr at the LowerBound. It also has to position
 	// the watermark to this point so new watermarks "align" correctly.

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -207,7 +207,10 @@ func (t *chunkerOptimistic) Open() (err error) {
 	return t.open()
 }
 
-func (t *chunkerOptimistic) setDynamicChunking(newValue bool) {
+// SetDynamicChunking enables (true) or disables (false) the optimistic
+// chunker's dynamic chunk-size adaptation. Disabling is intended for tests
+// that need deterministic chunk sizes; production callers should leave it on.
+func (t *chunkerOptimistic) SetDynamicChunking(newValue bool) {
 	t.Lock()
 	defer t.Unlock()
 	t.disableDynamicChunker = !newValue

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -30,7 +30,7 @@ func TestOptimisticChunkerBasic(t *testing.T) {
 		ChunkerTarget: ChunkerDefaultTarget,
 		logger:        slog.Default(),
 	}
-	chunker.setDynamicChunking(false)
+	chunker.SetDynamicChunking(false)
 
 	assert.NoError(t, t1.PrimaryKeyIsMemoryComparable())
 	t1.keyColumnsMySQLTp[0] = "varchar"
@@ -90,7 +90,7 @@ func TestLowWatermark(t *testing.T) {
 		lowerBoundWatermarkMap: make(map[string]*Chunk, 0),
 		logger:                 slog.Default(),
 	}
-	chunker.setDynamicChunking(false)
+	chunker.SetDynamicChunking(false)
 
 	assert.NoError(t, chunker.Open())
 
@@ -318,7 +318,7 @@ func TestOptimisticPrefetchChunking(t *testing.T) {
 		ChunkerTarget: time.Second,
 		logger:        slog.Default(),
 	}
-	chunker.setDynamicChunking(true)
+	chunker.SetDynamicChunking(true)
 	assert.NoError(t, chunker.Open())
 	assert.False(t, chunker.chunkPrefetchingEnabled)
 
@@ -354,7 +354,7 @@ func TestOptimisticChunkerReset(t *testing.T) {
 		lowerBoundWatermarkMap: make(map[string]*Chunk, 0),
 		logger:                 slog.Default(),
 	}
-	chunker.setDynamicChunking(false)
+	chunker.SetDynamicChunking(false)
 
 	// Test that Reset() fails when chunker is not open
 	err := chunker.Reset()


### PR DESCRIPTION
## Summary
`TestCheckpoint` (`pkg/migration/resume_test.go`) asserts an exact `ChunkSize=1000` watermark after 11 chunks while running with `TargetChunkTime: 100ms`. Under CI load the optimistic chunker shrank `ChunkSize` from 1000 → 100 and the assertion failed (see [run 25214878386](https://github.com/block/spirit/actions/runs/25214878386)).

This PR makes the chunker's existing `setDynamicChunking` toggle public (`SetDynamicChunking`) and has `TestCheckpoint` call it on the chunker after each setup path. With dynamic chunking off, `ChunkSize` is pinned at the starting value (1000) regardless of timing — the test gets deterministic chunk sizes without any reliance on internal `Feedback()` ordering.

(An earlier draft of this PR just bumped `TargetChunkTime` to 1h. Adversarial review: that prevented the panic-shrink path but left the upward `calculateNewTargetChunkSize` path live, which would fire after the 11th feedback and only happens to not break the assertion because `bumpWatermark` runs before the recalc inside `Feedback()` and no chunk #12 is dispensed. Too coupled to internal ordering. Disabling dynamic chunking outright is the deterministic fix.)

Fixes #757

## Test plan
- [x] `go test ./pkg/migration/ -run TestCheckpoint$ -count=3` passes locally
- [x] `go test ./pkg/table/ -run TestOptimistic` passes locally (renamed callers updated)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)