### PR TITLE
fix(#766,#772): pin chunk size in binlog E2E tests via SetDynamicChunking

### DIFF
--- a/pkg/migration/binlog_test.go
+++ b/pkg/migration/binlog_test.go
@@ -140,6 +140,11 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, m.setup(t.Context()))
 
+	// Pin chunk size so a slow first chunk under CI load can't shrink the
+	// chunker via the panic path and cause the second chunk to come back
+	// with both bounds (see issue #766).
+	disableDynamicChunking(t, m.copyChunker)
+
 	// Now we are ready to start copying rows.
 	// Instead of calling m.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
@@ -922,6 +927,11 @@ func TestE2EBinlogSubscribingRogueValues(t *testing.T) {
 
 	require.NoError(t, m.setup(t.Context()))
 
+	// Pin chunk size so a slow first chunk under CI load can't shrink the
+	// chunker via the panic path and cause the second chunk to come back
+	// with both bounds (see issue #772).
+	disableDynamicChunking(t, m.copyChunker)
+
 	// Now we are ready to start copying rows.
 	// Instead of calling m.copyRows() we will step through it manually.
 	// Since we want to checkpoint after a few chunks.
@@ -982,4 +992,15 @@ func TestE2EBinlogSubscribingRogueValues(t *testing.T) {
 	require.NoError(t, m.checksum(t.Context()))
 	require.Equal(t, "postChecksum", m.status.Get().String())
 	// All done!
+}
+
+// disableDynamicChunking turns off the chunker's adaptive resizing so the
+// caller sees a stable ChunkSize regardless of per-chunk timing under CI
+// load. Tests that assert exact chunk boundaries should call this after
+// setup; production callers should leave dynamic chunking on.
+func disableDynamicChunking(t *testing.T, c table.Chunker) {
+	t.Helper()
+	setter, ok := c.(interface{ SetDynamicChunking(bool) })
+	require.True(t, ok, "copyChunker does not expose SetDynamicChunking")
+	setter.SetDynamicChunking(false)
 }

--- a/pkg/migration/binlog_test.go
+++ b/pkg/migration/binlog_test.go
@@ -993,14 +993,3 @@ func TestE2EBinlogSubscribingRogueValues(t *testing.T) {
 	require.Equal(t, "postChecksum", m.status.Get().String())
 	// All done!
 }
-
-// disableDynamicChunking turns off the chunker's adaptive resizing so the
-// caller sees a stable ChunkSize regardless of per-chunk timing under CI
-// load. Tests that assert exact chunk boundaries should call this after
-// setup; production callers should leave dynamic chunking on.
-func disableDynamicChunking(t *testing.T, c table.Chunker) {
-	t.Helper()
-	setter, ok := c.(interface{ SetDynamicChunking(bool) })
-	require.True(t, ok, "copyChunker does not expose SetDynamicChunking")
-	setter.SetDynamicChunking(false)
-}

--- a/pkg/migration/helpers_test.go
+++ b/pkg/migration/helpers_test.go
@@ -6,10 +6,22 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
+
+// disableDynamicChunking turns off the chunker's adaptive resizing so the
+// caller sees a stable ChunkSize regardless of per-chunk timing under CI
+// load. Tests that assert exact chunk boundaries should call this after
+// setup; production callers should leave dynamic chunking on.
+func disableDynamicChunking(t *testing.T, c table.Chunker) {
+	t.Helper()
+	setter, ok := c.(interface{ SetDynamicChunking(bool) })
+	require.True(t, ok, "copyChunker does not expose SetDynamicChunking")
+	setter.SetDynamicChunking(false)
+}
 
 // mkPtr returns a pointer to the given value. Useful for optional fields.
 func mkPtr[T any](t T) *T {

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -129,17 +129,6 @@ func TestCheckpoint(t *testing.T) {
 		require.NoError(t, r.changes[0].dropOldTable(t.Context()))
 		return r
 	}
-	// disableDynamicChunking turns off the optimistic chunker's adaptive
-	// resizing so this test sees a stable ChunkSize=1000 regardless of
-	// per-chunk timing under CI load. The test asserts watermark contents,
-	// not chunker auto-sizing behavior.
-	disableDynamicChunking := func(c table.Chunker) {
-		t.Helper()
-		setter, ok := c.(interface{ SetDynamicChunking(bool) })
-		require.True(t, ok, "copyChunker does not expose SetDynamicChunking")
-		setter.SetDynamicChunking(false)
-	}
-
 	r := preSetup()
 	// migrationRunner.Run usually calls r.Setup() here.
 	// Which first checks if the table can be restored from checkpoint.
@@ -147,7 +136,7 @@ func TestCheckpoint(t *testing.T) {
 	require.Error(t, r.resumeFromCheckpoint(t.Context()))
 	// So we proceed with the initial steps.
 	require.NoError(t, r.newMigration(t.Context()))
-	disableDynamicChunking(r.copyChunker)
+	disableDynamicChunking(t, r.copyChunker)
 
 	// Now we are ready to start copying rows.
 	// Instead of calling r.copyRows() we will step through it manually.
@@ -207,7 +196,7 @@ func TestCheckpoint(t *testing.T) {
 	// Start the binary log feed just before copy rows starts.
 	// replClient.Run() is already called in resumeFromCheckpoint.
 	require.NoError(t, r.resumeFromCheckpoint(t.Context()))
-	disableDynamicChunking(r.copyChunker)
+	disableDynamicChunking(t, r.copyChunker)
 	// This opens the table at the checkpoint (table.OpenAtWatermark())
 	// which sets the chunkPtr at the LowerBound. It also has to position
 	// the watermark to this point so new watermarks "align" correctly.

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -17,15 +17,16 @@ import (
 type chunkerComposite struct {
 	sync.Mutex
 
-	Ti             *TableInfo
-	NewTi          *TableInfo // Destination table info
-	chunkSize      uint64
-	chunkPtrs      []Datum  // a list of Ptrs for each of the keys.
-	chunkKeys      []string // all the keys to chunk on (usually all the col names of the PK)
-	keyName        string   // the name of the key we are chunking on
-	where          string   // any additional WHERE conditions.
-	finalChunkSent bool
-	isOpen         bool
+	Ti                    *TableInfo
+	NewTi                 *TableInfo // Destination table info
+	chunkSize             uint64
+	chunkPtrs             []Datum  // a list of Ptrs for each of the keys.
+	chunkKeys             []string // all the keys to chunk on (usually all the col names of the PK)
+	keyName               string   // the name of the key we are chunking on
+	where                 string   // any additional WHERE conditions.
+	finalChunkSent        bool
+	isOpen                bool
+	disableDynamicChunker bool // only used by the test suite
 
 	columnMapping *ColumnMapping
 
@@ -218,6 +219,15 @@ func (t *chunkerComposite) Open() (err error) {
 	return t.open()
 }
 
+// SetDynamicChunking enables (true) or disables (false) the composite
+// chunker's dynamic chunk-size adaptation. Disabling is intended for tests
+// that need deterministic chunk sizes; production callers should leave it on.
+func (t *chunkerComposite) SetDynamicChunking(newValue bool) {
+	t.Lock()
+	defer t.Unlock()
+	t.disableDynamicChunker = !newValue
+}
+
 // OpenAtWatermark opens a table for the resume-from-checkpoint use case.
 // This will set the chunkPtr to a known safe value that is contained within
 // the checkpoint.
@@ -318,8 +328,8 @@ func (t *chunkerComposite) Feedback(chunk *Chunk, d time.Duration, actualRows ui
 
 	// Check if the feedback is based on an earlier chunker size.
 	// if it is, it is misleading to incorporate feedback now.
-	// We should just skip it.
-	if chunk.ChunkSize != t.chunkSize {
+	// We should just skip it. We also skip if dynamic chunking is disabled.
+	if chunk.ChunkSize != t.chunkSize || t.disableDynamicChunker {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Fixes https://github.com/block/spirit/issues/766 and Fixes https://github.com/block/spirit/issues/772
- Both tests assert a 2-chunk layout. Under CI load the first chunk's `CopyChunk` can exceed `ChunkerTarget*DynamicPanicFactor` (100ms × 5 = 500ms), tripping the composite chunker's panic path and shrinking `chunkSize` from 1000 to 100. The next prefetch then returns a real upper-bound row, so the second chunk comes back with both bounds and the equality check fails.
- Mirrors the optimistic-chunker fix from #770: expose `chunkerComposite.SetDynamicChunking` and have these two tests call it right after `m.setup()` to pin `ChunkSize=1000` deterministically.

## Test plan
- [x] `go test -run "TestE2EBinlogSubscribingCompositeKey$|TestE2EBinlogSubscribingRogueValues$" ./pkg/migration/`
- [x] `go test -run TestE2EBinlog ./pkg/migration/`
- [x] `go test ./pkg/table/...`
- [x] CI green across both flaky tests over multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)