### PR TITLE
test: cancel before Close in resume teardown to avoid fatalError race

### DIFF
--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -64,10 +64,12 @@ func TestChangeIntToBigIntPKResumeFromChkPt(t *testing.T) {
 
 	waitForCheckpoint(t, m)
 
-	// Close() before cancel() to free resources before context cancellation.
-	require.NoError(t, m.Close())
+	// Cancel first, wait for Run to return (so deferred MDL release runs and
+	// no in-flight goroutine can trip fatalError → dropCheckpoint), then Close
+	// to tear down the remaining resources.
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	// Insert some more dummy data
 	testutils.RunSQL(t, "INSERT INTO bigintpk (name,b) VALUES('t', 't')")
@@ -559,10 +561,11 @@ func TestResumeFromCheckpointE2E(t *testing.T) {
 
 	waitForCheckpoint(t, m)
 
-	// Close() before cancel() to avoid race conditions.
-	require.NoError(t, m.Close())
+	// Cancel + wait for Run to fully return before Close. See
+	// TestChangeIntToBigIntPKResumeFromChkPt for the rationale.
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	// Insert some more dummy data
 	testutils.RunSQL(t, "INSERT INTO chkpresumetest (pad) SELECT RANDOM_BYTES(1024) FROM chkpresumetest LIMIT 1000")
@@ -617,10 +620,11 @@ FROM compositevarcharpk a WHERE version='1'`)
 
 	waitForCheckpoint(t, m)
 
-	// Close() before cancel() to avoid race conditions.
-	require.NoError(t, m.Close())
+	// Cancel + wait for Run to fully return before Close. See
+	// TestChangeIntToBigIntPKResumeFromChkPt for the rationale.
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	m2 := NewTestRunner(t, "compositevarcharpk", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
@@ -656,10 +660,11 @@ func TestResumeFromCheckpointStrict(t *testing.T) {
 
 	waitForCheckpoint(t, m)
 
-	// Cancel context first to signal goroutines to stop, then Close() to clean up resources.
+	// Cancel + wait for Run to fully return before Close. See
+	// TestChangeIntToBigIntPKResumeFromChkPt for the rationale.
 	cancel()
+	<-done
 	require.NoError(t, m.Close())
-	<-done // Wait for the goroutine to finish
 
 	// Insert some more dummy data
 	testutils.RunSQL(t, "INSERT INTO resumestricttest (pad) SELECT RANDOM_BYTES(1024) FROM resumestricttest LIMIT 1000")
@@ -881,10 +886,11 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, lock)
 
-	// Close() before cancel() to avoid race conditions.
-	require.NoError(t, runner.Close())
+	// Cancel + wait for Run to fully return before Close. See
+	// TestChangeIntToBigIntPKResumeFromChkPt for the rationale.
 	cancel()
 	<-done
+	require.NoError(t, runner.Close())
 
 	// Manually create the sentinel table.
 	testutils.RunSQLInDatabase(t, dbName, "CREATE TABLE _spirit_sentinel (id int unsigned primary key)")
@@ -958,10 +964,11 @@ func TestResumeFromCheckpointCleanupOnFailure(t *testing.T) {
 	err = db.QueryRowContext(t.Context(), "SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '_cleanup_test_new'").Scan(&tableName)
 	require.NoError(t, err, "_cleanup_test_new table should exist after checkpoint")
 
-	// Close() before cancel() to avoid race conditions (see other tests)
-	require.NoError(t, m.Close())
+	// Cancel + wait for Run to fully return before Close. See
+	// TestChangeIntToBigIntPKResumeFromChkPt for the rationale.
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	// Now corrupt the checkpoint by setting an invalid binlog position.
 	// This simulates binlog expiry between stop and start.
@@ -998,9 +1005,9 @@ func TestResumeFromCheckpointStrictBinlogExpired(t *testing.T) {
 	}()
 
 	waitForCheckpoint(t, m)
-	require.NoError(t, m.Close())
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	// Corrupt binlog name to simulate expiry
 	testutils.RunSQL(t, `UPDATE _strictbinlogtest_chkpnt SET binlog_name = 'nonexistent-bin.999999', binlog_pos = 999999999`)
@@ -1042,9 +1049,9 @@ func TestResumeFromCheckpointTooOld(t *testing.T) {
 	}()
 
 	waitForCheckpoint(t, m)
-	require.NoError(t, m.Close())
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	// Backdate the checkpoint's created_at to simulate an old checkpoint (8 days ago).
 	testutils.RunSQL(t, `UPDATE _chkpttooold_chkpnt SET created_at = DATE_SUB(NOW(), INTERVAL 8 DAY)`)
@@ -1081,9 +1088,9 @@ func TestResumeFromCheckpointStrictTooOld(t *testing.T) {
 	}()
 
 	waitForCheckpoint(t, m)
-	require.NoError(t, m.Close())
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	// Backdate the checkpoint's created_at to simulate an old checkpoint (8 days ago).
 	testutils.RunSQL(t, `UPDATE _strictoldtest_chkpnt SET created_at = DATE_SUB(NOW(), INTERVAL 8 DAY)`)
@@ -1123,9 +1130,9 @@ func TestResumeFromCheckpointNotTooOld(t *testing.T) {
 	}()
 
 	waitForCheckpoint(t, m)
-	require.NoError(t, m.Close())
 	cancel()
 	<-done
+	require.NoError(t, m.Close())
 
 	// Do NOT backdate the checkpoint - it was just created, so it's fresh.
 	// The migration should resume from checkpoint successfully.

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -416,9 +416,11 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 
 	require.NoError(t, r.checksum(t.Context()))       // run the checksum, the original Run is blocked on sentinel.
 	require.NoError(t, r.DumpCheckpoint(t.Context())) // dump a checkpoint with the watermark.
-	require.NoError(t, r.Close())                     // close the run first to avoid race conditions.
-	cancel()                                          // unblock the original waiting on sentinel.
+	// Cancel + wait for Run to fully return before Close. See
+	// TestChangeIntToBigIntPKResumeFromChkPt for the rationale.
+	cancel() // unblocks the goroutine that was waiting on sentinel.
 	<-done
+	require.NoError(t, r.Close())
 
 	// drop the sentinel table.
 	testutils.RunSQLInDatabase(t, dbName, `DROP TABLE _spirit_sentinel`)


### PR DESCRIPTION
## Summary

The resume tests in `pkg/migration/resume_test.go` started `Run()` in a goroutine and tore down with `Close() → cancel() → <-done`. Closing the runner while `Run` was still executing closed `r.db`, `replClient`, and the throttler out from under the live goroutine — and any in-flight path that hit those closed resources could trip `fatalError() → dropCheckpoint()` (removing the checkpoint table the next runner needed) or stall `Run`'s unwind so the deferred MDL release didn't happen before the test moved on.

This flips the ordering to `cancel() → <-done → Close()` so `Run` unwinds cleanly: ctx cancellation reaches copier / checksum / replClient (they all share the runner ctx), the deferred MDL release runs inside `Run`, `Run` returns, and only then does `Close()` tear down the rest. After `<-done` we have a hard guarantee that `Run` has fully exited and every defer has fired.

Fixes #767 and fixes #742.

### Why this is the bug for #767

The test corrupted the checkpoint binlog name and expected `ErrBinlogNotFound` from `m2.Run`, but got `nil`. Walking [`resumeFromCheckpoint`](https://github.com/block/spirit/blob/main/pkg/migration/runner.go#L919) and [`setup`](https://github.com/block/spirit/blob/main/pkg/migration/runner.go#L732), strict mode only catches three sentinels:

```go
if r.migration.Strict && (errors.Is(err, status.ErrMismatchedAlter) ||
    errors.Is(err, status.ErrBinlogNotFound) ||
    errors.Is(err, status.ErrCheckpointTooOld)) {
    return err
}
// fall through to newMigration
```

For strict mode to silently start fresh, `resumeFromCheckpoint` has to return an error *not* in that allowlist. The most likely candidate is the checkpoint row read failing because the table no longer exists — and `fatalError()` calls `dropCheckpoint()`. `fatalError` could fire during the racy m1 shutdown (e.g. the binlog readStream or any apply path hitting the now-closed `r.db` before the readStream exits cleanly).

### Why this is the bug for #742

The failure was `could not acquire metadata lock for test.strictoldtest-077e2070, lock is held by another connection` — m2's `NewMetadataLock` saw m1's MDL still held. The explicit `RELEASE_LOCK` added in [25c92e5](https://github.com/block/spirit/commit/25c92e5) made release synchronous, but that fix relies on the MDL goroutine's `<-ctx.Done()` handler running, which is triggered by `lock.Close()` — and `lock.Close()` is a `defer` inside `Run`. The old test ordering closed the runner first, then cancelled, leaving a window where `Run` hadn't yet unwound to its defer when other resources were already torn down. With `cancel() → <-done → Close()`, by the time the test moves on, `Run` has returned and the MDL has been released synchronously — m2 always sees a free lock.

### Tests left alone

- `TestCheckpointPhantomRow` — drives the runner manually, no `Run` goroutine to wait on.

(`TestCheckpointResumeDuringChecksum` was the one exception I'd carved out initially, but a follow-up audit showed its `Close before cancel` was just choosing the lesser of two races before `<-done` existed. It's now fixed too in the second commit.)

### Follow-up worth considering (not in this PR)

Strict mode's silent fallback when the checkpoint table is missing is itself questionable — if a caller asked for strict mode and the checkpoint is *gone*, surfacing that explicitly is more useful than starting fresh. Worth a separate change.

## Test plan

- [ ] CI green on the affected resume tests
- [ ] Run `TestResumeFromCheckpointStrictBinlogExpired` and `TestResumeFromCheckpointStrictTooOld` in a loop locally to confirm no flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
