### PR TITLE
fix(#847): skip already-flushed events on rewind to avoid stale replay

### DIFF
--- a/pkg/repl/README.md
+++ b/pkg/repl/README.md
@@ -125,7 +125,16 @@ The subscription recovers automatically:
    `TableMapEvent`s — MySQL does not re-send TableMaps mid-file, so
    restarting at any later offset would leave the parser unable to
    decode subsequent `RowsEvent`s.
-4. Re-read events flow into the now queue-mode subscription in
+4. `readStream` filters out events ≤ `flushedPos` on the way in
+   (`Client.eventAlreadyFlushed`). Those events were already applied
+   to the destination by a prior flush; replaying them against the
+   now-newer destination state would overwrite correct rows with
+   stale row images and can recreate the very 1062 collision the
+   rewind was meant to resolve (e.g. an old "activate" event for
+   row A while the destination's current state has row B activated
+   for the same unique-key bucket). Only events strictly past
+   `flushedPos` enter the subscription's queue.
+5. The remaining events flow into the now queue-mode subscription in
    binlog (FIFO) order. `flushQueueLocked` carries that order into
    the multi-row upsert, so the swap pair lands deactivate-first
    and no longer collides. The subscription stays in queue mode for

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -301,6 +301,34 @@ func (c *Client) setBufferedPos(pos mysql.Position) {
 	c.bufferedPos = pos
 }
 
+// eventAlreadyFlushed reports whether a binlog event at the given
+// position is at or before c.flushedPos and therefore corresponds to
+// changes already committed to the destination table by a prior flush.
+//
+// In normal forward-flowing operation this is always false — flushedPos
+// only advances *after* its corresponding events have been applied, so
+// every new event has a position strictly past it. It only matters
+// during the rewind path (block/spirit#847): recreateStreamer can
+// restart the binlog reader at position 4 of c.flushedPos.Name to pick
+// up the file's TableMap events, and the events between position 4 and
+// the old flushedPos.Pos are events we already applied. Replaying them
+// would overwrite *newer* destination state with stale row images and
+// can recreate the very 1062 collision the rewind was meant to resolve
+// (an old "activate" event for row A while the destination's current
+// state has row B activated for the same unique-key bucket). Skipping
+// them keeps the destination at its already-correct state for those
+// rows; only events strictly past flushedPos are buffered for replay.
+func (c *Client) eventAlreadyFlushed(currentLogName string, logPos uint32) bool {
+	if logPos == 0 {
+		// FormatDescription / synthetic rotate / etc.
+		return false
+	}
+	c.Lock()
+	defer c.Unlock()
+	eventPos := mysql.Position{Name: currentLogName, Pos: logPos}
+	return eventPos.Compare(c.flushedPos) <= 0
+}
+
 // getBufferedPos returns the buffered position under a mutex.
 func (c *Client) getBufferedPos() mysql.Position {
 	c.Lock()
@@ -728,6 +756,16 @@ func (c *Client) readStream(ctx context.Context) {
 			})
 			continue
 		case *replication.RowsEvent:
+			// Skip events already covered by a prior flush. Normally this is a
+			// no-op (events flow forward from flushedPos); it only fires during
+			// a rewind, where we restarted the binlog reader at position 4 of
+			// the flushedPos file to pick up TableMap events. Replaying the
+			// already-applied prefix would overwrite newer destination state
+			// with stale row images and can recreate the 1062 the rewind was
+			// meant to resolve. See #847 and Client.eventAlreadyFlushed.
+			if c.eventAlreadyFlushed(currentLogName, ev.Header.LogPos) {
+				break
+			}
 			// Rows event, check if there are any active subscriptions
 			// for it, and pass it to the subscription.
 			if err = c.processRowsEvent(ev, event); err != nil {

--- a/pkg/repl/subscription_buffered_swap_test.go
+++ b/pkg/repl/subscription_buffered_swap_test.go
@@ -169,6 +169,47 @@ func TestBufferedMapSwapPairRecoversViaQueueMode(t *testing.T) {
 	sub.Unlock()
 }
 
+// TestEventAlreadyFlushedSkipsBeforeFlushedPos exercises the position
+// filter that readStream uses to skip events ≤ flushedPos during a
+// rewind. Without it, the rewind path (which restarts the binlog
+// reader at position 4 of flushedPos.Name to pick up TableMap events)
+// re-buffers events that were already applied to the destination by
+// a prior flush. Replaying those old row images against the now
+// newer destination state can recreate the 1062 collision the rewind
+// was meant to resolve. See block/spirit#847 and the production
+// regression in `balance_changes` reported on 2026-05-15.
+func TestEventAlreadyFlushedSkipsBeforeFlushedPos(t *testing.T) {
+	client := &Client{
+		db:              nil,
+		logger:          slog.Default(),
+		concurrency:     1,
+		targetBatchSize: 1000,
+		dbConfig:        dbconn.NewDBConfig(),
+		subscriptions:   map[string]Subscription{},
+	}
+	client.SetFlushedPos(mysql.Position{Name: "binlog.000042", Pos: 5000})
+
+	// Position 0 (FormatDescriptionEvent, synthetic rotates) is never skipped.
+	require.False(t, client.eventAlreadyFlushed("binlog.000042", 0))
+
+	// Earlier file → already flushed.
+	require.True(t, client.eventAlreadyFlushed("binlog.000041", 1234567))
+
+	// Same file, before flushedPos → already flushed.
+	require.True(t, client.eventAlreadyFlushed("binlog.000042", 100))
+
+	// Same file, exactly at flushedPos → already flushed (LogPos is the
+	// end of the event, so equal means the event ends at the flushed
+	// boundary and was part of the last fully-flushed batch).
+	require.True(t, client.eventAlreadyFlushed("binlog.000042", 5000))
+
+	// Same file, past flushedPos → not flushed, must be processed.
+	require.False(t, client.eventAlreadyFlushed("binlog.000042", 5001))
+
+	// Later file → not flushed, must be processed.
+	require.False(t, client.eventAlreadyFlushed("binlog.000043", 4))
+}
+
 // TestFlushDoesNotRegressFlushedPosAfterRewind covers the defensive
 // guard in `Client.flush` against a backwards checkpoint move when
 // a rewind has snapped `bufferedPos` back. Without the guard, a flush


### PR DESCRIPTION
## Summary

Follow-up to #850, which is now merged. A production deployment of the swap-pair recovery surfaced a remaining failure mode: after `requestRewind` restarts the binlog reader at position 4 of `flushedPos.Name`, the syncer re-reads every event between position 4 and the old `flushedPos.Pos` — events that were already applied to the destination by a prior flush. Replaying those (now stale) row images on top of the newer destination state can recreate the very 1062 the rewind was meant to resolve.

### The scenario

User reports a `balance_changes` migration in `financialaccount_staging` that hit the swap-pair 1062, recovered as designed (cleared map, flipped `forceQueueMode`, rewound to position 4 of file `mysql-bin-changelog.002556` from `flushedPos.Pos=32895440`), and then abandoned post-rewind. Excerpt:

```
WARN buffered-map flush hit a duplicate-key collision; clearing pending changes, switching to queue mode (FIFO), and rewinding binlog to flushed position
   table=financialaccount_staging.balance_changes
   error=failed to upsert rows: ... Error 1062 (23000): Duplicate entry '1-1-paybal-wazf2VR-T3SwVdcV0SrscA' for key '_balance_changes_new.uq_posted_balance_change_id'
   changes_cleared=20 queue_cleared=0
INFO Recreating streamer from file start file=mysql-bin-changelog.002556 new_start_position=(mysql-bin-changelog.002556, 4) rewinding_to_flushed_pos=true
INFO begin to sync binlog from position position=(mysql-bin-changelog.002556, 4)
...
INFO releasing metadata lock lock_name=financialaccount_sta.balance_changes-598f7eb9
```

### Why it failed

Concrete reproduction of the post-rewind 1062:

1. Pre-T1 source state: row 17 has `posted_amount=NULL`, row 18 has `posted_amount=100` (so `is_posted_balance_change=1` on row 18; unique-key bucket `(1, 'P', 'T', 'A')` is held by row 18).
2. T1 swaps: row 17 → `posted_amount=100`, row 18 → `posted_amount=NULL`. Two UPDATE events at positions P1a (row 17) and P1b (row 18). Source-valid: between them no two rows have `is_posted_balance_change=1` on the same bucket.
3. Original flush applies both events in binlog order. Destination now matches source: row 17 active, row 18 inactive. flushedPos advances past P1b.
4. Many more transactions follow; eventually the swap-pair 1062 fires on an unrelated transaction. `handleFlushError` clears the map, flips `forceQueueMode`, requests a rewind. recreateStreamer restarts at position 4.
5. The syncer re-reads T1's events. They flow into the FIFO queue and out through `flushQueueLocked`:
   - Replay event P1a (`row 17 → posted_amount=100`): destination row 17 is *already* active (from the original apply). But row 18 was activated by a *later* transaction that was also in the rewound range. If the later transaction is ordered such that its row-18-activate hasn't replayed yet, the destination has row 18 still active *and* we're now upserting row 17 to active — `Error 1062` on `(1, 'P', 'T', 'A')`.

The general shape is "replaying an old `activate` event for row A while the destination's current state still has row B activated for the same unique-key bucket." FIFO ordering inside a single batch doesn't help here because the colliding events were applied across separate batches originally — the rewind doesn't reconstruct the inter-batch state.

### Fix

Filter binlog events at the readStream dispatch layer. A new helper `Client.eventAlreadyFlushed` compares `(currentLogName, ev.Header.LogPos)` against `c.flushedPos`; when the event ends at or before `flushedPos`, it is skipped. `bufferedPos` still advances normally through the existing position update after the switch, so the filter only suppresses subscription buffering, not the syncer's forward motion.

In normal forward-flowing operation the comparison is always false — events flow past `flushedPos` by construction since `flushedPos` only advances after its events have been applied — so the filter is a no-op outside the rewind path. After a rewind, the filter skips events ≤ `flushedPos` (already applied), buffers events > `flushedPos` (the unapplied tail), and lets the FIFO queue mode handle them in binlog order without any stale-replay collision risk.

## What changed

- [pkg/repl/client.go](https://github.com/block/spirit/blob/fix-rewind-replay/pkg/repl/client.go): add `Client.eventAlreadyFlushed(name, pos)`; call it at the top of the `RowsEvent` case in `readStream` and `break` out of the switch if true. Position 0 (FormatDescription, synthetic rotates) is never skipped.
- [pkg/repl/subscription_buffered_swap_test.go](https://github.com/block/spirit/blob/fix-rewind-replay/pkg/repl/subscription_buffered_swap_test.go): unit test covering all the edges — pos=0, earlier file, same file before / at / after `flushedPos`, later file.
- [pkg/repl/README.md](https://github.com/block/spirit/blob/fix-rewind-replay/pkg/repl/README.md): document the filter as step 4 of the recovery flow (the existing "applying re-read events in FIFO order" became step 5).

## Tests

- `TestEventAlreadyFlushedSkipsBeforeFlushedPos` — unit test for the helper.
- All existing repl swap-pair tests (`TestBufferedMapSwapPairRecoversViaQueueMode`, `TestSwapPairFullRecoveryViaQueueMode`, `TestFlushDoesNotRegressFlushedPosAfterRewind`) continue to pass — they didn't exercise this corner because their pre-flush state was always trivial.

## Test plan

- [x] `go test ./pkg/repl/... -count=1` passes
- [x] `go test ./pkg/repl/ -run 'TestEventAlreadyFlushedSkipsBeforeFlushedPos|TestFlushDoesNotRegressFlushedPos|TestBufferedMapSwapPair|TestSwapPair' -count=10` passes (catches flakiness)
- [x] `golangci-lint run ./pkg/repl/...` clean