### PR TITLE
fix(#771): validate connection with Ping in testutils.RunSQL

### DIFF
--- a/pkg/testutils/testing.go
+++ b/pkg/testutils/testing.go
@@ -5,7 +5,10 @@ package testutils
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"sync"
@@ -100,25 +103,81 @@ func CreateUniqueTestDatabase(t *testing.T) (string, *sql.DB) {
 func RunSQLInDatabase(t *testing.T, dbName, stmt string) {
 	t.Helper()
 	dsn := DSNForDatabase(dbName)
-	db, err := sql.Open("mysql", dsn)
-	assert.NoError(t, err)
-	defer func() {
-		_ = db.Close()
-	}()
-	_, err = db.ExecContext(t.Context(), stmt)
+	err := execWithRetry(t.Context(), dsn, stmt)
 	assert.NoError(t, err)
 }
 
 func RunSQL(t *testing.T, stmt string) {
 	t.Helper()
-	db, err := sql.Open("mysql", DSN())
-	assert.NoError(t, err)
-	defer func() {
-		_ = db.Close()
-	}()
 	// Might be run in cleanup, use Background context
-	_, err = db.ExecContext(context.Background(), stmt)
+	err := execWithRetry(context.Background(), DSN(), stmt)
 	assert.NoError(t, err)
+}
+
+// execWithRetry opens a DB pool, executes stmt, and closes the pool.
+//
+// Under heavy parallel test load we have observed transient
+// "invalid connection" failures (mysql.ErrInvalidConn) on the very first
+// query against a freshly-opened pool — likely the server briefly
+// dropping the connection during the handshake, or a TCP RST. See #771.
+//
+// We do NOT retry the Exec itself, since the mysql driver returns
+// ErrInvalidConn for failures both before and after the query was sent
+// to the server, and a blind Exec retry could double-apply a
+// non-idempotent statement (INSERT, CREATE TABLE, etc.). Instead we
+// front the Exec with a Ping that we *do* retry — Ping has no
+// side-effects, so retrying it is always safe. Once Ping succeeds we
+// know the pool has a verified live connection, and the subsequent
+// Exec is highly unlikely to hit the same transient handshake glitch.
+func execWithRetry(ctx context.Context, dsn, stmt string) error {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	const maxPingAttempts = 4
+	for attempt := 0; attempt < maxPingAttempts; attempt++ {
+		if attempt > 0 {
+			// Brief randomized backoff so a thundering herd of parallel
+			// helpers don't all retry simultaneously.
+			delay := time.Duration(20*(1<<attempt))*time.Millisecond +
+				time.Duration(rand.Intn(50))*time.Millisecond
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		err = db.PingContext(ctx)
+		if err == nil {
+			break
+		}
+		if !isTransientConnError(err) {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = db.ExecContext(ctx, stmt)
+	return err
+}
+
+// isTransientConnError reports whether err looks like a transient
+// connection-level failure that is safe to retry. We deliberately match
+// on a small whitelist (driver.ErrBadConn and mysql.ErrInvalidConn) plus
+// a substring fallback because the mysql driver returns ErrInvalidConn
+// wrapped in op-specific contexts in some code paths.
+func isTransientConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) {
+		return true
+	}
+	return strings.Contains(err.Error(), "invalid connection")
 }
 
 var (


### PR DESCRIPTION
## Summary
- Fixes https://github.com/block/spirit/issues/771 (the RunSQL surface)
- `testutils.RunSQL` and `RunSQLInDatabase` open a fresh DB pool, run a single statement, and close the pool. Under heavy parallel test load (many `t.Parallel` tests each spinning up their own pool) we have observed transient \"invalid connection\" failures from the mysql driver on the very first query against a fresh pool — likely the server briefly dropping the connection during the handshake, or a TCP RST.
- Front the Exec with a `PingContext` that we retry on `driver.ErrBadConn` / `mysql.ErrInvalidConn` (up to 4 attempts, exponential backoff with jitter). Ping has no side effects, so retrying it is always safe. Once Ping succeeds the pool has a verified live connection, and the follow-up Exec is highly unlikely to hit the same transient handshake glitch.
- We deliberately do NOT retry the Exec itself: the mysql driver returns `ErrInvalidConn` for failures both before and after the query was sent, so a blind Exec retry could double-apply non-idempotent statements (INSERT, CREATE TABLE, etc.).

## Caveats
- This only addresses the RunSQL surface of #771 (e.g. `setupTestTables → DROP TABLE IF EXISTS` failing on first connection). The other pattern in the issue (an `m.Run()` returning \"invalid connection\" mid-migration, e.g. `TestPartitionedTable`) is a separate, deeper failure mode.

## Test plan
- [x] `go test -run TestAllChangesFlushed -count=3 ./pkg/repl/`
- [x] `go build ./... && go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)