### PR TITLE
feat(#475): enable buffered-map dedup by default, remove force-enable-buffered-map flag

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -20,7 +20,6 @@ spirit migrate --host mydb:3306 --username root --password secret \
 - [conf](#conf)
 - [database](#database)
 - [defer-cutover](#defer-cutover)
-- [force-enable-buffered-map](#force-enable-buffered-map)
 - [host](#host)
 - [lint](#lint)
 - [lint-only](#lint-only)
@@ -147,19 +146,6 @@ You can resume a migration from checkpoint and Spirit will start waiting again f
 If you start a migration and realize that you forgot to set defer-cutover, worry not! You can manually create a sentinel table `_spirit_sentinel`, and Spirit will detect the table before the cutover is completed and block as though defer-cutover had been enabled from the beginning.
 
 Note that the checksum, if enabled, will be computed after the sentinel table is dropped. Because the checksum step takes an estimated 10-20% of the migration, the cutover will not occur immediately after the sentinel table is dropped.
-
-### force-enable-buffered-map
-
-- Type: Boolean
-- Default value: `false`
-
-> **⚠️ Experimental.** Correctness relies on the post-cutover checksum to catch and repair any divergence. Leave this off unless you have a specific reason to enable it.
-
-Controls whether the replication subscription uses the LWW (last-write-wins) buffered-map dedup during the copy phase for tables whose primary key is **not memory-comparable** — typically a `VARCHAR` PK using a case-insensitive or otherwise collation-sensitive comparison (e.g. `utf8mb4_0900_ai_ci`). Memory-comparable PKs (integers, binary strings, etc.) always use the buffered map regardless of this flag.
-
-When `false` (the default), tables with non-memory-comparable PKs use a FIFO queue full-time during both the copy and post-copy phases. The FIFO queue replays binlog events in their original order, which is required for collation-sensitive PKs because the in-memory map's hash equality (`"A"` ≠ `"a"`) does not match MySQL's row identity (`"A"` = `"a"` under a CI collation), so map-mode iteration could apply events out of order.
-
-When `true`, Spirit opts into the optimization: buffered-map dedup during the copy phase, FIFO queue post-copy. This can significantly reduce the volume of binlog events Spirit has to apply when the workload re-touches the same logical rows during a long copy, but if the dedup ever produces a wrong end state for a row the divergence is only caught by the post-cutover checksum (which will then re-copy the affected chunks).
 
 ### host
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -15,7 +15,6 @@ This will copy all tables from the source database to the target database, verif
 
 - [create-sentinel](#create-sentinel)
 - [defer-secondary-indexes](#defer-secondary-indexes)
-- [force-enable-buffered-map](#force-enable-buffered-map)
 - [source-dsn](#source-dsn)
 - [target-chunk-time](#target-chunk-time)
 - [target-dsn](#target-dsn)
@@ -35,13 +34,6 @@ When set to `true`, a sentinel table (`_spirit_sentinel`) is created on the **so
 - Default value: `false`
 
 When set to `true`, target tables are created without secondary indexes. The indexes are restored from the source schema just before cutover. This can significantly speed up the initial data load for tables with many secondary indexes.
-
-### force-enable-buffered-map
-
-- Type: Boolean
-- Default value: `false`
-
-See the [migrate documentation](migrate.md#force-enable-buffered-map) for the full rationale. In short: this flag controls whether tables with non-memory-comparable primary keys (e.g. `VARCHAR` with a case-insensitive collation) use the LWW buffered-map dedup during the copy phase. The default is a FIFO queue full-time for those tables, which is the safer choice; setting this to `true` is experimental and relies on the post-cutover checksum to catch and repair any divergence.
 
 ### source-dsn
 

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -225,20 +225,14 @@ func TestInvalidOptions(t *testing.T) {
 // The optimistic chunker is selected automatically for single-column
 // auto_increment PKs; the composite chunker covers everything else (here we
 // force it via a composite (id, x_token) PK, where x_token is VARCHAR — that
-// makes the PK non-memory-comparable and routes the bufferedMap subscription
-// through its FIFO queue mode for the entire run, copy and post-copy).
+// makes the PK non-memory-comparable, so the bufferedMap subscription uses
+// LWW map dedup during the copy phase and the FIFO queue post-copy).
 //
 // All variants use the buffered replication subscription. The deltaMap path
 // was retired as part of #746 — it relied on `REPLACE INTO _new ... SELECT
 // FROM original ...` which is subject to the binlog/visibility race. The
 // composite-PK variants were dropped when deltaQueue went away (#821) and
 // are restored here against the unified bufferedMap implementation.
-//
-// We deliberately don't add a `--force-enable-buffered-map=true` variant
-// for the composite-PK case. With the default (false), the queue runs
-// full-time across copy and post-copy phases, which exercises the queue
-// path strictly more than the optimization (where the queue only runs
-// post-copy). The default is the higher-coverage variant.
 //
 // Note on FixDifferences: this test runs with the production default
 // (FixDifferences=true on the checksum). An earlier version of this test

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -55,20 +55,6 @@ type Migration struct {
 	// using INSERT IGNORE .. SELECT. This is also required for cross-server moves.
 	Buffered bool `name:"buffered" help:"Use the buffered copier based on the lock-free DBLog algorithm" optional:"" default:"false"`
 
-	// ForceEnableBufferedMap controls whether the LWW buffered-map mode of the
-	// replication subscription is used during the copy phase for tables with
-	// non-memory-comparable primary keys (e.g. VARCHAR with a CI collation).
-	//
-	// Default false: the FIFO queue runs full-time for those tables, mirroring
-	// the previous deltaQueue performance characteristics. We keep the queue
-	// hot in CI (notably TestCutoverAtomicityWithConcurrentWrites) so any bug
-	// in the queue path is caught before we flip the default.
-	//
-	// Set true to opt into the optimization: buffered-map dedup during copy,
-	// FIFO queue post-copy. Memory-comparable PKs always use the buffered map
-	// regardless of this flag.
-	ForceEnableBufferedMap bool `name:"force-enable-buffered-map" help:"Enable the buffered map during copy even for non-memory comparable PKs. This relies on the checksum to catch and fix mistakes, so it is still considered 'correct', but is experimental for now." optional:"" default:"false"`
-
 	CheckpointMaxAge     time.Duration `name:"checkpoint-max-age" help:"Maximum age of a checkpoint before refusing to resume from it" optional:"" default:"168h"`
 	ChecksumYieldTimeout time.Duration `name:"checksum-yield-timeout" help:"Maximum duration for a single checksum pass before yielding to release long-running REPEATABLE READ transactions (reduces InnoDB HLL growth)" optional:"" default:"24h"`
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -550,13 +550,12 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	// Set the binlog position.
 	// Create a binlog subscriber
 	r.replClient = repl.NewClient(r.db, r.migration.Host, r.migration.Username, *r.migration.Password, appl, &repl.ClientConfig{
-		Logger:                 r.logger,
-		Concurrency:            r.migration.Threads,
-		TargetBatchTime:        r.migration.TargetChunkTime,
-		CancelFunc:             r.fatalError,
-		ServerID:               repl.NewServerID(),
-		DBConfig:               r.dbConfig, // Pass database configuration to replication client
-		ForceEnableBufferedMap: r.migration.ForceEnableBufferedMap,
+		Logger:          r.logger,
+		Concurrency:     r.migration.Threads,
+		TargetBatchTime: r.migration.TargetChunkTime,
+		CancelFunc:      r.fatalError,
+		ServerID:        repl.NewServerID(),
+		DBConfig:        r.dbConfig, // Pass database configuration to replication client
 	})
 	// For each of the changes, we know the new table exists now
 	// So we should call SetInfo to populate the columns etc.

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -18,10 +18,6 @@ type Move struct {
 	CreateSentinel        bool          `name:"create-sentinel" help:"Create a sentinel table on the source database to block after table copy" default:"false"`
 	DeferSecondaryIndexes bool          `name:"defer-secondary-indexes" help:"Create target tables without secondary indexes, add them before cutover" default:"false"`
 
-	// ForceEnableBufferedMap mirrors pkg/migration.Migration.ForceEnableBufferedMap.
-	// See that field's doc for the full rationale.
-	ForceEnableBufferedMap bool `name:"force-enable-buffered-map" help:"Enable the buffered map during copy even for non-memory comparable PKs. This relies on the checksum to catch and fix mistakes, so it is still considered 'correct', but is experimental for now." default:"false"`
-
 	// SourceTables optionally specifies a list of tables to move.
 	// If empty, all tables in the source database will be moved.
 	// This is useful for Vitess MoveTables operations where only specific tables should be moved.

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -419,15 +419,14 @@ func (r *Runner) setup(ctx context.Context) error {
 	for i := range r.sources {
 		src := &r.sources[i]
 		src.replClient = repl.NewClient(src.db, src.config.Addr, src.config.User, src.config.Passwd, r.applier, &repl.ClientConfig{
-			Logger:                 r.logger,
-			Concurrency:            r.move.Threads,
-			TargetBatchTime:        r.move.TargetChunkTime,
-			CancelFunc:             r.fatalError,
-			DDLFilterSchema:        src.config.DBName,
-			DDLFilterTables:        r.move.SourceTables,
-			ServerID:               repl.NewServerID(),
-			DBConfig:               r.dbConfig,
-			ForceEnableBufferedMap: r.move.ForceEnableBufferedMap,
+			Logger:          r.logger,
+			Concurrency:     r.move.Threads,
+			TargetBatchTime: r.move.TargetChunkTime,
+			CancelFunc:      r.fatalError,
+			DDLFilterSchema: src.config.DBName,
+			DDLFilterTables: r.move.SourceTables,
+			ServerID:        repl.NewServerID(),
+			DBConfig:        r.dbConfig,
 		})
 	}
 

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -440,32 +440,15 @@ func TestMoveResumeDeletesAboveWatermark(t *testing.T) {
 // primary key (VARCHAR with a CI collation) — the case from issue #607. The
 // move runs under concurrent writes to exercise the binlog replay path.
 //
-// The two subtests cover both routing modes for non-memory-comparable PKs:
-//
-//   - default (forceEnableBufferedMap=false): FIFO queue full-time. This is
-//     the safe default — the queue replays binlog events in their original
-//     order, which is required for collation-sensitive PKs because the map's
-//     hash equality ("A" ≠ "a") does not match MySQL's row identity ("A" =
-//     "a" under a CI collation).
-//   - force-enable-buffered-map=true: LWW map dedup during copy, FIFO queue
-//     post-copy. This is the experimental optimization, kept honest by the
-//     post-cutover checksum.
+// For non-memory-comparable PKs the bufferedMap subscription uses LWW map
+// dedup during the copy phase and FIFO queue post-copy. The queue replays
+// binlog events in their original order, which is required for collation-
+// sensitive PKs because the map's hash equality ("A" ≠ "a") does not match
+// MySQL's row identity ("A" = "a" under a CI collation). The post-cutover
+// checksum keeps the optimization honest by repairing any divergence.
 func TestMoveWithVarcharPK(t *testing.T) {
-	t.Run("queue-full-time", func(t *testing.T) {
-		testMoveWithVarcharPK(t, false)
-	})
-	t.Run("force-enable-buffered-map", func(t *testing.T) {
-		testMoveWithVarcharPK(t, true)
-	})
-}
-
-func testMoveWithVarcharPK(t *testing.T, forceEnableBufferedMap bool) {
-	dbSuffix := "queue"
-	if forceEnableBufferedMap {
-		dbSuffix = "bufmap"
-	}
-	srcDB := "source_varcharpk_" + dbSuffix
-	dstDB := "dest_varcharpk_" + dbSuffix
+	srcDB := "source_varcharpk"
+	dstDB := "dest_varcharpk"
 
 	sourceDSN := testutils.DSNForDatabase(srcDB)
 	targetDSN := testutils.DSNForDatabase(dstDB)
@@ -533,20 +516,19 @@ func testMoveWithVarcharPK(t *testing.T, forceEnableBufferedMap bool) {
 	time.Sleep(100 * time.Millisecond)
 
 	move := &Move{
-		SourceDSN:              sourceDSN,
-		TargetDSN:              targetDSN,
-		TargetChunkTime:        100 * time.Millisecond,
-		Threads:                2,
-		WriteThreads:           2,
-		CreateSentinel:         false,
-		ForceEnableBufferedMap: forceEnableBufferedMap,
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+		WriteThreads:    2,
+		CreateSentinel:  false,
 	}
 	err = move.Run()
 	cancel()
 	wg.Wait()
 
-	t.Logf("forceEnableBufferedMap=%v: %d successful writes, %d errors during move",
-		forceEnableBufferedMap, writeCount.Load(), errorCount.Load())
+	t.Logf("%d successful writes, %d errors during move",
+		writeCount.Load(), errorCount.Load())
 	require.NoError(t, err, "move on VARCHAR PK table must succeed (issue #607)")
 
 	// Source/target row counts must match. The internal checksum step inside

--- a/pkg/repl/README.md
+++ b/pkg/repl/README.md
@@ -53,9 +53,10 @@ Applied:        UpsertRows({id=1, ...}); DeleteKeys({id=2});
 #### FIFO fallback for non-memory-comparable primary keys
 
 For tables with non-memory-comparable primary keys (e.g. `VARCHAR` with a
-case-insensitive collation), the subscription falls back to an internal
-FIFO queue. The queue still stores row images inline and applies them via
-the applier — there is no `REPLACE INTO ... SELECT`, so the #746 fix and
+case-insensitive collation), the subscription uses LWW buffered-map dedup
+during the copy phase and switches to an internal FIFO queue post-copy.
+The queue still stores row images inline and applies them via the
+applier — there is no `REPLACE INTO ... SELECT`, so the #746 fix and
 cross-server move support ([issue #607](https://github.com/block/spirit/issues/607))
 are preserved. The queue exists only to preserve binlog order:
 collation-equivalent keys like `"A"` and `"a"` hash to different map slots
@@ -64,26 +65,16 @@ would apply events out of order. FIFO replay through the applier preserves
 binlog order; the target's own collation-aware uniqueness then collapses
 the events onto the right row.
 
-Two routing policies are available, controlled by the
-`--force-enable-buffered-map` migration flag (and the equivalent
-`Move.ForceEnableBufferedMap` field):
+During the copy phase the chunker's own SELECT covers in-window
+case-collision races, so LWW map dedup is safe and considerably faster.
+When the watermark optimization is disabled at the end of the copy phase,
+`SetWatermarkOptimization` drains the map inline and the subscription
+switches into queue mode for the cutover/checksum window. The
+post-cutover checksum (with `FixDifferences=true`) repairs any residual
+divergence.
 
-- **Default (`--force-enable-buffered-map=false`):** queue-mode runs
-  full-time for non-memory-comparable PKs, in both copy and post-copy
-  phases. This mirrors the previous `deltaQueue` performance
-  characteristics but keeps the queue path warm in CI (especially
-  `TestCutoverAtomicityWithConcurrentWrites`) so any bug in the queue
-  surfaces against real workloads before we trust it as a corner-case
-  path.
-- **Optimization (`--force-enable-buffered-map=true`):** during the copy
-  phase the subscription uses LWW buffered-map dedup (faster, works
-  because the chunker's own SELECT covers in-window case-collision
-  races). When the watermark optimization is disabled at the end of the
-  copy phase, `SetWatermarkOptimization` drains the map inline and the
-  subscription switches into queue mode for the cutover/checksum window.
-
-Memory-comparable PKs always use the buffered map regardless of the
-flag, since map-key equality matches MySQL row identity.
+Memory-comparable PKs always use the buffered map, since map-key
+equality matches MySQL row identity.
 
 ## Features
 

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -138,12 +138,6 @@ type Client struct {
 	logger     *slog.Logger
 	streamWG   sync.WaitGroup // tracks readStream goroutine for proper cleanup
 
-	// forceEnableBufferedMap, when true, lets new subscriptions use LWW
-	// buffered-map dedup during the copy phase even for non-memory-comparable
-	// PKs (queue-mode kicks in only post-copy). Default false — see
-	// ClientConfig.ForceEnableBufferedMap.
-	forceEnableBufferedMap bool
-
 	// subscriptionSoftLimitBytes is the per-subscription byte cap passed
 	// to bufferedMap.softLimitBytes on construction. Zero disables the
 	// cap. See DefaultSubscriptionSoftLimitBytes.
@@ -180,7 +174,6 @@ func NewClient(db *sql.DB, host string, username, password string, appl applier.
 		ddlFilterTables:            toSet(config.DDLFilterTables),
 		serverID:                   config.ServerID,
 		applier:                    appl,
-		forceEnableBufferedMap:     config.ForceEnableBufferedMap,
 		subscriptionSoftLimitBytes: softLimit,
 	}
 }
@@ -211,14 +204,6 @@ type ClientConfig struct {
 	// tables in the same schema should not trigger cancellation.
 	// If empty (and DDLFilterSchema is set), all tables in the schema trigger cancellation.
 	DDLFilterTables []string
-
-	// ForceEnableBufferedMap, when true, lets subscriptions for non-memory-comparable
-	// PKs use the LWW buffered-map dedup during the copy phase, falling back to
-	// the FIFO queue only post-copy. Default false: those subscriptions run the
-	// FIFO queue full-time so it is exercised by integration tests like
-	// TestCutoverAtomicityWithConcurrentWrites. Memory-comparable PKs always use
-	// the buffered map regardless of this flag.
-	ForceEnableBufferedMap bool
 
 	// SubscriptionSoftLimitBytes overrides DefaultSubscriptionSoftLimitBytes
 	// for new subscriptions. Set to a negative value to disable the cap
@@ -286,15 +271,14 @@ func (c *Client) AddSubscription(currentTable, newTable *table.TableInfo, chunke
 		pkIsMemoryComparable = false
 	}
 	sub := &bufferedMap{
-		table:                  currentTable,
-		newTable:               newTable,
-		changes:                make(map[string]bufferedChange),
-		c:                      c,
-		chunker:                chunker,
-		applier:                c.applier,
-		pkIsMemoryComparable:   pkIsMemoryComparable,
-		forceEnableBufferedMap: c.forceEnableBufferedMap,
-		softLimitBytes:         c.subscriptionSoftLimitBytes,
+		table:                currentTable,
+		newTable:             newTable,
+		changes:              make(map[string]bufferedChange),
+		c:                    c,
+		chunker:              chunker,
+		applier:              c.applier,
+		pkIsMemoryComparable: pkIsMemoryComparable,
+		softLimitBytes:       c.subscriptionSoftLimitBytes,
 	}
 	sub.cond = sync.NewCond(&sub.Mutex)
 	c.subscriptions[subKey] = sub

--- a/pkg/repl/subscription.go
+++ b/pkg/repl/subscription.go
@@ -11,20 +11,17 @@ import (
 // implementation is bufferedMap; row images come straight from the binlog
 // and are written via the applier (no SELECT-from-source round trip).
 //
-// For non-memory-comparable PKs, bufferedMap routes events through an
-// internal FIFO queue rather than the hash map, since collation-equivalent
-// keys ("A" and "a") hash to different slots but resolve to the same MySQL
-// row — map iteration would apply events out of order. Two routing
-// policies are available, controlled by Client.forceEnableBufferedMap:
+// For non-memory-comparable PKs, bufferedMap uses LWW map dedup during the
+// copy phase and switches to an internal FIFO queue post-copy. The queue
+// exists because collation-equivalent keys ("A" and "a") hash to different
+// map slots but resolve to the same MySQL row — map iteration would apply
+// events out of order. During the copy phase the chunker's later SELECT
+// covers in-window case-collision races, and the post-cutover checksum
+// (with FixDifferences=true) repairs any residual divergence. The
+// transition happens inside SetWatermarkOptimization, which drains the
+// outgoing store inline.
 //
-//   - Default (forceEnableBufferedMap=false): queue mode is active full-time
-//     for non-memory-comparable PKs, in both copy and post-copy phases.
-//   - Optimization (forceEnableBufferedMap=true): map mode during the copy
-//     phase (LWW dedup), queue mode post-copy. The transition happens
-//     inside SetWatermarkOptimization, which drains the outgoing store
-//     inline.
-//
-// Memory-comparable PKs always use the map regardless of the flag. See
+// Memory-comparable PKs always use the map. See
 // pkg/repl/subscription_buffered.go for the routing rules.
 
 type Subscription interface {
@@ -34,11 +31,9 @@ type Subscription interface {
 	Tables() []*table.TableInfo // returns the tables related to the subscription in currentTable, newTable order
 
 	// SetWatermarkOptimization toggles both high and low watermark
-	// optimizations. Under the bufferedMap optimization
-	// (Client.forceEnableBufferedMap=true) toggling can switch a
-	// non-memory-comparable subscription between map mode and queue mode;
-	// on such a transition it drains the outgoing store via the applier
-	// so only one store has pending entries at a time. Returns the drain
-	// error if any.
+	// optimizations. For non-memory-comparable PKs toggling switches the
+	// subscription between map mode and queue mode; on such a transition
+	// it drains the outgoing store via the applier so only one store has
+	// pending entries at a time. Returns the drain error if any.
 	SetWatermarkOptimization(ctx context.Context, enabled bool) error
 }

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -25,18 +25,14 @@ import (
 // re-reading source via REPLACE INTO ... SELECT) sidesteps that race.
 //
 // Behaviour switches based on (watermarkOptimizationEnabled,
-// pkIsMemoryComparable, forceEnableBufferedMap):
+// pkIsMemoryComparable):
 //
 //   - pkIsMemoryComparable=true: always map mode. Map-key equality matches
 //     MySQL row identity, so LWW dedup is correct.
-//   - pkIsMemoryComparable=false && forceEnableBufferedMap=false (default):
-//     queue mode at all times. Mirrors the previous deltaQueue behaviour;
-//     keeps the queue path hot in CI (TestCutoverAtomicityWithConcurrentWrites)
-//     so any bug in the queue gets caught before we flip the default.
-//   - pkIsMemoryComparable=false && forceEnableBufferedMap=true: map mode
-//     during the copy phase (watermark on), queue mode post-copy. The
-//     chunker's later SELECT covers in-window case-collision races during
-//     the copy phase.
+//   - pkIsMemoryComparable=false: map mode during the copy phase
+//     (watermark on), queue mode post-copy. The chunker's later SELECT
+//     covers in-window case-collision races during the copy phase; the
+//     post-cutover checksum repairs any divergence that slips through.
 //
 // Why queue mode at all? With case-insensitive collations, "A" and "a"
 // hash to distinct keys but resolve to the same row in MySQL, so a map's
@@ -122,11 +118,6 @@ type bufferedMap struct {
 	timesParked      atomic.Int64 // HasChanged was parked at least once on the soft limit
 
 	pkIsMemoryComparable bool
-
-	// forceEnableBufferedMap controls whether non-memory-comparable PKs use
-	// the LWW buffered-map dedup during the copy phase. See the file-level
-	// comment and Client.forceEnableBufferedMap for the rationale.
-	forceEnableBufferedMap bool
 }
 
 // Per-entry overheads applied on top of estimateRowSize so the soft
@@ -203,16 +194,11 @@ func (s *bufferedMap) Tables() []*table.TableInfo {
 // FIFO queue rather than the map. Caller must hold s.Lock.
 //
 // Memory-comparable PKs are never queue-mode (map-key equality matches
-// MySQL row identity). For non-memory-comparable PKs, the default is
-// queue full-time so the path is exercised by integration tests; the
-// forceEnableBufferedMap opt-in flips us to map-during-copy /
-// queue-post-copy, which is the optimization we'll eventually default to.
+// MySQL row identity). Non-memory-comparable PKs run in map mode during
+// the copy phase (watermark on) and switch to queue mode post-copy.
 func (s *bufferedMap) queueModeActive() bool {
 	if s.pkIsMemoryComparable {
 		return false
-	}
-	if !s.forceEnableBufferedMap {
-		return true
 	}
 	return !s.watermarkOptimization
 }

--- a/pkg/repl/subscription_buffered_test.go
+++ b/pkg/repl/subscription_buffered_test.go
@@ -440,9 +440,9 @@ func TestBufferedMapFlushWithoutLockRespectsWatermark(t *testing.T) {
 	require.Error(t, err, "Row with id=5 (at watermark) should NOT exist yet")
 }
 
-// TestBufferedMapQueueModeRouting verifies the routing under
-// forceEnableBufferedMap=true (the optimization): map during copy,
-// queue post-copy. See subscription_buffered.go for the full state table.
+// TestBufferedMapQueueModeRouting verifies the routing for non-memory-
+// comparable PKs: map during copy, queue post-copy. See
+// subscription_buffered.go for the full state table.
 func TestBufferedMapQueueModeRouting(t *testing.T) {
 	t1 := `CREATE TABLE subscription_test (
 		id VARCHAR(64) NOT NULL,
@@ -470,17 +470,16 @@ func TestBufferedMapQueueModeRouting(t *testing.T) {
 	}
 
 	sub := &bufferedMap{
-		c:                      client,
-		table:                  srcTable,
-		newTable:               dstTable,
-		changes:                make(map[string]bufferedChange),
-		chunker:                mockChunker,
-		pkIsMemoryComparable:   false,
-		forceEnableBufferedMap: true, // exercise the map-during-copy optimization
+		c:                    client,
+		table:                srcTable,
+		newTable:             dstTable,
+		changes:              make(map[string]bufferedChange),
+		chunker:              mockChunker,
+		pkIsMemoryComparable: false,
 	}
 	sub.cond = sync.NewCond(&sub.Mutex)
 
-	// Watermark optimization on => map mode under the optimization.
+	// Watermark optimization on => map mode (copy phase).
 	sub.watermarkOptimization = true
 	sub.HasChanged([]any{"abc"}, []any{"abc", "value"}, false)
 	require.Len(t, sub.changes, 1, "watermark on: event must go to the map")
@@ -502,60 +501,6 @@ func TestBufferedMapQueueModeRouting(t *testing.T) {
 	require.Equal(t, utils.HashKey([]any{"ghi"}), sub.queue[1].key)
 	require.True(t, sub.queue[1].logicalRow.IsDeleted)
 	require.Equal(t, 3, sub.Length(), "Length reports map+queue combined")
-}
-
-// TestBufferedMapQueueFullTimeDefault verifies that with the default
-// forceEnableBufferedMap=false, non-memory-comparable PKs use the FIFO
-// queue at all times — even during the copy phase. This is the safety
-// default that keeps the queue path warm in CI until we trust the
-// optimization enough to flip the default.
-func TestBufferedMapQueueFullTimeDefault(t *testing.T) {
-	t1 := `CREATE TABLE subscription_test (
-		id VARCHAR(64) NOT NULL,
-		name VARCHAR(255) NOT NULL,
-		PRIMARY KEY (id)
-	)`
-	t2 := `CREATE TABLE _subscription_test_new (
-		id VARCHAR(64) NOT NULL,
-		name VARCHAR(255) NOT NULL,
-		PRIMARY KEY (id)
-	)`
-	srcTable, dstTable := setupTestTables(t, t1, t2)
-
-	mockChunker := table.NewMockChunker(srcTable.TableName, 1000)
-	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
-	mockChunker.SimulateProgress(0.5) // make in-range keys below-high-watermark
-
-	client := &Client{
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
-	}
-
-	sub := &bufferedMap{
-		c:                      client,
-		table:                  srcTable,
-		newTable:               dstTable,
-		changes:                make(map[string]bufferedChange),
-		chunker:                mockChunker,
-		watermarkOptimization:  true,  // copy phase
-		pkIsMemoryComparable:   false, // VARCHAR PK
-		forceEnableBufferedMap: false, // default
-	}
-	sub.cond = sync.NewCond(&sub.Mutex)
-
-	// Even with watermark on (copy phase), the default routes to the queue.
-	sub.HasChanged([]any{"a"}, []any{"a", "v"}, false)
-	require.Empty(t, sub.changes, "default + non-memory-comparable PK: events must not land in the map")
-	require.Len(t, sub.queue, 1, "default + non-memory-comparable PK: events must land in the queue")
-
-	// And when watermark is toggled off, we stay in queue mode (no transition).
-	require.NoError(t, sub.SetWatermarkOptimization(t.Context(), false))
-	require.Len(t, sub.queue, 1, "no mode change: queue contents preserved across the toggle")
-	sub.HasChanged([]any{"b"}, []any{"b", "v2"}, false)
-	require.Len(t, sub.queue, 2, "queue keeps accepting events post-copy")
-	require.Empty(t, sub.changes)
 }
 
 // TestBufferedMapQueueModeFlush exercises the queue-mode flush path end-to-end.
@@ -749,15 +694,14 @@ func TestBufferedMapTransitionDrainsOutgoing(t *testing.T) {
 	}
 
 	sub := &bufferedMap{
-		c:                      client,
-		applier:                applierInstance,
-		table:                  srcTable,
-		newTable:               dstTable,
-		changes:                make(map[string]bufferedChange),
-		chunker:                mockChunker,
-		watermarkOptimization:  true,
-		pkIsMemoryComparable:   false,
-		forceEnableBufferedMap: true, // opt into the optimization so transitions actually flip mode
+		c:                     client,
+		applier:               applierInstance,
+		table:                 srcTable,
+		newTable:              dstTable,
+		changes:               make(map[string]bufferedChange),
+		chunker:               mockChunker,
+		watermarkOptimization: true,
+		pkIsMemoryComparable:  false,
 	}
 	sub.cond = sync.NewCond(&sub.Mutex)
 
@@ -1557,16 +1501,16 @@ func TestBufferedMapRealFlushWakesParked(t *testing.T) {
 // TestBufferedMapQueueModeBackpressure exercises the soft-limit park/wake
 // cycle against the queue path, mirroring the map-mode coverage in
 // TestBufferedMapSoftLimitBackpressure. Queue mode is reached via a
-// non-memory-comparable PK with the default forceEnableBufferedMap=false
-// (queue full-time).
+// non-memory-comparable PK with the watermark optimization off (post-copy
+// phase).
 func TestBufferedMapQueueModeBackpressure(t *testing.T) {
 	sub := &bufferedMap{
-		changes:                make(map[string]bufferedChange),
-		softLimitBytes:         1024,
-		pkIsMemoryComparable:   false, // route to queue
-		forceEnableBufferedMap: false, // default: queue full-time
-		c:                      &Client{logger: slog.Default()},
-		table:                  &table.TableInfo{SchemaName: "test", TableName: "bare"},
+		changes:               make(map[string]bufferedChange),
+		softLimitBytes:        1024,
+		pkIsMemoryComparable:  false, // route to queue
+		watermarkOptimization: false, // post-copy: queue mode active
+		c:                     &Client{logger: slog.Default()},
+		table:                 &table.TableInfo{SchemaName: "test", TableName: "bare"},
 	}
 	sub.cond = sync.NewCond(&sub.Mutex)
 


### PR DESCRIPTION
## Summary

Closes #475.

- Removes the `--force-enable-buffered-map` migration flag and the equivalent `Move.ForceEnableBufferedMap` field.
- `bufferedMap` now always uses LWW map dedup during the copy phase for non-memory-comparable PKs, with the FIFO queue kicking in post-copy via `SetWatermarkOptimization` (the previous "optimization" path is now the only path).
- Post-cutover checksum (`FixDifferences=true`) still repairs any in-window divergence, which is what made it safe to add the flag in the first place — there is no longer a technical reason to keep the opt-in around.
- Drops the "queue full-time" code path and the doc/test scaffolding that supported it (`TestBufferedMapQueueFullTimeDefault`, the dual-subtest split in `TestMoveWithVarcharPK`, the cutover-test note explaining why we *didn't* add a force-enable variant).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `TestBufferedMapQueueModeRouting` (unit) passes against the new single-path logic
- [x] `TestBufferedMapQueueModeBackpressure` (unit) passes after switching to `watermarkOptimization=false` as the queue-mode trigger
- [x] Full CI run, including `TestMoveWithVarcharPK` and `TestCutoverAtomicityWithConcurrentWrites` against the unified bufferedMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)