### PR TITLE
test(#785): migrate pkg/migration tests to require.*

### DIFF
--- a/pkg/migration/change_test.go
+++ b/pkg/migration/change_test.go
@@ -115,15 +115,15 @@ func TestAutoIncrementEmptyTable(t *testing.T) {
 	}
 
 	expectedIDs := []int64{2979716, 2979717, 2979718}
-	assert.Equal(t, expectedIDs, insertedIDs, "Inserted IDs should start from 2979716, not 1")
+	require.Equal(t, expectedIDs, insertedIDs, "Inserted IDs should start from 2979716, not 1")
 
 	// Verify final AUTO_INCREMENT value
 	err = testDB.QueryRowContext(t.Context(),
 		"SELECT AUTO_INCREMENT FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?",
 		tableName).Scan(&autoIncValue)
 	require.NoError(t, err)
-	assert.True(t, autoIncValue.Valid)
-	assert.GreaterOrEqual(t, autoIncValue.Int64, int64(2979716), "Final AUTO_INCREMENT should be >= 2979716")
+	require.True(t, autoIncValue.Valid)
+	require.GreaterOrEqual(t, autoIncValue.Int64, int64(2979716), "Final AUTO_INCREMENT should be >= 2979716")
 }
 
 // TestAutoIncrementWithRows tests that AUTO_INCREMENT is preserved when migrating
@@ -201,7 +201,7 @@ func TestAutoIncrementWithRows(t *testing.T) {
 		migratedIDs = append(migratedIDs, id)
 	}
 	_ = rows.Close()
-	assert.Equal(t, expectedExistingIDs, migratedIDs, "Existing IDs should be preserved")
+	require.Equal(t, expectedExistingIDs, migratedIDs, "Existing IDs should be preserved")
 
 	// Insert new rows after migration
 	testutils.RunSQL(t, fmt.Sprintf(`
@@ -222,15 +222,15 @@ func TestAutoIncrementWithRows(t *testing.T) {
 	_ = rows.Close()
 
 	expectedAllIDs := []int64{2979716, 2979717, 2979718, 2979719, 2979720, 2979721}
-	assert.Equal(t, expectedAllIDs, allIDs, "New IDs should continue from 2979719")
+	require.Equal(t, expectedAllIDs, allIDs, "New IDs should continue from 2979719")
 
 	// Verify final AUTO_INCREMENT
 	err = testDB.QueryRowContext(t.Context(),
 		"SELECT AUTO_INCREMENT FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?",
 		tableName).Scan(&autoIncValue)
 	require.NoError(t, err)
-	assert.True(t, autoIncValue.Valid)
-	assert.GreaterOrEqual(t, autoIncValue.Int64, int64(2979719), "Final AUTO_INCREMENT should be >= 2979719")
+	require.True(t, autoIncValue.Valid)
+	require.GreaterOrEqual(t, autoIncValue.Int64, int64(2979719), "Final AUTO_INCREMENT should be >= 2979719")
 }
 
 func TestOldTableNameTruncation(t *testing.T) {
@@ -341,12 +341,12 @@ func TestOldTableNameTruncationCollision(t *testing.T) {
 	// Both should fit within the limit
 	result1 := c1.oldTableName()
 	result2 := c2.oldTableName()
-	assert.LessOrEqual(t, len(result1), utils.MaxTableNameLength)
-	assert.LessOrEqual(t, len(result2), utils.MaxTableNameLength)
+	require.LessOrEqual(t, len(result1), utils.MaxTableNameLength)
+	require.LessOrEqual(t, len(result2), utils.MaxTableNameLength)
 
 	// These collide because the distinguishing suffix is truncated.
 	// In practice this cannot happen since Spirit enforces a 56-char
 	// table name limit, so the truncation only removes characters
 	// beyond position 43 (which is still unique for valid table names).
-	assert.Equal(t, result1, result2)
+	require.Equal(t, result1, result2)
 }

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -309,13 +309,13 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 
 	// Verify that the old table (_old) and the new table (_new) have identical checksums.
 	// This proves that all changes were captured correctly up to the point of cutover.
-	// We use assert.Eventually to allow a brief window for any residual replication to
+	// We use require.Eventually to allow a brief window for any residual replication to
 	// settle. The cutover flushes binlog under lock, but in CI environments the Docker
 	// MySQL containers can have variable I/O latency that delays final event delivery.
 	checksumQuery := "SELECT BIT_XOR(CRC32(CONCAT_WS(',', id, x_token, cents, currency, s_token, r_token, version, IFNULL(c1,''), IFNULL(c2,''), IFNULL(c3,''), IFNULL(t1,''), IFNULL(t2,''), IFNULL(t3,''), IFNULL(b1,''), IFNULL(b2,''), created_at, updated_at))) FROM %s"
 
 	var oldChecksum, newChecksum string
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		err1 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_old")).Scan(&oldChecksum)
 		err2 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_new")).Scan(&newChecksum)
 		return err1 == nil && err2 == nil && oldChecksum == newChecksum

--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -249,7 +248,7 @@ func testEnumReorder(t *testing.T, enableBuffered bool) {
 
 	if enableBuffered {
 		require.Error(t, migrationErr)
-		assert.ErrorContains(t, migrationErr, "unsafe ENUM value reorder")
+		require.ErrorContains(t, migrationErr, "unsafe ENUM value reorder")
 		return
 	}
 
@@ -336,7 +335,7 @@ func testSetReorder(t *testing.T, enableBuffered bool) {
 	require.NoError(t, m.Close())
 
 	require.Error(t, migrationErr)
-	assert.ErrorContains(t, migrationErr, "unsafe SET value reorder")
+	require.ErrorContains(t, migrationErr, "unsafe SET value reorder")
 }
 
 // TestBufferedMigrationFailsGracefullyWithMinimalRBR verifies that a buffered

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -446,12 +446,12 @@ func TestMigrationParamsDefaultsUsed(t *testing.T) {
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, defaultUsername, migration.Username)
-	assert.Equal(t, defaultPassword, *migration.Password)
-	assert.Equal(t, fmt.Sprintf("%s:%d", defaultHost, defaultPort), migration.Host)
-	assert.Equal(t, defaultDatabase, migration.Database)
-	assert.Equal(t, defaultTLSMode, migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, defaultUsername, migration.Username)
+	require.Equal(t, defaultPassword, *migration.Password)
+	require.Equal(t, fmt.Sprintf("%s:%d", defaultHost, defaultPort), migration.Host)
+	require.Equal(t, defaultDatabase, migration.Database)
+	require.Equal(t, defaultTLSMode, migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsCLIUsed(t *testing.T) {
@@ -470,12 +470,12 @@ func TestMigrationParamsCLIUsed(t *testing.T) {
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "cli-host:3306", migration.Host)
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-password", *migration.Password)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "VERIFY_CA", migration.TLSMode)
-	assert.Equal(t, "/path/to/ca", migration.TLSCertificatePath)
+	require.Equal(t, "cli-host:3306", migration.Host)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-password", *migration.Password)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "VERIFY_CA", migration.TLSMode)
+	require.Equal(t, "/path/to/ca", migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsEmptyPasswordUsedIfProvided(t *testing.T) {
@@ -489,12 +489,12 @@ func TestMigrationParamsEmptyPasswordUsedIfProvided(t *testing.T) {
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, defaultUsername, migration.Username)
-	assert.Empty(t, *migration.Password)
-	assert.Equal(t, fmt.Sprintf("%s:%d", defaultHost, defaultPort), migration.Host)
-	assert.Equal(t, defaultDatabase, migration.Database)
-	assert.Equal(t, defaultTLSMode, migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, defaultUsername, migration.Username)
+	require.Empty(t, *migration.Password)
+	require.Equal(t, fmt.Sprintf("%s:%d", defaultHost, defaultPort), migration.Host)
+	require.Equal(t, defaultDatabase, migration.Database)
+	require.Equal(t, defaultTLSMode, migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileInvalidFile(t *testing.T) {
@@ -541,12 +541,12 @@ tls-ca = /path/from/file
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-password", *migration.Password)
-	assert.Equal(t, "cli-host:1234", migration.Host)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "REQUIRED", migration.TLSMode)
-	assert.Equal(t, "/path/to/cert", migration.TLSCertificatePath)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-password", *migration.Password)
+	require.Equal(t, "cli-host:1234", migration.Host)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "REQUIRED", migration.TLSMode)
+	require.Equal(t, "/path/to/cert", migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileNoCommandLineOptions(t *testing.T) {
@@ -570,12 +570,12 @@ tls-ca = /path/to/cert
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "fileuser", migration.Username)
-	assert.Equal(t, "filepass", *migration.Password)
-	assert.Equal(t, "filehost:5678", migration.Host)
-	assert.Equal(t, "filedb", migration.Database)
-	assert.Equal(t, "REQUIRED", migration.TLSMode)
-	assert.Equal(t, "/path/to/cert", migration.TLSCertificatePath)
+	require.Equal(t, "fileuser", migration.Username)
+	require.Equal(t, "filepass", *migration.Password)
+	require.Equal(t, "filehost:5678", migration.Host)
+	require.Equal(t, "filedb", migration.Database)
+	require.Equal(t, "REQUIRED", migration.TLSMode)
+	require.Equal(t, "/path/to/cert", migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileUseDefaultPort(t *testing.T) {
@@ -598,12 +598,12 @@ tls-ca = /path/to/another/ca
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "fileuser", migration.Username)
-	assert.Equal(t, "filepass", *migration.Password)
-	assert.Equal(t, "filehost:3306", migration.Host)
-	assert.Equal(t, "filedb", migration.Database)
-	assert.Equal(t, "VERIFY_IDENTITY", migration.TLSMode)
-	assert.Equal(t, "/path/to/another/ca", migration.TLSCertificatePath)
+	require.Equal(t, "fileuser", migration.Username)
+	require.Equal(t, "filepass", *migration.Password)
+	require.Equal(t, "filehost:3306", migration.Host)
+	require.Equal(t, "filedb", migration.Database)
+	require.Equal(t, "VERIFY_IDENTITY", migration.TLSMode)
+	require.Equal(t, "/path/to/another/ca", migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileOnlyUserSpecifiedInFile(t *testing.T) {
@@ -625,12 +625,12 @@ user = fileuser
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "fileuser", migration.Username)
-	assert.Equal(t, "cli-pass", *migration.Password)
-	assert.Equal(t, "cli-host:3306", migration.Host)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "PREFERRED", migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, "fileuser", migration.Username)
+	require.Equal(t, "cli-pass", *migration.Password)
+	require.Equal(t, "cli-host:3306", migration.Host)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "PREFERRED", migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileOnlyPasswordSpecifiedInFile(t *testing.T) {
@@ -651,12 +651,12 @@ password = filepass
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "filepass", *migration.Password)
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-host:3306", migration.Host)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "PREFERRED", migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, "filepass", *migration.Password)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-host:3306", migration.Host)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "PREFERRED", migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileEmptyPasswordPassedThrough(t *testing.T) {
@@ -678,12 +678,12 @@ password =
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Empty(t, *migration.Password)
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-host:3306", migration.Host)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "PREFERRED", migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Empty(t, *migration.Password)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-host:3306", migration.Host)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "PREFERRED", migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileEmptyPasswordOverridenByCommandLine(t *testing.T) {
@@ -706,12 +706,12 @@ password =
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "cli-password", *migration.Password)
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-host:3306", migration.Host)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "PREFERRED", migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, "cli-password", *migration.Password)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-host:3306", migration.Host)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "PREFERRED", migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileOnlyPortUsedFromFile(t *testing.T) {
@@ -734,12 +734,12 @@ port=1234
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "cli-password", *migration.Password)
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-host:1234", migration.Host)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "PREFERRED", migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, "cli-password", *migration.Password)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-host:1234", migration.Host)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "PREFERRED", migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileEmptyClientSection(t *testing.T) {
@@ -762,12 +762,12 @@ func TestMigrationParamsIniFileEmptyClientSection(t *testing.T) {
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "cli-host:3306", migration.Host)
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-password", *migration.Password)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "PREFERRED", migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, "cli-host:3306", migration.Host)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-password", *migration.Password)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "PREFERRED", migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 func TestMigrationParamsIniFileHasNoClientSection(t *testing.T) {
@@ -792,12 +792,12 @@ password = mysqlpass
 	_, err := migration.normalizeOptions()
 	require.NoError(t, err)
 
-	assert.Equal(t, "cli-host:3306", migration.Host)
-	assert.Equal(t, "cli-user", migration.Username)
-	assert.Equal(t, "cli-password", *migration.Password)
-	assert.Equal(t, "cli-db", migration.Database)
-	assert.Equal(t, "PREFERRED", migration.TLSMode)
-	assert.Empty(t, migration.TLSCertificatePath)
+	require.Equal(t, "cli-host:3306", migration.Host)
+	require.Equal(t, "cli-user", migration.Username)
+	require.Equal(t, "cli-password", *migration.Password)
+	require.Equal(t, "cli-db", migration.Database)
+	require.Equal(t, "PREFERRED", migration.TLSMode)
+	require.Empty(t, migration.TLSCertificatePath)
 }
 
 // --- Configuration and validation tests (extracted from runner_test.go) ---

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -468,7 +468,7 @@ func TestMigrationParamsCLIUsed(t *testing.T) {
 	}
 
 	_, err := migration.normalizeOptions()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "cli-host:3306", migration.Host)
 	assert.Equal(t, "cli-user", migration.Username)
@@ -510,8 +510,8 @@ func TestMigrationParamsIniFileInvalidFile(t *testing.T) {
 	}
 
 	_, err := migration.normalizeOptions()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "no such file or directory")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no such file or directory")
 }
 
 func TestMigrationParamsIniFilePreferCommandLineOptions(t *testing.T) {

--- a/pkg/migration/rename_column_test.go
+++ b/pkg/migration/rename_column_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/block/spirit/pkg/testutils"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,7 +47,7 @@ func TestRenameColumnSimple(t *testing.T) {
 			var count int
 			err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM rcol_simple WHERE new_name IN ('alice','bob','charlie')").Scan(&count)
 			require.NoError(t, err)
-			assert.Equal(t, 3, count)
+			require.Equal(t, 3, count)
 		},
 	)
 }
@@ -70,13 +69,13 @@ func TestRenameColumnChangeType(t *testing.T) {
 			var sum int64
 			err := db.QueryRowContext(t.Context(), "SELECT SUM(big_val) FROM rcol_chtype").Scan(&sum)
 			require.NoError(t, err)
-			assert.Equal(t, int64(600), sum)
+			require.Equal(t, int64(600), sum)
 
 			// Verify column type changed
 			var colType string
 			err = db.QueryRowContext(t.Context(), "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='rcol_chtype' AND COLUMN_NAME='big_val'").Scan(&colType)
 			require.NoError(t, err)
-			assert.Equal(t, "bigint", colType)
+			require.Equal(t, "bigint", colType)
 		},
 	)
 }
@@ -100,9 +99,9 @@ func TestRenameColumnMultiple(t *testing.T) {
 			var a, b, c string
 			err := db.QueryRowContext(t.Context(), "SELECT renamed_a, col_b, renamed_c FROM rcol_multi ORDER BY id LIMIT 1").Scan(&a, &b, &c)
 			require.NoError(t, err)
-			assert.Equal(t, "a1", a)
-			assert.Equal(t, "b1", b)
-			assert.Equal(t, "c1", c)
+			require.Equal(t, "a1", a)
+			require.Equal(t, "b1", b)
+			require.Equal(t, "c1", c)
 		},
 	)
 }
@@ -129,8 +128,8 @@ func TestRenameColumnWithGeneratedColumnEnd(t *testing.T) {
 			var groupName, fullName string
 			err := db.QueryRowContext(t.Context(), "SELECT group_name, full_name FROM rcol_genend ORDER BY id LIMIT 1").Scan(&groupName, &fullName)
 			require.NoError(t, err)
-			assert.Equal(t, "vip", groupName)
-			assert.Equal(t, "John Doe", fullName) // generated column still works
+			require.Equal(t, "vip", groupName)
+			require.Equal(t, "John Doe", fullName) // generated column still works
 		},
 	)
 }
@@ -159,9 +158,9 @@ func TestRenameColumnWithGeneratedColumnMiddle(t *testing.T) {
 			var desc string
 			err := db.QueryRowContext(t.Context(), "SELECT price, total, item_desc FROM rcol_genmid ORDER BY id LIMIT 1").Scan(&price, &total, &desc)
 			require.NoError(t, err)
-			assert.Equal(t, 100, price)
-			assert.InDelta(t, 110.0, total, 0.01)
-			assert.Equal(t, "item1", desc)
+			require.Equal(t, 100, price)
+			require.InDelta(t, 110.0, total, 0.01)
+			require.Equal(t, "item1", desc)
 		},
 	)
 }
@@ -184,8 +183,8 @@ func TestRenameColumnWithAddColumn(t *testing.T) {
 			var extra int
 			err := db.QueryRowContext(t.Context(), "SELECT new_col, extra FROM rcol_addcol ORDER BY id LIMIT 1").Scan(&newCol, &extra)
 			require.NoError(t, err)
-			assert.Equal(t, "val1", newCol)
-			assert.Equal(t, 0, extra)
+			require.Equal(t, "val1", newCol)
+			require.Equal(t, 0, extra)
 		},
 	)
 }
@@ -208,13 +207,13 @@ func TestRenameColumnWithDropColumn(t *testing.T) {
 			var val string
 			err := db.QueryRowContext(t.Context(), "SELECT renamed_col FROM rcol_dropcol ORDER BY id LIMIT 1").Scan(&val)
 			require.NoError(t, err)
-			assert.Equal(t, "keep1", val)
+			require.Equal(t, "keep1", val)
 
 			// Verify drop_col no longer exists
 			var count int
 			err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='rcol_dropcol' AND COLUMN_NAME='drop_col'").Scan(&count)
 			require.NoError(t, err)
-			assert.Equal(t, 0, count)
+			require.Equal(t, 0, count)
 		},
 	)
 }
@@ -250,13 +249,13 @@ func TestRenameColumnLargerDataset(t *testing.T) {
 	var count int
 	err = db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 16, count)
+	require.Equal(t, 16, count)
 
 	// Verify data accessible via new column name
 	var name string
 	err = db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT new_name FROM %s LIMIT 1", tableName)).Scan(&name)
 	require.NoError(t, err)
-	assert.Equal(t, "row", name)
+	require.Equal(t, "row", name)
 }
 
 // TestRenameColumnPKBlocked verifies that renaming a PK column is blocked
@@ -304,8 +303,8 @@ func TestRenameColumnChangeColumnWithTypeChange(t *testing.T) {
 			var total int64
 			err := db.QueryRowContext(t.Context(), "SELECT big_text, total FROM rcol_chg_tp ORDER BY id LIMIT 1").Scan(&text, &total)
 			require.NoError(t, err)
-			assert.Equal(t, "hello", text)
-			assert.Equal(t, int64(42), total)
+			require.Equal(t, "hello", text)
+			require.Equal(t, int64(42), total)
 		},
 	)
 }
@@ -332,12 +331,12 @@ func TestRenameColumnWithNullableColumns(t *testing.T) {
 			require.True(t, rows.Next())
 			var val *string
 			require.NoError(t, rows.Scan(&val))
-			assert.Nil(t, val) // first row should be NULL
+			require.Nil(t, val) // first row should be NULL
 
 			require.True(t, rows.Next())
 			require.NoError(t, rows.Scan(&val))
 			require.NotNil(t, val)
-			assert.Equal(t, "has_val", *val)
+			require.Equal(t, "has_val", *val)
 		},
 	)
 }
@@ -360,7 +359,7 @@ func TestRenameColumnCompositeKey(t *testing.T) {
 			var val string
 			err := db.QueryRowContext(t.Context(), "SELECT new_value FROM rcol_compkey WHERE tenant_id=1 AND item_id=2").Scan(&val)
 			require.NoError(t, err)
-			assert.Equal(t, "b", val)
+			require.Equal(t, "b", val)
 		},
 	)
 }
@@ -387,10 +386,10 @@ func TestRenameColumnAllCombined(t *testing.T) {
 			var amount, genCol, extra int
 			err := db.QueryRowContext(t.Context(), "SELECT new_name, amount, gen_col, extra FROM rcol_combo ORDER BY id LIMIT 1").Scan(&name, &amount, &genCol, &extra)
 			require.NoError(t, err)
-			assert.Equal(t, "alice", name)
-			assert.Equal(t, 10, amount)
-			assert.Equal(t, 20, genCol) // generated column should still work
-			assert.Equal(t, 99, extra)  // new column default
+			require.Equal(t, "alice", name)
+			require.Equal(t, 10, amount)
+			require.Equal(t, 20, genCol) // generated column should still work
+			require.Equal(t, 99, extra)  // new column default
 		},
 	)
 }
@@ -430,19 +429,19 @@ func TestRenameColumnForceCopyPath(t *testing.T) {
 	var count int
 	err = db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 32, count)
+	require.Equal(t, 32, count)
 
 	// Verify data accessible via new column name
 	var name string
 	err = db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT new_name FROM %s WHERE id=1", tableName)).Scan(&name)
 	require.NoError(t, err)
-	assert.Equal(t, "row1", name)
+	require.Equal(t, "row1", name)
 
 	// Verify column type changed
 	var colType string
 	err = db.QueryRowContext(t.Context(), "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME=? AND COLUMN_NAME='new_name'", tableName).Scan(&colType)
 	require.NoError(t, err)
-	assert.Equal(t, "varchar(200)", colType)
+	require.Equal(t, "varchar(200)", colType)
 }
 
 // TestRenameColumnEmpty tests rename on an empty table.
@@ -462,7 +461,7 @@ func TestRenameColumnEmpty(t *testing.T) {
 			var count int
 			err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='rcol_empty' AND COLUMN_NAME='new_col'").Scan(&count)
 			require.NoError(t, err)
-			assert.Equal(t, 1, count)
+			require.Equal(t, 1, count)
 		},
 	)
 }

--- a/pkg/migration/replica_tls_test.go
+++ b/pkg/migration/replica_tls_test.go
@@ -278,17 +278,17 @@ func TestReplicaTLSIntegration(t *testing.T) {
 
 	// Test that the replica DSN would be enhanced
 	enhanced, err := dbconn.EnhanceDSNWithTLS(replicaDSN, runner.dbConfig)
-	assert.NoError(t, err)
-	assert.Contains(t, enhanced, "tls=verify_ca")
-	assert.Contains(t, enhanced, "replica.example.com:3306")
+	require.NoError(t, err)
+	require.Contains(t, enhanced, "tls=verify_ca")
+	require.Contains(t, enhanced, "replica.example.com:3306")
 
 	// Verify that the enhancement preserves the original connection details
 	enhancedCfg, err := mysql.ParseDSN(enhanced)
-	assert.NoError(t, err)
-	assert.Equal(t, "replica_user", enhancedCfg.User)
-	assert.Equal(t, "replica_pass", enhancedCfg.Passwd)
-	assert.Equal(t, "replica.example.com:3306", enhancedCfg.Addr)
-	assert.Equal(t, "testdb", enhancedCfg.DBName)
+	require.NoError(t, err)
+	require.Equal(t, "replica_user", enhancedCfg.User)
+	require.Equal(t, "replica_pass", enhancedCfg.Passwd)
+	require.Equal(t, "replica.example.com:3306", enhancedCfg.Addr)
+	require.Equal(t, "testdb", enhancedCfg.DBName)
 }
 
 // generateTestCertForTLS creates a test certificate for TLS testing


### PR DESCRIPTION
Closes #785. Part of #779.

## Summary
- Migrate `assert.*` -> `require.*` in `pkg/migration/*_test.go` where appropriate.
- Loop and table-driven assertions kept as `assert.*` where seeing all failures at once is preferable.
- No production code changes.

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)