### PR TITLE
fix(#771): reduce CI test parallelism from 4 to 2

### DIFF
--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -21,7 +21,7 @@ services:
   test:
     build:
       context: ../
-    command: bash -c "go test -json -race -v  -timeout=10m -parallel=4  ./... | tee /proc/1/fd/1 | tparse -all"
+    command: bash -c "go test -json -race -v  -timeout=10m -parallel=2  ./... | tee /proc/1/fd/1 | tparse -all"
     depends_on:
       mysql:
         condition: service_healthy

--- a/compose/replication-tls/replication-ci.yml
+++ b/compose/replication-tls/replication-ci.yml
@@ -47,7 +47,7 @@ services:
   test:
     build:
       context: ../../.
-    command: go test -race -timeout=10m -parallel=4  ./...
+    command: go test -race -timeout=10m -parallel=2  ./...
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Fixes https://github.com/block/spirit/issues/771
- The \"invalid connection\" flake (`TestAllChangesFlushed`, `TestPartitionedTable`, etc.) looks consistent with the test MySQL server being overloaded by too many simultaneous connections — many `t.Parallel` tests each spinning up their own pools, plus the runner's own pool, hammering a single mysqld instance.
- Halving the per-package `-parallel` value gives the server more headroom. Both compose CI configs (`compose/compose.yml` and `compose/replication-tls/replication-ci.yml`) updated.
- Production callers do not retry transient driver errors at this level, so it would be wrong to do so in test helpers; reducing concurrency addresses the root cause.

## Test plan
- [x] CI run on this PR (the actual signal — flaky tests should stop reproducing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)