### PR TITLE
fix(#847): switch buffered map to FIFO queue on dup-key collision

### DIFF
--- a/pkg/repl/README.md
+++ b/pkg/repl/README.md
@@ -43,6 +43,12 @@ applies it through the applier interface:
 - Higher memory usage than a key-only map: stores full row data for each changed key.
 - Watermark optimizations (`KeyAboveHighWatermark` and `KeyBelowLowWatermark`) are available on `MappedChunker` implementations (both optimistic and composite chunkers). They work correctly for numeric, binary, and temporal primary key types. For `VARCHAR`/`TEXT` columns with collations, Go's byte-order comparison may differ from MySQL's collation order; any discrepancies are caught by the checksum phase (see [issue #479](https://github.com/block/spirit/issues/479)).
 
+**The map is optimistic.** It bets that the randomized iteration order of
+`s.changes` is harmless because each row's upsert depends only on its own
+PK. That bet holds for the overwhelmingly common case, but it breaks for
+workloads that move a unique value between rows inside a single
+transaction — see "Optimistic batching and the FIFO fallback" below.
+
 **Example scenario:**
 ```
 Binlog events:  INSERT(id=1, ...), UPDATE(id=1, ...), UPDATE(id=1, ...), DELETE(id=2)
@@ -75,6 +81,67 @@ divergence.
 
 Memory-comparable PKs always use the buffered map, since map-key
 equality matches MySQL row identity.
+
+#### Optimistic batching and the FIFO fallback (#847)
+
+The buffered map flush builds one multi-row
+`INSERT ... ON DUPLICATE KEY UPDATE` per batch. MySQL processes the
+`VALUES` list in array order, so the order of rows inside the batch
+matters whenever two rows in the same batch can collide on a unique
+key. The map's iteration is randomized, which is fine for the common
+case but is **unsafe for "swap" patterns**:
+
+```sql
+-- Legal in source: deactivate one row, then activate another,
+-- inside a single transaction. UNIQUE(slot_id) allows NULLs to
+-- duplicate, so the invariant holds.
+START TRANSACTION;
+UPDATE t SET slot_id = NULL  WHERE id = 1;  -- was 'S'
+UPDATE t SET slot_id = 'S'   WHERE id = 2;  -- was NULL
+COMMIT;
+```
+
+The two `UPDATE` binlog events can land in the same flush batch. If
+the map's random iteration places id=2 (activate) before id=1
+(deactivate), MySQL processes id=2's upsert first while id=1 still
+holds `'S'` in the shadow table and aborts with
+`Error 1062 (23000): Duplicate entry ...`.
+
+The subscription recovers automatically:
+
+1. `handleFlushError` recognises the 1062, clears the pending map,
+   flips an internal `forceQueueMode` flag, and asks the client to
+   rewind. The flush is reported as a no-op so `flushedPos` is not
+   advanced.
+2. `Client.requestRewind` sets a flag and closes the current binlog
+   syncer. `readStream` sees the closed syncer plus the rewind flag
+   and shortcuts straight into `recreateStreamer`, skipping the
+   consecutive-error backoff that exists for stream-level read
+   failures.
+3. `recreateStreamer` restarts the binlog reader at position 4 of
+   the `flushedPos` file (the start of the binlog file containing
+   the last fully-flushed position). Position 4 is required so the
+   syncer picks up the file's `FormatDescriptionEvent` and
+   `TableMapEvent`s — MySQL does not re-send TableMaps mid-file, so
+   restarting at any later offset would leave the parser unable to
+   decode subsequent `RowsEvent`s.
+4. Re-read events flow into the now queue-mode subscription in
+   binlog (FIFO) order. `flushQueueLocked` carries that order into
+   the multi-row upsert, so the swap pair lands deactivate-first
+   and no longer collides. The subscription stays in queue mode for
+   the rest of the migration; we don't flip back, since one
+   observed swap means the workload is likely to produce more.
+
+Tables whose workloads never produce a swap never trip the recovery
+path and keep the full dedup benefit of map mode. The cost of the
+recovery is one wasted flush and a re-read of every event since the
+last full flush; the destination ends up byte-identical to source
+because the re-applied events are idempotent for already-applied
+rows and correct for the unapplied tail.
+
+See `TestBufferedMapSwapPairRecoversViaQueueMode` (unit) and
+`TestSwapPairFullRecoveryViaQueueMode` (end-to-end) for the
+regression gates.
 
 ## Features
 

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -609,6 +609,14 @@ func (c *Client) readStream(ctx context.Context) {
 					// Fall through to normal error handling; the
 					// retry loop will pick it up.
 				} else {
+					// recreateStreamer snapped bufferedPos back to
+					// {flushedPos.Name, 4}; resync our local file-name
+					// tracker so position updates for events that arrive
+					// *before* the synthetic RotateEvent record the
+					// correct file. MySQL does send a RotateEvent at the
+					// start of every binlog dump, but we shouldn't rely
+					// on that arriving before any setBufferedPos call.
+					currentLogName = c.getBufferedPos().Name
 					consecutiveErrors = 0
 					recreateAttempts = 0
 					backoffDuration = initialBackoffDuration
@@ -1038,6 +1046,7 @@ func (c *Client) FlushUnderTableLock(ctx context.Context, lock *dbconn.TableLock
 func (c *Client) flush(ctx context.Context, underLock bool, lock *dbconn.TableLock) error {
 	c.Lock()
 	newFlushedPos := c.bufferedPos
+	currentFlushedPos := c.flushedPos
 	c.Unlock()
 	var allChangesFlushed = true
 	for _, subscription := range c.subscriptions {
@@ -1062,7 +1071,15 @@ func (c *Client) flush(ctx context.Context, underLock bool, lock *dbconn.TableLo
 	// for these high contention cases. But that's not a great solution either,
 	// because the low watermark optimization helps a lot in these cases because
 	// it reduces contention between the copier and the repl applier.
-	if allChangesFlushed {
+	//
+	// Guard against a backwards move: a rewind (see Client.requestRewind, #847)
+	// can snap c.bufferedPos back to position 4 of c.flushedPos.Name to mark
+	// the binlog reader's new read position. If a flush captured that snapped
+	// value before readStream advanced bufferedPos back past flushedPos, this
+	// branch would otherwise regress the checkpoint. Skip it instead — once
+	// readStream re-reads past the old flushedPos, a subsequent flush will
+	// advance the checkpoint normally.
+	if allChangesFlushed && newFlushedPos.Compare(currentFlushedPos) >= 0 {
 		c.SetFlushedPos(newFlushedPos)
 	}
 	return nil

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -144,6 +144,14 @@ type Client struct {
 	subscriptionSoftLimitBytes int64
 
 	flushedBinlogs atomic.Int64 // for testing binlog flushing frequency
+
+	// rewindRequested is set by requestRewind (called from a subscription
+	// that just recovered from a duplicate-key collision per #847). When
+	// set, the next recreateStreamer call restarts the binlog reader at
+	// position 4 of c.flushedPos.Name rather than c.bufferedPos.Name —
+	// re-reading every event since the last fully-flushed position so the
+	// (now queue-mode) subscription can apply them in binlog FIFO order.
+	rewindRequested atomic.Bool
 }
 
 // NewClient creates a new Client instance.
@@ -450,20 +458,51 @@ func (c *Client) Run(ctx context.Context) (err error) {
 	return nil
 }
 
-// recreateStreamer recreates the binlog streamer from the current buffered position.
-// When we recreate the syncer, the parser's table map is lost. MySQL only sends
-// TableMapEvents once per connection, so when we resume from a mid-stream position,
-// we won't have the table metadata needed to decode RowsEvents.
+// requestRewind asks readStream to recreate the binlog streamer from
+// position 4 of the flushedPos file. Called by a subscription's
+// handleFlushError after it recovers from a swap-pair duplicate-key
+// collision (block/spirit#847) and needs to replay every event since
+// the last fully-flushed position in binlog (FIFO) order.
 //
-// To handle this safely, we check if the binlog has rotated since we started:
-// - Same file as initial: error
-// - Different file: Safely recreate and resume from position 4.
+// Closing the syncer here causes the in-flight GetEvent in readStream
+// to error out; readStream sees rewindRequested and shortcuts straight
+// to recreateStreamer, skipping the consecutive-error / backoff path
+// that exists for stream-level read failures.
+func (c *Client) requestRewind() {
+	c.Lock()
+	c.rewindRequested.Store(true)
+	syncer := c.syncer
+	c.Unlock()
+	// Close the syncer *outside* the lock. recreateStreamer (which
+	// readStream is about to call) acquires the same lock, and
+	// syncer.Close blocks briefly on its internal goroutines — keeping
+	// the lock during that wait would deadlock.
+	if syncer != nil {
+		syncer.Close()
+	}
+}
+
+// recreateStreamer recreates the binlog streamer. By default it restarts
+// at position 4 of the current bufferedPos file (the existing recovery
+// path for stream-level read errors). When rewindRequested is set, it
+// restarts at position 4 of the flushedPos file instead — re-reading
+// every event since the last fully-flushed position. That path is taken
+// after a subscription's handleFlushError recovers from a swap-pair
+// duplicate-key collision per #847.
+//
+// Position 4 is the start of a binlog file; restarting there guarantees
+// the syncer sees the FormatDescriptionEvent and any TableMapEvents
+// needed to decode subsequent RowsEvents — MySQL does not re-send
+// TableMaps from earlier in the file when serving a mid-position dump,
+// so restarting mid-file would leave the parser unable to decode rows.
 func (c *Client) recreateStreamer() error {
 	c.Lock()
 	defer c.Unlock()
 
 	c.logger.Info("recreateStreamer called",
 		"buffered_position", c.bufferedPos,
+		"flushed_position", c.flushedPos,
+		"rewind_requested", c.rewindRequested.Load(),
 		"syncer_exists", c.syncer != nil,
 		"streamer_exists", c.streamer != nil)
 
@@ -473,18 +512,29 @@ func (c *Client) recreateStreamer() error {
 		c.syncer.Close()
 	}
 
-	// Still on the same binlog file we started with.
-	// Safe to replay from position 4 because the subscription data structures
-	// (deltaMap, bufferedMap, deltaQueue) are idempotent - reprocessing events
-	// will simply overwrite previous state with the same value.
+	// Pick the source file. Default: same file we'd previously been
+	// reading. Rewind path: the file that contains flushedPos so we
+	// catch every event since the last full flush, including any in a
+	// rotated-away earlier binlog.
+	sourceFile := c.bufferedPos.Name
+	rewinding := c.rewindRequested.Load()
+	if rewinding {
+		sourceFile = c.flushedPos.Name
+		c.rewindRequested.Store(false)
+		// Snap bufferedPos back so the position update in readStream
+		// (which uses ev.Header.LogPos) records a sensible value rather
+		// than a stale future one.
+		c.bufferedPos = mysql.Position{Name: sourceFile, Pos: 4}
+	}
+
 	newStartPos := mysql.Position{
-		Name: c.bufferedPos.Name,
+		Name: sourceFile,
 		Pos:  4, // Binlog files always start at position 4
 	}
 	c.logger.Info("Recreating streamer from file start",
-		"file", c.bufferedPos.Name,
-		"previous_position", c.bufferedPos.Pos,
+		"file", sourceFile,
 		"new_start_position", newStartPos,
+		"rewinding_to_flushed_pos", rewinding,
 	)
 
 	c.syncer = replication.NewBinlogSyncer(c.cfg)
@@ -544,6 +594,26 @@ func (c *Client) readStream(ctx context.Context) {
 			// We only stop processing for context cancelled errors.
 			if errors.Is(err, context.Canceled) || ctx.Err() != nil || c.isClosed.Load() {
 				return // stop processing
+			}
+
+			// Explicit rewind requested by a subscription that just
+			// recovered from a duplicate-key collision (#847). Skip
+			// the consecutive-error threshold and backoff — we want
+			// the rewind to happen *now*, not in 5 seconds. The
+			// recreateStreamer call below honors rewindRequested and
+			// restarts at position 4 of the flushedPos file.
+			if c.rewindRequested.Load() {
+				if recreateErr := c.recreateStreamer(); recreateErr != nil {
+					c.logger.Error("Failed to recreate streamer on explicit rewind",
+						"error", recreateErr)
+					// Fall through to normal error handling; the
+					// retry loop will pick it up.
+				} else {
+					consecutiveErrors = 0
+					recreateAttempts = 0
+					backoffDuration = initialBackoffDuration
+					continue
+				}
 			}
 
 			consecutiveErrors++

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -454,8 +454,16 @@ func (s *bufferedMap) handleFlushError(err error) bool {
 		"table", s.table.SchemaName+"."+s.table.TableName,
 		"error", err.Error(),
 		"changes_cleared", len(s.changes),
+		"queue_cleared", len(s.queue),
 	)
+	// Discard both stores. Anything that was in either is about to be
+	// re-read from the binlog by readStream after the rewind. Clearing
+	// the queue here (not just the map) also keeps sizeBytes accounting
+	// consistent — leaving stale queue entries while resetting sizeBytes
+	// would let flushQueueLocked drive sizeBytes negative when it
+	// subtracts drainedBytes on the next flush.
 	s.changes = make(map[string]bufferedChange)
+	s.queue = nil
 	s.sizeBytes = 0
 	s.forceQueueMode = true
 	s.cond.Broadcast() // wake HasChanged callers parked on the soft cap

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -26,30 +26,55 @@ import (
 // binlog_order_commits = ON. Storing the row image inline (rather than
 // re-reading source via REPLACE INTO ... SELECT) sidesteps that race.
 //
-// Behaviour switches based on (watermarkOptimizationEnabled,
-// pkIsMemoryComparable):
+// Behaviour switches based on (forceQueueMode,
+// watermarkOptimizationEnabled, pkIsMemoryComparable):
 //
-//   - pkIsMemoryComparable=true: always map mode. Map-key equality matches
+//   - forceQueueMode=true: always queue mode. Set permanently by
+//     handleFlushError after the subscription recovers from a duplicate-
+//     key collision (see "Optimistic batching" below and #847).
+//   - pkIsMemoryComparable=true: map mode. Map-key equality matches
 //     MySQL row identity, so LWW dedup is correct.
 //   - pkIsMemoryComparable=false: map mode during the copy phase
 //     (watermark on), queue mode post-copy. The chunker's later SELECT
 //     covers in-window case-collision races during the copy phase; the
 //     post-cutover checksum repairs any divergence that slips through.
 //
-// Why queue mode at all? With case-insensitive collations, "A" and "a"
-// hash to distinct keys but resolve to the same row in MySQL, so a map's
-// non-deterministic iteration would apply the events in the wrong order.
-// FIFO ordering applies them in binlog order, which the target's own
-// collation-aware uniqueness then collapses correctly. The queue still
-// stores row images and applies them via the applier — no
-// REPLACE INTO ... SELECT, so #746 stays fixed and cross-server moves
-// stay supported per #607.
+// Why queue mode at all? Two unrelated reasons:
 //
-// SetWatermarkOptimization owns the transition: when its toggle changes
-// which store is active, it drains the outgoing store inline. Past that
-// boundary the invariant holds — only the currently-active store may
-// have entries — so HasChanged never has to merge into a stale map and
-// Flush never has to drain both stores in the normal path.
+//  1. Collation-insensitive PKs: with case-insensitive collations "A"
+//     and "a" hash to distinct keys but resolve to the same row in
+//     MySQL, so a map's non-deterministic iteration would apply the
+//     events in the wrong order. FIFO ordering applies them in binlog
+//     order, which the target's own collation-aware uniqueness then
+//     collapses correctly.
+//  2. Optimistic batching for unique keys (#847): the map flush hands
+//     the applier a batched INSERT...ON DUPLICATE KEY UPDATE. MySQL
+//     processes its VALUES list in array order, so the row order in
+//     the batch matters when two rows in it can collide on a unique
+//     key. The map's randomized iteration is fine for the common case
+//     where each row's upsert depends only on its own PK, but it
+//     breaks for "swap" patterns — a workload that legally moves a
+//     unique value between two rows inside one transaction
+//     (UPDATE A SET col=NULL; UPDATE B SET col='val';). When the
+//     activating row happens to come first in the batch, MySQL fails
+//     it with Error 1062 because the deactivating row still holds the
+//     value in the shadow. handleFlushError catches the 1062, clears
+//     the map, flips forceQueueMode on, and asks the client to rewind
+//     the binlog reader so the lost events can be re-read FIFO and
+//     applied in binlog order.
+//
+// Either path keeps the row image inline and applies via the applier —
+// no REPLACE INTO ... SELECT, so #746 stays fixed and cross-server
+// moves stay supported per #607.
+//
+// SetWatermarkOptimization owns the watermark-driven transition: when
+// its toggle changes which store is active, it drains the outgoing
+// store inline. Past that boundary the invariant holds — only the
+// currently-active store may have entries — so HasChanged never has to
+// merge into a stale map and Flush never has to drain both stores in
+// the normal path. The forceQueueMode transition is *not* drained by
+// SetWatermarkOptimization; handleFlushError discards the map outright
+// because the rewind will re-read those events from the binlog.
 
 type bufferedChange struct {
 	logicalRow  applier.LogicalRow

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -2,6 +2,7 @@ package repl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -11,6 +12,7 @@ import (
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
 )
 
 // The bufferedMap avoids using REPLACE INTO .. SELECT.
@@ -118,6 +120,15 @@ type bufferedMap struct {
 	timesParked      atomic.Int64 // HasChanged was parked at least once on the soft limit
 
 	pkIsMemoryComparable bool
+
+	// forceQueueMode is set by handleFlushError after a recoverable
+	// duplicate-key collision (block/spirit#847). Once set, queueModeActive
+	// returns true regardless of pkIsMemoryComparable / watermarkOptimization,
+	// so subsequent events accumulate in s.queue (FIFO) and flushQueueLocked
+	// drives them through the applier in binlog order. We never flip it back —
+	// once a swap-pair has been observed, this subscription stays in queue mode
+	// for the rest of the migration.
+	forceQueueMode bool
 }
 
 // Per-entry overheads applied on top of estimateRowSize so the soft
@@ -196,7 +207,13 @@ func (s *bufferedMap) Tables() []*table.TableInfo {
 // Memory-comparable PKs are never queue-mode (map-key equality matches
 // MySQL row identity). Non-memory-comparable PKs run in map mode during
 // the copy phase (watermark on) and switch to queue mode post-copy.
+//
+// One escape hatch: if forceQueueMode is set (after a recoverable
+// duplicate-key collision per #847), queue mode wins regardless.
 func (s *bufferedMap) queueModeActive() bool {
+	if s.forceQueueMode {
+		return true
+	}
 	if s.pkIsMemoryComparable {
 		return false
 	}
@@ -344,6 +361,9 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 		}
 		if (i % target) == 0 {
 			if err := s.flushBatch(ctx, deleteKeys, upsertRows, lockToUse); err != nil {
+				if s.handleFlushError(err) {
+					return false, nil
+				}
 				return false, err
 			}
 			deleteKeys = nil
@@ -352,6 +372,9 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 	}
 
 	if err := s.flushBatch(ctx, deleteKeys, upsertRows, lockToUse); err != nil {
+		if s.handleFlushError(err) {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -367,6 +390,52 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 		s.cond.Broadcast()
 	}
 	return allChangesFlushed, nil
+}
+
+// handleFlushError implements the swap-pair recovery path for #847.
+//
+// When the multi-row INSERT ... ON DUPLICATE KEY UPDATE inside flushBatch
+// fails with Error 1062, the cause is almost always that the buffered
+// map's randomized iteration handed the applier a swap pair (deactivate
+// row A, activate row B from the same source-side transaction) in the
+// wrong order — B activates first while A still holds the unique value
+// in the shadow table.
+//
+// On 1062 we:
+//
+//  1. Discard all pending changes. Their *latest* row images are still
+//     in the source-side binlog (the binlog reader has not advanced
+//     flushedPos past them), so we can re-read them.
+//  2. Flip forceQueueMode on. Subsequent events will accumulate in the
+//     FIFO queue, and flushQueueLocked drives them through the applier
+//     in binlog order — no in-batch reordering, no spurious collision.
+//  3. Ask the client to rewind the binlog reader back to position 4 of
+//     the flushedPos file. recreateStreamer handles the actual rewind
+//     once readStream sees the closed syncer.
+//
+// Returns true if we recognized and handled the error; the caller
+// should then treat the flush as a no-op (return allChangesFlushed=false
+// without an error) so flushedPos is not advanced.
+//
+// Caller must hold s.Mutex.
+func (s *bufferedMap) handleFlushError(err error) bool {
+	var me *mysql2.MySQLError
+	if !errors.As(err, &me) || me.Number != 1062 {
+		return false
+	}
+	s.c.logger.Warn("buffered-map flush hit a duplicate-key collision; "+
+		"clearing pending changes, switching to queue mode (FIFO), "+
+		"and rewinding binlog to flushed position",
+		"table", s.table.SchemaName+"."+s.table.TableName,
+		"error", err.Error(),
+		"changes_cleared", len(s.changes),
+	)
+	s.changes = make(map[string]bufferedChange)
+	s.sizeBytes = 0
+	s.forceQueueMode = true
+	s.cond.Broadcast() // wake HasChanged callers parked on the soft cap
+	s.c.requestRewind()
+	return true
 }
 
 // flushBatch flushes a batch of deletes and upserts using the applier.

--- a/pkg/repl/subscription_buffered_swap_test.go
+++ b/pkg/repl/subscription_buffered_swap_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	mysql2 "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
@@ -166,6 +167,49 @@ func TestBufferedMapSwapPairRecoversViaQueueMode(t *testing.T) {
 	require.Empty(t, sub.changes, "new events must not land back in the map")
 	require.Len(t, sub.queue, 1, "new events must land in the FIFO queue")
 	sub.Unlock()
+}
+
+// TestFlushDoesNotRegressFlushedPosAfterRewind covers the defensive
+// guard in `Client.flush` against a backwards checkpoint move when
+// a rewind has snapped `bufferedPos` back. Without the guard, a flush
+// that happened to run between the rewind (which sets bufferedPos =
+// {flushedPos.Name, 4}) and readStream catching up past the old
+// flushedPos.Pos would publish the rewound bufferedPos as the new
+// flushedPos — silently rewinding checkpoints.
+//
+// We don't run a real binlog reader here. We exercise `flush` directly
+// on a client that has no subscriptions (so allChangesFlushed=true)
+// and assert that flushedPos does not move backwards when bufferedPos
+// is set behind it.
+func TestFlushDoesNotRegressFlushedPosAfterRewind(t *testing.T) {
+	client := &Client{
+		db:              nil, // unused: no subscriptions to flush
+		logger:          slog.Default(),
+		concurrency:     1,
+		targetBatchSize: 1000,
+		dbConfig:        dbconn.NewDBConfig(),
+		subscriptions:   map[string]Subscription{},
+	}
+
+	// Pretend we'd flushed up to (file, 5000) and then a rewind dropped
+	// bufferedPos back to the start of the file.
+	advanced := mysql.Position{Name: "binlog.000042", Pos: 5000}
+	rewound := mysql.Position{Name: "binlog.000042", Pos: 4}
+	client.SetFlushedPos(advanced)
+	client.setBufferedPos(rewound)
+
+	require.NoError(t, client.flush(t.Context(), false, nil))
+
+	require.Equal(t, advanced, client.GetBinlogApplyPosition(),
+		"flushedPos must not regress when a flush captures a rewound bufferedPos")
+
+	// Sanity: once bufferedPos advances back past the old flushedPos, a
+	// subsequent flush *does* move the checkpoint forward.
+	forward := mysql.Position{Name: "binlog.000042", Pos: 6000}
+	client.setBufferedPos(forward)
+	require.NoError(t, client.flush(t.Context(), false, nil))
+	require.Equal(t, forward, client.GetBinlogApplyPosition(),
+		"flushedPos should advance once bufferedPos is ahead again")
 }
 
 // TestSwapPairFullRecoveryViaQueueMode drives the full end-to-end

--- a/pkg/repl/subscription_buffered_swap_test.go
+++ b/pkg/repl/subscription_buffered_swap_test.go
@@ -1,0 +1,317 @@
+package repl
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBufferedMapSwapPairRecoversViaQueueMode is a deterministic,
+// single-threaded regression test for the fix to block/spirit#847.
+//
+// Background: `bufferedMap.flushMapLocked` iterates `s.changes` (a Go
+// map, randomized iteration) and hands the rows to the applier as a
+// single `INSERT ... ON DUPLICATE KEY UPDATE` with a multi-row VALUES
+// list. MySQL processes that list in array order. When a swap pair
+// lands in the same batch — row A's deactivation and row B's activation,
+// both from the same source-side transaction — the random map order can
+// place B's activation before A's deactivation, and MySQL rejects the
+// first row with Error 1062 because A still holds the unique value.
+//
+// The fix is detect-and-switch (`handleFlushError`): when Flush sees a
+// 1062, the subscription discards its pending map, flips into
+// forceQueueMode, and asks the client to rewind the binlog reader to
+// position 4 of the flushedPos file. The events that were lost when
+// the map was cleared are re-read FIFO and applied via flushQueueLocked,
+// which preserves binlog order in the resulting batch — no collision.
+//
+// This test exercises the subscription-level half of that fix: we
+// drive a swap pair into the map for 50 independent buckets (so the
+// probability that map iteration happens to land *every* pair in the
+// safe order is 2^-50, effectively zero), call Flush once, and assert:
+//
+//   - Flush returns no error (we recovered).
+//   - allChangesFlushed=false (so flushedPos won't advance).
+//   - The subscription is now in queue mode.
+//   - The map is empty (state was discarded).
+//
+// The end-to-end half of the fix — the client actually rewinding the
+// binlog reader and the queue mode applying the re-read events — is
+// covered by TestSwapPairFullRecoveryViaQueueMode below.
+func TestBufferedMapSwapPairRecoversViaQueueMode(t *testing.T) {
+	t1 := `CREATE TABLE subscription_test (
+		id INT NOT NULL,
+		slot_id VARCHAR(50) DEFAULT NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY uq_slot (slot_id)
+	)`
+	t2 := `CREATE TABLE _subscription_test_new (
+		id INT NOT NULL,
+		slot_id VARCHAR(50) DEFAULT NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY uq_slot (slot_id)
+	)`
+	srcTable, dstTable := setupTestTables(t, t1, t2)
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	target := applier.Target{
+		DB:       db,
+		KeyRange: "0",
+		Config:   cfg,
+	}
+	applierInstance, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	client := &Client{
+		db:              db,
+		logger:          slog.Default(),
+		concurrency:     2,
+		targetBatchSize: 1000,
+		dbConfig:        dbconn.NewDBConfig(),
+	}
+
+	// Seed the pre-swap state in the destination table directly. The
+	// source table doesn't need to be populated — we drive HasChanged
+	// ourselves instead of relying on the binlog reader.
+	//
+	// For each bucket i: PK = 2i+1 holds slot_id='S<i>'; PK = 2i+2 holds NULL.
+	const buckets = 50
+	seed := make([]string, 0, buckets*2)
+	for i := 0; i < buckets; i++ {
+		seed = append(seed,
+			fmt.Sprintf("(%d, 'S%d')", 2*i+1, i),
+			fmt.Sprintf("(%d, NULL)", 2*i+2),
+		)
+	}
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, slot_id) VALUES %s",
+		dstTable.QuotedTableName, strings.Join(seed, ", ")))
+
+	mockChunker := table.NewMockChunker(srcTable.TableName, uint64(buckets*2))
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+
+	sub := &bufferedMap{
+		c:                     client,
+		applier:               applierInstance,
+		table:                 srcTable,
+		newTable:              dstTable,
+		changes:               make(map[string]bufferedChange),
+		chunker:               mockChunker,
+		watermarkOptimization: false, // accept every event; no chunker-progress gating
+		pkIsMemoryComparable:  true,  // INT PK → map mode (the failing path)
+	}
+	sub.cond = sync.NewCond(&sub.Mutex)
+
+	// Inject the swap pair for every bucket. In source these two
+	// UPDATEs are committed inside one transaction:
+	//   UPDATE id=active SET slot_id=NULL;
+	//   UPDATE id=passive SET slot_id='S<i>';
+	// We bypass the binlog reader and call HasChanged with the
+	// post-transaction row image for each row.
+	for i := 0; i < buckets; i++ {
+		activePK := 2*i + 1
+		passivePK := 2*i + 2
+		sub.HasChanged([]any{activePK}, []any{activePK, nil}, false)
+		sub.HasChanged([]any{passivePK}, []any{passivePK, fmt.Sprintf("S%d", i)}, false)
+	}
+	require.Equal(t, buckets*2, sub.Length())
+
+	// With the buggy map-iteration order, the batched
+	// INSERT ... ON DUPLICATE KEY UPDATE will, with probability
+	// 1 - 2^-buckets, place at least one bucket's activation before its
+	// deactivation and trigger Error 1062 on uq_slot inside flushBatch.
+	// `handleFlushError` recognizes that, clears the map, flips
+	// forceQueueMode, asks the client to rewind, and returns the flush
+	// as a no-op (allChangesFlushed=false, no error).
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "recovery path should swallow the 1062")
+	require.False(t, allFlushed,
+		"allChangesFlushed must be false so flushedPos stays put — the events still need to be re-read FIFO")
+
+	// State assertions: the recovery path discarded pending changes and
+	// flipped the subscription into queue mode.
+	sub.Lock()
+	require.True(t, sub.forceQueueMode, "forceQueueMode should be set after a 1062 recovery")
+	require.True(t, sub.queueModeActive(), "queueModeActive should return true once forceQueueMode is on")
+	require.Empty(t, sub.changes, "pending map should be cleared")
+	require.Zero(t, sub.sizeBytes, "sizeBytes should be reset to 0")
+	sub.Unlock()
+
+	// The recovery also asks the client to rewind the binlog reader.
+	// (We constructed the Client directly without a syncer, so the
+	// close-the-syncer half of requestRewind is a no-op; the flag flip
+	// is the observable signal here.)
+	require.True(t, client.rewindRequested.Load(),
+		"client should have been asked to rewind the binlog reader")
+
+	// A subsequent HasChanged should route to the queue, not the map.
+	sub.HasChanged([]any{42}, []any{42, "after-recovery"}, false)
+	sub.Lock()
+	require.Empty(t, sub.changes, "new events must not land back in the map")
+	require.Len(t, sub.queue, 1, "new events must land in the FIFO queue")
+	sub.Unlock()
+}
+
+// TestSwapPairFullRecoveryViaQueueMode drives the full end-to-end
+// rewind path: real Client.Run, real binlog reader, real swap
+// transactions on source, real Flush calls, real recovery, real
+// destination state.
+//
+// The flow:
+//
+//  1. Source and destination tables are seeded with the pre-swap state.
+//     The seed inserts happen *before* Run starts so they are outside
+//     the subscription's binlog window (the rewind will still re-read
+//     them from the start of the file, but applying them is idempotent
+//     because their values match what's already in dest).
+//  2. Run starts the binlog reader at the current server position.
+//  3. The test executes N legal swap transactions on source.
+//  4. BlockWait waits for the subscription to receive every event.
+//  5. The first Flush hits the swap-pair 1062 inside flushMapLocked,
+//     recovers via handleFlushError, asks the client to rewind, and
+//     returns no error. The subscription is now in forceQueueMode.
+//  6. readStream notices the closed syncer, sees rewindRequested, and
+//     recreates the streamer at position 4 of flushedPos.Name. As it
+//     re-reads events they accumulate in the FIFO queue.
+//  7. Subsequent Flush loops drain the queue via flushQueueLocked,
+//     which preserves binlog order — no in-batch reordering.
+//  8. The destination ends up byte-equal to the source.
+func TestSwapPairFullRecoveryViaQueueMode(t *testing.T) {
+	t1 := `CREATE TABLE subscription_test (
+		id INT NOT NULL,
+		slot_id VARCHAR(50) DEFAULT NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY uq_slot (slot_id)
+	)`
+	t2 := `CREATE TABLE _subscription_test_new (
+		id INT NOT NULL,
+		slot_id VARCHAR(50) DEFAULT NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY uq_slot (slot_id)
+	)`
+	srcTable, dstTable := setupTestTables(t, t1, t2)
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	target := applier.Target{
+		DB:       db,
+		KeyRange: "0",
+		Config:   cfg,
+	}
+	applierInstance, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applierInstance, &ClientConfig{
+		Logger:          slog.Default(),
+		Concurrency:     4,
+		TargetBatchTime: time.Second,
+		ServerID:        NewServerID(),
+	})
+	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
+
+	// Seed both tables with identical pre-swap state BEFORE Run starts,
+	// so these inserts aren't in the subscription's window. (They will
+	// still be re-read once the rewind kicks in, but applying them via
+	// the FIFO queue is idempotent — they match what's already in dst.)
+	const buckets = 50
+	var seed []string
+	for i := 0; i < buckets; i++ {
+		seed = append(seed,
+			fmt.Sprintf("(%d, 'S%d')", 2*i+1, i),
+			fmt.Sprintf("(%d, NULL)", 2*i+2),
+		)
+	}
+	insertVals := strings.Join(seed, ", ")
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, slot_id) VALUES %s",
+		srcTable.QuotedTableName, insertVals))
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, slot_id) VALUES %s",
+		dstTable.QuotedTableName, insertVals))
+
+	require.NoError(t, client.Run(t.Context()))
+	defer client.Close()
+
+	sub := client.subscriptions[srcTable.SchemaName+"."+srcTable.TableName].(*bufferedMap)
+	// Disable the watermark optimization so every binlog event is
+	// admitted to the map (in production this is what happens after
+	// the copy phase finishes — the post-copy applier sees every event).
+	require.NoError(t, sub.SetWatermarkOptimization(t.Context(), false))
+
+	// Run swap transactions on source. Each is a legal
+	// deactivate-then-activate inside a single transaction.
+	for i := 0; i < buckets; i++ {
+		activePK := 2*i + 1
+		passivePK := 2*i + 2
+		slot := fmt.Sprintf("S%d", i)
+		tx, err := db.BeginTx(t.Context(), nil)
+		require.NoError(t, err)
+		_, err = tx.ExecContext(t.Context(),
+			fmt.Sprintf("UPDATE %s SET slot_id=NULL WHERE id=?", srcTable.QuotedTableName), activePK)
+		require.NoError(t, err)
+		_, err = tx.ExecContext(t.Context(),
+			fmt.Sprintf("UPDATE %s SET slot_id=? WHERE id=?", srcTable.QuotedTableName), slot, passivePK)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+	}
+
+	// Drive client.Flush through to completion. Internally it loops
+	// flush -> BlockWait -> flush until the delta is trivial; the
+	// recovery+rewind path is wholly contained inside that loop.
+	require.NoError(t, client.Flush(t.Context()))
+
+	// The subscription must have detected the swap-pair collision and
+	// switched modes — otherwise the bug would still be present.
+	sub.Lock()
+	require.True(t, sub.forceQueueMode,
+		"the swap-pair collision should have triggered the recovery path")
+	sub.Unlock()
+
+	// End-state assertion: dst must match src bucket-for-bucket. Active
+	// rows have moved from PK=2i+1 to PK=2i+2.
+	for i := 0; i < buckets; i++ {
+		activePK := 2*i + 1
+		passivePK := 2*i + 2
+		var srcActive, dstActive sql.NullString
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", srcTable.QuotedTableName), activePK).
+			Scan(&srcActive))
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), activePK).
+			Scan(&dstActive))
+		require.False(t, srcActive.Valid, "source bucket %d previously-active row should now be NULL", i)
+		require.Equal(t, srcActive, dstActive,
+			"bucket %d previously-active row (PK=%d) state must match between src and dst", i, activePK)
+
+		var srcPassive, dstPassive sql.NullString
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", srcTable.QuotedTableName), passivePK).
+			Scan(&srcPassive))
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), passivePK).
+			Scan(&dstPassive))
+		require.True(t, srcPassive.Valid, "source bucket %d previously-passive row should now hold the slot", i)
+		require.Equal(t, srcPassive, dstPassive,
+			"bucket %d previously-passive row (PK=%d) state must match between src and dst", i, passivePK)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #847.

When the source-side application performs a transaction that legally "swaps" a unique value between two rows (one row deactivates the value, another activates it), Spirit's `bufferedMap.flushMapLocked` can hand both events to the applier inside a single multi-row `INSERT ... ON DUPLICATE KEY UPDATE`. The map's randomized iteration places the rows in an arbitrary order; MySQL processes the VALUES list in array order. When the activating row comes first, the previous holder still has the unique value in the shadow table and MySQL aborts with Error 1062.

## Two ways to fix this

We considered two approaches before landing on the one in this PR. Documenting both so the next person who reads this code understands the trade-off.

### Option 1: "Safe buffered map" (rejected)

Make the existing map flush correct by construction, on every flush.

1. **Apply full transactions atomically to the buffered map.** Hold events until an XID boundary so a flush never sees half of a source-side transaction. Without this, a flush that batched only two of T1's four UPDATEs could leave the shadow in a state that violates a unique key (e.g. partway through a multi-row chain, B is set to a value that A still holds because A's deactivation event is in the *next* batch).
2. **DELETE all batch keys before re-inserting.** Issue a `DELETE` for every PK in the batch, then a single `INSERT ... ON DUPLICATE KEY UPDATE`. With the conflicting old state wiped first, intra-batch row order no longer matters.

This makes every flush correct, but it pays a real cost on the **common path** for every single flush, every migration:

- Two SQL statements per batch instead of one (always).
- Peak buffer size is bounded by the largest source-side transaction rather than the soft cap; the back-pressure logic in `HasChanged` has to learn to park at transaction granularity rather than per-event.
- The DELETE pass adds work even for tables that have no unique constraints to collide on in the first place.

Most workloads never produce a swap. Paying that cost forever to defend against an edge case felt wrong.

### Option 2: "Detect and switch" (this PR)

Stay optimistic in the common case; recover automatically the first time we observe a collision.

1. **Detect.** `bufferedMap.handleFlushError` recognises Error 1062 from `flushBatch`, clears the pending map *and* queue, flips `forceQueueMode` on, asks the client to rewind, and reports the flush as a no-op so `flushedPos` is not advanced.
2. **Rewind.** `Client.requestRewind` sets a flag and closes the current syncer; `readStream` short-circuits into `recreateStreamer`, which restarts at **position 4 of `flushedPos.Name`** (not `bufferedPos.Name`) so the syncer picks up the file's `TableMap` events and re-reads every binlog event since the last full flush.
3. **Switch.** Re-read events arrive into the now queue-mode subscription in binlog (FIFO) order; `flushQueueLocked` carries that order into MySQL, so the swap pair lands deactivate-first and no longer collides. The switch is permanent for the affected subscription — one observed swap means the workload is likely to produce more.

**Cost characterisation:**

- **Common path (no swap):** zero overhead. No extra SQL, no extra buffer pressure, dedup benefit fully preserved.
- **First swap observed:** one wasted flush (the 1062) + one binlog rewind + re-read of every event since the last full flush. The re-read is idempotent for already-applied rows and correct for the unapplied tail; final state is byte-identical to source.
- **Subsequent swaps on the same subscription:** zero overhead. We're in queue mode now, which preserves binlog order and avoids the collision by construction.

The bet is that swap-pair workloads are rare enough that the upfront cost of Option 1 on every migration outweighs the recovery cost of Option 2 on the few migrations that need it. If that assumption ever breaks (lots of tables hitting this), we can revisit and add Option 1 alongside.

The detect-and-switch path is the only path that's wired up in this PR. Option 1 is documented here for the record, not implemented.

## What changed

- [pkg/repl/subscription_buffered.go](https://github.com/block/spirit/blob/fix-unique-conflicts/pkg/repl/subscription_buffered.go): add `forceQueueMode` field, update `queueModeActive()` to honor it, add `handleFlushError(err)`, intercept errors at both `flushBatch` call sites in `flushMapLocked`.
- [pkg/repl/client.go](https://github.com/block/spirit/blob/fix-unique-conflicts/pkg/repl/client.go): add `rewindRequested atomic.Bool`, add `requestRewind()`, modify `recreateStreamer` to use `flushedPos.Name` when the flag is set, modify `readStream` error path to shortcut into `recreateStreamer` when a rewind has been requested (bypassing the consecutive-error / backoff path), guard `flush` from regressing `flushedPos` when a rewind has snapped `bufferedPos` back.
- [pkg/repl/subscription_buffered_swap_test.go](https://github.com/block/spirit/blob/fix-unique-conflicts/pkg/repl/subscription_buffered_swap_test.go): three new tests.
- [pkg/repl/README.md](https://github.com/block/spirit/blob/fix-unique-conflicts/pkg/repl/README.md): document the optimistic-batching limitation and the FIFO recovery path.

## Tests

- `TestBufferedMapSwapPairRecoversViaQueueMode` — deterministic single-threaded unit test. Seeds 50 swap pairs into the buffered map directly via `HasChanged`, calls `Flush` once, and asserts that the recovery path swallows the 1062, clears the map, flips `forceQueueMode`, and requests a rewind. With 50 independent buckets, P(no repro) ≈ 2^-50.
- `TestSwapPairFullRecoveryViaQueueMode` — end-to-end test through `Client.Run`. Seeds source + destination to matching pre-swap state, runs 50 real swap transactions on source, calls `client.Flush`, then asserts that the destination matches the source row-for-row after the rewind has re-read and re-applied events via the FIFO queue.
- `TestFlushDoesNotRegressFlushedPosAfterRewind` — covers the `flushedPos` no-regression guard in `Client.flush`.

## Test plan

- [x] `go test ./pkg/repl/... -count=3` passes (catches binlog-timing flakiness)
- [x] `go test ./pkg/migration/... -short` passes
- [x] `golangci-lint run ./pkg/repl/...` clean