### PR TITLE
test(#782): migrate pkg/statement tests to require.*

### DIFF
--- a/pkg/statement/classify_test.go
+++ b/pkg/statement/classify_test.go
@@ -283,13 +283,13 @@ func TestClassifyUnknown(t *testing.T) {
 
 func TestClassifyInvalid(t *testing.T) {
 	_, err := Classify("NOT VALID SQL HERE !@#$")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = Classify("-- just a comment")
-	assert.ErrorIs(t, err, ErrNoStatements)
+	require.ErrorIs(t, err, ErrNoStatements)
 
 	_, err = Classify("")
-	assert.ErrorIs(t, err, ErrNoStatements)
+	require.ErrorIs(t, err, ErrNoStatements)
 }
 
 func TestStatementTypeString(t *testing.T) {

--- a/pkg/statement/classify_test.go
+++ b/pkg/statement/classify_test.go
@@ -234,22 +234,22 @@ func TestClassifyMultiStatement(t *testing.T) {
 	results, err := Classify("ALTER TABLE t1 ADD COLUMN a INT; ALTER TABLE t2 ADD COLUMN b INT")
 	require.NoError(t, err)
 	require.Len(t, results, 2)
-	assert.Equal(t, StatementAlterTable, results[0].Type)
-	assert.Equal(t, "t1", results[0].Table)
-	assert.Equal(t, StatementAlterTable, results[1].Type)
-	assert.Equal(t, "t2", results[1].Table)
+	require.Equal(t, StatementAlterTable, results[0].Type)
+	require.Equal(t, "t1", results[0].Table)
+	require.Equal(t, StatementAlterTable, results[1].Type)
+	require.Equal(t, "t2", results[1].Table)
 }
 
 func TestClassifyMixed(t *testing.T) {
 	results, err := Classify("INSERT INTO t1 (a) VALUES (1); ALTER TABLE t2 ADD COLUMN b INT")
 	require.NoError(t, err)
 	require.Len(t, results, 2)
-	assert.Equal(t, StatementInsert, results[0].Type)
-	assert.Equal(t, "t1", results[0].Table)
-	assert.True(t, results[0].Type.IsDML())
-	assert.Equal(t, StatementAlterTable, results[1].Type)
-	assert.Equal(t, "t2", results[1].Table)
-	assert.True(t, results[1].Type.IsDDL())
+	require.Equal(t, StatementInsert, results[0].Type)
+	require.Equal(t, "t1", results[0].Table)
+	require.True(t, results[0].Type.IsDML())
+	require.Equal(t, StatementAlterTable, results[1].Type)
+	require.Equal(t, "t2", results[1].Table)
+	require.True(t, results[1].Type.IsDDL())
 }
 
 func TestClassifyDropMultipleTables(t *testing.T) {
@@ -257,8 +257,8 @@ func TestClassifyDropMultipleTables(t *testing.T) {
 	results, err := Classify("DROP TABLE t1, t2, t3")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, StatementDropTable, results[0].Type)
-	assert.Equal(t, "t1", results[0].Table)
+	require.Equal(t, StatementDropTable, results[0].Type)
+	require.Equal(t, "t1", results[0].Table)
 }
 
 func TestClassifyTruncateShorthand(t *testing.T) {
@@ -266,8 +266,8 @@ func TestClassifyTruncateShorthand(t *testing.T) {
 	results, err := Classify("TRUNCATE t1")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, StatementTruncateTable, results[0].Type)
-	assert.Equal(t, "t1", results[0].Table)
+	require.Equal(t, StatementTruncateTable, results[0].Type)
+	require.Equal(t, "t1", results[0].Table)
 }
 
 func TestClassifyUnknown(t *testing.T) {
@@ -275,10 +275,10 @@ func TestClassifyUnknown(t *testing.T) {
 	results, err := Classify("SELECT 1")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, StatementUnknown, results[0].Type)
-	assert.False(t, results[0].Type.IsDDL())
-	assert.False(t, results[0].Type.IsDML())
-	assert.Equal(t, "UNKNOWN", results[0].Type.String())
+	require.Equal(t, StatementUnknown, results[0].Type)
+	require.False(t, results[0].Type.IsDDL())
+	require.False(t, results[0].Type.IsDML())
+	require.Equal(t, "UNKNOWN", results[0].Type.String())
 }
 
 func TestClassifyInvalid(t *testing.T) {
@@ -293,16 +293,16 @@ func TestClassifyInvalid(t *testing.T) {
 }
 
 func TestStatementTypeString(t *testing.T) {
-	assert.Equal(t, "ALTER TABLE", StatementAlterTable.String())
-	assert.Equal(t, "CREATE TABLE", StatementCreateTable.String())
-	assert.Equal(t, "DROP TABLE", StatementDropTable.String())
-	assert.Equal(t, "RENAME TABLE", StatementRenameTable.String())
-	assert.Equal(t, "TRUNCATE TABLE", StatementTruncateTable.String())
-	assert.Equal(t, "CREATE INDEX", StatementCreateIndex.String())
-	assert.Equal(t, "DROP INDEX", StatementDropIndex.String())
-	assert.Equal(t, "CREATE VIEW", StatementCreateView.String())
-	assert.Equal(t, "INSERT", StatementInsert.String())
-	assert.Equal(t, "UPDATE", StatementUpdate.String())
-	assert.Equal(t, "DELETE", StatementDelete.String())
-	assert.Equal(t, "UNKNOWN", StatementUnknown.String())
+	require.Equal(t, "ALTER TABLE", StatementAlterTable.String())
+	require.Equal(t, "CREATE TABLE", StatementCreateTable.String())
+	require.Equal(t, "DROP TABLE", StatementDropTable.String())
+	require.Equal(t, "RENAME TABLE", StatementRenameTable.String())
+	require.Equal(t, "TRUNCATE TABLE", StatementTruncateTable.String())
+	require.Equal(t, "CREATE INDEX", StatementCreateIndex.String())
+	require.Equal(t, "DROP INDEX", StatementDropIndex.String())
+	require.Equal(t, "CREATE VIEW", StatementCreateView.String())
+	require.Equal(t, "INSERT", StatementInsert.String())
+	require.Equal(t, "UPDATE", StatementUpdate.String())
+	require.Equal(t, "DELETE", StatementDelete.String())
+	require.Equal(t, "UNKNOWN", StatementUnknown.String())
 }

--- a/pkg/statement/declarative_test.go
+++ b/pkg/statement/declarative_test.go
@@ -22,7 +22,7 @@ func assertChangesContain(t *testing.T, changes []*AbstractStatement, expected [
 				break
 			}
 		}
-		assert.True(t, found, "expected some statement to contain %q, got %v", exp, strs)
+		require.True(t, found, "expected some statement to contain %q, got %v", exp, strs)
 	}
 }
 
@@ -229,10 +229,10 @@ func TestDeclarativeToImperative_OrderingCreateAlterBeforeDrop(t *testing.T) {
 	}
 
 	// Additionally verify the exact order of statement types.
-	assert.Contains(t, changes[0].Statement, "CREATE TABLE")
-	assert.Contains(t, changes[1].Statement, "ALTER TABLE")
-	assert.Contains(t, changes[2].Statement, "DROP TABLE")
-	assert.Contains(t, changes[3].Statement, "DROP TABLE")
+	require.Contains(t, changes[0].Statement, "CREATE TABLE")
+	require.Contains(t, changes[1].Statement, "ALTER TABLE")
+	require.Contains(t, changes[2].Statement, "DROP TABLE")
+	require.Contains(t, changes[3].Statement, "DROP TABLE")
 }
 
 func TestToTableSchema(t *testing.T) {
@@ -241,9 +241,9 @@ func TestToTableSchema(t *testing.T) {
 
 	ts, err := ct.ToTableSchema()
 	require.NoError(t, err)
-	assert.Equal(t, "t1", ts.Name)
-	assert.Contains(t, ts.Schema, "CREATE TABLE")
-	assert.Contains(t, ts.Schema, "t1")
-	assert.Contains(t, ts.Schema, "id")
-	assert.Contains(t, ts.Schema, "name")
+	require.Equal(t, "t1", ts.Name)
+	require.Contains(t, ts.Schema, "CREATE TABLE")
+	require.Contains(t, ts.Schema, "t1")
+	require.Contains(t, ts.Schema, "id")
+	require.Contains(t, ts.Schema, "name")
 }

--- a/pkg/statement/declarative_test.go
+++ b/pkg/statement/declarative_test.go
@@ -176,7 +176,7 @@ func TestDeclarativeToImperativeWithOptions(t *testing.T) {
 
 	changes, err := DeclarativeToImperative(current, desired, NewDiffOptions())
 	require.NoError(t, err)
-	assert.Empty(t, changes, "AUTO_INCREMENT differences should be ignored with default options")
+	require.Empty(t, changes, "AUTO_INCREMENT differences should be ignored with default options")
 }
 
 func TestDeclarativeToImperative_OrderingCreateAlterBeforeDrop(t *testing.T) {

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -1118,17 +1118,17 @@ func TestDiff_ChangePartitionType(t *testing.T) {
 	stmts, err := ct1.Diff(ct2, nil)
 	require.NoError(t, err)
 	require.Len(t, stmts, 2, "changing partition type should produce two statements")
-	assert.Equal(t, "ALTER TABLE `t1` REMOVE PARTITIONING", stmts[0].Statement)
-	assert.Equal(t, "ALTER TABLE `t1` PARTITION BY KEY (`id`) PARTITIONS 4", stmts[1].Statement)
+	require.Equal(t, "ALTER TABLE `t1` REMOVE PARTITIONING", stmts[0].Statement)
+	require.Equal(t, "ALTER TABLE `t1` PARTITION BY KEY (`id`) PARTITIONS 4", stmts[1].Statement)
 }
 
 func TestNewDiffOptions(t *testing.T) {
 	opts := NewDiffOptions()
-	assert.True(t, opts.IgnoreAutoIncrement, "IgnoreAutoIncrement should default to true")
-	assert.True(t, opts.IgnoreEngine, "IgnoreEngine should default to true")
-	assert.False(t, opts.IgnoreCharsetCollation, "IgnoreCharsetCollation should default to false")
-	assert.False(t, opts.IgnorePartitioning, "IgnorePartitioning should default to false")
-	assert.True(t, opts.IgnoreRowFormat, "IgnoreRowFormat should default to true")
+	require.True(t, opts.IgnoreAutoIncrement, "IgnoreAutoIncrement should default to true")
+	require.True(t, opts.IgnoreEngine, "IgnoreEngine should default to true")
+	require.False(t, opts.IgnoreCharsetCollation, "IgnoreCharsetCollation should default to false")
+	require.False(t, opts.IgnorePartitioning, "IgnorePartitioning should default to false")
+	require.True(t, opts.IgnoreRowFormat, "IgnoreRowFormat should default to true")
 }
 
 // TestHelperFunctions tests the helper functions used in diff.go
@@ -1138,11 +1138,11 @@ func TestHelperFunctions(t *testing.T) {
 		str2 := "test"
 		str3 := "different"
 
-		assert.True(t, stringPtrEqual(nil, nil))
-		assert.True(t, stringPtrEqual(&str1, &str2))
-		assert.False(t, stringPtrEqual(&str1, nil))
-		assert.False(t, stringPtrEqual(nil, &str1))
-		assert.False(t, stringPtrEqual(&str1, &str3))
+		require.True(t, stringPtrEqual(nil, nil))
+		require.True(t, stringPtrEqual(&str1, &str2))
+		require.False(t, stringPtrEqual(&str1, nil))
+		require.False(t, stringPtrEqual(nil, &str1))
+		require.False(t, stringPtrEqual(&str1, &str3))
 	})
 
 	t.Run("intPtrEqual", func(t *testing.T) {
@@ -1150,11 +1150,11 @@ func TestHelperFunctions(t *testing.T) {
 		int2 := 10
 		int3 := 20
 
-		assert.True(t, intPtrEqual(nil, nil))
-		assert.True(t, intPtrEqual(&int1, &int2))
-		assert.False(t, intPtrEqual(&int1, nil))
-		assert.False(t, intPtrEqual(nil, &int1))
-		assert.False(t, intPtrEqual(&int1, &int3))
+		require.True(t, intPtrEqual(nil, nil))
+		require.True(t, intPtrEqual(&int1, &int2))
+		require.False(t, intPtrEqual(&int1, nil))
+		require.False(t, intPtrEqual(nil, &int1))
+		require.False(t, intPtrEqual(&int1, &int3))
 	})
 
 	t.Run("boolPtrEqual", func(t *testing.T) {
@@ -1162,36 +1162,36 @@ func TestHelperFunctions(t *testing.T) {
 		bool2 := true
 		bool3 := false
 
-		assert.True(t, boolPtrEqual(nil, nil))
-		assert.True(t, boolPtrEqual(&bool1, &bool2))
-		assert.False(t, boolPtrEqual(&bool1, nil))
-		assert.False(t, boolPtrEqual(nil, &bool1))
-		assert.False(t, boolPtrEqual(&bool1, &bool3))
+		require.True(t, boolPtrEqual(nil, nil))
+		require.True(t, boolPtrEqual(&bool1, &bool2))
+		require.False(t, boolPtrEqual(&bool1, nil))
+		require.False(t, boolPtrEqual(nil, &bool1))
+		require.False(t, boolPtrEqual(&bool1, &bool3))
 	})
 
 	t.Run("needsQuotes", func(t *testing.T) {
 		// Functions and keywords should not be quoted
-		assert.False(t, needsQuotes("NULL"))
-		assert.False(t, needsQuotes("null"))
-		assert.False(t, needsQuotes("CURRENT_TIMESTAMP"))
-		assert.False(t, needsQuotes("current_timestamp"))
-		assert.False(t, needsQuotes("NOW()"))
-		assert.False(t, needsQuotes("now()"))
-		assert.False(t, needsQuotes("CURRENT_TIMESTAMP(6)"))
+		require.False(t, needsQuotes("NULL"))
+		require.False(t, needsQuotes("null"))
+		require.False(t, needsQuotes("CURRENT_TIMESTAMP"))
+		require.False(t, needsQuotes("current_timestamp"))
+		require.False(t, needsQuotes("NOW()"))
+		require.False(t, needsQuotes("now()"))
+		require.False(t, needsQuotes("CURRENT_TIMESTAMP(6)"))
 
 		// Numeric values should not be quoted
-		assert.False(t, needsQuotes("0"))
-		assert.False(t, needsQuotes("123"))
-		assert.False(t, needsQuotes("-456"))
-		assert.False(t, needsQuotes("3.14"))
-		assert.False(t, needsQuotes("-2.5"))
+		require.False(t, needsQuotes("0"))
+		require.False(t, needsQuotes("123"))
+		require.False(t, needsQuotes("-456"))
+		require.False(t, needsQuotes("3.14"))
+		require.False(t, needsQuotes("-2.5"))
 
 		// String values should be quoted
-		assert.True(t, needsQuotes("active"))
-		assert.True(t, needsQuotes("hello world"))
-		assert.True(t, needsQuotes("2023-01-01 00:00:00"))
-		assert.True(t, needsQuotes(""))
-		assert.True(t, needsQuotes("O'Brien"))
+		require.True(t, needsQuotes("active"))
+		require.True(t, needsQuotes("hello world"))
+		require.True(t, needsQuotes("2023-01-01 00:00:00"))
+		require.True(t, needsQuotes(""))
+		require.True(t, needsQuotes("O'Brien"))
 	})
 
 	t.Run("getPreviousColumn", func(t *testing.T) {
@@ -1202,38 +1202,38 @@ func TestHelperFunctions(t *testing.T) {
 			{Name: "created_at"},
 		}
 
-		assert.Equal(t, "", getPreviousColumn(columns, "id"))
-		assert.Equal(t, "id", getPreviousColumn(columns, "name"))
-		assert.Equal(t, "name", getPreviousColumn(columns, "email"))
-		assert.Equal(t, "email", getPreviousColumn(columns, "created_at"))
-		assert.Equal(t, "", getPreviousColumn(columns, "nonexistent"))
+		require.Equal(t, "", getPreviousColumn(columns, "id"))
+		require.Equal(t, "id", getPreviousColumn(columns, "name"))
+		require.Equal(t, "name", getPreviousColumn(columns, "email"))
+		require.Equal(t, "email", getPreviousColumn(columns, "created_at"))
+		require.Equal(t, "", getPreviousColumn(columns, "nonexistent"))
 	})
 
 	t.Run("getPrimaryKeyIndex", func(t *testing.T) {
 		// Table with no primary key
 		ct1, err := ParseCreateTable("CREATE TABLE t1 (id INT, name VARCHAR(100))")
 		require.NoError(t, err)
-		assert.Nil(t, ct1.getPrimaryKeyIndex())
+		require.Nil(t, ct1.getPrimaryKeyIndex())
 
 		// Table with inline primary key (column-level)
 		ct2, err := ParseCreateTable("CREATE TABLE t2 (id INT PRIMARY KEY)")
 		require.NoError(t, err)
-		assert.Nil(t, ct2.getPrimaryKeyIndex()) // inline PK is not in Indexes
+		require.Nil(t, ct2.getPrimaryKeyIndex()) // inline PK is not in Indexes
 
 		// Table with table-level primary key
 		ct3, err := ParseCreateTable("CREATE TABLE t3 (id INT, PRIMARY KEY (id))")
 		require.NoError(t, err)
 		pk := ct3.getPrimaryKeyIndex()
 		require.NotNil(t, pk)
-		assert.Equal(t, "PRIMARY KEY", pk.Type)
-		assert.Equal(t, []string{"id"}, pk.Columns)
+		require.Equal(t, "PRIMARY KEY", pk.Type)
+		require.Equal(t, []string{"id"}, pk.Columns)
 
 		// Table with composite primary key
 		ct4, err := ParseCreateTable("CREATE TABLE t4 (a INT, b INT, PRIMARY KEY (a, b))")
 		require.NoError(t, err)
 		pk = ct4.getPrimaryKeyIndex()
 		require.NotNil(t, pk)
-		assert.Equal(t, "PRIMARY KEY", pk.Type)
-		assert.Equal(t, []string{"a", "b"}, pk.Columns)
+		require.Equal(t, "PRIMARY KEY", pk.Type)
+		require.Equal(t, []string{"a", "b"}, pk.Columns)
 	})
 }

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -915,7 +915,7 @@ func TestDiff_DifferentTableNames(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = ct1.Diff(ct2, nil)
-	assert.Error(t, err, "expected error when diffing tables with different names")
+	require.Error(t, err, "expected error when diffing tables with different names")
 }
 
 func TestDiff_DiffOptions(t *testing.T) {

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -23,36 +23,36 @@ func TestParseCreateTable_BasicTable(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test basic table info
-	assert.Equal(t, "users", ct.GetTableName())
+	require.Equal(t, "users", ct.GetTableName())
 
 	// Test columns
 	columns := ct.GetColumns()
-	assert.Len(t, columns, 4)
+	require.Len(t, columns, 4)
 
 	// Test first column (id)
 	idCol := columns[0]
-	assert.Equal(t, "id", idCol.Name)
-	assert.Contains(t, idCol.Type, "int") // TiDB returns "int(11)" not just "int"
-	assert.True(t, idCol.AutoInc)
-	assert.False(t, idCol.Nullable)
+	require.Equal(t, "id", idCol.Name)
+	require.Contains(t, idCol.Type, "int") // TiDB returns "int(11)" not just "int"
+	require.True(t, idCol.AutoInc)
+	require.False(t, idCol.Nullable)
 
 	// Test second column (name)
 	nameCol := columns[1]
-	assert.Equal(t, "name", nameCol.Name)
-	assert.Contains(t, nameCol.Type, "varchar") // TiDB returns "varchar(255)" not just "varchar"
-	assert.NotNil(t, nameCol.Length)
-	assert.Equal(t, 255, *nameCol.Length)
-	assert.False(t, nameCol.Nullable)
+	require.Equal(t, "name", nameCol.Name)
+	require.Contains(t, nameCol.Type, "varchar") // TiDB returns "varchar(255)" not just "varchar"
+	require.NotNil(t, nameCol.Length)
+	require.Equal(t, 255, *nameCol.Length)
+	require.False(t, nameCol.Nullable)
 
 	// Test indexes (PRIMARY KEY and UNIQUE should be detected)
 	indexes := ct.GetIndexes()
-	assert.GreaterOrEqual(t, len(indexes), 2) // At least PRIMARY KEY and UNIQUE
+	require.GreaterOrEqual(t, len(indexes), 2) // At least PRIMARY KEY and UNIQUE
 
 	// Test table options
 	options := ct.GetTableOptions()
-	assert.Equal(t, "InnoDB", options["engine"])
-	assert.Equal(t, "utf8mb4", options["charset"])
-	assert.Equal(t, "User table", options["comment"])
+	require.Equal(t, "InnoDB", options["engine"])
+	require.Equal(t, "utf8mb4", options["charset"])
+	require.Equal(t, "User table", options["comment"])
 }
 
 func TestSchemaAnalyzer_StructuredAccess(t *testing.T) {
@@ -69,32 +69,32 @@ func TestSchemaAnalyzer_StructuredAccess(t *testing.T) {
 
 	// Test direct structured access
 	createTable := ct.GetCreateTable()
-	assert.Equal(t, "products", createTable.TableName)
+	require.Equal(t, "products", createTable.TableName)
 
 	// Test columns access
 	columns := createTable.Columns
 	require.Len(t, columns, 3)
-	assert.Equal(t, "id", columns[0].Name)
+	require.Equal(t, "id", columns[0].Name)
 
 	// Test table options access
 	options := ct.GetTableOptions()
-	assert.Equal(t, "InnoDB", options["engine"])
+	require.Equal(t, "InnoDB", options["engine"])
 
 	// Test using ByName methods
 	if nameCol := columns.ByName("name"); nameCol != nil {
-		assert.Equal(t, "name", nameCol.Name)
-		assert.Contains(t, nameCol.Type, "varchar")
-		assert.False(t, nameCol.Nullable)
+		require.Equal(t, "name", nameCol.Name)
+		require.Contains(t, nameCol.Type, "varchar")
+		require.False(t, nameCol.Nullable)
 		// Comment parsing might not work perfectly with TiDB parser
 		if nameCol.Comment != nil {
-			assert.Equal(t, "Product name", *nameCol.Comment)
+			require.Equal(t, "Product name", *nameCol.Comment)
 		}
 	} else {
 		t.Error("Should find column 'name'")
 	}
 
 	// Test column count
-	assert.Len(t, columns, 3)
+	require.Len(t, columns, 3)
 
 	// Test finding nullable columns using structured approach
 	var nullableColumns []Column
@@ -105,7 +105,7 @@ func TestSchemaAnalyzer_StructuredAccess(t *testing.T) {
 		}
 	}
 
-	assert.GreaterOrEqual(t, len(nullableColumns), 1) // price should be nullable
+	require.GreaterOrEqual(t, len(nullableColumns), 1) // price should be nullable
 }
 
 func TestSchemaAnalyzer_ComplexConstraints(t *testing.T) {
@@ -124,9 +124,9 @@ func TestSchemaAnalyzer_ComplexConstraints(t *testing.T) {
 	constraints := ct.GetConstraints()
 
 	// Should have at least the FOREIGN KEY constraint
-	assert.GreaterOrEqual(t, len(constraints), 1)
+	require.GreaterOrEqual(t, len(constraints), 1)
 
-	assert.True(t, constraints.HasForeignKeys())
+	require.True(t, constraints.HasForeignKeys())
 
 	// Find the foreign key constraint
 	var fkConstraint *Constraint
@@ -139,8 +139,8 @@ func TestSchemaAnalyzer_ComplexConstraints(t *testing.T) {
 	}
 
 	require.NotNil(t, fkConstraint)
-	assert.Equal(t, "fk_orders_user", fkConstraint.Name)
-	assert.Contains(t, *fkConstraint.Definition, "REFERENCES users")
+	require.Equal(t, "fk_orders_user", fkConstraint.Name)
+	require.Contains(t, *fkConstraint.Definition, "REFERENCES users")
 }
 
 func TestSchemaAnalyzer_UnsignedSupport(t *testing.T) {
@@ -166,36 +166,36 @@ func TestSchemaAnalyzer_UnsignedSupport(t *testing.T) {
 	// Test signed columns (should have Unsigned = nil or false)
 	signedInt := columns.ByName("signed_int")
 	require.NotNil(t, signedInt)
-	assert.Nil(t, signedInt.Unsigned, "signed_int should not have Unsigned field set")
+	require.Nil(t, signedInt.Unsigned, "signed_int should not have Unsigned field set")
 
 	signedBigint := columns.ByName("signed_bigint")
 	require.NotNil(t, signedBigint)
-	assert.Nil(t, signedBigint.Unsigned, "signed_bigint should not have Unsigned field set")
+	require.Nil(t, signedBigint.Unsigned, "signed_bigint should not have Unsigned field set")
 
 	signedTinyint := columns.ByName("signed_tinyint")
 	require.NotNil(t, signedTinyint)
-	assert.Nil(t, signedTinyint.Unsigned, "signed_tinyint should not have Unsigned field set")
+	require.Nil(t, signedTinyint.Unsigned, "signed_tinyint should not have Unsigned field set")
 
 	// Test unsigned columns (should have Unsigned = true)
 	unsignedInt := columns.ByName("unsigned_int")
 	require.NotNil(t, unsignedInt)
 	require.NotNil(t, unsignedInt.Unsigned, "unsigned_int should have Unsigned field set")
-	assert.True(t, *unsignedInt.Unsigned, "unsigned_int should be marked as unsigned")
+	require.True(t, *unsignedInt.Unsigned, "unsigned_int should be marked as unsigned")
 
 	unsignedBigint := columns.ByName("unsigned_bigint")
 	require.NotNil(t, unsignedBigint)
 	require.NotNil(t, unsignedBigint.Unsigned, "unsigned_bigint should have Unsigned field set")
-	assert.True(t, *unsignedBigint.Unsigned, "unsigned_bigint should be marked as unsigned")
+	require.True(t, *unsignedBigint.Unsigned, "unsigned_bigint should be marked as unsigned")
 
 	unsignedTinyint := columns.ByName("unsigned_tinyint")
 	require.NotNil(t, unsignedTinyint)
 	require.NotNil(t, unsignedTinyint.Unsigned, "unsigned_tinyint should have Unsigned field set")
-	assert.True(t, *unsignedTinyint.Unsigned, "unsigned_tinyint should be marked as unsigned")
+	require.True(t, *unsignedTinyint.Unsigned, "unsigned_tinyint should be marked as unsigned")
 
 	// Test id column (should not be unsigned)
 	idCol := columns.ByName("id")
 	require.NotNil(t, idCol)
-	assert.Nil(t, idCol.Unsigned, "id should not have Unsigned field set")
+	require.Nil(t, idCol.Unsigned, "id should not have Unsigned field set")
 }
 
 func TestSchemaAnalyzer_JSONSerialization(t *testing.T) {
@@ -222,13 +222,13 @@ func TestSchemaAnalyzer_JSONSerialization(t *testing.T) {
 	// Verify columns match by comparing key fields
 	require.Len(t, deserializedColumns, 2)
 
-	assert.Equal(t, "id", deserializedColumns[0].Name)
-	assert.Equal(t, "int", deserializedColumns[0].Type)
-	assert.True(t, deserializedColumns[0].PrimaryKey)
+	require.Equal(t, "id", deserializedColumns[0].Name)
+	require.Equal(t, "int", deserializedColumns[0].Type)
+	require.True(t, deserializedColumns[0].PrimaryKey)
 
-	assert.Equal(t, "name", deserializedColumns[1].Name)
-	assert.Contains(t, deserializedColumns[1].Type, "varchar")
-	assert.False(t, deserializedColumns[1].Nullable)
+	require.Equal(t, "name", deserializedColumns[1].Name)
+	require.Contains(t, deserializedColumns[1].Type, "varchar")
+	require.False(t, deserializedColumns[1].Nullable)
 }
 
 func TestSchemaAnalyzer_IndexVisibilityStructured(t *testing.T) {
@@ -269,25 +269,25 @@ func TestSchemaAnalyzer_IndexVisibilityStructured(t *testing.T) {
 	emailIdx := indexes.ByName("idx_email")
 	require.NotNil(t, emailIdx, "Should find idx_email")
 	require.NotNil(t, emailIdx.Invisible)
-	assert.True(t, *emailIdx.Invisible, "idx_email should be invisible")
+	require.True(t, *emailIdx.Invisible, "idx_email should be invisible")
 
 	multiIdx := indexes.ByName("uk_email_multi")
 	require.NotNil(t, multiIdx, "Should find uk_email_multi")
 	require.NotNil(t, multiIdx.Invisible)
-	assert.True(t, *multiIdx.Invisible, "uk_email_multi should be invisible")
+	require.True(t, *multiIdx.Invisible, "uk_email_multi should be invisible")
 	require.NotNil(t, multiIdx.Using)
-	assert.Equal(t, "BTREE", *multiIdx.Using, "uk_email_multi should use BTREE")
+	require.Equal(t, "BTREE", *multiIdx.Using, "uk_email_multi should use BTREE")
 	require.NotNil(t, multiIdx.Comment)
-	assert.Equal(t, "Multi-option unique", *multiIdx.Comment)
+	require.Equal(t, "Multi-option unique", *multiIdx.Comment)
 
 	statusIdx := indexes.ByName("idx_status")
 	require.NotNil(t, statusIdx, "Should find idx_status")
 	require.NotNil(t, statusIdx.Invisible)
-	assert.False(t, *statusIdx.Invisible, "idx_status should be explicitly visible")
+	require.False(t, *statusIdx.Invisible, "idx_status should be explicitly visible")
 
 	nameIdx := indexes.ByName("idx_name")
 	require.NotNil(t, nameIdx, "Should find idx_name")
-	assert.Nil(t, nameIdx.Invisible, "idx_name should have no invisibility setting")
+	require.Nil(t, nameIdx.Invisible, "idx_name should have no invisibility setting")
 
 	// Test finding all invisible indexes using structured approach
 	var invisibleIndexes []Index
@@ -298,7 +298,7 @@ func TestSchemaAnalyzer_IndexVisibilityStructured(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, invisibleIndexes, 2, "Should find exactly 2 invisible indexes")
+	require.Len(t, invisibleIndexes, 2, "Should find exactly 2 invisible indexes")
 
 	// Verify the invisible indexes are the ones we expect
 	invisibleNames := make(map[string]bool)
@@ -306,8 +306,8 @@ func TestSchemaAnalyzer_IndexVisibilityStructured(t *testing.T) {
 		invisibleNames[idx.Name] = true
 	}
 
-	assert.True(t, invisibleNames["idx_email"], "Should include idx_email in invisible indexes")
-	assert.True(t, invisibleNames["uk_email_multi"], "Should include uk_email_multi in invisible indexes")
+	require.True(t, invisibleNames["idx_email"], "Should include idx_email in invisible indexes")
+	require.True(t, invisibleNames["uk_email_multi"], "Should include uk_email_multi in invisible indexes")
 }
 
 // Benchmark to show performance characteristics
@@ -527,46 +527,46 @@ func TestSchemaAnalyzer_EnumAndSetSupport(t *testing.T) {
 	// Test ENUM column with default
 	statusCol := columns.ByName("status")
 	require.NotNil(t, statusCol)
-	assert.Equal(t, "enum", statusCol.Type)
+	require.Equal(t, "enum", statusCol.Type)
 	require.NotNil(t, statusCol.EnumValues)
-	assert.Equal(t, []string{"active", "inactive", "pending"}, statusCol.EnumValues)
-	assert.Nil(t, statusCol.SetValues, "ENUM column should not have SetValues")
+	require.Equal(t, []string{"active", "inactive", "pending"}, statusCol.EnumValues)
+	require.Nil(t, statusCol.SetValues, "ENUM column should not have SetValues")
 	require.NotNil(t, statusCol.Default)
-	assert.Equal(t, "active", *statusCol.Default)
-	assert.True(t, statusCol.Nullable)
+	require.Equal(t, "active", *statusCol.Default)
+	require.True(t, statusCol.Nullable)
 
 	// Test SET column with default
 	permissionsCol := columns.ByName("permissions")
 	require.NotNil(t, permissionsCol)
-	assert.Equal(t, "set", permissionsCol.Type)
+	require.Equal(t, "set", permissionsCol.Type)
 	require.NotNil(t, permissionsCol.SetValues)
-	assert.Equal(t, []string{"read", "write", "execute"}, permissionsCol.SetValues)
-	assert.Nil(t, permissionsCol.EnumValues, "SET column should not have EnumValues")
+	require.Equal(t, []string{"read", "write", "execute"}, permissionsCol.SetValues)
+	require.Nil(t, permissionsCol.EnumValues, "SET column should not have EnumValues")
 	require.NotNil(t, permissionsCol.Default)
-	assert.Equal(t, "read", *permissionsCol.Default)
+	require.Equal(t, "read", *permissionsCol.Default)
 
 	// Test ENUM column NOT NULL
 	priorityCol := columns.ByName("priority")
 	require.NotNil(t, priorityCol)
-	assert.Equal(t, "enum", priorityCol.Type)
+	require.Equal(t, "enum", priorityCol.Type)
 	require.NotNil(t, priorityCol.EnumValues)
-	assert.Equal(t, []string{"low", "medium", "high"}, priorityCol.EnumValues)
-	assert.False(t, priorityCol.Nullable)
+	require.Equal(t, []string{"low", "medium", "high"}, priorityCol.EnumValues)
+	require.False(t, priorityCol.Nullable)
 
 	// Test SET column without default
 	flagsCol := columns.ByName("flags")
 	require.NotNil(t, flagsCol)
-	assert.Equal(t, "set", flagsCol.Type)
+	require.Equal(t, "set", flagsCol.Type)
 	require.NotNil(t, flagsCol.SetValues)
-	assert.Equal(t, []string{"flag1", "flag2", "flag3", "flag4"}, flagsCol.SetValues)
-	assert.Nil(t, flagsCol.Default)
+	require.Equal(t, []string{"flag1", "flag2", "flag3", "flag4"}, flagsCol.SetValues)
+	require.Nil(t, flagsCol.Default)
 
 	// Test regular column (should have no enum/set values)
 	nameCol := columns.ByName("name")
 	require.NotNil(t, nameCol)
-	assert.Contains(t, nameCol.Type, "varchar")
-	assert.Nil(t, nameCol.EnumValues)
-	assert.Nil(t, nameCol.SetValues)
+	require.Contains(t, nameCol.Type, "varchar")
+	require.Nil(t, nameCol.EnumValues)
+	require.Nil(t, nameCol.SetValues)
 }
 
 func TestSchemaAnalyzer_EnumSetJSONSerialization(t *testing.T) {
@@ -596,27 +596,27 @@ func TestSchemaAnalyzer_EnumSetJSONSerialization(t *testing.T) {
 	require.Len(t, deserializedColumns, 3)
 
 	// Check id column
-	assert.Equal(t, "id", deserializedColumns[0].Name)
-	assert.Equal(t, "int", deserializedColumns[0].Type)
-	assert.True(t, deserializedColumns[0].PrimaryKey)
-	assert.Nil(t, deserializedColumns[0].EnumValues)
-	assert.Nil(t, deserializedColumns[0].SetValues)
+	require.Equal(t, "id", deserializedColumns[0].Name)
+	require.Equal(t, "int", deserializedColumns[0].Type)
+	require.True(t, deserializedColumns[0].PrimaryKey)
+	require.Nil(t, deserializedColumns[0].EnumValues)
+	require.Nil(t, deserializedColumns[0].SetValues)
 
 	// Verify enum values are preserved
 	statusCol := deserializedColumns[1]
-	assert.Equal(t, "status", statusCol.Name)
-	assert.Equal(t, "enum", statusCol.Type)
-	assert.Equal(t, []string{"active", "inactive"}, statusCol.EnumValues)
-	assert.Nil(t, statusCol.SetValues)
+	require.Equal(t, "status", statusCol.Name)
+	require.Equal(t, "enum", statusCol.Type)
+	require.Equal(t, []string{"active", "inactive"}, statusCol.EnumValues)
+	require.Nil(t, statusCol.SetValues)
 	require.NotNil(t, statusCol.Default)
-	assert.Equal(t, "active", *statusCol.Default)
+	require.Equal(t, "active", *statusCol.Default)
 
 	// Verify set values are preserved
 	permissionsCol := deserializedColumns[2]
-	assert.Equal(t, "permissions", permissionsCol.Name)
-	assert.Equal(t, "set", permissionsCol.Type)
-	assert.Equal(t, []string{"read", "write"}, permissionsCol.SetValues)
-	assert.Nil(t, permissionsCol.EnumValues)
+	require.Equal(t, "permissions", permissionsCol.Name)
+	require.Equal(t, "set", permissionsCol.Type)
+	require.Equal(t, []string{"read", "write"}, permissionsCol.SetValues)
+	require.Nil(t, permissionsCol.EnumValues)
 }
 
 func TestSchemaAnalyzer_EnumSingleValue(t *testing.T) {
@@ -633,9 +633,9 @@ func TestSchemaAnalyzer_EnumSingleValue(t *testing.T) {
 	require.Len(t, columns, 1)
 
 	statusCol := columns[0]
-	assert.Equal(t, "enum", statusCol.Type)
+	require.Equal(t, "enum", statusCol.Type)
 	require.NotNil(t, statusCol.EnumValues)
-	assert.Equal(t, []string{"only_one"}, statusCol.EnumValues)
+	require.Equal(t, []string{"only_one"}, statusCol.EnumValues)
 }
 
 func Test_Sloppy(t *testing.T) {
@@ -666,37 +666,37 @@ func Test_Sloppy(t *testing.T) {
 
 	// This accounts for the two different primary keys and 2 different unique indexes,
 	// each given once as a column attribute and once as a table constraint.
-	assert.Len(t, ct.GetIndexes(), 7)
+	require.Len(t, ct.GetIndexes(), 7)
 
 	// The "first" index should be the first one defined as a table attribute, not the PK or UNIQUE
 	// index defined as a column attribute.
 	firstIdx := ct.GetCreateTable().Indexes[0]
 	require.NotNil(t, firstIdx)
 	// Unnamed indexes are auto-named after their first column (MySQL convention)
-	assert.Equal(t, "user_id", firstIdx.Name)
-	assert.Equal(t, []string{"user_id", "customerEmail"}, firstIdx.Columns)
-	assert.Nil(t, firstIdx.Comment)
+	require.Equal(t, "user_id", firstIdx.Name)
+	require.Equal(t, []string{"user_id", "customerEmail"}, firstIdx.Columns)
+	require.Nil(t, firstIdx.Comment)
 
-	assert.True(t, ct.GetIndexes().HasInvisible())
+	require.True(t, ct.GetIndexes().HasInvisible())
 	idx_created_at := ct.GetCreateTable().Indexes.ByName("idx_created_at")
 	require.NotNil(t, idx_created_at)
 	require.NotNil(t, idx_created_at.Invisible)
-	assert.True(t, *idx_created_at.Invisible)
+	require.True(t, *idx_created_at.Invisible)
 
 	enum := ct.GetColumns().ByName("order_status")
 	require.NotNil(t, enum)
-	assert.True(t, strings.EqualFold("ENUM", enum.Type))
+	require.True(t, strings.EqualFold("ENUM", enum.Type))
 
 	// Verify enum values are captured
 	require.NotNil(t, enum.EnumValues)
-	assert.Equal(t, []string{"pending", "processing", "shipped", "delivered", "cancelled"}, enum.EnumValues)
-	assert.Equal(t, "pending", *enum.Default)
+	require.Equal(t, []string{"pending", "processing", "shipped", "delivered", "cancelled"}, enum.EnumValues)
+	require.Equal(t, "pending", *enum.Default)
 
 	total_amount := ct.GetColumns().ByName("total_amount")
 	require.NotNil(t, total_amount)
-	assert.Contains(t, strings.ToLower(total_amount.Type), "decimal")
-	assert.NotNil(t, total_amount.Default)
-	assert.Equal(t, "0.00", *total_amount.Default)
+	require.Contains(t, strings.ToLower(total_amount.Type), "decimal")
+	require.NotNil(t, total_amount.Default)
+	require.Equal(t, "0.00", *total_amount.Default)
 }
 
 // ComprehensiveTestCase represents a test case with SQL, expected success, and validation function
@@ -2127,10 +2127,10 @@ func TestCharsetCollationOverride(t *testing.T) {
 	// Verify that charset and collation are captured
 	// The exact behavior depends on how TiDB parser handles these attributes
 	if col.Charset != nil {
-		assert.Equal(t, "utf8", *col.Charset)
+		require.Equal(t, "utf8", *col.Charset)
 	}
 	if col.Collation != nil {
-		assert.Equal(t, "utf8_bin", *col.Collation)
+		require.Equal(t, "utf8_bin", *col.Collation)
 	}
 }
 
@@ -2200,7 +2200,7 @@ func TestComplexTableWithBinaryAndCharset(t *testing.T) {
 
 	ct, err := ParseCreateTable(sql)
 	require.NoError(t, err)
-	assert.Equal(t, "users", ct.GetTableName())
+	require.Equal(t, "users", ct.GetTableName())
 
 	columns := ct.GetColumns()
 	require.Len(t, columns, 8)
@@ -2208,63 +2208,63 @@ func TestComplexTableWithBinaryAndCharset(t *testing.T) {
 	// Test username column (VARCHAR with charset and collation)
 	username := columns.ByName("username")
 	require.NotNil(t, username)
-	assert.Contains(t, username.Type, "varchar")
-	assert.False(t, username.Nullable)
+	require.Contains(t, username.Type, "varchar")
+	require.False(t, username.Nullable)
 	if username.Charset != nil {
-		assert.Equal(t, "utf8mb4", *username.Charset)
+		require.Equal(t, "utf8mb4", *username.Charset)
 	}
 	if username.Collation != nil {
-		assert.Equal(t, "utf8mb4_unicode_ci", *username.Collation)
+		require.Equal(t, "utf8mb4_unicode_ci", *username.Collation)
 	}
 
 	// Test password_hash column (VARBINARY)
 	passwordHash := columns.ByName("password_hash")
 	require.NotNil(t, passwordHash)
-	assert.Equal(t, "varbinary", passwordHash.Type)
-	assert.False(t, passwordHash.Nullable)
+	require.Equal(t, "varbinary", passwordHash.Type)
+	require.False(t, passwordHash.Nullable)
 	require.NotNil(t, passwordHash.Length)
-	assert.Equal(t, 64, *passwordHash.Length)
+	require.Equal(t, 64, *passwordHash.Length)
 
 	// Test email column (VARCHAR with charset)
 	email := columns.ByName("email")
 	require.NotNil(t, email)
-	assert.Contains(t, email.Type, "varchar")
+	require.Contains(t, email.Type, "varchar")
 	if email.Charset != nil {
-		assert.Equal(t, "utf8mb4", *email.Charset)
+		require.Equal(t, "utf8mb4", *email.Charset)
 	}
 
 	// Test profile_data column (BLOB)
 	profileData := columns.ByName("profile_data")
 	require.NotNil(t, profileData)
-	assert.Equal(t, "blob", profileData.Type)
+	require.Equal(t, "blob", profileData.Type)
 
 	// Test bio column (TEXT with charset and collation)
 	bio := columns.ByName("bio")
 	require.NotNil(t, bio)
-	assert.Equal(t, "text", bio.Type)
+	require.Equal(t, "text", bio.Type)
 	if bio.Charset != nil {
-		assert.Equal(t, "utf8mb4", *bio.Charset)
+		require.Equal(t, "utf8mb4", *bio.Charset)
 	}
 	if bio.Collation != nil {
-		assert.Equal(t, "utf8mb4_unicode_ci", *bio.Collation)
+		require.Equal(t, "utf8mb4_unicode_ci", *bio.Collation)
 	}
 
 	// Test session_token column (BINARY)
 	sessionToken := columns.ByName("session_token")
 	require.NotNil(t, sessionToken)
-	assert.Equal(t, "binary", sessionToken.Type)
+	require.Equal(t, "binary", sessionToken.Type)
 	require.NotNil(t, sessionToken.Length)
-	assert.Equal(t, 32, *sessionToken.Length)
+	require.Equal(t, 32, *sessionToken.Length)
 
 	// Test metadata column (MEDIUMBLOB)
 	metadata := columns.ByName("metadata")
 	require.NotNil(t, metadata)
-	assert.Equal(t, "mediumblob", metadata.Type)
+	require.Equal(t, "mediumblob", metadata.Type)
 
 	// Verify table options
 	options := ct.GetTableOptions()
-	assert.Equal(t, "InnoDB", options["engine"])
-	assert.Equal(t, "utf8mb4", options["charset"])
+	require.Equal(t, "InnoDB", options["engine"])
+	require.Equal(t, "utf8mb4", options["charset"])
 }
 
 // TestBinaryTypeJSONSerialization tests that binary types can be serialized
@@ -2291,15 +2291,15 @@ func TestBinaryTypeJSONSerialization(t *testing.T) {
 
 	// Verify data column (VARBINARY)
 	dataCol := deserializedColumns[1]
-	assert.Equal(t, "data", dataCol.Name)
-	assert.Equal(t, "varbinary", dataCol.Type)
+	require.Equal(t, "data", dataCol.Name)
+	require.Equal(t, "varbinary", dataCol.Type)
 	require.NotNil(t, dataCol.Length)
-	assert.Equal(t, 255, *dataCol.Length)
+	require.Equal(t, 255, *dataCol.Length)
 
 	// Verify content column (BLOB)
 	contentCol := deserializedColumns[2]
-	assert.Equal(t, "content", contentCol.Name)
-	assert.Equal(t, "blob", contentCol.Type)
+	require.Equal(t, "content", contentCol.Name)
+	require.Equal(t, "blob", contentCol.Type)
 }
 
 // Helper function to create int pointer

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -662,7 +662,7 @@ func Test_Sloppy(t *testing.T) {
 	) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC COMMENT='E-commerce order tracking table'
 	`
 	ct, err := ParseCreateTable(sql)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// This accounts for the two different primary keys and 2 different unique indexes,
 	// each given once as a column attribute and once as a table constraint.

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -3,7 +3,6 @@ package statement
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -14,34 +13,34 @@ func TestMain(m *testing.M) {
 func TestExtractFromStatement(t *testing.T) {
 	abstractStmt, err := New("ALTER TABLE t1 ADD INDEX (something)")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Equal(t, "ADD INDEX(`something`)", abstractStmt[0].Alter)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Equal(t, "ADD INDEX(`something`)", abstractStmt[0].Alter)
 
 	abstractStmt, err = New("ALTER TABLE test.t1 ADD INDEX (something)")
 	require.NoError(t, err)
-	assert.Equal(t, "test", abstractStmt[0].Schema)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Equal(t, "ADD INDEX(`something`)", abstractStmt[0].Alter)
+	require.Equal(t, "test", abstractStmt[0].Schema)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Equal(t, "ADD INDEX(`something`)", abstractStmt[0].Alter)
 
 	abstractStmt, err = New("ALTER TABLE t1aaaa ADD COLUMN newcol int")
 	require.NoError(t, err)
-	assert.Equal(t, "t1aaaa", abstractStmt[0].Table)
-	assert.Equal(t, "ADD COLUMN `newcol` INT", abstractStmt[0].Alter)
-	assert.True(t, abstractStmt[0].IsAlterTable())
+	require.Equal(t, "t1aaaa", abstractStmt[0].Table)
+	require.Equal(t, "ADD COLUMN `newcol` INT", abstractStmt[0].Alter)
+	require.True(t, abstractStmt[0].IsAlterTable())
 
 	abstractStmt, err = New("ALTER TABLE t1 DROP COLUMN foo")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Equal(t, "DROP COLUMN `foo`", abstractStmt[0].Alter)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Equal(t, "DROP COLUMN `foo`", abstractStmt[0].Alter)
 
 	abstractStmt, err = New("CREATE TABLE t1 (a int)")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Empty(t, abstractStmt[0].Alter)
-	assert.False(t, abstractStmt[0].IsAlterTable())
-	assert.True(t, abstractStmt[0].IsCreateTable())
-	assert.False(t, abstractStmt[0].IsDropTable())
-	assert.False(t, abstractStmt[0].IsRenameTable())
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Empty(t, abstractStmt[0].Alter)
+	require.False(t, abstractStmt[0].IsAlterTable())
+	require.True(t, abstractStmt[0].IsCreateTable())
+	require.False(t, abstractStmt[0].IsDropTable())
+	require.False(t, abstractStmt[0].IsRenameTable())
 
 	// Try and extract multiple statements.
 	// This works
@@ -55,7 +54,7 @@ func TestExtractFromStatement(t *testing.T) {
 	// Include the schema name.
 	abstractStmt, err = New("ALTER TABLE test.t1 ADD INDEX (something)")
 	require.NoError(t, err)
-	assert.Equal(t, "test", abstractStmt[0].Schema)
+	require.Equal(t, "test", abstractStmt[0].Schema)
 
 	// Try and parse an invalid statement.
 	_, err = New("ALTER TABLE t1 yes")
@@ -64,65 +63,65 @@ func TestExtractFromStatement(t *testing.T) {
 	// Test create index is rewritten.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (a)")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Equal(t, "ADD INDEX `idx` (`a`)", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`a`)", abstractStmt[0].Statement)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Equal(t, "ADD INDEX `idx` (`a`)", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`a`)", abstractStmt[0].Statement)
 
 	abstractStmt, err = New("CREATE INDEX idx ON test.`t1` (a)")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Equal(t, "ADD INDEX `idx` (`a`)", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`a`)", abstractStmt[0].Statement)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Equal(t, "ADD INDEX `idx` (`a`)", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`a`)", abstractStmt[0].Statement)
 
 	// Test create index with spaces in identifiers (requires quoting).
 	abstractStmt, err = New("CREATE UNIQUE INDEX `an index` ON `a table` (id)")
 	require.NoError(t, err)
-	assert.Equal(t, "a table", abstractStmt[0].Table)
-	assert.Equal(t, "ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `a table` ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Statement)
+	require.Equal(t, "a table", abstractStmt[0].Table)
+	require.Equal(t, "ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `a table` ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Statement)
 
 	// Test functional index is rewritten.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 ((`a` IS NULL))")
 	require.NoError(t, err)
-	assert.Equal(t, "ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Statement)
+	require.Equal(t, "ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Statement)
 
 	// Test mixed functional + plain columns.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (a, (LOWER(`b`)))")
 	require.NoError(t, err)
-	assert.Equal(t, "ADD INDEX `idx` (`a`, (LOWER(`b`)))", abstractStmt[0].Alter)
+	require.Equal(t, "ADD INDEX `idx` (`a`, (LOWER(`b`)))", abstractStmt[0].Alter)
 
 	// Test create index with prefix length.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (name(10))")
 	require.NoError(t, err)
-	assert.Equal(t, "ADD INDEX `idx` (`name`(10))", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10))", abstractStmt[0].Statement)
+	require.Equal(t, "ADD INDEX `idx` (`name`(10))", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10))", abstractStmt[0].Statement)
 
 	// Test create index with prefix length on multiple columns.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (name(10), id)")
 	require.NoError(t, err)
-	assert.Equal(t, "ADD INDEX `idx` (`name`(10), `id`)", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10), `id`)", abstractStmt[0].Statement)
+	require.Equal(t, "ADD INDEX `idx` (`name`(10), `id`)", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10), `id`)", abstractStmt[0].Statement)
 
 	// Test create index with prefix length on all columns.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (name(10), description(20))")
 	require.NoError(t, err)
-	assert.Equal(t, "ADD INDEX `idx` (`name`(10), `description`(20))", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10), `description`(20))", abstractStmt[0].Statement)
+	require.Equal(t, "ADD INDEX `idx` (`name`(10), `description`(20))", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10), `description`(20))", abstractStmt[0].Statement)
 
 	// Test drop index is rewritten.
 	abstractStmt, err = New("DROP INDEX idx ON t1")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Equal(t, "DROP INDEX `idx`", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from DROP INDEX */ ALTER TABLE `t1` DROP INDEX `idx`", abstractStmt[0].Statement)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Equal(t, "DROP INDEX `idx`", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from DROP INDEX */ ALTER TABLE `t1` DROP INDEX `idx`", abstractStmt[0].Statement)
 
 	abstractStmt, err = New("DROP INDEX idx ON test.`t1`")
 	require.NoError(t, err)
-	assert.Equal(t, "test", abstractStmt[0].Schema)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Equal(t, "DROP INDEX `idx`", abstractStmt[0].Alter)
-	assert.Equal(t, "/* rewritten from DROP INDEX */ ALTER TABLE `t1` DROP INDEX `idx`", abstractStmt[0].Statement)
+	require.Equal(t, "test", abstractStmt[0].Schema)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Equal(t, "DROP INDEX `idx`", abstractStmt[0].Alter)
+	require.Equal(t, "/* rewritten from DROP INDEX */ ALTER TABLE `t1` DROP INDEX `idx`", abstractStmt[0].Statement)
 
 	// test unsupported.
 	_, err = New("INSERT INTO t1 (a) VALUES (1)")
@@ -131,12 +130,12 @@ func TestExtractFromStatement(t *testing.T) {
 	// drop table
 	abstractStmt, err = New("DROP TABLE t1")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Empty(t, abstractStmt[0].Alter)
-	assert.False(t, abstractStmt[0].IsAlterTable())
-	assert.True(t, abstractStmt[0].IsDropTable())
-	assert.False(t, abstractStmt[0].IsRenameTable())
-	assert.False(t, abstractStmt[0].IsCreateTable())
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Empty(t, abstractStmt[0].Alter)
+	require.False(t, abstractStmt[0].IsAlterTable())
+	require.True(t, abstractStmt[0].IsDropTable())
+	require.False(t, abstractStmt[0].IsRenameTable())
+	require.False(t, abstractStmt[0].IsCreateTable())
 
 	// drop table with multiple schemas
 	_, err = New("DROP TABLE test.t1, test2.t1")
@@ -145,12 +144,12 @@ func TestExtractFromStatement(t *testing.T) {
 	// rename table
 	abstractStmt, err = New("RENAME TABLE t1 TO t2")
 	require.NoError(t, err)
-	assert.Equal(t, "t1", abstractStmt[0].Table)
-	assert.Empty(t, abstractStmt[0].Alter)
-	assert.False(t, abstractStmt[0].IsAlterTable())
-	assert.True(t, abstractStmt[0].IsRenameTable())
-	assert.False(t, abstractStmt[0].IsDropTable())
-	assert.Equal(t, "RENAME TABLE t1 TO t2", abstractStmt[0].Statement)
+	require.Equal(t, "t1", abstractStmt[0].Table)
+	require.Empty(t, abstractStmt[0].Alter)
+	require.False(t, abstractStmt[0].IsAlterTable())
+	require.True(t, abstractStmt[0].IsRenameTable())
+	require.False(t, abstractStmt[0].IsDropTable())
+	require.Equal(t, "RENAME TABLE t1 TO t2", abstractStmt[0].Statement)
 
 	_, err = New("-- commented out sql")
 	require.ErrorIs(t, err, ErrNoStatements)
@@ -165,87 +164,87 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	}
 
 	// Safe metadata-only operations
-	assert.NoError(t, test("drop index `a`")) // DROP INDEX now uses INPLACE for better performance
-	assert.NoError(t, test("rename index `a` to `b`"))
-	assert.NoError(t, test("drop index `a`, drop index `b`"))        // Multiple DROP INDEX operations are safe
-	assert.NoError(t, test("drop index `a`, rename index `b` to c")) // Mixed safe operations
-	assert.NoError(t, test("ALTER INDEX b INVISIBLE"))
-	assert.NoError(t, test("ALTER INDEX b VISIBLE"))
-	assert.NoError(t, test("drop partition `p1`, `p2`"))
-	assert.NoError(t, test("truncate partition `p1`, `p3`"))
-	assert.NoError(t, test("add partition (partition `p1` values less than (100))"))
-	assert.NoError(t, test("add partition partitions 4"))
+	require.NoError(t, test("drop index `a`")) // DROP INDEX now uses INPLACE for better performance
+	require.NoError(t, test("rename index `a` to `b`"))
+	require.NoError(t, test("drop index `a`, drop index `b`"))        // Multiple DROP INDEX operations are safe
+	require.NoError(t, test("drop index `a`, rename index `b` to c")) // Mixed safe operations
+	require.NoError(t, test("ALTER INDEX b INVISIBLE"))
+	require.NoError(t, test("ALTER INDEX b VISIBLE"))
+	require.NoError(t, test("drop partition `p1`, `p2`"))
+	require.NoError(t, test("truncate partition `p1`, `p3`"))
+	require.NoError(t, test("add partition (partition `p1` values less than (100))"))
+	require.NoError(t, test("add partition partitions 4"))
 
 	// VARCHAR column modifications are safe (metadata-only)
-	assert.NoError(t, test("modify `a` varchar(100)"))
-	assert.NoError(t, test("change column `a` `a` varchar(100)"))
-	assert.NoError(t, test("modify `a` varchar(255)"))
-	assert.NoError(t, test("change column `a` `new_a` varchar(50)"))
+	require.NoError(t, test("modify `a` varchar(100)"))
+	require.NoError(t, test("change column `a` `a` varchar(100)"))
+	require.NoError(t, test("modify `a` varchar(255)"))
+	require.NoError(t, test("change column `a` `new_a` varchar(50)"))
 
 	// Non-VARCHAR column modifications should be unsafe (table-rebuilding)
-	assert.ErrorIs(t, test("modify `a` int"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("change column `a` `a` int"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("modify `a` text"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("change column `a` `new_a` bigint"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("modify `a` decimal(10,2)"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("change column `a` `a` datetime"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("modify `a` int"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("change column `a` `a` int"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("modify `a` text"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("change column `a` `new_a` bigint"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("modify `a` decimal(10,2)"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("change column `a` `a` datetime"), ErrUnsafeForInplace)
 
 	// Other unsafe operations (table-rebuilding)
-	assert.ErrorIs(t, test("ADD COLUMN `a` INT"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("ADD index (a)"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("drop index `a`, add index `b` (`b`)"), ErrMultipleAlterClauses)
-	assert.ErrorIs(t, test("engine=innodb"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("partition by HASH(`id`) partitions 8;"), ErrUnsafeForInplace)
-	assert.ErrorIs(t, test("remove partitioning"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("ADD COLUMN `a` INT"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("ADD index (a)"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("drop index `a`, add index `b` (`b`)"), ErrMultipleAlterClauses)
+	require.ErrorIs(t, test("engine=innodb"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("partition by HASH(`id`) partitions 8;"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("remove partitioning"), ErrUnsafeForInplace)
 
 	// Mixed safe and unsafe operations should be unsafe - these cannot be split
 	// because we cannot safely detect which operations are INSTANT vs INPLACE
-	assert.ErrorIs(t, test("drop index `a`, add column `b` int"), ErrMultipleAlterClauses)
-	assert.ErrorIs(t, test("ALTER INDEX b INVISIBLE, add column `c` int"), ErrMultipleAlterClauses)
-	assert.ErrorIs(t, test("modify `a` varchar(100), add index (b)"), ErrMultipleAlterClauses)
-	assert.ErrorIs(t, test("drop index `a`, modify `b` int"), ErrMultipleAlterClauses) // non-VARCHAR modification makes it unsafe
+	require.ErrorIs(t, test("drop index `a`, add column `b` int"), ErrMultipleAlterClauses)
+	require.ErrorIs(t, test("ALTER INDEX b INVISIBLE, add column `c` int"), ErrMultipleAlterClauses)
+	require.ErrorIs(t, test("modify `a` varchar(100), add index (b)"), ErrMultipleAlterClauses)
+	require.ErrorIs(t, test("drop index `a`, modify `b` int"), ErrMultipleAlterClauses) // non-VARCHAR modification makes it unsafe
 }
 
 func TestAlterIsAddUnique(t *testing.T) {
 	var test = func(stmt string) error {
 		return MustNew("ALTER TABLE `t1` " + stmt)[0].AlterContainsAddUnique()
 	}
-	assert.NoError(t, test("drop index `a`"))
-	assert.NoError(t, test("rename index `a` to `b`"))
-	assert.NoError(t, test("drop index `a`, drop index `b`"))
-	assert.NoError(t, test("drop index `a`, rename index `b` to c"))
+	require.NoError(t, test("drop index `a`"))
+	require.NoError(t, test("rename index `a` to `b`"))
+	require.NoError(t, test("drop index `a`, drop index `b`"))
+	require.NoError(t, test("drop index `a`, rename index `b` to c"))
 
-	assert.NoError(t, test("ADD COLUMN `a` INT"))
-	assert.NoError(t, test("ADD index (a)"))
-	assert.NoError(t, test("drop index `a`, add index `b` (`b`)"))
-	assert.NoError(t, test("engine=innodb"))
-	assert.ErrorIs(t, test("add unique(b)"), ErrAlterContainsUnique) // this is potentially lossy.
+	require.NoError(t, test("ADD COLUMN `a` INT"))
+	require.NoError(t, test("ADD index (a)"))
+	require.NoError(t, test("drop index `a`, add index `b` (`b`)"))
+	require.NoError(t, test("engine=innodb"))
+	require.ErrorIs(t, test("add unique(b)"), ErrAlterContainsUnique) // this is potentially lossy.
 }
 
 func TestAlterContainsUnsupportedClause(t *testing.T) {
 	var test = func(stmt string) error {
 		return MustNew("ALTER TABLE `t1` " + stmt)[0].AlterContainsUnsupportedClause()
 	}
-	assert.NoError(t, test("drop index `a`"))
-	assert.Error(t, test("drop index `a`, algorithm=inplace"))
-	assert.NoError(t, test("drop index `a`, rename index `b` to `c`"))
-	assert.Error(t, test("drop index `a`, drop index `b`, lock=none"))
+	require.NoError(t, test("drop index `a`"))
+	require.Error(t, test("drop index `a`, algorithm=inplace"))
+	require.NoError(t, test("drop index `a`, rename index `b` to `c`"))
+	require.Error(t, test("drop index `a`, drop index `b`, lock=none"))
 }
 
 func TestTrimAlter(t *testing.T) {
 	stmt := &AbstractStatement{}
 
 	stmt.Alter = "ADD COLUMN `a` INT"
-	assert.Equal(t, "ADD COLUMN `a` INT", stmt.TrimAlter())
+	require.Equal(t, "ADD COLUMN `a` INT", stmt.TrimAlter())
 
 	stmt.Alter = "engine=innodb;"
-	assert.Equal(t, "engine=innodb", stmt.TrimAlter())
+	require.Equal(t, "engine=innodb", stmt.TrimAlter())
 
 	stmt.Alter = "add column a, add column b"
-	assert.Equal(t, "add column a, add column b", stmt.TrimAlter())
+	require.Equal(t, "add column a, add column b", stmt.TrimAlter())
 
 	stmt.Alter = "add column a, add column b;"
-	assert.Equal(t, "add column a, add column b", stmt.TrimAlter())
+	require.Equal(t, "add column a, add column b", stmt.TrimAlter())
 }
 
 func TestMixedOperationsLogic(t *testing.T) {
@@ -257,18 +256,18 @@ func TestMixedOperationsLogic(t *testing.T) {
 	}
 
 	// Multiple VARCHAR modifications should be safe
-	assert.NoError(t, testInplace("modify `a` varchar(100), modify `b` varchar(200)"))
-	assert.NoError(t, testInplace("change column `a` `a` varchar(50), change column `b` `b` varchar(75)"))
+	require.NoError(t, testInplace("modify `a` varchar(100), modify `b` varchar(200)"))
+	require.NoError(t, testInplace("change column `a` `a` varchar(50), change column `b` `b` varchar(75)"))
 
 	// Mixed VARCHAR and non-VARCHAR should be unsafe
-	assert.ErrorIs(t, testInplace("modify `a` varchar(100), modify `b` int"), ErrMultipleAlterClauses)
-	assert.ErrorIs(t, testInplace("change column `a` `a` varchar(50), change column `b` `b` text"), ErrMultipleAlterClauses)
+	require.ErrorIs(t, testInplace("modify `a` varchar(100), modify `b` int"), ErrMultipleAlterClauses)
+	require.ErrorIs(t, testInplace("change column `a` `a` varchar(50), change column `b` `b` text"), ErrMultipleAlterClauses)
 
 	// Complex mixed operations that should be safe (all metadata-only)
-	assert.NoError(t, testInplace("ALTER INDEX a INVISIBLE, rename index `b` to `new_b`, modify `col` varchar(100)"))
+	require.NoError(t, testInplace("ALTER INDEX a INVISIBLE, rename index `b` to `new_b`, modify `col` varchar(100)"))
 
 	// Complex mixed operations that should be unsafe (contains table-rebuilding)
-	assert.ErrorIs(t, testInplace("ALTER INDEX a INVISIBLE, rename index `b` to `new_b`, modify `col` int"), ErrMultipleAlterClauses)
+	require.ErrorIs(t, testInplace("ALTER INDEX a INVISIBLE, rename index `b` to `new_b`, modify `col` int"), ErrMultipleAlterClauses)
 }
 
 func TestNewWithOptions(t *testing.T) {
@@ -285,23 +284,23 @@ func TestNewWithOptions(t *testing.T) {
 	stmts, err := NewWithOptions("CREATE TABLE t1 (a INT); CREATE TABLE t2 (b INT)", opts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 2)
-	assert.Equal(t, "t1", stmts[0].Table)
-	assert.True(t, stmts[0].IsCreateTable())
-	assert.Equal(t, "t2", stmts[1].Table)
-	assert.True(t, stmts[1].IsCreateTable())
+	require.Equal(t, "t1", stmts[0].Table)
+	require.True(t, stmts[0].IsCreateTable())
+	require.Equal(t, "t2", stmts[1].Table)
+	require.True(t, stmts[1].IsCreateTable())
 
 	stmts, err = NewWithOptions("CREATE TABLE t1 (a INT); ALTER TABLE t2 ADD COLUMN b INT", opts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 2)
-	assert.True(t, stmts[0].IsCreateTable())
-	assert.True(t, stmts[1].IsAlterTable())
+	require.True(t, stmts[0].IsCreateTable())
+	require.True(t, stmts[1].IsAlterTable())
 
 	stmts, err = NewWithOptions("CREATE TABLE t1 (a INT); DROP TABLE t2; ALTER TABLE t3 ADD COLUMN c INT", opts)
 	require.NoError(t, err)
 	require.Len(t, stmts, 3)
-	assert.True(t, stmts[0].IsCreateTable())
-	assert.True(t, stmts[1].IsDropTable())
-	assert.True(t, stmts[2].IsAlterTable())
+	require.True(t, stmts[0].IsCreateTable())
+	require.True(t, stmts[1].IsDropTable())
+	require.True(t, stmts[2].IsAlterTable())
 
 	// AllowMixedStatementTypes does not affect other validations
 	_, err = NewWithOptions("DROP TABLE test.t1, test2.t1", opts)
@@ -316,7 +315,7 @@ func TestNewWithOptions(t *testing.T) {
 	// Multiple ALTER TABLE still works (was already supported)
 	stmts, err = NewWithOptions("ALTER TABLE t1 ADD COLUMN x INT; ALTER TABLE t2 ADD COLUMN y INT", opts)
 	require.NoError(t, err)
-	assert.Len(t, stmts, 2)
+	require.Len(t, stmts, 2)
 
 	// NewWithOptions with zero-value options behaves like New
 	_, err = NewWithOptions("CREATE TABLE t1 (a INT); CREATE TABLE t2 (b INT)", Options{})
@@ -330,9 +329,9 @@ func TestStatementWithSQLComments(t *testing.T) {
 	stmts, err := New("-- This is a comment\nALTER TABLE t1 ADD INDEX (a)")
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
-	assert.Equal(t, "t1", stmts[0].Table)
-	assert.Equal(t, "ADD INDEX(`a`)", stmts[0].Alter)
-	assert.True(t, stmts[0].IsAlterTable())
+	require.Equal(t, "t1", stmts[0].Table)
+	require.Equal(t, "ADD INDEX(`a`)", stmts[0].Alter)
+	require.True(t, stmts[0].IsAlterTable())
 
 	// Multiple comment lines before the ALTER (reproduces a support ticket)
 	stmts, err = New(`-- Migration for JIRA-1234
@@ -342,14 +341,14 @@ func TestStatementWithSQLComments(t *testing.T) {
 ALTER TABLE t1 ADD INDEX idx_a (a)`)
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
-	assert.Equal(t, "t1", stmts[0].Table)
-	assert.Contains(t, stmts[0].Alter, "ADD INDEX")
+	require.Equal(t, "t1", stmts[0].Table)
+	require.Contains(t, stmts[0].Alter, "ADD INDEX")
 
 	// Block comments (/* ... */) before the ALTER
 	stmts, err = New("/* block comment */ ALTER TABLE t1 ADD COLUMN b INT")
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
-	assert.Equal(t, "t1", stmts[0].Table)
+	require.Equal(t, "t1", stmts[0].Table)
 
 	// Comments only (no actual DDL) should still return ErrNoStatements
 	_, err = New("-- just a comment\n-- another comment")
@@ -360,40 +359,40 @@ func TestColumnRenameMap(t *testing.T) {
 	// RENAME COLUMN syntax
 	stmts := MustNew("ALTER TABLE t1 RENAME COLUMN a TO b")
 	renames := stmts[0].ColumnRenameMap()
-	assert.Equal(t, map[string]string{"a": "b"}, renames)
+	require.Equal(t, map[string]string{"a": "b"}, renames)
 
 	// CHANGE COLUMN syntax (rename + type change)
 	stmts = MustNew("ALTER TABLE t1 CHANGE COLUMN old_col new_col BIGINT")
 	renames = stmts[0].ColumnRenameMap()
-	assert.Equal(t, map[string]string{"old_col": "new_col"}, renames)
+	require.Equal(t, map[string]string{"old_col": "new_col"}, renames)
 
 	// CHANGE COLUMN without rename (same name, different type) should not produce a rename
 	stmts = MustNew("ALTER TABLE t1 CHANGE COLUMN a a BIGINT")
 	renames = stmts[0].ColumnRenameMap()
-	assert.Nil(t, renames)
+	require.Nil(t, renames)
 
 	// Multiple renames in one ALTER
 	stmts = MustNew("ALTER TABLE t1 RENAME COLUMN a TO b, RENAME COLUMN c TO d")
 	renames = stmts[0].ColumnRenameMap()
-	assert.Equal(t, map[string]string{"a": "b", "c": "d"}, renames)
+	require.Equal(t, map[string]string{"a": "b", "c": "d"}, renames)
 
 	// Mixed: rename + change column
 	stmts = MustNew("ALTER TABLE t1 RENAME COLUMN a TO b, CHANGE COLUMN x y INT")
 	renames = stmts[0].ColumnRenameMap()
-	assert.Equal(t, map[string]string{"a": "b", "x": "y"}, renames)
+	require.Equal(t, map[string]string{"a": "b", "x": "y"}, renames)
 
 	// No rename at all (ADD COLUMN)
 	stmts = MustNew("ALTER TABLE t1 ADD COLUMN z INT")
 	renames = stmts[0].ColumnRenameMap()
-	assert.Nil(t, renames)
+	require.Nil(t, renames)
 
 	// Non-ALTER statement
 	stmts = MustNew("CREATE TABLE t1 (a INT PRIMARY KEY)")
 	renames = stmts[0].ColumnRenameMap()
-	assert.Nil(t, renames)
+	require.Nil(t, renames)
 
 	// Rename + other operations in same ALTER
 	stmts = MustNew("ALTER TABLE t1 RENAME COLUMN a TO b, ADD COLUMN c INT")
 	renames = stmts[0].ColumnRenameMap()
-	assert.Equal(t, map[string]string{"a": "b"}, renames)
+	require.Equal(t, map[string]string{"a": "b"}, renames)
 }

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -12,29 +13,29 @@ func TestMain(m *testing.M) {
 }
 func TestExtractFromStatement(t *testing.T) {
 	abstractStmt, err := New("ALTER TABLE t1 ADD INDEX (something)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Equal(t, "ADD INDEX(`something`)", abstractStmt[0].Alter)
 
 	abstractStmt, err = New("ALTER TABLE test.t1 ADD INDEX (something)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", abstractStmt[0].Schema)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Equal(t, "ADD INDEX(`something`)", abstractStmt[0].Alter)
 
 	abstractStmt, err = New("ALTER TABLE t1aaaa ADD COLUMN newcol int")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1aaaa", abstractStmt[0].Table)
 	assert.Equal(t, "ADD COLUMN `newcol` INT", abstractStmt[0].Alter)
 	assert.True(t, abstractStmt[0].IsAlterTable())
 
 	abstractStmt, err = New("ALTER TABLE t1 DROP COLUMN foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Equal(t, "DROP COLUMN `foo`", abstractStmt[0].Alter)
 
 	abstractStmt, err = New("CREATE TABLE t1 (a int)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Empty(t, abstractStmt[0].Alter)
 	assert.False(t, abstractStmt[0].IsAlterTable())
@@ -45,79 +46,79 @@ func TestExtractFromStatement(t *testing.T) {
 	// Try and extract multiple statements.
 	// This works
 	_, err = New("ALTER TABLE t1 ADD INDEX (something); ALTER TABLE t2 ADD INDEX (something)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// This doesn't though:
 	_, err = New("CREATE TABLE tnn (a int); ALTER TABLE t2 ADD INDEX (something)")
-	assert.ErrorIs(t, err, ErrMixMatchMultiStatements)
+	require.ErrorIs(t, err, ErrMixMatchMultiStatements)
 
 	// Include the schema name.
 	abstractStmt, err = New("ALTER TABLE test.t1 ADD INDEX (something)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", abstractStmt[0].Schema)
 
 	// Try and parse an invalid statement.
 	_, err = New("ALTER TABLE t1 yes")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Test create index is rewritten.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (a)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Equal(t, "ADD INDEX `idx` (`a`)", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`a`)", abstractStmt[0].Statement)
 
 	abstractStmt, err = New("CREATE INDEX idx ON test.`t1` (a)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Equal(t, "ADD INDEX `idx` (`a`)", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`a`)", abstractStmt[0].Statement)
 
 	// Test create index with spaces in identifiers (requires quoting).
 	abstractStmt, err = New("CREATE UNIQUE INDEX `an index` ON `a table` (id)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "a table", abstractStmt[0].Table)
 	assert.Equal(t, "ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `a table` ADD UNIQUE INDEX `an index` (`id`)", abstractStmt[0].Statement)
 
 	// Test functional index is rewritten.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 ((`a` IS NULL))")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` ((`a` IS NULL))", abstractStmt[0].Statement)
 
 	// Test mixed functional + plain columns.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (a, (LOWER(`b`)))")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "ADD INDEX `idx` (`a`, (LOWER(`b`)))", abstractStmt[0].Alter)
 
 	// Test create index with prefix length.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (name(10))")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "ADD INDEX `idx` (`name`(10))", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10))", abstractStmt[0].Statement)
 
 	// Test create index with prefix length on multiple columns.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (name(10), id)")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "ADD INDEX `idx` (`name`(10), `id`)", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10), `id`)", abstractStmt[0].Statement)
 
 	// Test create index with prefix length on all columns.
 	abstractStmt, err = New("CREATE INDEX idx ON t1 (name(10), description(20))")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "ADD INDEX `idx` (`name`(10), `description`(20))", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from CREATE INDEX */ ALTER TABLE `t1` ADD INDEX `idx` (`name`(10), `description`(20))", abstractStmt[0].Statement)
 
 	// Test drop index is rewritten.
 	abstractStmt, err = New("DROP INDEX idx ON t1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Equal(t, "DROP INDEX `idx`", abstractStmt[0].Alter)
 	assert.Equal(t, "/* rewritten from DROP INDEX */ ALTER TABLE `t1` DROP INDEX `idx`", abstractStmt[0].Statement)
 
 	abstractStmt, err = New("DROP INDEX idx ON test.`t1`")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", abstractStmt[0].Schema)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Equal(t, "DROP INDEX `idx`", abstractStmt[0].Alter)
@@ -125,11 +126,11 @@ func TestExtractFromStatement(t *testing.T) {
 
 	// test unsupported.
 	_, err = New("INSERT INTO t1 (a) VALUES (1)")
-	assert.ErrorIs(t, err, ErrNotSupportedStatement)
+	require.ErrorIs(t, err, ErrNotSupportedStatement)
 
 	// drop table
 	abstractStmt, err = New("DROP TABLE t1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Empty(t, abstractStmt[0].Alter)
 	assert.False(t, abstractStmt[0].IsAlterTable())
@@ -139,11 +140,11 @@ func TestExtractFromStatement(t *testing.T) {
 
 	// drop table with multiple schemas
 	_, err = New("DROP TABLE test.t1, test2.t1")
-	assert.ErrorIs(t, err, ErrMultipleSchemas)
+	require.ErrorIs(t, err, ErrMultipleSchemas)
 
 	// rename table
 	abstractStmt, err = New("RENAME TABLE t1 TO t2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "t1", abstractStmt[0].Table)
 	assert.Empty(t, abstractStmt[0].Alter)
 	assert.False(t, abstractStmt[0].IsAlterTable())
@@ -152,10 +153,10 @@ func TestExtractFromStatement(t *testing.T) {
 	assert.Equal(t, "RENAME TABLE t1 TO t2", abstractStmt[0].Statement)
 
 	_, err = New("-- commented out sql")
-	assert.ErrorIs(t, err, ErrNoStatements)
+	require.ErrorIs(t, err, ErrNoStatements)
 
 	_, err = New("RENAME TABLE test.t1 TO test2.t2")
-	assert.ErrorIs(t, err, ErrMultipleSchemas)
+	require.ErrorIs(t, err, ErrMultipleSchemas)
 }
 
 func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
@@ -273,53 +274,53 @@ func TestMixedOperationsLogic(t *testing.T) {
 func TestNewWithOptions(t *testing.T) {
 	// Default behavior: mixed statement types are rejected
 	_, err := New("CREATE TABLE t1 (a INT); CREATE TABLE t2 (b INT)")
-	assert.ErrorIs(t, err, ErrMixMatchMultiStatements)
+	require.ErrorIs(t, err, ErrMixMatchMultiStatements)
 
 	_, err = New("CREATE TABLE t1 (a INT); ALTER TABLE t2 ADD COLUMN b INT")
-	assert.ErrorIs(t, err, ErrMixMatchMultiStatements)
+	require.ErrorIs(t, err, ErrMixMatchMultiStatements)
 
 	// With AllowMixedStatementTypes: mixed types are accepted
 	opts := Options{AllowMixedStatementTypes: true}
 
 	stmts, err := NewWithOptions("CREATE TABLE t1 (a INT); CREATE TABLE t2 (b INT)", opts)
-	assert.NoError(t, err)
-	assert.Len(t, stmts, 2)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
 	assert.Equal(t, "t1", stmts[0].Table)
 	assert.True(t, stmts[0].IsCreateTable())
 	assert.Equal(t, "t2", stmts[1].Table)
 	assert.True(t, stmts[1].IsCreateTable())
 
 	stmts, err = NewWithOptions("CREATE TABLE t1 (a INT); ALTER TABLE t2 ADD COLUMN b INT", opts)
-	assert.NoError(t, err)
-	assert.Len(t, stmts, 2)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
 	assert.True(t, stmts[0].IsCreateTable())
 	assert.True(t, stmts[1].IsAlterTable())
 
 	stmts, err = NewWithOptions("CREATE TABLE t1 (a INT); DROP TABLE t2; ALTER TABLE t3 ADD COLUMN c INT", opts)
-	assert.NoError(t, err)
-	assert.Len(t, stmts, 3)
+	require.NoError(t, err)
+	require.Len(t, stmts, 3)
 	assert.True(t, stmts[0].IsCreateTable())
 	assert.True(t, stmts[1].IsDropTable())
 	assert.True(t, stmts[2].IsAlterTable())
 
 	// AllowMixedStatementTypes does not affect other validations
 	_, err = NewWithOptions("DROP TABLE test.t1, test2.t1", opts)
-	assert.ErrorIs(t, err, ErrMultipleSchemas)
+	require.ErrorIs(t, err, ErrMultipleSchemas)
 
 	_, err = NewWithOptions("INSERT INTO t1 (a) VALUES (1)", opts)
-	assert.ErrorIs(t, err, ErrNotSupportedStatement)
+	require.ErrorIs(t, err, ErrNotSupportedStatement)
 
 	_, err = NewWithOptions("-- commented out sql", opts)
-	assert.ErrorIs(t, err, ErrNoStatements)
+	require.ErrorIs(t, err, ErrNoStatements)
 
 	// Multiple ALTER TABLE still works (was already supported)
 	stmts, err = NewWithOptions("ALTER TABLE t1 ADD COLUMN x INT; ALTER TABLE t2 ADD COLUMN y INT", opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, stmts, 2)
 
 	// NewWithOptions with zero-value options behaves like New
 	_, err = NewWithOptions("CREATE TABLE t1 (a INT); CREATE TABLE t2 (b INT)", Options{})
-	assert.ErrorIs(t, err, ErrMixMatchMultiStatements)
+	require.ErrorIs(t, err, ErrMixMatchMultiStatements)
 }
 
 // Verify that SQL comments before/after ALTER TABLE are handled correctly.
@@ -327,8 +328,8 @@ func TestNewWithOptions(t *testing.T) {
 func TestStatementWithSQLComments(t *testing.T) {
 	// Single-line comments before the ALTER
 	stmts, err := New("-- This is a comment\nALTER TABLE t1 ADD INDEX (a)")
-	assert.NoError(t, err)
-	assert.Len(t, stmts, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
 	assert.Equal(t, "t1", stmts[0].Table)
 	assert.Equal(t, "ADD INDEX(`a`)", stmts[0].Alter)
 	assert.True(t, stmts[0].IsAlterTable())
@@ -339,20 +340,20 @@ func TestStatementWithSQLComments(t *testing.T) {
 -- Date: 2025-07-01
 -- Description: Add index on column a for performance
 ALTER TABLE t1 ADD INDEX idx_a (a)`)
-	assert.NoError(t, err)
-	assert.Len(t, stmts, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
 	assert.Equal(t, "t1", stmts[0].Table)
 	assert.Contains(t, stmts[0].Alter, "ADD INDEX")
 
 	// Block comments (/* ... */) before the ALTER
 	stmts, err = New("/* block comment */ ALTER TABLE t1 ADD COLUMN b INT")
-	assert.NoError(t, err)
-	assert.Len(t, stmts, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
 	assert.Equal(t, "t1", stmts[0].Table)
 
 	// Comments only (no actual DDL) should still return ErrNoStatements
 	_, err = New("-- just a comment\n-- another comment")
-	assert.ErrorIs(t, err, ErrNoStatements)
+	require.ErrorIs(t, err, ErrNoStatements)
 }
 
 func TestColumnRenameMap(t *testing.T) {


### PR DESCRIPTION
Closes #782. Part of #779.

## Summary
- Migrate `assert.*` → `require.*` in `pkg/statement/*_test.go` where appropriate.
- Loop and table-driven assertions kept as `assert.*` where seeing all failures at once is preferable.
- No production code changes.

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)