### PR TITLE
test(#848): lock in reserved-word table-name classification

### DIFF
--- a/pkg/statement/classify_test.go
+++ b/pkg/statement/classify_test.go
@@ -291,6 +291,64 @@ func TestClassifyInvalid(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoStatements)
 }
 
+// TestClassifyReservedWordTable verifies that ALTER TABLE statements on
+// tables whose names are SQL reserved words (e.g. `groups`, `order`, `user`)
+// are classified correctly when the identifier is backtick-quoted. The
+// unquoted form is rejected by the parser — same as MySQL itself — and is
+// not Spirit's responsibility to accept.
+func TestClassifyReservedWordTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantTable string
+		wantErr   bool
+	}{
+		{
+			name:      "MODIFY + AUTO_INCREMENT compound on `groups`",
+			sql:       "ALTER TABLE `groups` MODIFY `gid` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT = 5000210000",
+			wantTable: "groups",
+		},
+		{
+			name:      "AUTO_INCREMENT alone on `groups`",
+			sql:       "ALTER TABLE `groups` AUTO_INCREMENT = 5000210000",
+			wantTable: "groups",
+		},
+		{
+			name:      "MODIFY alone on `groups`",
+			sql:       "ALTER TABLE `groups` MODIFY `gid` bigint NOT NULL AUTO_INCREMENT",
+			wantTable: "groups",
+		},
+		{
+			name:      "ADD COLUMN on `order`",
+			sql:       "ALTER TABLE `order` ADD COLUMN foo INT",
+			wantTable: "order",
+		},
+		{
+			name:      "schema-qualified `groups`",
+			sql:       "ALTER TABLE test.`groups` ADD COLUMN foo INT",
+			wantTable: "groups",
+		},
+		{
+			name:    "unquoted reserved word rejected by parser",
+			sql:     "ALTER TABLE groups ADD COLUMN foo INT",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := Classify(tt.sql)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.Equal(t, StatementAlterTable, results[0].Type)
+			require.Equal(t, tt.wantTable, results[0].Table)
+		})
+	}
+}
+
 func TestStatementTypeString(t *testing.T) {
 	require.Equal(t, "ALTER TABLE", StatementAlterTable.String())
 	require.Equal(t, "CREATE TABLE", StatementCreateTable.String())

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -10,6 +10,7 @@ import (
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
+
 // TestExtractFromReservedWordTable verifies that New() correctly extracts the
 // alter clause (the part after `ALTER TABLE <name>`) when the table name is a
 // SQL reserved word. The trimLen arithmetic in New() must not be tripped up by

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -10,6 +10,34 @@ import (
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
+// TestExtractFromReservedWordTable verifies that New() correctly extracts the
+// alter clause (the part after `ALTER TABLE <name>`) when the table name is a
+// SQL reserved word. The trimLen arithmetic in New() must not be tripped up by
+// the parser's backtick-quoting of reserved identifiers.
+func TestExtractFromReservedWordTable(t *testing.T) {
+	stmts, err := New("ALTER TABLE `groups` MODIFY `gid` bigint NOT NULL AUTO_INCREMENT, AUTO_INCREMENT = 5000210000")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	require.Equal(t, "groups", stmts[0].Table)
+	require.Equal(t, "MODIFY COLUMN `gid` BIGINT NOT NULL AUTO_INCREMENT, AUTO_INCREMENT = 5000210000", stmts[0].Alter)
+
+	stmts, err = New("ALTER TABLE `groups` AUTO_INCREMENT = 5000210000")
+	require.NoError(t, err)
+	require.Equal(t, "groups", stmts[0].Table)
+	require.Equal(t, "AUTO_INCREMENT = 5000210000", stmts[0].Alter)
+
+	stmts, err = New("ALTER TABLE `order` ADD COLUMN foo INT")
+	require.NoError(t, err)
+	require.Equal(t, "order", stmts[0].Table)
+	require.Equal(t, "ADD COLUMN `foo` INT", stmts[0].Alter)
+
+	stmts, err = New("ALTER TABLE test.`groups` ADD COLUMN foo INT")
+	require.NoError(t, err)
+	require.Equal(t, "test", stmts[0].Schema)
+	require.Equal(t, "groups", stmts[0].Table)
+	require.Equal(t, "ADD COLUMN `foo` INT", stmts[0].Alter)
+}
+
 func TestExtractFromStatement(t *testing.T) {
 	abstractStmt, err := New("ALTER TABLE t1 ADD INDEX (something)")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Closes #848.

Adds regression tests confirming that `statement.Classify()` and `statement.New()` handle ALTER TABLE on reserved-word table names (`groups`, `order`, schema-qualified `` test.`groups` ``, …) correctly when the identifier is backtick-quoted. Includes the exact compound `MODIFY` + `AUTO_INCREMENT` DDL from the original bug report.

The unquoted-reserved-word case is asserted to fail — that's the TiDB parser doing its job, same as MySQL itself, and is not something Spirit should try to "fix" by being more lenient.

## Why tests-only

I traced the original failure end-to-end (issue #848 has the full writeup): Spirit handles the DDL correctly when backticks are present, so the failure must be a caller stripping them upstream. Nothing in Spirit needs to change. The risk this PR addresses is silent regression — without these tests, a future change to `statement.New()`'s `trimLen` arithmetic or to the TiDB parser fork's `DefaultRestoreFlags` could quietly break reserved-word handling and send the next investigator chasing the same dead end.

## Test plan

- [x] `go test ./pkg/statement/` — green locally
- [x] New tests fail on a sabotaged `New()` (verified by hand: removing `RestoreNameBackQuotes` from the restore flags makes `TestExtractFromReservedWordTable` fail with a parse error on the rebuilt SQL)