### PR TITLE
fix(#828): backtick-quote PK column names in chunker and checksum SQL

### DIFF
--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -122,7 +121,7 @@ func (c *SingleChecker) inspectDifferences(ctx context.Context, trx *sql.Tx, chu
 	}
 	sourceRows, err := trx.QueryContext(ctx, fmt.Sprintf(queryTemplate,
 		sourceChecksumCols,
-		strings.Join(chunk.Table.KeyColumns, ", "),
+		table.QuoteColumns(chunk.Table.KeyColumns),
 		chunk.Table.QuotedTableName,
 		chunk.String(),
 	))
@@ -146,7 +145,7 @@ func (c *SingleChecker) inspectDifferences(ctx context.Context, trx *sql.Tx, chu
 
 	targetRows, err := trx.QueryContext(ctx, fmt.Sprintf(queryTemplate,
 		targetChecksumCols,
-		strings.Join(chunk.NewTable.KeyColumns, ", "),
+		table.QuoteColumns(chunk.NewTable.KeyColumns),
 		chunk.NewTable.QuotedTableName,
 		chunk.String(),
 	))

--- a/pkg/migration/e2e_test.go
+++ b/pkg/migration/e2e_test.go
@@ -455,3 +455,26 @@ func TestMigrationCancelledFromTableModification(t *testing.T) {
 	require.Error(t, gErr)
 	require.NoError(t, m.Close())
 }
+
+// TestReservedWordPKMigration is a regression test for issue #828.
+// Migrating a table whose primary key includes columns named with MySQL
+// reserved words (like `key`/`value`) used to fail with a SQL syntax error
+// when the chunker_composite prefetch query joined chunkKeys without
+// backticks.
+func TestReservedWordPKMigration(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "reserved_word_pk_migrate", "CREATE TABLE reserved_word_pk_migrate ("+
+		"osm_id BIGINT NOT NULL, "+
+		"`key` VARCHAR(64) NOT NULL, "+
+		"`value` TEXT, "+
+		"PRIMARY KEY (osm_id, `key`)"+
+		")")
+	tt.SeedRows(t, "INSERT INTO reserved_word_pk_migrate (osm_id, `key`, `value`) "+
+		"SELECT FLOOR(RAND()*1000000), CONCAT('amenity_', UUID()), 'restaurant'", 4096)
+
+	m := NewTestRunner(t, "reserved_word_pk_migrate", "ENGINE=InnoDB")
+	require.NoError(t, m.Run(t.Context()))
+	require.False(t, m.usedInstantDDL)
+	require.False(t, m.usedInplaceDDL)
+	require.NoError(t, m.Close())
+}

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -212,3 +212,52 @@ func TestEmptyDatabaseMove(t *testing.T) {
 	// Clean up
 	require.NoError(t, runner.Close())
 }
+
+// TestMoveReservedWordPK is a regression test for issue #828. Moving a
+// table whose primary key contains columns named with MySQL reserved
+// words used to fail because the chunker_composite prefetch query joined
+// chunkKeys without backticks. The move path drives the same chunker, so
+// it failed on the first chunk fetch.
+func TestMoveReservedWordPK(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	src := cfg.Clone()
+	src.DBName = "source_reserved_word"
+	dest := cfg.Clone()
+	dest.DBName = "dest_reserved_word"
+
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS source_reserved_word`)
+	testutils.RunSQL(t, `CREATE DATABASE source_reserved_word`)
+	testutils.RunSQL(t, "CREATE TABLE source_reserved_word.osm_points_of_interest ("+
+		"osm_id BIGINT NOT NULL, "+
+		"`key` VARCHAR(64) NOT NULL, "+
+		"`value` TEXT, "+
+		"PRIMARY KEY (osm_id, `key`)"+
+		") ENGINE=InnoDB")
+	testutils.RunSQL(t, "INSERT INTO source_reserved_word.osm_points_of_interest (osm_id, `key`, `value`) "+
+		"VALUES (1,'amenity','restaurant'),(2,'amenity','cafe'),(3,'shop','grocery'),"+
+		"(4,'tourism','hotel'),(5,'amenity','pub'),(6,'shop','bakery')")
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS dest_reserved_word`)
+	testutils.RunSQL(t, `CREATE DATABASE dest_reserved_word`)
+	testutils.RunSQL(t, "CREATE TABLE dest_reserved_word.osm_points_of_interest ("+
+		"osm_id BIGINT NOT NULL, "+
+		"`key` VARCHAR(64) NOT NULL, "+
+		"`value` TEXT, "+
+		"PRIMARY KEY (osm_id, `key`)"+
+		") ENGINE=InnoDB")
+
+	move := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 5 * time.Second,
+		Threads:         2,
+		WriteThreads:    2,
+		CreateSentinel:  false,
+	}
+	require.NoError(t, move.Run())
+}

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -261,3 +261,48 @@ func TestMoveReservedWordPK(t *testing.T) {
 	}
 	require.NoError(t, move.Run())
 }
+
+// TestMoveReservedWordTableName covers issue #828 — moving a table whose
+// name is itself a MySQL reserved word (e.g. `order`). The migration paths
+// rely on QuotedTableName being backtick-quoted; this test guards against
+// any SQL builder regressing to the unquoted TableName.
+func TestMoveReservedWordTableName(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	src := cfg.Clone()
+	src.DBName = "source_reserved_table_name"
+	dest := cfg.Clone()
+	dest.DBName = "dest_reserved_table_name"
+
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS source_reserved_table_name`)
+	testutils.RunSQL(t, `CREATE DATABASE source_reserved_table_name`)
+	testutils.RunSQL(t, "CREATE TABLE source_reserved_table_name.`order` ("+
+		"id BIGINT NOT NULL AUTO_INCREMENT, "+
+		"v VARCHAR(64) NOT NULL, "+
+		"PRIMARY KEY (id)"+
+		") ENGINE=InnoDB")
+	testutils.RunSQL(t, "INSERT INTO source_reserved_table_name.`order` (v) "+
+		"VALUES ('a'),('b'),('c'),('d'),('e'),('f')")
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS dest_reserved_table_name`)
+	testutils.RunSQL(t, `CREATE DATABASE dest_reserved_table_name`)
+	testutils.RunSQL(t, "CREATE TABLE dest_reserved_table_name.`order` ("+
+		"id BIGINT NOT NULL AUTO_INCREMENT, "+
+		"v VARCHAR(64) NOT NULL, "+
+		"PRIMARY KEY (id)"+
+		") ENGINE=InnoDB")
+
+	move := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 5 * time.Second,
+		Threads:         2,
+		WriteThreads:    2,
+		CreateSentinel:  false,
+	}
+	require.NoError(t, move.Run())
+}

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"reflect"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -86,23 +85,24 @@ func (t *chunkerComposite) Next() (*Chunk, error) {
 	// Start prefetching the next chunk
 	// First assume it's the first chunk, we can overwrite this
 	// just below.
+	quotedChunkKeys := QuoteColumns(t.chunkKeys)
 	query := fmt.Sprintf("SELECT %s FROM %s FORCE INDEX (%s) %s ORDER BY %s LIMIT 1 OFFSET %d",
-		strings.Join(t.chunkKeys, ","),
+		quotedChunkKeys,
 		t.Ti.QuotedTableName,
 		t.keyName,
 		t.additionalConditionsSQL(false),
-		strings.Join(t.chunkKeys, ","),
+		quotedChunkKeys,
 		t.chunkSize,
 	)
 	if !t.isFirstChunk() {
 		// This is not the first chunk, since we have pointers set.
 		query = fmt.Sprintf("SELECT %s FROM %s FORCE INDEX (%s) WHERE %s %s ORDER BY %s LIMIT 1 OFFSET %d",
-			strings.Join(t.chunkKeys, ","),
+			quotedChunkKeys,
 			t.Ti.QuotedTableName,
 			t.keyName,
 			expandRowConstructorComparison(t.chunkKeys, OpGreaterThan, t.chunkPtrs),
 			t.additionalConditionsSQL(true),
-			strings.Join(t.chunkKeys, ","), // order by
+			quotedChunkKeys, // order by
 			t.chunkSize,
 		)
 	}

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -86,10 +86,11 @@ func (t *chunkerComposite) Next() (*Chunk, error) {
 	// First assume it's the first chunk, we can overwrite this
 	// just below.
 	quotedChunkKeys := QuoteColumns(t.chunkKeys)
+	quotedKeyName := QuoteColumns([]string{t.keyName})
 	query := fmt.Sprintf("SELECT %s FROM %s FORCE INDEX (%s) %s ORDER BY %s LIMIT 1 OFFSET %d",
 		quotedChunkKeys,
 		t.Ti.QuotedTableName,
-		t.keyName,
+		quotedKeyName,
 		t.additionalConditionsSQL(false),
 		quotedChunkKeys,
 		t.chunkSize,
@@ -99,7 +100,7 @@ func (t *chunkerComposite) Next() (*Chunk, error) {
 		query = fmt.Sprintf("SELECT %s FROM %s FORCE INDEX (%s) WHERE %s %s ORDER BY %s LIMIT 1 OFFSET %d",
 			quotedChunkKeys,
 			t.Ti.QuotedTableName,
-			t.keyName,
+			quotedKeyName,
 			expandRowConstructorComparison(t.chunkKeys, OpGreaterThan, t.chunkPtrs),
 			t.additionalConditionsSQL(true),
 			quotedChunkKeys, // order by

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -1440,16 +1440,20 @@ func TestCompositeChunkerCheckpointHighPtr(t *testing.T) {
 }
 
 // TestCompositeChunkerReservedWordPK is a regression test for issue #828.
-// The chunker_composite prefetch query joined chunkKeys without backticks,
-// which produced a SQL syntax error when the primary key contained columns
-// whose names are MySQL reserved words (e.g. `key`, `value`).
+// The chunker_composite prefetch query joined chunkKeys without backticks
+// and passed t.keyName into FORCE INDEX(...) unquoted, which produced a
+// SQL syntax error when either the PK columns or the index name was a
+// MySQL reserved word (e.g. `key`, `value`).
 func TestCompositeChunkerReservedWordPK(t *testing.T) {
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS reserved_word_pk_t1")
+	// Note: the secondary index is intentionally named `key` to also cover
+	// the FORCE INDEX (reserved-word) code path.
 	testutils.RunSQL(t, "CREATE TABLE reserved_word_pk_t1 ("+
 		"osm_id BIGINT NOT NULL, "+
 		"`key` VARCHAR(64) NOT NULL, "+
 		"`value` TEXT, "+
-		"PRIMARY KEY (osm_id, `key`)"+
+		"PRIMARY KEY (osm_id, `key`), "+
+		"KEY `key` (`key`)"+
 		") ENGINE=InnoDB")
 	testutils.RunSQL(t, "INSERT INTO reserved_word_pk_t1 (osm_id, `key`, `value`) "+
 		"VALUES (1,'amenity','restaurant'),(2,'amenity','cafe'),(3,'shop','grocery')")
@@ -1462,14 +1466,13 @@ func TestCompositeChunkerReservedWordPK(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	require.Equal(t, []string{"osm_id", "key"}, t1.KeyColumns)
 
+	// Walk the PRIMARY chunker to completion. Before the fix, the very first
+	// call to Next() failed with: Error 1064 (42000) ... near 'key,value FROM
+	// ... ORDER BY osm_id,key' because the column list was unquoted.
 	chunker, err := NewChunker(t1, ChunkerConfig{})
 	require.NoError(t, err)
 	require.IsType(t, &chunkerComposite{}, chunker)
 	require.NoError(t, chunker.Open())
-
-	// Walk the chunker to completion. Before the fix, the very first call to
-	// Next() failed with: Error 1064 (42000) ... near 'key,value FROM ...
-	// ORDER BY osm_id,key' because the column list was unquoted.
 	for {
 		chunk, err := chunker.Next()
 		if err != nil {
@@ -1479,4 +1482,24 @@ func TestCompositeChunkerReservedWordPK(t *testing.T) {
 		require.NotNil(t, chunk)
 	}
 	require.NoError(t, chunker.Close())
+
+	// Now exercise the FORCE INDEX (reserved-word) code path by chunking on
+	// the secondary index named `key`. Before the fix, FORCE INDEX (key)
+	// failed because the index name was not quoted.
+	chunker2 := &chunkerComposite{
+		Ti:            t1,
+		ChunkerTarget: 100 * time.Millisecond,
+		logger:        slog.Default(),
+	}
+	require.NoError(t, chunker2.SetKey("key", ""))
+	require.NoError(t, chunker2.Open())
+	for {
+		chunk, err := chunker2.Next()
+		if err != nil {
+			require.ErrorIs(t, err, ErrTableIsRead)
+			break
+		}
+		require.NotNil(t, chunk)
+	}
+	require.NoError(t, chunker2.Close())
 }

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
 
 	"github.com/stretchr/testify/require"
 )
@@ -1455,11 +1456,7 @@ func TestCompositeChunkerReservedWordPK(t *testing.T) {
 
 	db, err := sql.Open("mysql", testutils.DSN())
 	require.NoError(t, err)
-	defer func() {
-		if err := db.Close(); err != nil {
-			t.Logf("failed to close db: %v", err)
-		}
-	}()
+	defer utils.CloseAndLog(db)
 
 	t1 := NewTableInfo(db, "test", "reserved_word_pk_t1")
 	require.NoError(t, t1.SetInfo(t.Context()))

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -1437,3 +1437,49 @@ func TestCompositeChunkerCheckpointHighPtr(t *testing.T) {
 
 	require.NoError(t, comp.Close())
 }
+
+// TestCompositeChunkerReservedWordPK is a regression test for issue #828.
+// The chunker_composite prefetch query joined chunkKeys without backticks,
+// which produced a SQL syntax error when the primary key contained columns
+// whose names are MySQL reserved words (e.g. `key`, `value`).
+func TestCompositeChunkerReservedWordPK(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS reserved_word_pk_t1")
+	testutils.RunSQL(t, "CREATE TABLE reserved_word_pk_t1 ("+
+		"osm_id BIGINT NOT NULL, "+
+		"`key` VARCHAR(64) NOT NULL, "+
+		"`value` TEXT, "+
+		"PRIMARY KEY (osm_id, `key`)"+
+		") ENGINE=InnoDB")
+	testutils.RunSQL(t, "INSERT INTO reserved_word_pk_t1 (osm_id, `key`, `value`) "+
+		"VALUES (1,'amenity','restaurant'),(2,'amenity','cafe'),(3,'shop','grocery')")
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Logf("failed to close db: %v", err)
+		}
+	}()
+
+	t1 := NewTableInfo(db, "test", "reserved_word_pk_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	require.Equal(t, []string{"osm_id", "key"}, t1.KeyColumns)
+
+	chunker, err := NewChunker(t1, ChunkerConfig{})
+	require.NoError(t, err)
+	require.IsType(t, &chunkerComposite{}, chunker)
+	require.NoError(t, chunker.Open())
+
+	// Walk the chunker to completion. Before the fix, the very first call to
+	// Next() failed with: Error 1064 (42000) ... near 'key,value FROM ...
+	// ORDER BY osm_id,key' because the column list was unquoted.
+	for {
+		chunk, err := chunker.Next()
+		if err != nil {
+			require.ErrorIs(t, err, ErrTableIsRead)
+			break
+		}
+		require.NotNil(t, chunk)
+	}
+	require.NoError(t, chunker.Close())
+}

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -1503,3 +1503,42 @@ func TestCompositeChunkerReservedWordPK(t *testing.T) {
 	}
 	require.NoError(t, chunker2.Close())
 }
+
+// TestCompositeChunkerReservedWordTableName covers issue #828 from the
+// table-name angle, paired with the reserved-word PK columns case.
+func TestCompositeChunkerReservedWordTableName(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS `order`")
+	testutils.RunSQL(t, "CREATE TABLE `order` ("+
+		"a BIGINT NOT NULL, "+
+		"b VARCHAR(64) NOT NULL, "+
+		"v TEXT, "+
+		"PRIMARY KEY (a, b)"+
+		") ENGINE=InnoDB")
+	testutils.RunSQL(t, "INSERT INTO `order` (a, b, v) "+
+		"VALUES (1,'x','one'),(2,'x','two'),(3,'y','three'),(4,'z','four')")
+	t.Cleanup(func() { testutils.RunSQL(t, "DROP TABLE IF EXISTS `order`") })
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := NewTableInfo(db, "test", "order")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	require.Equal(t, "`order`", t1.QuotedTableName)
+	require.Equal(t, []string{"a", "b"}, t1.KeyColumns)
+
+	chunker, err := NewChunker(t1, ChunkerConfig{})
+	require.NoError(t, err)
+	require.IsType(t, &chunkerComposite{}, chunker)
+	require.NoError(t, chunker.Open())
+
+	for {
+		chunk, err := chunker.Next()
+		if err != nil {
+			require.ErrorIs(t, err, ErrTableIsRead)
+			break
+		}
+		require.NotNil(t, chunk)
+	}
+	require.NoError(t, chunker.Close())
+}

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -57,7 +57,7 @@ var _ MappedChunker = &chunkerOptimistic{}
 // When this mode is enabled, the chunkSize is "reset" to 1000 rows, so we know that
 // t.chunkSize is reliable. It is also expanded again based on feedback.
 func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
-	key := t.Ti.KeyColumns[0]
+	key := "`" + t.Ti.KeyColumns[0] + "`"
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s > ? ORDER BY %s LIMIT 1 OFFSET %d",
 		key, t.Ti.QuotedTableName, key, key, t.chunkSize,
 	)

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -57,7 +57,7 @@ var _ MappedChunker = &chunkerOptimistic{}
 // When this mode is enabled, the chunkSize is "reset" to 1000 rows, so we know that
 // t.chunkSize is reliable. It is also expanded again based on feedback.
 func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
-	key := "`" + t.Ti.KeyColumns[0] + "`"
+	key := QuoteColumns(t.Ti.KeyColumns[:1])
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s > ? ORDER BY %s LIMIT 1 OFFSET %d",
 		key, t.Ti.QuotedTableName, key, key, t.chunkSize,
 	)

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -484,11 +485,7 @@ func TestOptimisticChunkerPrefetchReservedWord(t *testing.T) {
 
 	db, err := sql.Open("mysql", testutils.DSN())
 	require.NoError(t, err)
-	defer func() {
-		if err := db.Close(); err != nil {
-			t.Logf("failed to close db: %v", err)
-		}
-	}()
+	defer utils.CloseAndLog(db)
 
 	t1 := NewTableInfo(db, "test", "reserved_word_optimistic_t1")
 	require.NoError(t, t1.SetInfo(t.Context()))

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -468,3 +468,46 @@ func TestOptimisticChunkerReset(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, chunk1.String(), finalResetChunk.String(), "First chunk after second reset should still match original")
 }
+
+// TestOptimisticChunkerPrefetchReservedWord is a regression test for
+// issue #828 covering the optimistic chunker's prefetch path. Before the
+// fix, nextChunkByPrefetching emitted bare column names in SELECT and ORDER
+// BY, which fails when the auto-inc PK column has a reserved-word name.
+func TestOptimisticChunkerPrefetchReservedWord(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS reserved_word_optimistic_t1")
+	testutils.RunSQL(t, "CREATE TABLE reserved_word_optimistic_t1 ("+
+		"`key` BIGINT NOT NULL AUTO_INCREMENT, "+
+		"v VARCHAR(64) NOT NULL, "+
+		"PRIMARY KEY (`key`)"+
+		") ENGINE=InnoDB")
+	testutils.RunSQL(t, "INSERT INTO reserved_word_optimistic_t1 (v) VALUES ('a'),('b'),('c'),('d'),('e')")
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Logf("failed to close db: %v", err)
+		}
+	}()
+
+	t1 := NewTableInfo(db, "test", "reserved_word_optimistic_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	require.Equal(t, []string{"key"}, t1.KeyColumns)
+	require.True(t, t1.KeyIsAutoInc)
+
+	chunker, err := NewChunker(t1, ChunkerConfig{})
+	require.NoError(t, err)
+	opt, ok := chunker.(*chunkerOptimistic)
+	require.True(t, ok, "expected optimistic chunker for auto-inc single-column PK")
+	require.NoError(t, opt.Open())
+
+	// Force the prefetch path. nextChunkByPrefetching is what builds the
+	// query that previously broke with reserved-word PK column names.
+	opt.chunkPrefetchingEnabled = true
+	opt.chunkPtr = Datum{Val: int64(0), Tp: signedType}
+
+	_, err = opt.nextChunkByPrefetching()
+	require.NoError(t, err, "prefetch query must succeed when PK column is a reserved word")
+
+	require.NoError(t, opt.Close())
+}

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -508,3 +508,51 @@ func TestOptimisticChunkerPrefetchReservedWord(t *testing.T) {
 
 	require.NoError(t, opt.Close())
 }
+
+// TestOptimisticChunkerReservedWordTableName covers issue #828 from the
+// table-name angle. Even though TableInfo backtick-wraps QuotedTableName
+// at construction, this test guards against any future regression where a
+// SQL builder forgets to use QuotedTableName.
+func TestOptimisticChunkerReservedWordTableName(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS `order`")
+	testutils.RunSQL(t, "CREATE TABLE `order` ("+
+		"id BIGINT NOT NULL AUTO_INCREMENT, "+
+		"v VARCHAR(64) NOT NULL, "+
+		"PRIMARY KEY (id)"+
+		") ENGINE=InnoDB")
+	testutils.RunSQL(t, "INSERT INTO `order` (v) VALUES ('a'),('b'),('c'),('d'),('e')")
+	t.Cleanup(func() { testutils.RunSQL(t, "DROP TABLE IF EXISTS `order`") })
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := NewTableInfo(db, "test", "order")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	require.Equal(t, "`order`", t1.QuotedTableName)
+	require.True(t, t1.KeyIsAutoInc)
+
+	chunker, err := NewChunker(t1, ChunkerConfig{})
+	require.NoError(t, err)
+	opt, ok := chunker.(*chunkerOptimistic)
+	require.True(t, ok)
+	require.NoError(t, opt.Open())
+
+	// Walk the chunker — this exercises Next() on the standard path.
+	for {
+		_, err := opt.Next()
+		if err != nil {
+			require.ErrorIs(t, err, ErrTableIsRead)
+			break
+		}
+	}
+
+	// Also exercise the prefetch path explicitly.
+	opt.chunkPrefetchingEnabled = true
+	opt.chunkPtr = Datum{Val: int64(0), Tp: signedType}
+	opt.finalChunkSent = false
+	_, err = opt.nextChunkByPrefetching()
+	require.NoError(t, err)
+
+	require.NoError(t, opt.Close())
+}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -309,7 +309,8 @@ func (t *TableInfo) setMinMax(ctx context.Context) error {
 	if t.keyDatums[0] == binaryType {
 		return nil // we don't min/max binary types for now.
 	}
-	query := fmt.Sprintf("SELECT IFNULL(min(%s),'0'), IFNULL(max(%s),'0') FROM %s", t.KeyColumns[0], t.KeyColumns[0], t.QuotedTableName)
+	quotedKey := "`" + t.KeyColumns[0] + "`"
+	query := fmt.Sprintf("SELECT IFNULL(min(%s),'0'), IFNULL(max(%s),'0') FROM %s", quotedKey, quotedKey, t.QuotedTableName)
 	var minimum, maximum string
 	err := t.db.QueryRowContext(ctx, query).Scan(&minimum, &maximum)
 	if err != nil {

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -309,7 +309,7 @@ func (t *TableInfo) setMinMax(ctx context.Context) error {
 	if t.keyDatums[0] == binaryType {
 		return nil // we don't min/max binary types for now.
 	}
-	quotedKey := "`" + t.KeyColumns[0] + "`"
+	quotedKey := QuoteColumns(t.KeyColumns[:1])
 	query := fmt.Sprintf("SELECT IFNULL(min(%s),'0'), IFNULL(max(%s),'0') FROM %s", quotedKey, quotedKey, t.QuotedTableName)
 	var minimum, maximum string
 	err := t.db.QueryRowContext(ctx, query).Scan(&minimum, &maximum)


### PR DESCRIPTION
Fixes [#828](https://github.com/block/spirit/issues/828).

## Summary

- Migrating or moving a table whose primary key contains MySQL reserved words (e.g. `key`, `value`) failed immediately with Error 1064 because several SQL builders interpolated bare PK column names.
- Affected sites:
  - `pkg/table/chunker_composite.go::Next()` — composite prefetch query (the user-reported failure path).
  - `pkg/table/chunker_optimistic.go::nextChunkByPrefetching` — single-key prefetch query.
  - `pkg/table/tableinfo.go::setMinMax` — min/max query that runs during `SetInfo`.
  - `pkg/checksum/single.go::inspectDifferences` — PK list passed into `queryTemplate`.
- All four sites now backtick-quote columns. The composite chunker uses the existing `table.QuoteColumns` helper.

## Note on origin

This is **not** a regression from #701/#702. The unquoted `strings.Join` in the composite chunker has been there since `36877bb` (2023-08-02), when composite-key chunking was first introduced. PR #702 doesn't touch the prefetch query. The bug surfaced now only because no existing test covered a reserved-word PK column.

## Test plan

- [x] `pkg/table` regression test: composite chunker walks a table with PK `(osm_id, \`key\`)` to completion.
- [x] `pkg/table` regression test: optimistic chunker prefetch path with a single-column auto-inc PK named `\`key\``.
- [x] `pkg/migration` regression test: end-to-end ALTER through the copy path (the user's reported scenario).
- [x] `pkg/move` regression test: end-to-end move with a reserved-word composite PK.
- [x] Existing `pkg/table`, `pkg/checksum`, `pkg/copier` test suites still pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)