### PR TITLE
fix(#769): stop reusing Migration in TestMultiChangesDifferentSchemas + improve checksum retry diagnostics

### DIFF
--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -360,6 +360,7 @@ func (c *SingleChecker) Run(ctx context.Context) error {
 	}()
 
 	// Try the checksum up to n times if differences are found and we can fix them
+	var lastErr error
 	for attempt := 1; attempt <= c.maxRetries; attempt++ {
 		if attempt > 1 {
 			c.logger.Error("checksum failed, retrying", "attempt", attempt, "maxRetries", c.maxRetries)
@@ -371,6 +372,15 @@ func (c *SingleChecker) Run(ctx context.Context) error {
 			c.differencesFound.Store(0)
 		}
 
+		// If the parent context is already cancelled, retrying is pointless —
+		// every subsequent attempt will fail the same way at the first
+		// ctx-aware call. Bail out with the cancellation cause directly so
+		// the caller sees the real reason rather than the generic
+		// "checksum failed after N attempts" wrapper below.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		// Run the checksum with yield support. A single checksum pass may be
 		// split across multiple runChecksum calls if the yield timeout fires.
 		// Between yields we release the REPEATABLE READ transactions to limit
@@ -378,6 +388,7 @@ func (c *SingleChecker) Run(ctx context.Context) error {
 		// and fresh snapshot before resuming from the low watermark.
 		if err := c.runChecksumWithYield(ctx); err != nil {
 			c.logger.Error("checksum encountered an error", "error", err)
+			lastErr = err
 			continue
 		}
 
@@ -388,15 +399,27 @@ func (c *SingleChecker) Run(ctx context.Context) error {
 			c.logger.Info("checksum passed")
 			return nil
 		}
+		// Differences were found and (because we got here) recopied. Record
+		// this as the "last attempt outcome" so the exhausted-retries error
+		// below can distinguish it from a hard error path.
+		lastErr = nil
 	}
 
-	// Retries exhausted:
-	// This used to say "checksum failed, this should never happen" but that's not entirely true.
-	// If the user attempts a lossy schema change such as adding a UNIQUE INDEX to non-unique data,
-	// then the checksum will fail. This is entirely expected, and not considered a bug. We should
-	// do our best-case to differentiate that we believe this ALTER statement is lossy, and
-	// customize the returned error based on it.
-	return fmt.Errorf("checksum failed after %d attempts. This likely indicates either a bug in Spirit, or a manual modification to the _new table outside of Spirit. Please report @ github.com/block/spirit", c.maxRetries)
+	// Retries exhausted. There are two distinct shapes of failure here:
+	//
+	//   1. Every attempt returned an error (lastErr != nil) — e.g. a
+	//      transient context cancellation, a connection issue, or a bug
+	//      that surfaces as an error rather than a row diff. Surface the
+	//      underlying error verbatim so it's actually triagable.
+	//
+	//   2. Every attempt completed but kept finding row differences
+	//      (lastErr == nil) — this is the original "lossy ALTER or bug"
+	//      shape (e.g. adding a UNIQUE INDEX to non-unique data, or a real
+	//      bug in Spirit's copy phase). Keep the original guidance.
+	if lastErr != nil {
+		return fmt.Errorf("checksum errored on every attempt (%d/%d); last error: %w", c.maxRetries, c.maxRetries, lastErr)
+	}
+	return fmt.Errorf("checksum found differences on every attempt (%d/%d). This likely indicates either a bug in Spirit, or a manual modification to the _new table outside of Spirit. Please report @ github.com/block/spirit", c.maxRetries, c.maxRetries)
 }
 
 // runChecksumWithYield runs the checksum, automatically yielding and resuming

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -153,7 +153,12 @@ func TestUnfixableUniqueChecksum(t *testing.T) {
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, config)
 	assert.NoError(t, err)
 	err = checker.Run(t.Context())
-	assert.ErrorContains(t, err, "checksum failed")
+	// Adding a UNIQUE INDEX to non-unique data: every attempt finds row
+	// differences (and recopies don't help), so we exhaust retries on the
+	// "found differences" path. The migration layer wraps this into a more
+	// user-friendly "lossy unique-index" message; here we just assert the
+	// underlying checksum-layer error.
+	assert.ErrorContains(t, err, "checksum found differences on every attempt")
 }
 
 func TestFixCorrupt(t *testing.T) {

--- a/pkg/migration/change_test.go
+++ b/pkg/migration/change_test.go
@@ -34,17 +34,19 @@ func TestMultiChangesDifferentSchemas(t *testing.T) {
 		testutils.RunSQL(t, `DROP DATABASE IF EXISTS multichangedb1`)
 	})
 
-	migration := NewTestMigration(t,
-		WithStatement("ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT, ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT"))
-	require.Error(t, migration.Run())
-	migration.Statement = "ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT; ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT"
-	require.Error(t, migration.Run())
-	migration.Statement = "ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT"
-	require.Error(t, migration.Run())
-	migration.Statement = "ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT"
-	require.Error(t, migration.Run()) // even this is an error because we have schema + explicit DB.
-	migration.Statement = "ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT"
-	require.NoError(t, migration.Run())
+	// Build a fresh *Migration per Run. Reusing a single *Migration across
+	// multiple Run() calls is not a supported production path, and stale
+	// internal state from prior failed Runs (replication subscriptions,
+	// useTestCutover bookkeeping, etc.) has been observed to surface in
+	// the next Run as transient checksum failures. See block/spirit#769.
+	run := func(statement string) error {
+		return NewTestMigration(t, WithStatement(statement)).Run()
+	}
+	require.Error(t, run("ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT, ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT"))
+	require.Error(t, run("ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT; ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT"))
+	require.Error(t, run("ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT"))
+	require.Error(t, run("ALTER TABLE multichangedb1.multichange1 ADD COLUMN a INT")) // even this is an error because we have schema + explicit DB.
+	require.NoError(t, run("ALTER TABLE multichange2 ADD COLUMN a INT; ALTER TABLE multichange3 ADD COLUMN a INT"))
 }
 
 // TestAutoIncrementEmptyTable tests that AUTO_INCREMENT is preserved when migrating


### PR DESCRIPTION
## Summary

Fixes #769 

Fixes the latent flake and improves the diagnostic shape of `SingleChecker`'s retry-exhausted error so the next occurrence (here or elsewhere) is actually triagable.

- **Behavioral fix.** `TestMultiChangesDifferentSchemas` reused a single `*Migration` across five sequential `Run()` calls. Reusing a `*Migration` is not a supported production path, and stale state from prior failed Runs was the most plausible explanation for the symptom in #769 (three identical `context canceled` errors on attempts 1–3 with `checksum-progress=0/1 0.00%`). Build a fresh `*Migration` per Run in this test.
- **Bail out early on cancelled parent ctx** in `SingleChecker.Run()`. Once the parent ctx is cancelled, every subsequent attempt fails the same way at the first ctx-aware call — return `ctx.Err()` directly instead of the generic "checksum failed after N attempts" wrapper.
- **Differentiate the final retry-exhausted error.** Split into:
  - `checksum errored on every attempt (N/N); last error: %w` — the underlying error is wrapped, so context cancellations / connection issues / etc. surface verbatim.
  - `checksum found differences on every attempt (N/N). This likely indicates either a bug in Spirit, or a manual modification to the _new table…` — keeps the original guidance for the lossy-ALTER / real-bug shape.

  Previously the single message pointed users at "a bug in Spirit, or a manual modification to the _new table" even when every attempt was just `context.Canceled`.

The `pkg/migration/runner.go` lossy-unique-index wrapper is unchanged, so `TestUniqueIndexAddNonUnique`-style tests continue to assert the same user-facing message.

## Test plan
- [x] `TestMultiChangesDifferentSchemas` passes locally.
- [x] `pkg/checksum/...` test suite passes (updated `TestUnfixableUniqueChecksum` to match the new wording on the diff path).
- [x] `pkg/migration/...` test suite passes on a clean re-run.
- [ ] CI green.

The hard-to-repro nature of the flake means we can't directly prove the fix; the test change removes the only known mechanism for cross-Run state leakage in this test, and the diagnostic changes ensure that if anything *like* this recurs the failure mode is much clearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)