### PR TITLE
test(#834): rate-limit writers in TestMoveWithVarcharPK

### DIFF
--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -506,6 +506,13 @@ func testMoveWithVarcharPK(t *testing.T, forceEnableBufferedMap bool) {
 	// 4 writers doing INSERT / UPDATE / DELETE on VARCHAR PKs while the
 	// move runs. The FIFO queue must replay these in binlog order to land
 	// on the correct end state on the target.
+	//
+	// A short delay between iterations rate-limits the writers to ~400 ops/sec
+	// total. Without this, an uncapped tight loop generates binlog faster than
+	// the reader can drain it on slow CI runners — the source position
+	// outruns the buffered position indefinitely and Flush()'s BlockWait loop
+	// never converges below binlogTrivialThreshold, eventually tripping the
+	// 10-minute test timeout (issue #834).
 	for range 4 {
 		wg.Go(func() {
 			for {
@@ -519,6 +526,7 @@ func testMoveWithVarcharPK(t *testing.T, forceEnableBufferedMap bool) {
 				} else {
 					writeCount.Add(1)
 				}
+				time.Sleep(10 * time.Millisecond)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #834 — `TestMoveWithVarcharPK` timing out at 10 minutes.

The test runs 4 writer goroutines in an uncapped tight loop, each doing INSERT + UPDATE + (sometimes) DELETE per iteration with no delay. On slow CI runners this generates binlog faster than the move's reader can drain it. Inside `Flush()` ([pkg/repl/client.go:1000](https://github.com/block/spirit/blob/main/pkg/repl/client.go#L1000)) the loop never sees `GetDeltaLen() < binlogTrivialThreshold` because the source position keeps outrunning the buffered position. `move.Run()` never returns → writers never stop → `wg.Wait()` hangs → the 10-minute Go test timeout fires.

The MySQL 8.4 GA failure earlier today on `main` showed the same symptom on the *other* subtest (`queue-full-time` vs the `force-enable-buffered-map` one in #834), with the reader ~460 binlog files behind the live source — same root cause.

## Fix

Add `time.Sleep(10 * time.Millisecond)` between writer iterations. Caps total throughput at ~400 ops/sec (~1200 statements/sec). The test exists to verify FIFO-queue replay correctness for VARCHAR PKs, not raw throughput, so pacing doesn't undermine its purpose.

## Test plan

- [ ] CI passes (both subtests on all MySQL versions, especially 8.4 GA which already flaked once today)
- [ ] Spot-check locally that the test still meaningfully exercises concurrent writes (writeCount > 0 in the t.Logf output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)