### PR TITLE
fix(#773): wait for WatchTask goroutines in Runner.Close()

### DIFF
--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -73,6 +73,12 @@ type Runner struct {
 	logger     *slog.Logger
 	cancelFunc context.CancelFunc
 
+	// watchTaskWait blocks until the WatchTask goroutines (status/checkpoint
+	// dumpers) have exited. Set in startBackgroundRoutines and invoked from
+	// Close() before tearing down the database connection so that no late
+	// checkpoint INSERT can race with post-Close cleanup.
+	watchTaskWait func()
+
 	// MetricsSink
 	metricsSink metrics.Sink
 }
@@ -716,8 +722,10 @@ func (r *Runner) startBackgroundRoutines(ctx context.Context) {
 		go change.table.AutoUpdateStatistics(ctx, tableStatUpdateInterval, r.logger)
 	}
 	go r.replClient.StartPeriodicFlush(ctx, repl.DefaultFlushInterval)
-	// Start go routines for checkpointing and dumping status
-	status.WatchTask(ctx, r, r.logger)
+	// Start go routines for checkpointing and dumping status. The returned
+	// wait function is invoked from Close() so we can be sure no late
+	// checkpoint INSERT lands after teardown begins.
+	r.watchTaskWait = status.WatchTask(ctx, r, r.logger)
 }
 
 // setup performs all the initial steps to prepare for the migration,
@@ -889,6 +897,21 @@ func (r *Runner) createSentinelTable(ctx context.Context) error {
 
 func (r *Runner) Close() error {
 	r.status.Set(status.Close)
+	// Cancel the migration context so background goroutines started in
+	// startBackgroundRoutines (notably the status.WatchTask checkpoint
+	// dumper) observe ctx.Done() and exit. This is normally already done
+	// by Run's deferred cancel, but Close() may be called via paths that
+	// don't run that defer; calling it here is idempotent and cheap.
+	if r.cancelFunc != nil {
+		r.cancelFunc()
+	}
+	// Wait for the status/checkpoint dumper goroutines to exit *before*
+	// tearing down the database connection, so a late DumpCheckpoint INSERT
+	// cannot land in the checkpoint table after the caller assumes Close()
+	// has fully quiesced the runner.
+	if r.watchTaskWait != nil {
+		r.watchTaskWait()
+	}
 	for _, change := range r.changes {
 		err := change.Close()
 		if err != nil {

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -87,6 +87,11 @@ type Runner struct {
 	logger     *slog.Logger
 	cancelFunc context.CancelFunc
 	dbConfig   *dbconn.DBConfig
+
+	// watchTaskWait blocks until the WatchTask goroutines have exited.
+	// Set in startBackgroundRoutines and invoked from Close() so that
+	// late status/checkpoint goroutine activity cannot race with teardown.
+	watchTaskWait func()
 }
 
 var _ status.Task = (*Runner)(nil)
@@ -100,6 +105,17 @@ func NewRunner(m *Move) (*Runner, error) {
 }
 
 func (r *Runner) Close() error {
+	// Cancel the runner context so background goroutines (status.WatchTask)
+	// observe ctx.Done() and exit. Idempotent.
+	if r.cancelFunc != nil {
+		r.cancelFunc()
+	}
+	// Wait for the status/checkpoint dumper goroutines to exit before
+	// tearing down connections, so a late DumpCheckpoint cannot race with
+	// post-Close cleanup.
+	if r.watchTaskWait != nil {
+		r.watchTaskWait()
+	}
 	if r.copyChunker != nil {
 		if err := r.copyChunker.Close(); err != nil {
 			return err
@@ -725,8 +741,10 @@ func (r *Runner) startBackgroundRoutines(ctx context.Context) {
 		go r.sources[i].replClient.StartPeriodicFlush(ctx, repl.DefaultFlushInterval)
 	}
 
-	// Start go routines for checkpointing and dumping status
-	status.WatchTask(ctx, r, r.logger)
+	// Start go routines for checkpointing and dumping status. The returned
+	// wait function is invoked from Close() so we can be sure no late
+	// checkpoint INSERT lands after teardown begins.
+	r.watchTaskWait = status.WatchTask(ctx, r, r.logger)
 }
 
 // fatalError is the callback provided to the replication client.

--- a/pkg/status/task.go
+++ b/pkg/status/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -22,9 +23,25 @@ type Task interface {
 // WatchTask periodically does the status reporting for a task.
 // This includes writing to the logger the current state,
 // and dumping checkpoints.
-func WatchTask(ctx context.Context, task Task, logger *slog.Logger) {
-	go continuallyDumpStatus(ctx, task, logger)
-	go continuallyDumpCheckpoint(ctx, task, logger)
+//
+// It returns a wait function the caller can invoke during shutdown
+// to block until the spawned goroutines have exited. This avoids races
+// where a still-running checkpoint goroutine writes a fresh row after
+// the caller has closed/torn down the surrounding state — a pattern
+// that has produced flakes in tests that mutate the checkpoint table
+// after Run() returns (see #773).
+func WatchTask(ctx context.Context, task Task, logger *slog.Logger) (wait func()) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		continuallyDumpStatus(ctx, task, logger)
+	}()
+	go func() {
+		defer wg.Done()
+		continuallyDumpCheckpoint(ctx, task, logger)
+	}()
+	return wg.Wait
 }
 
 func continuallyDumpStatus(ctx context.Context, task Task, logger *slog.Logger) {

--- a/pkg/status/task.go
+++ b/pkg/status/task.go
@@ -32,15 +32,8 @@ type Task interface {
 // after Run() returns (see #773).
 func WatchTask(ctx context.Context, task Task, logger *slog.Logger) (wait func()) {
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		continuallyDumpStatus(ctx, task, logger)
-	}()
-	go func() {
-		defer wg.Done()
-		continuallyDumpCheckpoint(ctx, task, logger)
-	}()
+	wg.Go(func() { continuallyDumpStatus(ctx, task, logger) })
+	wg.Go(func() { continuallyDumpCheckpoint(ctx, task, logger) })
 	return wg.Wait
 }
 


### PR DESCRIPTION
## Summary
- Fixes https://github.com/block/spirit/issues/773
- `status.WatchTask` spawns the periodic status and checkpoint dumpers as fire-and-forget goroutines that exit only when their parent ctx is done. `Runner.Close()` did not wait for them: a late `DumpCheckpoint` INSERT could land *after* `Close()` returned, racing with test-side mutations of the checkpoint table.
- In `TestResumeFromCheckpointCleanupOnFailure` this manifests as the checkpoint UPDATE being out-raced by a background INSERT — the new row has a higher auto-increment id and a real binlog name, so the resumed migration's `ORDER BY id DESC LIMIT 1` picks the *valid* row and sets `usedResumeFromCheckpoint=true`, failing `require.False(t, m2.usedResumeFromCheckpoint)`.
- Have `WatchTask` return a wait function. Both callers (`pkg/migration`, `pkg/move`) store it and invoke it from `Close()` (after cancelling their ctx) before tearing down DB connections. `Close()` also now invokes the runner's `cancelFunc` explicitly so the background goroutines are guaranteed to observe `ctx.Done()` even on paths that bypass `Run`'s deferred cancel.
- This is the broader of the two fixes morgo proposed in the issue (option 2). It eliminates this whole class of \"late background-goroutine writes after Close\" races, not just the specific symptom in #773.

## Test plan
- [x] `go test -run TestResumeFromCheckpointCleanupOnFailure -count=5 ./pkg/migration/`
- [x] `go test -run TestResumeFrom -count=2 ./pkg/migration/` (all resume tests, ~130s)
- [x] `go test -short ./pkg/migration/...` (no regressions; only pre-existing privilege-test failures unrelated to this change)
- [x] `go build ./... && go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)