### PR TITLE
test(#630): use WithTestThrottler for race-window tests

### DIFF
--- a/pkg/migration/check_constraint_test.go
+++ b/pkg/migration/check_constraint_test.go
@@ -135,7 +135,8 @@ func TestCheckConstraintWithDML(t *testing.T) {
 
 	m := NewTestRunner(t, "chk_dml", "ENGINE=InnoDB",
 		WithThreads(1),
-		WithTargetChunkTime(100*time.Millisecond))
+		WithTargetChunkTime(100*time.Millisecond),
+		WithTestThrottler())
 
 	var wg sync.WaitGroup
 	wg.Go(func() {

--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -213,7 +213,8 @@ func testEnumReorder(t *testing.T, enableBuffered bool) {
 	m := NewTestRunner(t, "enumreorder", "MODIFY COLUMN status ENUM('pending', 'active', 'inactive') NOT NULL",
 		WithThreads(1),
 		WithTargetChunkTime(100*time.Millisecond),
-		WithBuffered(enableBuffered))
+		WithBuffered(enableBuffered),
+		WithTestThrottler())
 
 	// Concurrent DML during copy phase to exercise binlog replay.
 	ctx, cancel := context.WithCancel(t.Context())
@@ -301,7 +302,8 @@ func testSetReorder(t *testing.T, enableBuffered bool) {
 	m := NewTestRunner(t, "setreorder", "MODIFY COLUMN perms SET('execute', 'read', 'write') NOT NULL",
 		WithThreads(1),
 		WithTargetChunkTime(100*time.Millisecond),
-		WithBuffered(enableBuffered))
+		WithBuffered(enableBuffered),
+		WithTestThrottler())
 
 	// Concurrent DML during copy phase.
 	ctx, cancel := context.WithCancel(t.Context())
@@ -524,7 +526,8 @@ func testAlterPKIntToBigIntWithDML(t *testing.T, enableBuffered bool) {
 	)`)
 	tt.SeedRows(t, "INSERT INTO altpk_dml (name, val) SELECT 'seed', 1", 4096)
 	m := NewTestRunner(t, "altpk_dml", "MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT",
-		WithBuffered(enableBuffered))
+		WithBuffered(enableBuffered),
+		WithTestThrottler())
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
@@ -611,7 +614,8 @@ func testAlterPKIntToBigIntWithDMLAndAdditionalColumnChange(t *testing.T, enable
 		"MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT, MODIFY COLUMN name VARCHAR(255) NOT NULL",
 		WithThreads(2),
 		WithTargetChunkTime(100*time.Millisecond),
-		WithBuffered(enableBuffered))
+		WithBuffered(enableBuffered),
+		WithTestThrottler())
 
 	var wg sync.WaitGroup
 	wg.Go(func() {

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -859,6 +859,7 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 		WithDBName(dbName),
 		WithThreads(1),
 		WithTargetChunkTime(100*time.Millisecond),
+		WithTestThrottler(),
 		WithRespectSentinel())
 
 	ctx, cancel := context.WithCancel(t.Context())


### PR DESCRIPTION
## Summary

- Fixes #630. The first migration in `TestResumeFromCheckpointE2EWithManualSentinel` was finishing CopyRows before the test's `cancel()` arrived, so the second migration sometimes had no checkpoint to resume from and didn't reach `WaitingOnSentinelTable` within the 30s `Eventually` window. Adding `WithTestThrottler()` keeps it predictably slow.
- Audited the rest of `pkg/migration/*_test.go` for the same hazard: a goroutine waits for `status >= CopyRows` then runs a fixed-iteration DML loop. Five tests had this pattern without the throttler — they were relying on table size + CI hardware speed for the race window. Added the throttler to all of them so timing is bounded by `BlockWait` (1s/chunk) instead of row count:
  - `testEnumReorder` / `testSetReorder` ([datatype_test.go](pkg/migration/datatype_test.go))
  - `testAlterPKIntToBigIntWithDML` / `testAlterPKIntToBigIntWithDMLAndAdditionalColumnChange` ([datatype_test.go](pkg/migration/datatype_test.go))
  - `TestCheckConstraintWithDML` ([check_constraint_test.go](pkg/migration/check_constraint_test.go))

Tests deliberately skipped: `TestMigrationCancelledFromTableModification` (DDL detection only requires `< CutOver`, much wider window), `runCutoverAtomicityTest` (throttler would defeat the cutover-race intent), and the `WithDeferCutOver`/sentinel-blocked tests (sentinel itself bounds timing).

## Test plan

- [x] CI green across MySQL 8.0 / 8.0.45 / 8.4 / 9.7 / Aurora variants
- [x] Run the touched tests in a tight loop to confirm no regressions:
  - `go test ./pkg/migration -run 'TestResumeFromCheckpointE2EWithManualSentinel|TestEnumReorder|TestSetReorder|TestAlterPKIntToBigIntWithDML|TestAlterPKIntToBigIntWithDMLAndAdditionalColumnChange|TestCheckConstraintWithDML' -count=20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)