### PR TITLE
test(#786): migrate pkg/checksum tests to require.*

### DIFF
--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
 	mysql "github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,9 +76,9 @@ func TestFixCorruptWithApplier(t *testing.T) {
 
 	checker, err := NewChecker([]*sql.DB{src}, chunker, []*repl.Client{feed}, config)
 	require.NoError(t, err)
-	assert.Equal(t, "0/3 0.00%", checker.GetProgress())
+	require.Equal(t, "0/3 0.00%", checker.GetProgress())
 	require.NoError(t, checker.Run(t.Context())) // should be fixed!
-	assert.Equal(t, "3/3 100.00%", checker.GetProgress())
+	require.Equal(t, "3/3 100.00%", checker.GetProgress())
 }
 
 func TestDistributedChecksum(t *testing.T) {

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestFixCorruptWithApplier(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	newDBName, _ := testutils.CreateUniqueTestDatabase(t)
 
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS corruptt1")
@@ -37,16 +37,16 @@ func TestFixCorruptWithApplier(t *testing.T) {
 	destDB.DBName = newDBName
 
 	src, err := dbconn.New(cfg.FormatDSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(src)
 	dest, err := dbconn.New(destDB.FormatDSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(dest)
 
 	t1 := table.NewTableInfo(src, "test", "corruptt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(dest, newDBName, "corruptt1")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 	target := applier.Target{
 		DB:       dest,
@@ -66,19 +66,19 @@ func TestFixCorruptWithApplier(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
 	config.FixDifferences = true
 	config.Applier = applier
 
 	checker, err := NewChecker([]*sql.DB{src}, chunker, []*repl.Client{feed}, config)
+	require.NoError(t, err)
 	assert.Equal(t, "0/3 0.00%", checker.GetProgress())
-	assert.NoError(t, err)
-	assert.NoError(t, checker.Run(t.Context())) // should be fixed!
+	require.NoError(t, checker.Run(t.Context())) // should be fixed!
 	assert.Equal(t, "3/3 100.00%", checker.GetProgress())
 }
 
@@ -196,7 +196,7 @@ func TestDistributedChecksum(t *testing.T) {
 	err = sourceDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM t1").Scan(&sourceCount)
 	require.NoError(t, err)
 
-	assert.Equal(t, sourceCount, shard0Count+shard1Count, "Total rows in shards should equal source")
+	require.Equal(t, sourceCount, shard0Count+shard1Count, "Total rows in shards should equal source")
 }
 
 // TestDistributedChecksumNtoM tests the distributed checksum with 2 sources and 2 targets (N:M).

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/block/spirit/pkg/utils"
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -29,17 +30,17 @@ func TestBasicChecksum(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO _basic_checksum_new VALUES (1, 2, 3)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "basic_checksum")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_basic_checksum_new")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -48,14 +49,14 @@ func TestBasicChecksum(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, checker.Run(t.Context()))
+	require.NoError(t, checker.Run(t.Context()))
 }
 
 func TestBasicValidation(t *testing.T) {
@@ -67,17 +68,17 @@ func TestBasicValidation(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO basic_validation2 VALUES (1, 2, 3)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "basic_validation")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "basic_validation2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -86,9 +87,9 @@ func TestBasicValidation(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
 
 	_, err = NewChecker(nil, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig()) // no source DBs
 	assert.EqualError(t, err, "at least one source database must be provided")
@@ -124,17 +125,17 @@ func TestUnfixableUniqueChecksum(t *testing.T) {
 	testutils.RunSQL(t, `INSERT IGNORE INTO uniqfailuret2 SELECT * FROM uniqfailuret1`)       // will not copy all data
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "uniqfailuret1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "uniqfailuret2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -143,22 +144,22 @@ func TestUnfixableUniqueChecksum(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
 	config.FixDifferences = true
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = checker.Run(t.Context())
 	// Adding a UNIQUE INDEX to non-unique data: every attempt finds row
 	// differences (and recopies don't help), so we exhaust retries on the
 	// "found differences" path. The migration layer wraps this into a more
 	// user-friendly "lossy unique-index" message; here we just assert the
 	// underlying checksum-layer error.
-	assert.ErrorContains(t, err, "checksum found differences on every attempt")
+	require.ErrorContains(t, err, "checksum found differences on every attempt")
 }
 
 func TestFixCorrupt(t *testing.T) {
@@ -171,17 +172,17 @@ func TestFixCorrupt(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO _fixcorruption_t1_new VALUES (2, 2, 3)") // corrupt
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "fixcorruption_t1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_fixcorruption_t1_new")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -190,31 +191,31 @@ func TestFixCorrupt(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
 	config.FixDifferences = true
 	config.MaxRetries = 2
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = checker.Run(t.Context())
-	assert.NoError(t, err) // yes there is corruption, but it was fixed.
+	require.NoError(t, err) // yes there is corruption, but it was fixed.
 
 	// Type assert the checker to *SingleChecker to access differencesFound
 	singleChecker, ok := checker.(*SingleChecker)
-	assert.True(t, ok, "checker is not of type *SingleChecker")
+	require.True(t, ok, "checker is not of type *SingleChecker")
 	assert.Equal(t, uint64(0), singleChecker.differencesFound.Load()) // this is "0", because we fixed it.
 
 	// If we run the checker again, it will report zero differences.
 	checker2, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = checker2.Run(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	singleChecker, ok = checker2.(*SingleChecker)
-	assert.True(t, ok, "checker2 is not of type *SingleChecker")
+	require.True(t, ok, "checker2 is not of type *SingleChecker")
 	assert.Equal(t, uint64(0), singleChecker.differencesFound.Load())
 }
 
@@ -228,17 +229,17 @@ func TestCorruptChecksum(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO _chkpcorruptt1_new VALUES (2, 2, 3)") // corrupt
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "chkpcorruptt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_chkpcorruptt1_new")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -247,17 +248,17 @@ func TestCorruptChecksum(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	singleChecker, ok := checker.(*SingleChecker)
-	assert.True(t, ok, "checker is not of type *SingleChecker")
+	require.True(t, ok, "checker is not of type *SingleChecker")
 	err = singleChecker.runChecksum(t.Context())
-	assert.ErrorContains(t, err, "checksum mismatch")
+	require.ErrorContains(t, err, "checksum mismatch")
 }
 
 func TestBoundaryCases(t *testing.T) {
@@ -269,17 +270,17 @@ func TestBoundaryCases(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO _checkert1_new VALUES (1, 2.2, NULL)") // should not compare
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "checkert1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_checkert1_new")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -288,26 +289,26 @@ func TestBoundaryCases(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Type assert to *SingleChecker to access runChecksum
 	singleChecker, ok := checker.(*SingleChecker)
-	assert.True(t, ok, "checker is not of type *SingleChecker")
-	assert.Error(t, singleChecker.runChecksum(t.Context()))
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	require.Error(t, singleChecker.runChecksum(t.Context()))
 
 	// UPDATE t1 to also be NULL
 	testutils.RunSQL(t, "UPDATE checkert1 SET c = NULL")
 	checker, err = NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Type assert to *SingleChecker to access runChecksum
 	singleChecker, ok = checker.(*SingleChecker)
-	assert.True(t, ok, "checker is not of type *SingleChecker")
-	assert.NoError(t, singleChecker.runChecksum(t.Context()))
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	require.NoError(t, singleChecker.runChecksum(t.Context()))
 }
 
 func TestChangeDataTypeDatetime(t *testing.T) {
@@ -346,17 +347,17 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 	testutils.RunSQL(t, "CREATE TABLE IF NOT EXISTS _tdatetime_chkpnt (id int)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "tdatetime")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_tdatetime_new")
-	assert.NoError(t, t2.SetInfo(t.Context())) // fails
+	require.NoError(t, t2.SetInfo(t.Context())) // fails
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -365,14 +366,14 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig())
-	assert.NoError(t, err)
-	assert.NoError(t, checker.Run(t.Context())) // fails
+	require.NoError(t, err)
+	require.NoError(t, checker.Run(t.Context())) // fails
 }
 
 func TestYieldTimeout(t *testing.T) {
@@ -388,17 +389,17 @@ func TestYieldTimeout(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO _yield_t1_new SELECT * FROM yield_t1")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "yield_t1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_yield_t1_new")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -407,10 +408,10 @@ func TestYieldTimeout(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
 	config.Concurrency = 1
@@ -421,10 +422,10 @@ func TestYieldTimeout(t *testing.T) {
 	// but short enough to trigger multiple yields over 100k rows.
 	config.YieldTimeout = 100 * time.Millisecond
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// The checksum should still pass despite yielding — it resumes from the watermark.
-	assert.NoError(t, checker.Run(t.Context()))
+	require.NoError(t, checker.Run(t.Context()))
 
 	// Verify that at least one yield actually occurred.
 	singleChecker := checker.(*SingleChecker)
@@ -440,17 +441,17 @@ func TestFromWatermark(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO _tfromwatermark_new VALUES (1, 2, 3)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "tfromwatermark")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_tfromwatermark_new")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, &repl.ClientConfig{
 		Logger:          logger,
 		Concurrency:     4,
@@ -459,14 +460,14 @@ func TestFromWatermark(t *testing.T) {
 	})
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	assert.NoError(t, err)
-	assert.NoError(t, feed.AddSubscription(t1, t2, chunker))
-	assert.NoError(t, feed.Run(t.Context()))
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Run(t.Context()))
+	require.NoError(t, chunker.Open())
 
 	config := NewCheckerDefaultConfig()
 	config.Watermark = "{\"Key\":[\"a\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\": [\"2\"],\"Inclusive\":true},\"UpperBound\":{\"Value\": [\"3\"],\"Inclusive\":false}}"
 	checker, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, config)
-	assert.NoError(t, err)
-	assert.NoError(t, checker.Run(t.Context()))
+	require.NoError(t, err)
+	require.NoError(t, checker.Run(t.Context()))
 }

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
 	mysql "github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -92,13 +91,13 @@ func TestBasicValidation(t *testing.T) {
 	require.NoError(t, feed.Run(t.Context()))
 
 	_, err = NewChecker(nil, chunker, []*repl.Client{feed}, NewCheckerDefaultConfig()) // no source DBs
-	assert.EqualError(t, err, "at least one source database must be provided")
+	require.EqualError(t, err, "at least one source database must be provided")
 
 	_, err = NewChecker([]*sql.DB{db}, nil, []*repl.Client{feed}, NewCheckerDefaultConfig())
-	assert.EqualError(t, err, "chunker must be non-nil")
+	require.EqualError(t, err, "chunker must be non-nil")
 
 	_, err = NewChecker([]*sql.DB{db}, chunker, nil, NewCheckerDefaultConfig()) // no feed
-	assert.EqualError(t, err, "at least one feed must be provided")
+	require.EqualError(t, err, "at least one feed must be provided")
 }
 
 func TestUnfixableUniqueChecksum(t *testing.T) {
@@ -207,7 +206,7 @@ func TestFixCorrupt(t *testing.T) {
 	// Type assert the checker to *SingleChecker to access differencesFound
 	singleChecker, ok := checker.(*SingleChecker)
 	require.True(t, ok, "checker is not of type *SingleChecker")
-	assert.Equal(t, uint64(0), singleChecker.differencesFound.Load()) // this is "0", because we fixed it.
+	require.Equal(t, uint64(0), singleChecker.differencesFound.Load()) // this is "0", because we fixed it.
 
 	// If we run the checker again, it will report zero differences.
 	checker2, err := NewChecker([]*sql.DB{db}, chunker, []*repl.Client{feed}, config)
@@ -216,7 +215,7 @@ func TestFixCorrupt(t *testing.T) {
 	require.NoError(t, err)
 	singleChecker, ok = checker2.(*SingleChecker)
 	require.True(t, ok, "checker2 is not of type *SingleChecker")
-	assert.Equal(t, uint64(0), singleChecker.differencesFound.Load())
+	require.Equal(t, uint64(0), singleChecker.differencesFound.Load())
 }
 
 func TestCorruptChecksum(t *testing.T) {
@@ -429,7 +428,7 @@ func TestYieldTimeout(t *testing.T) {
 
 	// Verify that at least one yield actually occurred.
 	singleChecker := checker.(*SingleChecker)
-	assert.Greater(t, singleChecker.yieldsPerformed.Load(), uint64(0), "expected at least one yield to occur")
+	require.Greater(t, singleChecker.yieldsPerformed.Load(), uint64(0), "expected at least one yield to occur")
 	t.Logf("yields performed: %d", singleChecker.yieldsPerformed.Load())
 }
 


### PR DESCRIPTION
Closes #786. Part of #779.

## Summary
- Migrate `assert.*` → `require.*` in `pkg/checksum/*_test.go` where appropriate.
- Loop and table-driven assertions kept as `assert.*` where seeing all failures at once is preferable.
- No production code changes.

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)