### PR TITLE
docs(resume): document cross-version checkpoint compatibility

### DIFF
--- a/pkg/migration/resume-from-checkpoint.md
+++ b/pkg/migration/resume-from-checkpoint.md
@@ -82,8 +82,8 @@ Practical implications:
 
 - **Upgrading Spirit mid-migration** (older binary → newer binary). The newer binary's `Scan` expects a different number of columns than the on-disk checkpoint provides, so the read fails.
 - **Rolling back Spirit mid-migration** (newer binary → older binary). Same failure mode in reverse.
-- **Effect without `--strict`:** Spirit logs the read error and falls through to `newMigration()`, restarting the copy from scratch. All checkpoint progress is lost silently.
-- **Effect with `--strict`:** the failure is a generic `"could not read from table"` error wrapping the underlying `database/sql` scan error rather than one of the typed `status.Err…` values. It does not currently surface as a distinct strict-mode error class.
+- **Effect in both `--strict` and non-strict mode:** the read returns a generic `"could not read from table"` error wrapping the underlying `database/sql` scan error. This error is not one of the typed `status.Err…` values that strict mode promotes (`ErrMismatchedAlter`, `ErrBinlogNotFound`, `ErrCheckpointTooOld`), so Spirit logs the error and falls through to `newMigration()` regardless of strict mode. The copy restarts from scratch and all checkpoint progress is lost silently.
+- **Operator implication:** do **not** rely on `--strict` alerting to catch a Spirit upgrade or rollback. Strict mode does not currently distinguish a cross-version checkpoint schema mismatch from a healthy fresh start.
 
 Operational guidance:
 

--- a/pkg/migration/resume-from-checkpoint.md
+++ b/pkg/migration/resume-from-checkpoint.md
@@ -73,3 +73,22 @@ With `Strict: true`, Spirit returns a hard error for two specific resume failure
 Both errors work with `errors.Is()`, letting callers handle each case differently. See [strict](../docs/migrate.md#strict) for more details.
 
 Other resume failures (missing shadow table, corrupt checkpoint data) still fall through to `newMigration()` in both modes, since these typically indicate there was nothing valid to resume.
+
+## Cross-version compatibility
+
+Checkpoint tables are version-specific. Spirit deliberately uses `SELECT *` when reading the checkpoint, so any change to the checkpoint schema (e.g. columns added, removed, or reordered in a newer release) will cause the read to fail. This is by design — Spirit does not attempt to migrate or backfill checkpoint data across versions.
+
+Practical implications:
+
+- **Upgrading Spirit mid-migration** (older binary → newer binary). The newer binary's `Scan` expects a different number of columns than the on-disk checkpoint provides, so the read fails.
+- **Rolling back Spirit mid-migration** (newer binary → older binary). Same failure mode in reverse.
+- **Effect without `--strict`:** Spirit logs the read error and falls through to `newMigration()`, restarting the copy from scratch. All checkpoint progress is lost silently.
+- **Effect with `--strict`:** the failure is a generic `"could not read from table"` error wrapping the underlying `database/sql` scan error rather than one of the typed `status.Err…` values. It does not currently surface as a distinct strict-mode error class.
+
+Operational guidance:
+
+- Prefer to finish in-flight migrations on the same Spirit version they were started with.
+- If you must upgrade or roll back mid-migration, expect the copy to restart from zero. Plan binlog retention and operational windows accordingly.
+- Treat any Spirit version change as equivalent to a `binlog_expire_logs_seconds` event for the purposes of capacity planning.
+
+This is an intentional safety boundary: silently reading a checkpoint with a different schema risks misinterpreting fields and corrupting the migration. We prefer to lose progress loudly than to corrupt data silently.


### PR DESCRIPTION
## What and Why ?
Adds a **"Cross-version compatibility"** section to `pkg/migration/resume-from-checkpoint.md` explaining that checkpoint tables are version-specific by design.

Spirit deliberately uses `SELECT *` when reading the checkpoint table so that any schema drift (columns added, removed, or reordered in a newer release) fails the read. This is intentional — silently reading a checkpoint with a different schema risks misinterpreting fields and corrupting the migration. The behavior was previously documented only in a Go comment in `runner.go` (`resumeFromCheckpoint`) and was not surfaced in the user-facing markdown.

## What the new section covers

- Why `SELECT *` is intentional and what it guards against.
- **Upgrade mid-migration** (older binary → newer binary) and **rollback mid-migration** (newer → older) both fail the read.
- **Non-strict mode** falls through to `newMigration()` and restarts the copy from scratch silently.
- **Strict mode** currently surfaces this as a generic `"could not read from table"` error rather than a typed `status.Err…` value (called out as a known observability gap).
- **Operational guidance:**
  - Finish in-flight migrations on the same Spirit version they were started with.

## Scope

Docs-only change. No code or test changes.