### PR TITLE
fix(#746): KeyAboveHighWatermark must not silently drop in IsNil state

### DIFF
--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -124,14 +124,16 @@ func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*ta
 		return err
 	}
 	defer utils.CloseAndLogWithContext(ctx, tableLock)
-	if err := c.feed.FlushUnderTableLock(ctx, tableLock); err != nil {
-		return err
-	}
-	// Perform a second FlushUnderTableLock to handle the rare case where
-	// the first flush's own binlog events (from REPLACE INTO/DELETE statements)
-	// need to be read back and processed. The first flush writes changes to
-	// the _new table, which generates binlog events. The second flush ensures
-	// those events are consumed and the positions are fully synchronized.
+	// FlushUnderTableLock itself does flush → BlockWait → flush, so the
+	// flush's own binlog events (REPLACE INTO _new / DELETE FROM _new) are
+	// already read back inside the BlockWait of the same call. The earlier
+	// "second FlushUnderTableLock" workaround was added under the
+	// assumption that an extra round-trip would close a position-bookkeeping
+	// gap, but the real bug was upstream — events were being silently
+	// dropped by KeyAboveHighWatermark in the chunkPtr.IsNil window
+	// (issue #746, fixed in chunker_optimistic.go / chunker_composite.go).
+	// Now that the source of the divergence is gone, a single
+	// FlushUnderTableLock is sufficient.
 	if err := c.feed.FlushUnderTableLock(ctx, tableLock); err != nil {
 		return err
 	}

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -216,9 +216,20 @@ func TestInvalidOptions(t *testing.T) {
 //
 // This test proves that the window does not introduce inconsistency, even when
 // there are concurrent writes happening that are trying to introduce it.
+//
+// The test runs four times — across the cross product of:
+//   - chunker selection (optimistic vs composite)
+//   - copier mode (unbuffered vs buffered)
+//
+// The optimistic chunker is selected automatically for single-column
+// auto_increment PKs; the composite chunker covers everything else (here we
+// force it via a composite (id, x_token) PK). Buffered mode uses the
+// SingleTargetApplier path; both modes have surfaced the issue-#746
+// dead-zone bug in CI history (see e.g. PRs #801, #797, #795, #804).
 func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 	t.Parallel()
-	tt := testutils.NewTestTable(t, "t1concurrent", `CREATE TABLE t1concurrent (
+
+	const optimisticSchema = `CREATE TABLE %s (
 		id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 		x_token VARCHAR(36) NOT NULL,
 		cents INT NOT NULL,
@@ -239,9 +250,72 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 		UNIQUE KEY idx_x_token (x_token),
 		KEY idx_s_token (s_token),
 		KEY idx_r_token (r_token)
-	)`)
-	testutils.RunSQL(t, `INSERT INTO t1concurrent (x_token, cents, currency, s_token, r_token, version, created_at, updated_at)
-		VALUES ('initial-1', 100, 'USD', 'sender-1', 'receiver-1', 1, NOW(), NOW())`)
+	)`
+
+	// Composite-PK schema. Putting x_token in the PK forces NewChunker to
+	// pick the composite chunker instead of the optimistic one (which only
+	// handles a single-column auto_increment PK). Drop the redundant
+	// UNIQUE KEY on x_token since the PK now enforces uniqueness on
+	// (id, x_token).
+	const compositeSchema = `CREATE TABLE %s (
+		id INT NOT NULL AUTO_INCREMENT,
+		x_token VARCHAR(36) NOT NULL,
+		cents INT NOT NULL,
+		currency VARCHAR(3) NOT NULL,
+		s_token VARCHAR(36) NOT NULL,
+		r_token VARCHAR(36) NOT NULL,
+		version INT NOT NULL DEFAULT 1,
+		c1 VARCHAR(20),
+		c2 VARCHAR(200),
+		c3 VARCHAR(10),
+		t1 DATETIME,
+		t2 DATETIME,
+		t3 DATETIME,
+		b1 TINYINT,
+		b2 TINYINT,
+		created_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL,
+		PRIMARY KEY (id, x_token),
+		KEY idx_s_token (s_token),
+		KEY idx_r_token (r_token)
+	)`
+
+	cases := []struct {
+		name      string
+		tableName string
+		schema    string
+		buffered  bool
+	}{
+		{"optimistic_unbuffered", "t1concurrent_oub", optimisticSchema, false},
+		{"optimistic_buffered", "t1concurrent_obu", optimisticSchema, true},
+		{"composite_unbuffered", "t1concurrent_cub", compositeSchema, false},
+		{"composite_buffered", "t1concurrent_cbu", compositeSchema, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.buffered && testutils.IsMinimalRBRTestRunner(t) {
+				t.Skip("buffered copier requires binlog_row_image=FULL")
+			}
+			runCutoverAtomicityTest(t, tc.tableName, tc.schema, tc.buffered)
+		})
+	}
+}
+
+// runCutoverAtomicityTest runs the body of the cutover-atomicity probe
+// against an arbitrary table/schema pair, in either unbuffered or buffered
+// copier mode. tableName must be unique per call so the four variants can
+// run in parallel without conflicting on `_<name>_old`/`_<name>_new`.
+func runCutoverAtomicityTest(t *testing.T, tableName, schemaTmpl string, buffered bool) {
+	t.Helper()
+
+	tt := testutils.NewTestTable(t, tableName, fmt.Sprintf(schemaTmpl, tableName))
+
+	insertInitial := fmt.Sprintf(`INSERT INTO %s
+		(x_token, cents, currency, s_token, r_token, version, created_at, updated_at)
+		VALUES ('initial-1', 100, 'USD', 'sender-1', 'receiver-1', 1, NOW(), NOW())`, tableName)
+	testutils.RunSQL(t, insertInitial)
 
 	// Start concurrent write load
 	ctx, cancel := context.WithCancel(t.Context())
@@ -255,7 +329,7 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 	// Start write threads
 	for range numThreads {
 		wg.Go(func() {
-			migrationConcurrentWriteThread(ctx, tt.DB, &writeCount, &errorCount)
+			migrationConcurrentWriteThread(ctx, tt.DB, tableName, &writeCount, &errorCount)
 		})
 	}
 
@@ -264,8 +338,9 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 
 	// Create and configure the migration with a custom cutover algorithm
 	// that intentionally fails after renaming the original table.
-	migration := NewTestMigration(t, WithTable("t1concurrent"), WithAlter("ENGINE=InnoDB"),
-		WithThreads(2), WithTargetChunkTime(100*time.Millisecond))
+	migration := NewTestMigration(t, WithTable(tableName), WithAlter("ENGINE=InnoDB"),
+		WithThreads(2), WithTargetChunkTime(100*time.Millisecond),
+		WithBuffered(buffered))
 	migration.useTestCutover = true
 
 	// Run the migration — we expect it to fail with our intentional error.
@@ -296,12 +371,19 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 		t.Fatalf("issue #746 reproduced at checksum step (FixDifferences disabled via useTestCutover): %v — see preceding 'inspection revealed row does not exist in target' Warn logs for missing PKs", err)
 	}
 
-	// The partial cutover should have renamed t1concurrent to _t1concurrent_old
+	oldTable := "_" + tableName + "_old"
+	newTable := "_" + tableName + "_new"
+
+	// The partial cutover should have renamed tableName to <_old>
 	// Let's verify both tables exist
 	var oldTableExists, newTableExists bool
-	err = tt.DB.QueryRowContext(t.Context(), "SELECT COUNT(*) > 0 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '_t1concurrent_old'").Scan(&oldTableExists)
+	err = tt.DB.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) > 0 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?",
+		oldTable).Scan(&oldTableExists)
 	require.NoError(t, err)
-	err = tt.DB.QueryRowContext(t.Context(), "SELECT COUNT(*) > 0 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '_t1concurrent_new'").Scan(&newTableExists)
+	err = tt.DB.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) > 0 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?",
+		newTable).Scan(&newTableExists)
 	require.NoError(t, err)
 
 	require.True(t, oldTableExists, "The _old table should exist after partial cutover")
@@ -318,9 +400,9 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 	checksumQuery := "SELECT BIT_XOR(CRC32(CONCAT_WS(',', id, x_token, cents, currency, s_token, r_token, version, IFNULL(c1,''), IFNULL(c2,''), IFNULL(c3,''), IFNULL(t1,''), IFNULL(t2,''), IFNULL(t3,''), IFNULL(b1,''), IFNULL(b2,''), created_at, updated_at))) FROM %s"
 
 	var oldChecksum, newChecksum string
-	err1 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_old")).Scan(&oldChecksum)
+	err1 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, oldTable)).Scan(&oldChecksum)
 	require.NoError(t, err1)
-	err2 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_new")).Scan(&newChecksum)
+	err2 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, newTable)).Scan(&newChecksum)
 	require.NoError(t, err2)
 	require.Equal(t, oldChecksum, newChecksum, "Checksums should match between old and new tables")
 
@@ -328,9 +410,9 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 
 	// Also verify row counts match
 	var oldCount, newCount int
-	err = tt.DB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM _t1concurrent_old").Scan(&oldCount)
+	err = tt.DB.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", oldTable)).Scan(&oldCount)
 	require.NoError(t, err)
-	err = tt.DB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM _t1concurrent_new").Scan(&newCount)
+	err = tt.DB.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", newTable)).Scan(&newCount)
 	require.NoError(t, err)
 
 	t.Logf("Old table count: %d, New table count: %d", oldCount, newCount)
@@ -340,27 +422,28 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 	// latest (cutover-window race) or scattered through the range (copy-phase race).
 	if oldChecksum != newChecksum || oldCount != newCount {
 		var maxOld int
-		_ = tt.DB.QueryRowContext(t.Context(), "SELECT IFNULL(MAX(id),0) FROM _t1concurrent_old").Scan(&maxOld)
-		t.Logf("max(id) in _old=%d", maxOld)
+		_ = tt.DB.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT IFNULL(MAX(id),0) FROM %s", oldTable)).Scan(&maxOld)
+		t.Logf("max(id) in %s=%d", oldTable, maxOld)
 		missingRows, _ := tt.DB.QueryContext(t.Context(),
-			`SELECT o.id, o.x_token, o.version, o.created_at, o.updated_at
-			   FROM _t1concurrent_old o LEFT JOIN _t1concurrent_new n ON n.id = o.id
-			   WHERE n.id IS NULL ORDER BY o.id`)
+			fmt.Sprintf(`SELECT o.id, o.x_token, o.version, o.created_at, o.updated_at
+			   FROM %s o LEFT JOIN %s n ON n.id = o.id
+			   WHERE n.id IS NULL ORDER BY o.id`, oldTable, newTable))
 		if missingRows != nil {
 			defer func() { _ = missingRows.Close() }()
 			for missingRows.Next() {
 				var id, version int
 				var xtoken, createdAt, updatedAt string
 				_ = missingRows.Scan(&id, &xtoken, &version, &createdAt, &updatedAt)
-				t.Logf("MISSING in _new: id=%d x_token=%s version=%d created_at=%s updated_at=%s",
-					id, xtoken, version, createdAt, updatedAt)
+				t.Logf("MISSING in %s: id=%d x_token=%s version=%d created_at=%s updated_at=%s",
+					newTable, id, xtoken, version, createdAt, updatedAt)
 			}
 		}
 		divergedRows, _ := tt.DB.QueryContext(t.Context(),
-			`SELECT o.id, o.version AS old_v, n.version AS new_v, o.updated_at AS old_u, n.updated_at AS new_u
-			   FROM _t1concurrent_old o JOIN _t1concurrent_new n ON n.id = o.id
+			fmt.Sprintf(`SELECT o.id, o.version AS old_v, n.version AS new_v, o.updated_at AS old_u, n.updated_at AS new_u
+			   FROM %s o JOIN %s n ON n.id = o.id
 			   WHERE o.version != n.version OR o.updated_at != n.updated_at
-			   ORDER BY o.id`)
+			   ORDER BY o.id`, oldTable, newTable))
 		if divergedRows != nil {
 			defer func() { _ = divergedRows.Close() }()
 			for divergedRows.Next() {
@@ -376,13 +459,13 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 }
 
 // migrationConcurrentWriteThread simulates concurrent write load during migration
-func migrationConcurrentWriteThread(ctx context.Context, db *sql.DB, writeCount, errorCount *atomic.Int64) {
+func migrationConcurrentWriteThread(ctx context.Context, db *sql.DB, tableName string, writeCount, errorCount *atomic.Int64) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			if err := doOneMigrationWriteLoop(ctx, db); err != nil {
+			if err := doOneMigrationWriteLoop(ctx, db, tableName); err != nil {
 				errorCount.Add(1)
 				// Continue on error - some errors are expected during cutover
 			} else {
@@ -393,7 +476,7 @@ func migrationConcurrentWriteThread(ctx context.Context, db *sql.DB, writeCount,
 }
 
 // doOneMigrationWriteLoop performs one iteration of insert + update + reads
-func doOneMigrationWriteLoop(ctx context.Context, db *sql.DB) error {
+func doOneMigrationWriteLoop(ctx context.Context, db *sql.DB, tableName string) error {
 	trx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -409,23 +492,25 @@ func doOneMigrationWriteLoop(ctx context.Context, db *sql.DB) error {
 	rtoken := fmt.Sprintf("r-%d", time.Now().UnixNano())
 
 	//nolint: dupword
-	_, err = trx.ExecContext(ctx, `INSERT INTO t1concurrent (x_token, cents, currency, s_token, r_token, version, c1, c2, c3, t1, t2, t3, b1, b2, created_at, updated_at)
-		VALUES (?, 100, 'USD', ?, ?, 1, HEX(RANDOM_BYTES(10)), HEX(RANDOM_BYTES(100)), HEX(RANDOM_BYTES(5)), NOW(), NOW(), NOW(), 1, 2, NOW(), NOW())`,
-		xtoken, stoken, rtoken)
+	insertSQL := fmt.Sprintf(`INSERT INTO %s (x_token, cents, currency, s_token, r_token, version, c1, c2, c3, t1, t2, t3, b1, b2, created_at, updated_at)
+		VALUES (?, 100, 'USD', ?, ?, 1, HEX(RANDOM_BYTES(10)), HEX(RANDOM_BYTES(100)), HEX(RANDOM_BYTES(5)), NOW(), NOW(), NOW(), 1, 2, NOW(), NOW())`, tableName)
+	_, err = trx.ExecContext(ctx, insertSQL, xtoken, stoken, rtoken)
 	if err != nil {
 		return err
 	}
 
 	// Update
-	_, err = trx.ExecContext(ctx, `UPDATE t1concurrent SET version = 2, updated_at = NOW() WHERE x_token = ?`, xtoken)
+	updateSQL := fmt.Sprintf(`UPDATE %s SET version = 2, updated_at = NOW() WHERE x_token = ?`, tableName)
+	_, err = trx.ExecContext(ctx, updateSQL, xtoken)
 	if err != nil {
 		return err
 	}
 
 	// Do some cached reads
+	selectSQL := fmt.Sprintf(`SELECT id, x_token, cents, currency, s_token, r_token, version, c1, c2, c3, t1, t2, t3, b1, b2, created_at, updated_at FROM %s WHERE x_token = ?`, tableName)
 	var rows *sql.Rows
 	for range 10 {
-		rows, err = trx.QueryContext(ctx, `SELECT id, x_token, cents, currency, s_token, r_token, version, c1, c2, c3, t1, t2, t3, b1, b2, created_at, updated_at FROM t1concurrent WHERE x_token = ?`, xtoken)
+		rows, err = trx.QueryContext(ctx, selectSQL, xtoken)
 		if err != nil {
 			return err
 		}

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -309,17 +309,20 @@ func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 
 	// Verify that the old table (_old) and the new table (_new) have identical checksums.
 	// This proves that all changes were captured correctly up to the point of cutover.
-	// We use require.Eventually to allow a brief window for any residual replication to
-	// settle. The cutover flushes binlog under lock, but in CI environments the Docker
-	// MySQL containers can have variable I/O latency that delays final event delivery.
+	// The cutover protocol guarantees consistency under the lock — there's no
+	// "residual replication to settle" once FlushUnderTableLock + BlockWait +
+	// AllChangesFlushed have all returned. The previous require.Eventually(5s)
+	// wrapper masked the now-fixed issue #746 (KeyAboveHighWatermark dropping
+	// events in the chunkPtr.IsNil window) but couldn't actually fix it: a
+	// single missing row stays missing after 5 s of polling.
 	checksumQuery := "SELECT BIT_XOR(CRC32(CONCAT_WS(',', id, x_token, cents, currency, s_token, r_token, version, IFNULL(c1,''), IFNULL(c2,''), IFNULL(c3,''), IFNULL(t1,''), IFNULL(t2,''), IFNULL(t3,''), IFNULL(b1,''), IFNULL(b2,''), created_at, updated_at))) FROM %s"
 
 	var oldChecksum, newChecksum string
-	require.Eventually(t, func() bool {
-		err1 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_old")).Scan(&oldChecksum)
-		err2 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_new")).Scan(&newChecksum)
-		return err1 == nil && err2 == nil && oldChecksum == newChecksum
-	}, 5*time.Second, 250*time.Millisecond, "Checksums should eventually match between old and new tables")
+	err1 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_old")).Scan(&oldChecksum)
+	require.NoError(t, err1)
+	err2 := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(checksumQuery, "_t1concurrent_new")).Scan(&newChecksum)
+	require.NoError(t, err2)
+	require.Equal(t, oldChecksum, newChecksum, "Checksums should match between old and new tables")
 
 	t.Logf("Old table checksum: %s, New table checksum: %s", oldChecksum, newChecksum)
 

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -112,10 +112,17 @@ func TestReplClientComplex(t *testing.T) {
 	defer client.Close()
 	client.SetWatermarkOptimization(true)
 
-	// Insert into t1, but because there is no read yet, the key is above the watermark
+	// DELETE before the chunker has advanced. Previously this returned 0
+	// because KeyAboveHighWatermark with chunkPtr.IsNil() silently dropped
+	// every event — the bug behind issue #746. Post-fix the events are
+	// buffered into the delta map and will be drained by a later flush
+	// once the chunker advances. (See pkg/table/chunker_optimistic.go.)
 	testutils.RunSQL(t, "DELETE FROM replcomplext1 WHERE a BETWEEN 10 and 500")
 	require.NoError(t, client.BlockWait(t.Context()))
-	require.Equal(t, 0, client.GetDeltaLen())
+	// Number of rows in [10, 500] that actually existed (auto_increment has
+	// small gaps from the previous bulk INSERT … SELECT … LIMIT inserts).
+	preChunkerDeltas := client.GetDeltaLen()
+	require.Positive(t, preChunkerDeltas, "events committed before the chunker advances must accumulate, not silently drop")
 
 	// Read from the copier so that the key is below the watermark
 	// + give feedback
@@ -129,15 +136,19 @@ func TestReplClientComplex(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "`a` >= 1 AND `a` < 1001", chk.String())
 
-	// Now if we delete below 1001 we should see 10 deltas accumulate
+	// Delete a small range while the second chunk is in flight. The 491
+	// deltas from the previous DELETE are still buffered, so the count is
+	// the union of the two ranges.
 	testutils.RunSQL(t, "DELETE FROM replcomplext1 WHERE a >= 550 AND a < 560")
 	require.NoError(t, client.BlockWait(t.Context()))
-	require.Equal(t, 10, client.GetDeltaLen()) // 10 keys did not exist on t1
+	require.Equal(t, preChunkerDeltas+10, client.GetDeltaLen())
 
-	// Try to flush the changeset
-	// It should be empty, but it's not! This is because of KeyBelowWatermark
+	// Try to flush the changeset.
+	// Nothing flushes because KeyBelowLowWatermark defers any key whose
+	// chunk hasn't been Feedback'd yet — the watermark is still at upper
+	// bound 1 (only the `a < 1` chunk has been fed back).
 	require.NoError(t, client.Flush(t.Context()))
-	require.Equal(t, 10, client.GetDeltaLen())
+	require.Equal(t, preChunkerDeltas+10, client.GetDeltaLen())
 
 	// However after we give feedback, then it should be able to flush these deltas.
 	// This is because the watermark advances above 1000.

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -545,13 +545,21 @@ func (t *chunkerComposite) KeyAboveHighWatermark(key0 any) bool {
 	t.Lock()
 	defer t.Unlock()
 
-	// If we haven't dispatched any chunks yet (chunkPtrs is empty),
-	// everything is "above" the high watermark (we haven't started copying yet)
-	// Return true to discard binlog events that are ahead of our progress.
-	// But if checkpointHighPtr is set (resume case), we must not discard
-	// events below it — those rows may already exist in the target.
+	// We haven't claimed any range yet (no chunks dispatched, no resume
+	// checkpoint). The previous behavior returned TRUE here ("everything is
+	// above the high watermark"), which silently dropped binlog events
+	// during the window between SetWatermarkOptimization(true) and the
+	// first chunker.Next() call. The intent was that the chunker's later
+	// SELECT would pick the row up from source, but that only works for
+	// rows committed before the SELECT's snapshot. Rows committed AFTER
+	// the SELECT but BEFORE chunkPtrs is set are invisible to both paths
+	// and lost — see issue #746.
+	//
+	// Per the contract above ("if there is any ambiguity, return FALSE"),
+	// return FALSE: buffer the change. Once chunks start being dispatched,
+	// the watermark logic at flush time routes it correctly.
 	if len(t.chunkPtrs) == 0 && t.checkpointHighPtr.IsNil() {
-		return true
+		return false
 	}
 
 	// If we've sent the final chunk, nothing is above
@@ -589,7 +597,13 @@ func (t *chunkerComposite) KeyAboveHighWatermark(key0 any) bool {
 	// Check if key is greater than or equal to the current chunkPtr[0]
 	// Use GreaterThanOrEqual which supports all types (numeric, string, temporal)
 	if len(t.chunkPtrs) == 0 {
-		return true // no chunkPtrs yet, but above checkpointHighPtr
+		// chunkPtrs not dispatched yet, key is above checkpointHighPtr.
+		// Same reasoning as the IsNil branch above: returning TRUE here
+		// would silently drop events for keys that the chunker hasn't
+		// yet dispatched, on the assumption that the later SELECT will
+		// pick them up — which is unsafe for rows committed after the
+		// SELECT's snapshot. Return FALSE so the change is buffered.
+		return false
 	}
 	return keyDatum.GreaterThanOrEqual(t.chunkPtrs[0])
 }

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -833,15 +833,19 @@ func TestCompositeChunkerWatermarkOptimizations(t *testing.T) {
 	require.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 
-	// Before opening, everything is above high watermark
-	require.True(t, comp.KeyAboveHighWatermark(1))
-	require.True(t, comp.KeyAboveHighWatermark(100))
+	// Before opening, no chunks dispatched and no resume checkpoint —
+	// per the ambiguity contract on KeyAboveHighWatermark we must return
+	// FALSE so the binlog applier buffers the change rather than silently
+	// dropping it. See issue #746.
+	require.False(t, comp.KeyAboveHighWatermark(1))
+	require.False(t, comp.KeyAboveHighWatermark(100))
 	require.False(t, comp.KeyBelowLowWatermark(1)) // watermark not ready
 
 	require.NoError(t, comp.Open())
 
-	// After opening but before first chunk, key=1 should still be above
-	require.True(t, comp.KeyAboveHighWatermark(1))
+	// After Open() but before first Next(), still no chunks dispatched,
+	// so the IsNil branch keeps returning FALSE for the same reason.
+	require.False(t, comp.KeyAboveHighWatermark(1))
 	require.False(t, comp.KeyBelowLowWatermark(1))
 
 	// Get first chunk for tenant_id=1
@@ -1402,8 +1406,10 @@ func TestCompositeChunkerCheckpointHighPtr(t *testing.T) {
 	require.NoError(t, err)
 	comp := chunker.(*chunkerComposite)
 
-	// Before OpenAtWatermark: everything should be "above" (no chunks dispatched)
-	require.True(t, comp.KeyAboveHighWatermark(1))
+	// Before OpenAtWatermark: no chunks dispatched and no checkpoint
+	// loaded yet, so the IsNil-both branch returns FALSE per the ambiguity
+	// contract (events buffered, not dropped). See issue #746.
+	require.False(t, comp.KeyAboveHighWatermark(1))
 
 	// Simulate a watermark at a=200 — the copier had reached this point before interruption.
 	watermark := `{"ChunkJSON":"{\"Key\":[\"a\",\"b\"],\"ChunkSize\":1000,\"LowerBound\":{\"Value\":[\"100\",\"1\"],\"Inclusive\":true},\"UpperBound\":{\"Value\":[\"200\",\"1\"],\"Inclusive\":false}}","RowsCopied":200}`

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -561,7 +561,26 @@ func (t *chunkerOptimistic) KeyAboveHighWatermark(key0 any) bool {
 	t.Lock()
 	defer t.Unlock()
 	if t.chunkPtr.IsNil() && t.checkpointHighPtr.IsNil() {
-		return true // every key is above because we haven't started copying.
+		// We haven't claimed any range yet (no chunk advanced, no resume
+		// checkpoint). The previous behavior returned TRUE here ("every key is
+		// above"), which silently dropped binlog events during the window
+		// between SetWatermarkOptimization(true) and the first chunker.Next().
+		// The intent was to rely on the chunker's later SELECT picking the row
+		// up from the source — but that only works if the writer committed
+		// before the SELECT's snapshot. A writer that commits AFTER the
+		// SELECT and BEFORE chunkPtr is set produces a row that the SELECT
+		// misses AND the binlog drops; the row is lost. (Observed in #746
+		// as 4 consecutive missing PKs in chunk [1,1001) on
+		// TestCutoverAtomicityWithConcurrentWrites.)
+		//
+		// Per this method's contract above ("if there is any ambiguity, it's
+		// important to return FALSE"), return FALSE: keep the change in the
+		// delta/buffered map. Once the chunker advances, the watermark logic
+		// at flush time will route it correctly — either flushing it via
+		// REPLACE INTO ... SELECT FROM original (idempotent with anything the
+		// chunker's own SELECT picked up) or deferring it until the chunker
+		// passes its key.
+		return false
 	}
 	if t.finalChunkSent {
 		return false // we're done, so everything is below.

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -43,8 +43,13 @@ func TestOptimisticChunkerBasic(t *testing.T) {
 	require.Equal(t, "`t1`", t1.QuotedTableName)
 
 	require.NoError(t, chunker.Open())
-	require.Error(t, chunker.Open())                  // can't open twice.
-	require.True(t, chunker.KeyAboveHighWatermark(1)) // we haven't started copying.
+	require.Error(t, chunker.Open()) // can't open twice.
+	// We haven't claimed any range yet (chunkPtr is Nil and there's no
+	// resume checkpoint). Per the contract — "if there is any ambiguity,
+	// it's important to return FALSE" — this returns FALSE so the binlog
+	// applier buffers the change rather than silently dropping it. See
+	// issue #746.
+	require.False(t, chunker.KeyAboveHighWatermark(1))
 
 	_, err := chunker.Next()
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #746.

## Root cause

`chunkerOptimistic.KeyAboveHighWatermark` (and `chunkerComposite.KeyAboveHighWatermark`) returned `true` when the chunker hadn't dispatched any chunks yet (`chunkPtr.IsNil() && checkpointHighPtr.IsNil()`), with the comment *"every key is above because we haven't started copying."* This caused `deltaMap.HasChanged` and `bufferedMap.HasChanged` to silently drop every binlog event during the window between `runner.go`'s `SetWatermarkOptimization(true)` (filter on, just before copier startup) and the first `chunker.Next()` (chunkPtr set).

The intent was: *"the chunker's later SELECT will pick the row up from source."* That's only true for rows committed before the SELECT's snapshot. A writer that commits AFTER the snapshot but BEFORE chunkPtr is updated is in a dead zone — invisible to the SELECT (too late) AND silently dropped by the applier (`KeyAboveHighWatermark` returns `true`). The row is permanently lost.

## Likelihood in practical workloads

For a real workload to lose a row, all of the following must coincide:

1. The migration must run while the source table is actively receiving writes — idle or low-traffic migrations are not affected.
2. A writer must commit during a window of a few milliseconds between `SetWatermarkOptimization(true)` and the first `chunker.Next()` advancing `chunkPtr`. This window stretches under CPU/I/O pressure (Docker, race detector, noisy neighbours).
3. The committed row must be one whose chunk has *not yet been read* by the copier's snapshot. (Rows committed before the SELECT's snapshot are picked up by the copier directly and aren't affected.)
4. The downstream checksum (`FixDifferences=true`, default in production) must fail to repair the divergence. Checksum re-checks every chunk and re-copies any whose CRC doesn't match — so the bug is masked the vast majority of the time.

Empirically this matched the failure rate observed in CI: across 99 failed docker-compose runs from 2026-04-30/05-01, only 2 hits on `TestCutoverAtomicityWithConcurrentWrites` (the test purpose-built to provoke this). And before PR #764 disabled `FixDifferences` for that test, even those two hits sometimes recovered after the checksum repair — the original #746 report was a 2-row deficit, not all four PKs in the dead zone.

In a production OLTP migration the practical risk is small but not zero: enough sustained write traffic during setup gives a non-zero chance of one or more silent row losses. **The mode is silent data loss (rows in source missing from target after cutover), so it warrants a fix at any frequency.** Most existing users on busy schemas have probably not been bitten, but anyone who has should re-checksum source vs the migrated table.

This is what makes a `v0.12.1` cherry-pick the right call.

## Why it took so long to pin down

In production, `FixDifferences=true` re-copies any chunk whose CRC doesn't match, so this bug was almost always masked. The rare flake of `TestCutoverAtomicityWithConcurrentWrites` was the slice that escaped repair.

PR #764 disabled `FixDifferences` for that test specifically so copy-phase loss would surface at the checksum step instead. After that landed, the failure became deterministic across #801, #797, #795, #804 with a consistent signature: a contiguous run of 3-5 PKs missing from chunk `[1, 1001)` (`pk=62-65`; `pk=102-105`; etc.) — exactly the shape of *several writer transactions committing during the dead zone, autoinc funneling them through in PK order, all silently dropped.*

## What this PR does

1. **Optimistic chunker** ([chunker_optimistic.go](pkg/table/chunker_optimistic.go)): the IsNil branch now returns `false` (buffer the change) instead of `true` (drop). Per the method's own contract: *"if there is any ambiguity, it's important to return FALSE."*

2. **Composite chunker** ([chunker_composite.go](pkg/table/chunker_composite.go)): same fix in two places. The `len(chunkPtrs) == 0 && checkpointHighPtr.IsNil()` branch and the `len(chunkPtrs) == 0 && key > checkpointHighPtr` resume branch — both now return `false` for the same reason.

3. **Test coverage extended to 4 variants**. `TestCutoverAtomicityWithConcurrentWrites` previously only exercised the optimistic chunker in unbuffered copier mode. The cutover-atomicity probe has proven its value as the canonical detector for issue-#746-shaped bugs, and both the composite chunker and the buffered copier path have the same dead-zone window between `SetWatermarkOptimization(true)` and the chunker's first `Next()`. The test body is now extracted into `runCutoverAtomicityTest(t, tableName, schemaTmpl, buffered)` and invoked four times via `t.Run`:

   | variant | chunker | copier mode |
   |---|---|---|
   | `optimistic_unbuffered` | optimistic (single-col auto_inc PK) | unbuffered |
   | `optimistic_buffered`   | optimistic                          | buffered |
   | `composite_unbuffered`  | composite (forced via `(id, x_token)` PK) | unbuffered |
   | `composite_buffered`    | composite                           | buffered |

   The composite variants use a `PRIMARY KEY (id, x_token)` so `NewChunker` selects the composite chunker (which only handles single-column auto_increment otherwise). Buffered variants opt in via `WithBuffered(true)` and skip on the minimal-RBR runner since buffered requires `binlog_row_image=FULL`. All four subtests run in parallel under `t.Parallel()` with unique `t1concurrent_*` table names so they don't collide on `_<name>_old` / `_<name>_new` artifacts.

4. **Test updates** for the four tests that encoded the buggy behavior:
   - `TestReplClientComplex` — previously expected `GetDeltaLen() == 0` after a `DELETE` issued before the chunker's first `Next()`. Now expects the deletes to accumulate in the delta map and be drained when feedback advances the watermark. End-state row count assertion unchanged.
   - `TestOptimisticChunkerBasic` — flipped `KeyAboveHighWatermark(1)` assertion from TRUE to FALSE for the pre-Next state.
   - `TestCompositeChunkerWatermarkOptimizations` — same flip for both pre-Open and pre-Next states.
   - `TestCompositeChunkerCheckpointHighPtr` — same flip for the pre-OpenAtWatermark state.

5. **Reverts two prior workarounds** that the root-cause fix makes unnecessary:
   - **`require.Eventually(5s, 250ms, ...)`** in the cutover atomicity test. The wrapper was added under the theory that *"Docker MySQL has variable I/O latency that delays final event delivery"* (commits 9ab22fe, f0f44fb), but a 1-row deficit cannot be masked by 5 s of polling once cutover has completed — it stays a deficit. Replaced with a strict single-shot `require.Equal`.
   - **The second `FlushUnderTableLock`** in `executeRenameUnderLock` (commit 3001db2). Each call already does flush → BlockWait → flush internally, so the flush's own binlog events (REPLACE INTO _new / DELETE FROM _new) are read back in the same call's BlockWait. The doubled call was a speculative hedge for the same divergence the IsNil bug actually caused. A single call is sufficient.

## Verified locally

- `go test -count=5 -run TestCutoverAtomicityWithConcurrentWrites ./pkg/migration/` — all 4 variants × 5 iterations PASS.
- A single run produces:
  ```
  --- PASS: TestCutoverAtomicityWithConcurrentWrites/composite_unbuffered (2.86s)
  --- PASS: TestCutoverAtomicityWithConcurrentWrites/optimistic_buffered  (3.04s)
  --- PASS: TestCutoverAtomicityWithConcurrentWrites/optimistic_unbuffered (3.21s)
  --- PASS: TestCutoverAtomicityWithConcurrentWrites/composite_buffered   (3.22s)
  ```
- Full `pkg/migration` suite — PASS (~3 min).
- Full `pkg/repl`, `pkg/copier`, `pkg/table` suites — PASS.

## Cherry-pick

Recommend cherry-picking the chunker fixes (commit `045117c` for optimistic + the chunker portion of the composite-and-reverts commit) to `v0.12.1`. The two reverts (require.Eventually wrapper, second FlushUnderTableLock) are cleanups and don't strictly need to ride along. The 4-variant test extension is independent and not needed in the patch release — but harmless if cherry-picking the whole branch is simpler.

## Refs

- Closes #746
- Surfaced in CI on #801, #797, #795, #804 (all unrelated PRs that just happened to inherit the now-strict test from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)