### PR TITLE
test: fast-fail TestE2ENullAlterWithReplicas when CI replica isn't healthy

### DIFF
--- a/compose/replication-tls/init-ci-replica.sql
+++ b/compose/replication-tls/init-ci-replica.sql
@@ -1,1 +1,2 @@
 change replication source to source_host='mysql',source_user='rsandbox',source_password='rsandbox',source_auto_position=1,get_source_public_key=1;
+start replica;

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -99,6 +99,7 @@ func TestE2ENullAlterWithReplicas(t *testing.T) {
 	if replicaDSN == "" {
 		t.Skip("skipping replica tests because REPLICA_DSN not set")
 	}
+	testutils.WaitForReplicaHealthy(t, replicaDSN, 30*time.Second)
 	testutils.NewTestTable(t, "replicatest", `CREATE TABLE replicatest (
 		id int(11) NOT NULL AUTO_INCREMENT,
 		name varchar(255) NOT NULL,

--- a/pkg/testutils/testing.go
+++ b/pkg/testutils/testing.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
@@ -149,6 +150,74 @@ func IsMinimalRBRTestRunner(t *testing.T) bool {
 		}
 	})
 	return isRBRTestRunnerCached
+}
+
+// WaitForReplicaHealthy polls SHOW REPLICA STATUS until both the IO and SQL
+// threads report Yes, or the timeout elapses. On timeout it skips the test
+// with an infra-attribution message — when the replica isn't running at the
+// start of a test, that's almost always a CI setup issue, not a Spirit bug,
+// so failing late inside m.Run() is misleading.
+func WaitForReplicaHealthy(t *testing.T, dsn string, timeout time.Duration) {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	deadline := time.Now().Add(timeout)
+	var lastIO, lastSQL, lastIOState string
+	for {
+		ioRunning, sqlRunning, ioState, err := readReplicaStatus(t.Context(), db)
+		if err == nil {
+			if ioRunning == "Yes" && sqlRunning == "Yes" {
+				return
+			}
+			lastIO, lastSQL, lastIOState = ioRunning, sqlRunning, ioState
+		}
+		if time.Now().After(deadline) {
+			t.Skipf("test infra: replica not healthy after %s "+
+				"(Replica_IO_Running=%q Replica_SQL_Running=%q Replica_IO_State=%q lastErr=%v); "+
+				"this indicates a CI setup issue, not a Spirit bug",
+				timeout, lastIO, lastSQL, lastIOState, err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func readReplicaStatus(ctx context.Context, db *sql.DB) (ioRunning, sqlRunning, ioState string, err error) {
+	rows, err := db.QueryContext(ctx, "SHOW REPLICA STATUS")
+	if err != nil {
+		return "", "", "", err
+	}
+	defer func() { _ = rows.Close() }()
+	cols, err := rows.Columns()
+	if err != nil {
+		return "", "", "", err
+	}
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", "", "", err
+		}
+		return "", "", "", fmt.Errorf("SHOW REPLICA STATUS returned no rows")
+	}
+	values := make([]any, len(cols))
+	for i := range values {
+		values[i] = new(sql.NullString)
+	}
+	if err := rows.Scan(values...); err != nil {
+		return "", "", "", err
+	}
+	for i, name := range cols {
+		v := values[i].(*sql.NullString).String
+		switch name {
+		case "Replica_IO_Running":
+			ioRunning = v
+		case "Replica_SQL_Running":
+			sqlRunning = v
+		case "Replica_IO_State":
+			ioState = v
+		}
+	}
+	return ioRunning, sqlRunning, ioState, nil
 }
 
 // EvenOddHasher is a test hash function that shards assuming -80 and 80- shards.

--- a/pkg/testutils/testing.go
+++ b/pkg/testutils/testing.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/utils"
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -153,15 +154,14 @@ func IsMinimalRBRTestRunner(t *testing.T) bool {
 }
 
 // WaitForReplicaHealthy polls SHOW REPLICA STATUS until both the IO and SQL
-// threads report Yes, or the timeout elapses. On timeout it skips the test
-// with an infra-attribution message — when the replica isn't running at the
-// start of a test, that's almost always a CI setup issue, not a Spirit bug,
-// so failing late inside m.Run() is misleading.
+// threads report Yes, or the timeout elapses. On timeout it fails the test
+// with an infra-attribution message so a broken CI replica setup is clearly
+// distinguishable from a Spirit migration bug.
 func WaitForReplicaHealthy(t *testing.T, dsn string, timeout time.Duration) {
 	t.Helper()
 	db, err := sql.Open("mysql", dsn)
 	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
+	defer utils.CloseAndLog(db)
 
 	deadline := time.Now().Add(timeout)
 	var lastIO, lastSQL, lastIOState string
@@ -174,7 +174,7 @@ func WaitForReplicaHealthy(t *testing.T, dsn string, timeout time.Duration) {
 			lastIO, lastSQL, lastIOState = ioRunning, sqlRunning, ioState
 		}
 		if time.Now().After(deadline) {
-			t.Skipf("test infra: replica not healthy after %s "+
+			t.Fatalf("test infra: replica not healthy after %s "+
 				"(Replica_IO_Running=%q Replica_SQL_Running=%q Replica_IO_State=%q lastErr=%v); "+
 				"this indicates a CI setup issue, not a Spirit bug",
 				timeout, lastIO, lastSQL, lastIOState, err)
@@ -188,7 +188,7 @@ func readReplicaStatus(ctx context.Context, db *sql.DB) (ioRunning, sqlRunning, 
 	if err != nil {
 		return "", "", "", err
 	}
-	defer func() { _ = rows.Close() }()
+	defer utils.CloseAndLog(rows)
 	cols, err := rows.Columns()
 	if err != nil {
 		return "", "", "", err


### PR DESCRIPTION
## Summary
Fixes [#756](https://github.com/block/spirit/issues/756). The flake was attributable to two things:

- The CI replica init script (`compose/replication-tls/init-ci-replica.sql`) ran `CHANGE REPLICATION SOURCE TO …` but never `START REPLICA;`. The TLS-enabled init script (`init-replica-db-unified.sql:73`) does. Without an explicit start, the replica relied on MySQL's implicit auto-start-on-restart from persisted `slave_master_info` — which raced against source availability and occasionally left the IO thread "not running" with an empty `Replica_IO_State`. That surfaced later as `TestE2ENullAlterWithReplicas` failing inside `m.Run()` rather than as a setup error.
- The test had no pre-check, so a broken-CI failure looked indistinguishable from a Spirit bug.

## Changes
- `compose/replication-tls/init-ci-replica.sql`: add `start replica;` so the IO thread starts deterministically during initdb instead of relying on auto-resume. (The three TLS variants already share `init-replica-db-unified.sql`, which has this — only the no-TLS CI variant was missing it.)
- `pkg/testutils/testing.go`: new `WaitForReplicaHealthy(t, dsn, timeout)` that polls `SHOW REPLICA STATUS` for `Replica_IO_Running=Yes` and `Replica_SQL_Running=Yes`. On timeout it `t.Fatalf`s with an infra-attribution message including the last observed `Replica_IO_State` and any error — so a broken CI replica fails loudly as a setup issue rather than as a misleading migration bug. Uses `utils.CloseAndLog` for the deferred closes to match the rest of the codebase.
- `pkg/migration/migration_test.go`: call `WaitForReplicaHealthy` at the top of `TestE2ENullAlterWithReplicas` (30s budget).

Other replica-using tests (`pkg/throttler/throttler_test.go`, `pkg/migration/check/replicaprivileges_test.go`, `pkg/migration/check/replicahealth_test.go`) are intentionally left alone — once the init-script fix lands they should also be reliable, and the helper is available if any of them flake similarly.

## Test plan
- [ ] CI green on the replication job
- [ ] Locally with `REPLICA_DSN` unset: `TestE2ENullAlterWithReplicas` skips on the existing `REPLICA_DSN` guard as before (verified)
- [ ] Locally with a healthy replica: `TestE2ENullAlterWithReplicas` passes (verified)
- [ ] Manually exercise the unhealthy path by stopping the replica IO thread and re-running — should `t.Fatalf` with the infra-attribution message rather than fail mid-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
