### PR TITLE
test(#791): migrate pkg/copier tests to require.*

### DIFF
--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -25,14 +25,14 @@ func TestBufferedCopier(t *testing.T) {
 	testutils.RunSQL(t, `INSERT INTO bufferedt1 VALUES (2, 42, 'string with \\ backslash', RANDOM_BYTES(10), JSON_OBJECT('key', 'value\\ \''), NOW(), NOW())`)
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "bufferedt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "bufferedt2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	cfg := NewCopierDefaultConfig()
 	target := applier.Target{
@@ -42,22 +42,22 @@ func TestBufferedCopier(t *testing.T) {
 	cfg.Applier, err = applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, chunker.Open())
 
 	copier, err := NewCopier(db, chunker, cfg)
-	assert.NoError(t, err)
-	assert.NoError(t, copier.Run(t.Context())) // works.
+	require.NoError(t, err)
+	require.NoError(t, copier.Run(t.Context())) // works.
 
 	// We should expect to have the same number of rows
 	// and a basic checksum confirms a match.
 	var checksumSrc, checksumDst string
 	err = db.QueryRowContext(t.Context(), "SELECT BIT_XOR(CRC32(CONCAT(a, IFNULL(b, ''), c, d, e, f, g))) as checksum FROM bufferedt1").Scan(&checksumSrc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = db.QueryRowContext(t.Context(), "SELECT BIT_XOR(CRC32(CONCAT(a, IFNULL(b, ''), c, d, e, f, g))) as checksum FROM bufferedt2").Scan(&checksumDst)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, checksumSrc, checksumDst, "Checksums do not match between source and destination tables")
 
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
@@ -87,40 +87,40 @@ func TestBufferedCopierCharsetConversion(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO charsetsrc VALUES (NULL, 'à'), (NULL, '€')")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "charsetsrc")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "charsetdst")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	cfg := NewCopierDefaultConfig()
 	cfg.Applier, err = applier.NewSingleTargetApplier(applier.Target{DB: db}, applier.NewApplierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, chunker.Open())
 
 	copier, err := NewCopier(db, chunker, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// The copy should succeed because we set the connection charset to utf8mb4
 	// On read from the src it will be converted from latin1 to utf8mb4
 	err = copier.Run(t.Context())
-	assert.NoError(t, err, "Charset conversion from latin1 to utf8mb4 should succeed")
+	require.NoError(t, err, "Charset conversion from latin1 to utf8mb4 should succeed")
 
 	// Reverse the copy to show the other direction works too
 	// Start by emptying the "src" table, which is our intended destination.
 	testutils.RunSQL(t, "TRUNCATE TABLE charsetsrc")
 	chunker, err = table.NewChunker(t2, table.ChunkerConfig{NewTable: t1, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	copier, err = NewCopier(db, chunker, cfg)
-	assert.NoError(t, err)
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, err)
+	require.NoError(t, chunker.Open())
 	err = copier.Run(t.Context())
-	assert.NoError(t, err, "Charset conversion from utf8mb4 to latin1 should succeed")
+	require.NoError(t, err, "Charset conversion from utf8mb4 to latin1 should succeed")
 }
 
 // TestBufferedCopierDataTypeConversionError tests that the buffered copier
@@ -143,25 +143,25 @@ func TestBufferedCopierDataTypeConversionError(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO datatypesrc (id, b) SELECT NULL, 'not_a_number' FROM datatypesrc a JOIN datatypesrc b JOIN datatypesrc c LIMIT 100000")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "datatypesrc")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "datatypedst")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	cfg := NewCopierDefaultConfig()
 	cfg.TargetChunkTime = 10 // Small chunk time to create more chunks
 	cfg.Applier, err = applier.NewSingleTargetApplier(applier.Target{DB: db}, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, chunker.Open())
+	require.NoError(t, chunker.Open())
 
 	copier, err := NewCopier(db, chunker, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Run the copier - should fail with conversion error
 	err = copier.Run(t.Context())
@@ -190,7 +190,7 @@ func TestBufferedCopierDataTypeConversionError(t *testing.T) {
 // the callback, and a mock chunker to capture the duration passed to Feedback().
 func TestBufferedCopierChunkTimingIncludesCallbackDelay(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	// Create test tables
@@ -202,9 +202,9 @@ func TestBufferedCopierChunkTimingIncludesCallbackDelay(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO timing_test_src VALUES (1, 'test1'), (2, 'test2'), (3, 'test3')")
 
 	t1 := table.NewTableInfo(db, "test", "timing_test_src")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "timing_test_dst")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	// Create copier config first so we can use its logger
 	cfg := NewCopierDefaultConfig()
@@ -212,7 +212,7 @@ func TestBufferedCopierChunkTimingIncludesCallbackDelay(t *testing.T) {
 	// Create a real chunker (we need real chunk metadata for the copier)
 	realChunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: 1000 * time.Millisecond, Logger: cfg.Logger})
 	require.NoError(t, err)
-	assert.NoError(t, realChunker.Open())
+	require.NoError(t, realChunker.Open())
 
 	// Wrap it to capture feedback calls
 	wrappedChunker := &feedbackCapturingChunker{
@@ -252,7 +252,7 @@ func TestBufferedCopierChunkTimingIncludesCallbackDelay(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err = copier.Run(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get feedback calls from the wrapped chunker
 	feedbackCalls := wrappedChunker.GetFeedbackCalls()
@@ -269,7 +269,7 @@ func TestBufferedCopierChunkTimingIncludesCallbackDelay(t *testing.T) {
 	// Verify the rows were actually copied
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM timing_test_dst").Scan(&count)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 3, count, "All rows should be copied")
 }
 

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,7 +57,7 @@ func TestBufferedCopier(t *testing.T) {
 
 	err = db.QueryRowContext(t.Context(), "SELECT BIT_XOR(CRC32(CONCAT(a, IFNULL(b, ''), c, d, e, f, g))) as checksum FROM bufferedt2").Scan(&checksumDst)
 	require.NoError(t, err)
-	assert.Equal(t, checksumSrc, checksumDst, "Checksums do not match between source and destination tables")
+	require.Equal(t, checksumSrc, checksumDst, "Checksums do not match between source and destination tables")
 
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 }
@@ -169,7 +168,7 @@ func TestBufferedCopierDataTypeConversionError(t *testing.T) {
 
 	// Verify early exit by checking how many chunks were processed
 	_, chunksCopied, _ := copier.GetChunker().Progress()
-	assert.Less(t, chunksCopied, uint64(10))
+	require.Less(t, chunksCopied, uint64(10))
 
 	// Also check destination table is zero
 	var copiedRows int
@@ -263,14 +262,14 @@ func TestBufferedCopierChunkTimingIncludesCallbackDelay(t *testing.T) {
 	// We can't precisely measure read time, but we know it should be much less than the delay
 	// So the total should be at least the callback delay
 	actualDuration := feedbackCalls[0].duration
-	assert.GreaterOrEqual(t, actualDuration, callbackDelay,
+	require.GreaterOrEqual(t, actualDuration, callbackDelay,
 		"Chunk timing should include the callback delay (read + write time)")
 
 	// Verify the rows were actually copied
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM timing_test_dst").Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 3, count, "All rows should be copied")
+	require.Equal(t, 3, count, "All rows should be copied")
 }
 
 // feedbackCall captures the parameters passed to chunker.Feedback()

--- a/pkg/copier/copier_eta_history_test.go
+++ b/pkg/copier/copier_eta_history_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCopierETAHistory(t *testing.T) {
@@ -13,23 +13,23 @@ func TestCopierETAHistory(t *testing.T) {
 
 	// Add an ETA
 	history.addCurrentEstimateAndCompare(1 * time.Hour)
-	assert.Len(t, history.etaHistory, 1)
-	assert.Empty(t, history.getComparison())
+	require.Len(t, history.etaHistory, 1)
+	require.Empty(t, history.getComparison())
 
 	// Add another ETA and confirm it is NOT stored because it is too recent
 	history.addCurrentEstimateAndCompare(55 * time.Minute)
-	assert.Len(t, history.etaHistory, 1)
+	require.Len(t, history.etaHistory, 1)
 
 	// Even though the ETA was not stored, the latest estimate should still be updated
-	assert.Equal(t, "5m from 0s ago", history.getComparison())
+	require.Equal(t, "5m from 0s ago", history.getComparison())
 
 	// Create new CopierETAHistory with a history of 3 ETAs
 	history = newcopierEtaHistory()
 	history.addETA(copierETA{estimate: 3 * time.Hour, asOf: time.Now().Add(-2 * time.Hour)})
 	history.addETA(copierETA{estimate: 2 * time.Hour, asOf: time.Now().Add(-1 * time.Hour)})
 	history.addETA(copierETA{estimate: 1 * time.Hour, asOf: time.Now()})
-	assert.Len(t, history.etaHistory, 3)
-	assert.Equal(t, "±0m from 2h ago", history.getComparison())
+	require.Len(t, history.etaHistory, 3)
+	require.Equal(t, "±0m from 2h ago", history.getComparison())
 
 	// Create a new CopierETAHistory with a history of 24 ETAs
 	history = newcopierEtaHistory()
@@ -40,10 +40,10 @@ func TestCopierETAHistory(t *testing.T) {
 		})
 	}
 	// Oldest history was auto-removed
-	assert.Len(t, history.etaHistory, 23)
-	assert.Equal(t, "±0m from 22h ago", history.getComparison())
+	require.Len(t, history.etaHistory, 23)
+	require.Equal(t, "±0m from 22h ago", history.getComparison())
 
 	comparison := history.addCurrentEstimateAndCompare(30 * time.Minute)
-	assert.Len(t, history.etaHistory, 24)
-	assert.Equal(t, "-30m from 23h ago", comparison)
+	require.Len(t, history.etaHistory, 24)
+	require.Equal(t, "-30m from 23h ago", comparison)
 }

--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -48,29 +48,29 @@ func TestCopier(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO copiert1 VALUES (1, 2, 3)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "copiert1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "copiert2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	copierConfig := NewCopierDefaultConfig()
 	testMetricsSink := &TestMetricsSink{}
 	copierConfig.MetricsSink = testMetricsSink
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: copierConfig.TargetChunkTime, Logger: copierConfig.Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, copierConfig)
-	assert.NoError(t, err)
-	assert.NoError(t, copier.Run(t.Context())) // works
+	require.NoError(t, err)
+	require.NoError(t, copier.Run(t.Context())) // works
 
 	// Verify that t2 has one row.
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM copiert2").Scan(&count)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, count)
 
 	// Verify that testMetricsSink.Send was called >0 times
@@ -86,26 +86,26 @@ func TestThrottler(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO throttlert1 VALUES (1, 2, 3)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "throttlert1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "throttlert2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	copier.SetThrottler(&throttler.Noop{})
 	require.NoError(t, chunker.Open())
-	assert.NoError(t, copier.Run(t.Context())) // works
+	require.NoError(t, copier.Run(t.Context())) // works
 
 	// Verify that t2 has one row.
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM throttlert2").Scan(&count)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, count)
 }
 
@@ -120,29 +120,29 @@ func TestCopierUniqueDestination(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO copieruniqt1 VALUES (1, 2, 3), (2,2,3)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "copieruniqt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "copieruniqt2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	// Because of the checksum, the unique violation will be ignored.
 	// This is because it's not possible to differentiate between a resume from checkpoint
 	// causing a duplicate key, and the DDL being applied causing it.
 	t1 = table.NewTableInfo(db, "test", "copieruniqt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 = table.NewTableInfo(db, "test", "copieruniqt2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
-	assert.NoError(t, copier.Run(t.Context())) // works
-	require.Equal(t, 0, db.Stats().InUse)      // no connections in use.
+	require.NoError(t, err)
+	require.NoError(t, copier.Run(t.Context())) // works
+	require.Equal(t, 0, db.Stats().InUse)       // no connections in use.
 }
 
 func TestCopierLossyDataTypeConversion(t *testing.T) {
@@ -152,23 +152,23 @@ func TestCopierLossyDataTypeConversion(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO datatpt1 VALUES (1, 2, 'aaa'), (2,2,'bbb')")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "datatpt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "datatpt2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = copier.Run(t.Context())
-	assert.Contains(t, err.Error(), "unsafe warning")
+	require.ErrorContains(t, err, "unsafe warning")
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 }
 
@@ -179,23 +179,23 @@ func TestCopierNullToNotNullConversion(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO null2notnullt1 VALUES (1, 2, 123), (2,2,NULL)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 
 	t1 := table.NewTableInfo(db, "test", "null2notnullt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "null2notnullt2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = copier.Run(t.Context())
-	assert.Contains(t, err.Error(), "unsafe warning")
+	require.ErrorContains(t, err, "unsafe warning")
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 }
 
@@ -206,26 +206,26 @@ func TestSQLModeAllowZeroInvalidDates(t *testing.T) {
 	testutils.RunSQL(t, "INSERT IGNORE INTO invaliddt1 VALUES (1, 2, '0000-00-00')")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "invaliddt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "invaliddt2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	// Checksum flag does not affect this error.
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = copier.Run(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Verify that t2 has one row.
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM invaliddt2").Scan(&count)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, count)
 }
 
@@ -236,13 +236,13 @@ func TestLockWaitTimeoutIsRetyable(t *testing.T) {
 	testutils.RunSQL(t, "INSERT IGNORE INTO lockt1 VALUES (1, 2, 3)")
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "lockt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "lockt2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 	wg1, wg2 := sync.WaitGroup{}, sync.WaitGroup{}
 	wg1.Add(1)
 	// Lock table t2 for 2 seconds.
@@ -259,12 +259,12 @@ func TestLockWaitTimeoutIsRetyable(t *testing.T) {
 	})
 	wg1.Wait()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = copier.Run(t.Context())
-	assert.NoError(t, err) // succeeded within retry.
+	require.NoError(t, err) // succeeded within retry.
 	wg2.Wait()
 }
 
@@ -280,15 +280,15 @@ func TestLockWaitTimeoutRetryExceeded(t *testing.T) {
 	config.InnodbLockWaitTimeout = 1
 
 	db, err := dbconn.New(testutils.DSN(), config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 	require.Equal(t, config.MaxOpenConnections, db.Stats().MaxOpenConnections)
 	require.Equal(t, 0, db.Stats().InUse)
 
 	t1 := table.NewTableInfo(db, "test", "lock2t1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "lock2t2")
-	assert.NoError(t, t2.SetInfo(t.Context()))
+	require.NoError(t, t2.SetInfo(t.Context()))
 
 	// Lock again but for 10 seconds.
 	// This will cause a failure because the retry is less than this (2 retries * 1 sec + backoff)
@@ -307,22 +307,22 @@ func TestLockWaitTimeoutRetryExceeded(t *testing.T) {
 	})
 	wg1.Wait() // Wait only for the lock to be acquired.
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = copier.Run(t.Context())
-	assert.Error(t, err) // exceeded retry.
+	require.Error(t, err) // exceeded retry.
 	wg2.Wait()
 }
 
 func TestCopierValidation(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	// Test that NewCopier fails with nil chunker
 	_, err = NewCopier(db, nil, NewCopierDefaultConfig())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCopierFromCheckpoint(t *testing.T) {
@@ -333,34 +333,34 @@ func TestCopierFromCheckpoint(t *testing.T) {
 	testutils.RunSQL(t, "INSERT INTO _copierchkpt1_new VALUES (1, 2, 3),(2,3,4),(3,4,5)") // 1-3 row is already copied
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "copierchkpt1")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t1new := table.NewTableInfo(db, "test", "_copierchkpt1_new")
-	assert.NoError(t, t1new.SetInfo(t.Context()))
+	require.NoError(t, t1new.SetInfo(t.Context()))
 
 	lowWatermark := `{"Key":["a"],"ChunkSize":1,"LowerBound":{"Value":["3"],"Inclusive":true},"UpperBound":{"Value":["4"],"Inclusive":false}}`
 
 	// Create chunker first and open at the checkpoint watermark
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Open chunker at the specified watermark
 	err = chunker.OpenAtWatermark(lowWatermark)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create copier with the prepared chunker
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, copier.Run(t.Context())) // works
+	require.NoError(t, copier.Run(t.Context())) // works
 
 	// Verify that t1new has 10 rows
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM _copierchkpt1_new").Scan(&count)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 10, count)
 }
 
@@ -379,32 +379,32 @@ func TestRangeOptimizationMustApply(t *testing.T) {
 	config := dbconn.NewDBConfig()
 	config.RangeOptimizerMaxMemSize = 1024 // 1KB
 	db, err := dbconn.New(testutils.DSN(), config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	t1 := table.NewTableInfo(db, "test", "rangeoptimizertest")
-	assert.NoError(t, t1.SetInfo(t.Context()))
+	require.NoError(t, t1.SetInfo(t.Context()))
 	t1new := table.NewTableInfo(db, "test", "_rangeoptimizertest_new")
-	assert.NoError(t, t1new.SetInfo(t.Context()))
+	require.NoError(t, t1new.SetInfo(t.Context()))
 
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker.Open())
 	copier, err := NewCopier(db, chunker, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = copier.Run(t.Context())
-	assert.ErrorContains(t, err, "range_optimizer_max_mem_size") // verify that spirit refuses to run if it encounters range optimizer memory limits.
+	require.ErrorContains(t, err, "range_optimizer_max_mem_size") // verify that spirit refuses to run if it encounters range optimizer memory limits.
 
 	// Now create a new DB config, which should default to be unlimited.
 	db2, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer utils.CloseAndLog(db2)
 	testutils.RunSQL(t, "TRUNCATE _rangeoptimizertest_new")
 	chunker2, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new, TargetChunkTime: NewCopierDefaultConfig().TargetChunkTime, Logger: NewCopierDefaultConfig().Logger})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NoError(t, chunker2.Open())
 	copier, err = NewCopier(db2, chunker2, NewCopierDefaultConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = copier.Run(t.Context())
-	assert.NoError(t, err) // works now.
+	require.NoError(t, err) // works now.
 }

--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -71,11 +71,11 @@ func TestCopier(t *testing.T) {
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM copiert2").Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+	require.Equal(t, 1, count)
 
 	// Verify that testMetricsSink.Send was called >0 times
 	// It will be 1 with the composite chunker, 3 with optimistic.
-	assert.Positive(t, testMetricsSink.called)
+	require.Positive(t, testMetricsSink.called)
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 }
 
@@ -106,7 +106,7 @@ func TestThrottler(t *testing.T) {
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM throttlert2").Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+	require.Equal(t, 1, count)
 }
 
 // The expected behavior of the copier is it tolerates non-unique data
@@ -226,7 +226,7 @@ func TestSQLModeAllowZeroInvalidDates(t *testing.T) {
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM invaliddt2").Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+	require.Equal(t, 1, count)
 }
 
 func TestLockWaitTimeoutIsRetyable(t *testing.T) {
@@ -361,7 +361,7 @@ func TestCopierFromCheckpoint(t *testing.T) {
 	var count int
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM _copierchkpt1_new").Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 10, count)
+	require.Equal(t, 10, count)
 }
 
 func TestRangeOptimizationMustApply(t *testing.T) {


### PR DESCRIPTION
Closes #791. Part of #779.

## Summary
- Migrate `assert.*` -> `require.*` in `pkg/copier/*_test.go` where appropriate.
- Loop and table-driven assertions kept as `assert.*` where seeing all failures at once is preferable.
- No production code changes.

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)