### PR TITLE
test(#788): migrate pkg/utils tests to require.*

### DIFF
--- a/pkg/utils/close_test.go
+++ b/pkg/utils/close_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock closers for testing
@@ -38,7 +38,7 @@ func (m *mockContextCloser) Close(ctx context.Context) error {
 
 func TestCloseAndLog(t *testing.T) {
 	t.Run("nil closer should not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() {
+		require.NotPanics(t, func() {
 			CloseAndLog(nil)
 		})
 	})
@@ -46,16 +46,16 @@ func TestCloseAndLog(t *testing.T) {
 	t.Run("successful close", func(t *testing.T) {
 		closer := &mockCloser{shouldFail: false}
 		CloseAndLog(closer)
-		assert.True(t, closer.closed, "Close should have been called")
+		require.True(t, closer.closed, "Close should have been called")
 	})
 
 	t.Run("failed close logs error", func(t *testing.T) {
 		closer := &mockCloser{shouldFail: true}
 		// The function will log an error, but should not panic
-		assert.NotPanics(t, func() {
+		require.NotPanics(t, func() {
 			CloseAndLog(closer)
 		})
-		assert.True(t, closer.closed, "Close should have been called even though it failed")
+		require.True(t, closer.closed, "Close should have been called even though it failed")
 	})
 }
 
@@ -63,7 +63,7 @@ func TestCloseAndLogWithContext(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("nil closer should not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() {
+		require.NotPanics(t, func() {
 			CloseAndLogWithContext(ctx, nil)
 		})
 	})
@@ -71,16 +71,16 @@ func TestCloseAndLogWithContext(t *testing.T) {
 	t.Run("successful close", func(t *testing.T) {
 		closer := &mockContextCloser{shouldFail: false}
 		CloseAndLogWithContext(ctx, closer)
-		assert.True(t, closer.closed, "Close should have been called")
+		require.True(t, closer.closed, "Close should have been called")
 	})
 
 	t.Run("failed close logs error", func(t *testing.T) {
 		closer := &mockContextCloser{shouldFail: true}
 		// The function will log an error, but should not panic
-		assert.NotPanics(t, func() {
+		require.NotPanics(t, func() {
 			CloseAndLogWithContext(ctx, closer)
 		})
-		assert.True(t, closer.closed, "Close should have been called even though it failed")
+		require.True(t, closer.closed, "Close should have been called even though it failed")
 	})
 
 	t.Run("canceled context", func(t *testing.T) {
@@ -88,9 +88,9 @@ func TestCloseAndLogWithContext(t *testing.T) {
 		cancel() // Cancel immediately
 		closer := &mockContextCloser{shouldFail: false}
 		// Should still work even with canceled context
-		assert.NotPanics(t, func() {
+		require.NotPanics(t, func() {
 			CloseAndLogWithContext(canceledCtx, closer)
 		})
-		assert.True(t, closer.closed, "Close should have been called")
+		require.True(t, closer.closed, "Close should have been called")
 	})
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -16,36 +16,36 @@ func TestHashAndUnhashKey(t *testing.T) {
 	// This func helps put composite keys in a map.
 	key := []any{"1234", "ACDC", "12"}
 	hashed := HashKey(key)
-	assert.Equal(t, "1234-#-ACDC-#-12", hashed)
+	require.Equal(t, "1234-#-ACDC-#-12", hashed)
 	unhashed := UnhashKeyToString(hashed)
 	// unhashed returns as a string, not the original any
-	assert.Equal(t, "('1234','ACDC','12')", unhashed)
+	require.Equal(t, "('1234','ACDC','12')", unhashed)
 
 	// This also works on single keys.
 	key = []any{"1234"}
 	hashed = HashKey(key)
-	assert.Equal(t, "1234", hashed)
+	require.Equal(t, "1234", hashed)
 	unhashed = UnhashKeyToString(hashed)
-	assert.Equal(t, "'1234'", unhashed)
+	require.Equal(t, "'1234'", unhashed)
 }
 
 func TestTruncateTableName(t *testing.T) {
 	// Short name that doesn't need truncation
-	assert.Equal(t, "mytable", TruncateTableName("mytable", 21))
+	require.Equal(t, "mytable", TruncateTableName("mytable", 21))
 
 	// Name that exactly fits (64 - 21 = 43)
 	name43 := strings.Repeat("a", 43)
-	assert.Equal(t, name43, TruncateTableName(name43, 21))
+	require.Equal(t, name43, TruncateTableName(name43, 21))
 
 	// Name that exceeds the limit and needs truncation
 	name56 := strings.Repeat("b", 56)
-	assert.Equal(t, strings.Repeat("b", 43), TruncateTableName(name56, 21))
+	require.Equal(t, strings.Repeat("b", 43), TruncateTableName(name56, 21))
 
 	// Zero suffix length means full 64 chars available
 	name64 := strings.Repeat("d", 64)
-	assert.Equal(t, name64, TruncateTableName(name64, 0))
+	require.Equal(t, name64, TruncateTableName(name64, 0))
 
 	// Name longer than 64 with zero suffix gets truncated to 64
 	name70 := strings.Repeat("e", 70)
-	assert.Equal(t, strings.Repeat("e", 64), TruncateTableName(name70, 0))
+	require.Equal(t, strings.Repeat("e", 64), TruncateTableName(name70, 0))
 }


### PR DESCRIPTION
Closes #788. Part of #779.

## Summary
- Migrate `assert.*` → `require.*` in `pkg/utils/*_test.go` where appropriate.
- Loop and table-driven assertions kept as `assert.*` where seeing all failures at once is preferable.
- No production code changes.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)