### PR TITLE
test: disable FixDifferences in TestCutoverAtomicityWithConcurrentWrites for #746 repro

### DIFF
--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -283,6 +284,17 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 	// The migration should fail - either with our intentional error or because
 	// the table doesn't exist after the partial rename
 	require.Error(t, err, "Migration should fail")
+
+	// useTestCutover also flips FixDifferences off (see runner.go), so if the
+	// copy + applier path lost rows during the migration the checksum step
+	// surfaces it as "checksum mismatch" before partial cutover runs. That's
+	// the dominant signal we want for issue #746 — checksum's Warn logs name
+	// the diverged PKs via inspectDifferences. Treat the error as a real
+	// failure here so CI reports it; the partial cutover never ran, so the
+	// _old/_new comparison below isn't applicable.
+	if strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("issue #746 reproduced at checksum step (FixDifferences disabled via useTestCutover): %v — see preceding 'inspection revealed row does not exist in target' Warn logs for missing PKs", err)
+	}
 
 	// The partial cutover should have renamed t1concurrent to _t1concurrent_old
 	// Let's verify both tables exist

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -566,9 +566,14 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 		TargetChunkTime: r.migration.TargetChunkTime,
 		DBConfig:        r.dbConfig,
 		Logger:          r.logger,
-		FixDifferences:  true, // we want to repair the differences.
-		MaxRetries:      3,
-		YieldTimeout:    r.migration.ChecksumYieldTimeout,
+		// In production we always want the checksum to repair differences. The
+		// useTestCutover hook (only set by TestCutoverAtomicityWithConcurrentWrites)
+		// flips this off so any copy-phase / applier-path row loss surfaces as a
+		// checksum-mismatch error before cutover, instead of being silently
+		// repaired. This is what makes that test a real probe of issue #746.
+		FixDifferences: !r.migration.useTestCutover,
+		MaxRetries:     3,
+		YieldTimeout:   r.migration.ChecksumYieldTimeout,
 	})
 
 	return err


### PR DESCRIPTION
## Summary

The root cause of TestCutoverAtomicityWithConcurrentWrites is not yet known. However, it looks like it might be changes lost in the replication stream. Because of the checksum fixing differences, these changes can only be between the checksum start and cutover. By disabling FixDifferences _for this test_ it extends the time window and makes the race hopefully more likely to occur.


🤖 Generated with [Claude Code](https://claude.com/claude-code)