### PR TITLE
test(migration): re-enable FixDifferences in TestCutoverAtomicityWithConcurrentWrites

### DIFF
--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -239,6 +238,24 @@ func TestInvalidOptions(t *testing.T) {
 // full-time across copy and post-copy phases, which exercises the queue
 // path strictly more than the optimization (where the queue only runs
 // post-copy). The default is the higher-coverage variant.
+//
+// Note on FixDifferences: this test runs with the production default
+// (FixDifferences=true on the checksum). An earlier version of this test
+// flipped FixDifferences off via useTestCutover so that any copy-phase row
+// loss surfaced as a "checksum mismatch" error before partial cutover ran.
+// That made the test a sharper probe of issue #746, but it also turned the
+// `KeyAboveHighWatermark` optimization's "drop the binlog event, the
+// chunker's later SELECT will pick it up" contract into a hard correctness
+// assertion. That contract relies on the source-side SELECT being able to
+// see every row the binlog streamer has already observed — which the MySQL
+// binlog/visibility race documented in #746 violates under sufficient
+// parallel-commit load. In production this is harmless because the
+// checksum's repair pass (FixDifferences=true) re-copies any missed rows
+// before cutover; in the test it surfaced as a CI flake on the
+// composite_unbuffered variant. We accept that FixDifferences=true masks
+// algorithmic bugs in the copy/applier path here: the production cutover
+// path has the same masking, so probing without it was probing a stricter
+// invariant than spirit actually offers.
 func TestCutoverAtomicityWithConcurrentWrites(t *testing.T) {
 	t.Parallel()
 
@@ -371,17 +388,6 @@ func runCutoverAtomicityTest(t *testing.T, tableName, schemaTmpl string, buffere
 	// the table doesn't exist after the partial rename
 	require.Error(t, err, "Migration should fail")
 
-	// useTestCutover also flips FixDifferences off (see runner.go), so if the
-	// copy + applier path lost rows during the migration the checksum step
-	// surfaces it as "checksum mismatch" before partial cutover runs. That's
-	// the dominant signal we want for issue #746 — checksum's Warn logs name
-	// the diverged PKs via inspectDifferences. Treat the error as a real
-	// failure here so CI reports it; the partial cutover never ran, so the
-	// _old/_new comparison below isn't applicable.
-	if strings.Contains(err.Error(), "checksum mismatch") {
-		t.Fatalf("issue #746 reproduced at checksum step (FixDifferences disabled via useTestCutover): %v — see preceding 'inspection revealed row does not exist in target' Warn logs for missing PKs", err)
-	}
-
 	oldTable := "_" + tableName + "_old"
 	newTable := "_" + tableName + "_new"
 
@@ -417,9 +423,10 @@ func runCutoverAtomicityTest(t *testing.T, tableName, schemaTmpl string, buffere
 	require.NoError(t, err2)
 	// Use assert.Equal (not require.Equal) so the diagnostic block below
 	// still runs when the checksums differ. The block enumerates the
-	// missing/diverged PKs which are the actual signal we need to debug
-	// the second issue-#746 bug; halting here would just print the two
-	// CRC integers and lose the per-PK detail. The final require.Equal
+	// missing/diverged PKs which are the signal we need if a future
+	// regression resurfaces #746-class divergence; halting here would
+	// just print the two CRC integers and lose the per-PK detail.
+	// The final require.Equal
 	// on row counts at the end of the function still fails the test.
 	assert.Equal(t, oldChecksum, newChecksum, "Checksums should match between old and new tables")
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -576,14 +576,9 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 		TargetChunkTime: r.migration.TargetChunkTime,
 		DBConfig:        r.dbConfig,
 		Logger:          r.logger,
-		// In production we always want the checksum to repair differences. The
-		// useTestCutover hook (only set by TestCutoverAtomicityWithConcurrentWrites)
-		// flips this off so any copy-phase / applier-path row loss surfaces as a
-		// checksum-mismatch error before cutover, instead of being silently
-		// repaired. This is what makes that test a real probe of issue #746.
-		FixDifferences: !r.migration.useTestCutover,
-		MaxRetries:     3,
-		YieldTimeout:   r.migration.ChecksumYieldTimeout,
+		FixDifferences:  true,
+		MaxRetries:      3,
+		YieldTimeout:    r.migration.ChecksumYieldTimeout,
 	})
 
 	return err


### PR DESCRIPTION
## Summary

In #746 we discovered that MySQL has a read-after-write violation where some changes are not immediately visible. This was proved in a reproduction script in https://github.com/block/spirit/pull/820 which requires no spirit code.

Spirit is now safe from this bug.

### Why this it test was flaky

This test contained a different case of the same problem. There is a race where the repl client may ignore a row because it is above the high watermark knowing the copier will copy the up to date version when it gets to it. But the copier copies too soon after, and MySQL violates read-after-write.

The 'fix' for this is that we need to disable key above watermark before we start the checksum (which we already do) and fix any of the read-after-write races introduced during copying (which we already do in production, we just disabled for this test intentionally to catch algorithmic issues).

So the fix for this test is just to allow FixDifferences for this test.

### To spell it out

- KeyAboveWatermark is not safe without a checksum that fixes differences. While it is algorithmically correct, there is a MySQL read-after-write violation that breaks this (we no longer permit disabling the checksum, so this is OK).
- We need to disable this optimization after the copier is complete, which we currently do.