### PR TITLE
fix(#847): switch applier to REPLACE INTO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,9 +204,11 @@ Each package has its own `README.md` with detailed documentation. Key packages t
 The main orchestrator. `runner.go` contains the core migration loop. `Migration` struct is the Kong CLI binding. The `Run()` method drives the full lifecycle. See `cutover.go` for the atomic rename logic.
 
 ### `pkg/repl`
-Acts as a MySQL replica using [go-mysql](https://github.com/go-mysql-org/go-mysql). Two subscription types:
-- **BufferedMap** (default) — stores the full row image from the binlog and writes via the applier. Used for memory-comparable PKs (integers, binary strings, etc.). Sidesteps the binlog/visibility race that motivates `binlog_row_image=FULL` (see #746).
-- **DeltaQueue** (fallback) — FIFO queue using `REPLACE INTO ... SELECT` for non-memory-comparable PKs (e.g. `VARCHAR` collations). Slower; used only when `BufferedMap` cannot be.
+Acts as a MySQL replica using [go-mysql](https://github.com/go-mysql-org/go-mysql). One subscription type — the **bufferedMap** — stores the full row image from the binlog and writes via the applier. It has two internal flush modes:
+- **Map mode** (default for memory-comparable PKs) — keeps one entry per PK in a map; multiple events on the same PK dedupe to the latest image. Used for integer/binary PKs where Go map-key equality matches MySQL row identity.
+- **Queue mode** (post-copy for non-memory-comparable PKs like `VARCHAR` collations) — FIFO queue preserving binlog order. Required because case-insensitive collations break the map-key-equality assumption. Slower; only entered after `SetWatermarkOptimization(false)`.
+
+The applier issues `REPLACE INTO target VALUES (...)` from inline row images (not `SELECT FROM source`), which sidesteps the binlog/visibility race that motivated `binlog_row_image=FULL` (see #746) and makes flushes order-independent for swap-pair workloads (see #847). REPLACE may delete rows on unique-key conflicts as well as PK conflicts — those rows are re-inserted by their own events in subsequent batches, so the destination is *eventually consistent* between batches and converges once every event for each affected PK has been applied.
 
 ### `pkg/copier`
 Two algorithms:

--- a/pkg/applier/README.md
+++ b/pkg/applier/README.md
@@ -63,12 +63,39 @@ The applier interface provides both asynchronous and synchronous methods:
 - `Apply(ctx, chunk, rows, callback)`: Queues rows for writing and returns immediately. The callback is invoked when all rows have been written.
 
 **Synchronous (used by subscription)**:
-- `DeleteKeys(ctx, sourceTable, targetTable, keys, lock)`: Deletes rows by primary key and waits for completion.
-- `UpsertRows(ctx, mapping, rows, lock)`: Upserts rows using a `ColumnMapping` and waits for completion.
+- `DeleteKeys(ctx, sourceTable, targetTable, keys, lock)`: Deletes rows by primary key and waits for completion. Emits `DELETE FROM target WHERE (pk) IN (...)`.
+- `UpsertRows(ctx, mapping, rows, lock)`: Upserts rows using a `ColumnMapping` and waits for completion. Emits `REPLACE INTO target (cols) VALUES (...)` — see [REPLACE INTO semantics](#replace-into-semantics-and-eventual-consistency) below.
 
 This distinction exists because:
 - The **copier** processes large batches of rows and benefits from async processing with callbacks to advance its watermark.
 - The **subscription** processes individual binlog events and needs immediate confirmation that changes have been applied before advancing the binlog position.
+
+### REPLACE INTO semantics and eventual consistency
+
+`UpsertRows` uses `REPLACE INTO target (cols) VALUES (...)`, not `INSERT ... ON DUPLICATE KEY UPDATE`. Per MySQL's manual:
+
+> REPLACE works exactly like INSERT, except that if an old row in the table has the same value as a new row for a PRIMARY KEY or a UNIQUE index, the old row is deleted before the new row is inserted.
+
+Two consequences for callers:
+
+1. **REPLACE may delete rows whose PKs are not in the `rows` argument.** If a new row's image collides on a unique key with some *other* row currently in the destination (the previous holder of that unique value), REPLACE deletes that other row to make room. A single REPLACE statement may therefore delete more than one row. This is what makes the multi-row VALUES list order-independent — within a batch, every row's conflicts (on PK or any unique index) are resolved before its insert runs.
+
+2. **The destination is only eventually consistent with source mid-flush.** Between the moment REPLACE deletes a row to resolve a unique-key conflict and the moment that row's own event re-inserts it, the destination is briefly missing that row. Spirit relies on the replication client's `bufferedMap` being an up-to-date and *disjoint* representation of pending changes — every PK in the buffer holds the latest image MySQL has emitted for it — so any transiently-deleted row is guaranteed to be re-inserted as flushes progress. The destination converges back to source's current state once every event for each affected PK has been applied. The post-cutover checksum (with `FixDifferences=true`) is the backstop for any divergence that survives.
+
+The row image is supplied inline (the binlog reader stored it on `HasChanged`); the applier never re-reads source. This avoids the binlog/visibility race fixed in [#746](https://github.com/block/spirit/issues/746) that earlier `REPLACE INTO ... SELECT` paths could lose to.
+
+#### Why this matters for workloads that move unique values
+
+The motivating case is a source-side transaction that legally moves a unique value between two rows:
+
+```sql
+START TRANSACTION;
+UPDATE t SET slot_id = NULL WHERE id = 1;  -- was 'S'
+UPDATE t SET slot_id = 'S'  WHERE id = 2;  -- was NULL
+COMMIT;
+```
+
+With `INSERT ... ON DUPLICATE KEY UPDATE`, the random map iteration order in the subscription could land "activate id=2" before "deactivate id=1" in the same multi-row statement; MySQL would resolve id=2's UPDATE branch, then fail with `Error 1062 (23000): Duplicate entry 'S'` because id=1 still held the value. With `REPLACE INTO` the same batch in any order works: each REPLACE deletes the prior holder of `'S'` before inserting its own row. See [block/spirit#847](https://github.com/block/spirit/issues/847).
 
 ### Callbacks and Feedback
 

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -765,21 +765,20 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 				valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
 			}
 
-			// Build the ON DUPLICATE KEY UPDATE clause (all non-PK columns)
-			var updateClauses []string
-			for _, col := range sourceTable.NonGeneratedColumns {
-				if !slices.Contains(sourceTable.KeyColumns, col) {
-					updateClauses = append(updateClauses, fmt.Sprintf("`%s` = new.`%s`", col, col))
-				}
-			}
-
-			// Use just the table name, not the fully qualified name, because
-			// the database connection (shard.writeDB) already determines which database to write to
-			upsertStmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s AS new ON DUPLICATE KEY UPDATE %s",
+			// Use REPLACE INTO for the same reason the single-target applier
+			// does — it makes the applier idempotent across any subset/order
+			// of binlog events in the same batch, by deleting any row that
+			// conflicts on PRIMARY KEY *or any UNIQUE index* before each
+			// insert. See SingleTargetApplier.UpsertRows for the full
+			// rationale and #847 for the bug that motivated the switch.
+			//
+			// Just the table name, not the fully qualified name — the
+			// database connection (shard.writeDB) already determines which
+			// database to write to.
+			upsertStmt := fmt.Sprintf("REPLACE INTO %s (%s) VALUES %s",
 				sourceTable.QuotedTableName,
 				columnList,
 				strings.Join(valuesClauses, ", "),
-				strings.Join(updateClauses, ", "),
 			)
 			a.logger.Debug("executing upsert on shard",
 				"shardID", sid,

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -645,7 +645,14 @@ func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.T
 }
 
 // UpsertRows performs upserts synchronously, distributing across shards.
-// The rows are LogicalRow structs containing the row images.
+// The rows are LogicalRow structs containing inline row images from the
+// binlog. Each shard issues `REPLACE INTO target (cols) VALUES (...)`;
+// the REPLACE semantics — and their eventual-consistency implications
+// for callers — are documented on SingleTargetApplier.UpsertRows. The
+// short version: REPLACE may delete rows whose PKs are not in the
+// `rows` argument (via the unique-key conflict resolution) and those
+// rows are re-inserted by their own events in subsequent batches.
+//
 // If lock is non-nil, operations are executed under table locks (one per shard).
 //
 // Note: we only track modifications by PRIMARY KEY, not be shard key (aka primary vindex).
@@ -765,16 +772,10 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 				valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
 			}
 
-			// Use REPLACE INTO for the same reason the single-target applier
-			// does — it makes the applier idempotent across any subset/order
-			// of binlog events in the same batch, by deleting any row that
-			// conflicts on PRIMARY KEY *or any UNIQUE index* before each
-			// insert. See SingleTargetApplier.UpsertRows for the full
-			// rationale and #847 for the bug that motivated the switch.
-			//
-			// Just the table name, not the fully qualified name — the
-			// database connection (shard.writeDB) already determines which
-			// database to write to.
+			// See ShardedApplier.UpsertRows (and SingleTargetApplier.UpsertRows)
+			// for the REPLACE rationale and the eventual-consistency
+			// implications. Just the table name here — the per-shard DB
+			// connection already determines which database to write to.
 			upsertStmt := fmt.Sprintf("REPLACE INTO %s (%s) VALUES %s",
 				sourceTable.QuotedTableName,
 				columnList,

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -471,9 +471,46 @@ func (a *SingleTargetApplier) DeleteKeys(ctx context.Context, sourceTable, targe
 	return affectedRows, nil
 }
 
-// UpsertRows performs an upsert (INSERT ... ON DUPLICATE KEY UPDATE) synchronously.
-// The rows are LogicalRow structs containing the row images.
-// If lock is non-nil, the upsert is executed under the table lock.
+// UpsertRows performs an upsert (REPLACE INTO ... VALUES) synchronously.
+// The rows are LogicalRow structs containing inline row images from the
+// binlog. If lock is non-nil, the upsert is executed under the table lock.
+//
+// REPLACE semantics, and why we use them:
+//
+// MySQL's `REPLACE INTO target (cols) VALUES (...)` treats each value
+// tuple as an INSERT, except that for any row in `target` that conflicts
+// with the new row on PRIMARY KEY *or any UNIQUE index*, the old row is
+// deleted before the new row is inserted. Per the docs, conflicts on
+// multiple unique indexes can lead to multiple deletions for a single
+// new row.
+//
+// Two implications matter for callers reading this code:
+//
+//  1. A single REPLACE may delete rows whose PKs are *not* in the
+//     `rows` argument. If row B's image collides on a unique key with
+//     some other row A currently in the destination (because A was the
+//     previous holder of that unique value), REPLACE deletes A while
+//     inserting B. A is then transiently missing from the destination
+//     until its own event arrives in a later flush (or a later batch in
+//     the same flush) and re-inserts it. This is what restores the
+//     order-independence the pre-#821 deltaMap had with `REPLACE INTO
+//     ... SELECT`. See block/spirit#847.
+//
+//  2. Eventual consistency. Between the moment REPLACE deletes A and
+//     the moment A's image is re-applied, the destination is not a
+//     valid snapshot of source — it has fewer rows. Spirit relies on
+//     the bufferedMap being an *up-to-date and disjoint* representation
+//     of pending changes (each PK appears at most once, holding the
+//     latest row image) so that every transiently-deleted row will be
+//     re-inserted as flushes progress. The destination converges back
+//     to source's current state once the last unflushed event for each
+//     affected PK has been applied. The post-cutover checksum (with
+//     `FixDifferences=true`) is the backstop that catches any
+//     divergence that survives.
+//
+// We supply inline row images rather than `REPLACE INTO ... SELECT FROM
+// source`, so the read-after-commit race that motivated #746 does not
+// apply.
 func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []LogicalRow, lock *dbconn.TableLock) (int64, error) {
 	if len(rows) == 0 {
 		return 0, nil
@@ -513,22 +550,9 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.Col
 		return 0, nil
 	}
 
-	// Use REPLACE INTO rather than INSERT ... ON DUPLICATE KEY UPDATE so the
-	// applier is idempotent for any subset/order of binlog events that all
-	// land in the same multi-row batch. REPLACE's "delete any row that
-	// conflicts on PRIMARY KEY *or any UNIQUE index*, then insert" semantics
-	// resolve transient unique-key collisions that occur when a source-side
-	// transaction legally moves a unique value between two rows (e.g.
-	// UPDATE A SET col=NULL; UPDATE B SET col='value';). ON DUPLICATE KEY
-	// UPDATE detects only the first conflict and switches to UPDATE on
-	// that row, so a subsequent unique-key collision the UPDATE introduces
-	// becomes a hard Error 1062 (block/spirit#847). REPLACE absorbs that
-	// collision by deleting the prior holder.
-	//
-	// We supply the row image inline, so this does *not* re-introduce the
-	// `REPLACE INTO ... SELECT FROM source` round-trip that motivated #746.
-	// The semantics match the pre-#821 deltaMap behavior without the
-	// read-after-commit race.
+	// See the function-level doc for the REPLACE-vs-ODKU rationale and
+	// the eventual-consistency implications of REPLACE deleting rows on
+	// unique-key conflicts.
 	upsertStmt := fmt.Sprintf("REPLACE INTO %s (%s) VALUES %s",
 		mapping.TargetTable().QuotedTableName,
 		targetColumnList,

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -480,7 +479,7 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.Col
 		return 0, nil
 	}
 	_, targetColumnList := mapping.Columns()
-	sourceColumnNames, targetColumnNames := mapping.ColumnsSlice()
+	sourceColumnNames, _ := mapping.ColumnsSlice()
 	intersectedColumns := mapping.SourceColumnIndices()
 
 	// Build the VALUES clause from the row images
@@ -514,37 +513,29 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.Col
 		return 0, nil
 	}
 
-	// Build the ON DUPLICATE KEY UPDATE clause using target column names.
-	var updateClauses []string
-	for _, col := range targetColumnNames {
-		if !slices.Contains(mapping.TargetTable().KeyColumns, col) {
-			updateClauses = append(updateClauses, fmt.Sprintf("`%s` = new.`%s`", col, col))
-		}
-	}
+	// Use REPLACE INTO rather than INSERT ... ON DUPLICATE KEY UPDATE so the
+	// applier is idempotent for any subset/order of binlog events that all
+	// land in the same multi-row batch. REPLACE's "delete any row that
+	// conflicts on PRIMARY KEY *or any UNIQUE index*, then insert" semantics
+	// resolve transient unique-key collisions that occur when a source-side
+	// transaction legally moves a unique value between two rows (e.g.
+	// UPDATE A SET col=NULL; UPDATE B SET col='value';). ON DUPLICATE KEY
+	// UPDATE detects only the first conflict and switches to UPDATE on
+	// that row, so a subsequent unique-key collision the UPDATE introduces
+	// becomes a hard Error 1062 (block/spirit#847). REPLACE absorbs that
+	// collision by deleting the prior holder.
+	//
+	// We supply the row image inline, so this does *not* re-introduce the
+	// `REPLACE INTO ... SELECT FROM source` round-trip that motivated #746.
+	// The semantics match the pre-#821 deltaMap behavior without the
+	// read-after-commit race.
+	upsertStmt := fmt.Sprintf("REPLACE INTO %s (%s) VALUES %s",
+		mapping.TargetTable().QuotedTableName,
+		targetColumnList,
+		strings.Join(valuesClauses, ", "),
+	)
 
-	// If every column is part of the PK there's nothing to UPDATE on conflict
-	// (the row's content is the PK and a same-PK conflict means same content).
-	// `INSERT … ON DUPLICATE KEY UPDATE` with an empty clause is a SQL syntax
-	// error, so use `INSERT IGNORE` for that case instead — same semantics.
-	var upsertStmt, upsertPath string
-	if len(updateClauses) == 0 {
-		upsertPath = "insert-ignore"
-		upsertStmt = fmt.Sprintf("INSERT IGNORE INTO %s (%s) VALUES %s",
-			mapping.TargetTable().QuotedTableName,
-			targetColumnList,
-			strings.Join(valuesClauses, ", "),
-		)
-	} else {
-		upsertPath = "on-duplicate-key-update"
-		upsertStmt = fmt.Sprintf("INSERT INTO %s (%s) VALUES %s AS new ON DUPLICATE KEY UPDATE %s",
-			mapping.TargetTable().QuotedTableName,
-			targetColumnList,
-			strings.Join(valuesClauses, ", "),
-			strings.Join(updateClauses, ", "),
-		)
-	}
-
-	a.logger.Debug("executing upsert", "rowCount", len(valuesClauses), "table", mapping.TargetTable().TableName, "path", upsertPath)
+	a.logger.Debug("executing upsert", "rowCount", len(valuesClauses), "table", mapping.TargetTable().TableName, "path", "replace-into")
 
 	// Execute under lock if provided
 	if lock != nil {

--- a/pkg/repl/README.md
+++ b/pkg/repl/README.md
@@ -130,6 +130,49 @@ This is the same robustness the pre-#821 `deltaMap` had with
 read-after-commit race that motivated #746 — we supply the inline
 row image, not a `SELECT` against source.
 
+##### Eventual consistency between batches
+
+REPLACE's "delete any unique-key conflict before each insert"
+semantic means a single REPLACE statement can delete *more rows* than
+the ones in its VALUES list — specifically, any row currently in the
+destination that previously held a unique value the new row is now
+claiming. That row is briefly missing from the destination until its
+own event arrives in a later batch (or in the same batch but
+processed later) and re-inserts it.
+
+Concretely, for the swap pair above with batches of size 1:
+
+| Step | Batch | Destination state |
+|------|-------|-------------------|
+| 0    | —     | id=1: 'S', id=2: NULL |
+| 1    | `REPLACE (id=1, slot=NULL)` | id=1: NULL, id=2: NULL |
+| 2    | `REPLACE (id=2, slot='S')`  | id=1: NULL, id=2: 'S' |
+
+And for the same swap pair if the activate landed first across batches:
+
+| Step | Batch | Destination state |
+|------|-------|-------------------|
+| 0    | —     | id=1: 'S', id=2: NULL |
+| 1    | `REPLACE (id=2, slot='S')` | id=2: 'S' (id=1 **deleted** — unique-key conflict on 'S') |
+| 2    | `REPLACE (id=1, slot=NULL)` | id=1: NULL, id=2: 'S' (id=1 re-inserted) |
+
+Binlog ordering gives us the first table in practice — within a
+single source-side transaction, the deactivate event has a lower
+binlog position than the activate — but Spirit's correctness does
+not depend on which case occurs. The destination converges to
+source's current state once the last unflushed event for each
+affected PK has been applied.
+
+This eventual consistency is safe because the `bufferedMap` is an
+**up-to-date and disjoint** representation of pending changes: every
+PK appears at most once at flush time, holding the latest row image
+MySQL emitted for it. Any row transiently deleted by REPLACE's
+conflict resolution is therefore guaranteed to have its own event in
+the buffer (or arriving shortly) — its row image isn't lost,
+just temporarily not yet applied. The post-cutover checksum (with
+`FixDifferences=true`) is the backstop for anything that slips
+through.
+
 See `TestBufferedMapSwapPairFlushesViaReplace` (unit) and
 `TestSwapPairEndToEndViaReplace` (end-to-end) for the regression gates.
 

--- a/pkg/repl/README.md
+++ b/pkg/repl/README.md
@@ -44,10 +44,13 @@ applies it through the applier interface:
 - Watermark optimizations (`KeyAboveHighWatermark` and `KeyBelowLowWatermark`) are available on `MappedChunker` implementations (both optimistic and composite chunkers). They work correctly for numeric, binary, and temporal primary key types. For `VARCHAR`/`TEXT` columns with collations, Go's byte-order comparison may differ from MySQL's collation order; any discrepancies are caught by the checksum phase (see [issue #479](https://github.com/block/spirit/issues/479)).
 
 **The map is optimistic.** It bets that the randomized iteration order of
-`s.changes` is harmless because each row's upsert depends only on its own
-PK. That bet holds for the overwhelmingly common case, but it breaks for
+`s.changes` is harmless for each row's upsert. That bet would break for
 workloads that move a unique value between rows inside a single
-transaction — see "Optimistic batching and the FIFO fallback" below.
+transaction (a "swap" pattern) if the applier used `INSERT ... ON
+DUPLICATE KEY UPDATE`, since that statement resolves only the first
+conflict and leaves any other unique-key collision as a hard 1062. We
+side-step that by issuing **`REPLACE INTO target VALUES (...)`** in the
+applier instead — see "Applier idempotence via REPLACE INTO" below.
 
 **Example scenario:**
 ```
@@ -82,14 +85,18 @@ divergence.
 Memory-comparable PKs always use the buffered map, since map-key
 equality matches MySQL row identity.
 
-#### Optimistic batching and the FIFO fallback (#847)
+#### Applier idempotence via REPLACE INTO (#847)
 
-The buffered map flush builds one multi-row
-`INSERT ... ON DUPLICATE KEY UPDATE` per batch. MySQL processes the
-`VALUES` list in array order, so the order of rows inside the batch
-matters whenever two rows in the same batch can collide on a unique
-key. The map's iteration is randomized, which is fine for the common
-case but is **unsafe for "swap" patterns**:
+The applier writes a multi-row statement per batch. We use:
+
+```sql
+REPLACE INTO target (cols) VALUES (...), (...), ...;
+```
+
+rather than `INSERT ... ON DUPLICATE KEY UPDATE`. The choice matters
+whenever two rows in the same batch can collide on a unique key —
+typically because a source-side transaction legally moves a unique
+value between rows:
 
 ```sql
 -- Legal in source: deactivate one row, then activate another,
@@ -101,47 +108,44 @@ UPDATE t SET slot_id = 'S'   WHERE id = 2;  -- was NULL
 COMMIT;
 ```
 
-The two `UPDATE` binlog events can land in the same flush batch. If
-the map's random iteration places id=2 (activate) before id=1
-(deactivate), MySQL processes id=2's upsert first while id=1 still
-holds `'S'` in the shadow table and aborts with
-`Error 1062 (23000): Duplicate entry ...`.
+With `INSERT ... ON DUPLICATE KEY UPDATE`, MySQL processes the
+multi-row VALUES list in array order and resolves only the *first*
+conflict on each row (via the UPDATE clause). If the resulting update
+introduces a *second* unique-key collision the statement fails with
+`Error 1062`. The map's randomized iteration meant a swap pair could
+land "activate-first" in the batch, hitting that exact failure.
 
-The subscription recovers automatically:
+`REPLACE INTO` is order-independent for this case. Per the docs:
 
-1. `handleFlushError` recognises the 1062, clears the pending map,
-   flips an internal `forceQueueMode` flag, and asks the client to
-   rewind. The flush is reported as a no-op so `flushedPos` is not
-   advanced.
-2. `Client.requestRewind` sets a flag and closes the current binlog
-   syncer. `readStream` sees the closed syncer plus the rewind flag
-   and shortcuts straight into `recreateStreamer`, skipping the
-   consecutive-error backoff that exists for stream-level read
-   failures.
-3. `recreateStreamer` restarts the binlog reader at position 4 of
-   the `flushedPos` file (the start of the binlog file containing
-   the last fully-flushed position). Position 4 is required so the
-   syncer picks up the file's `FormatDescriptionEvent` and
-   `TableMapEvent`s — MySQL does not re-send TableMaps mid-file, so
-   restarting at any later offset would leave the parser unable to
-   decode subsequent `RowsEvent`s.
-4. Re-read events flow into the now queue-mode subscription in
-   binlog (FIFO) order. `flushQueueLocked` carries that order into
-   the multi-row upsert, so the swap pair lands deactivate-first
-   and no longer collides. The subscription stays in queue mode for
-   the rest of the migration; we don't flip back, since one
-   observed swap means the workload is likely to produce more.
+> REPLACE works exactly like INSERT, except that if an old row in
+> the table has the same value as a new row for a PRIMARY KEY or a
+> UNIQUE index, the old row is deleted before the new row is
+> inserted.
 
-Tables whose workloads never produce a swap never trip the recovery
-path and keep the full dedup benefit of map mode. The cost of the
-recovery is one wasted flush and a re-read of every event since the
-last full flush; the destination ends up byte-identical to source
-because the re-applied events are idempotent for already-applied
-rows and correct for the unapplied tail.
+So each row's conflicts — on PK or any unique index — are deleted
+before that row's insert runs, irrespective of where the conflicting
+row sits in the batch. The swap pair collapses to "delete the
+previous holder, insert the new holder" and the order of the two
+events inside the batch doesn't matter.
 
-See `TestBufferedMapSwapPairRecoversViaQueueMode` (unit) and
-`TestSwapPairFullRecoveryViaQueueMode` (end-to-end) for the
-regression gates.
+This is the same robustness the pre-#821 `deltaMap` had with
+`REPLACE INTO target SELECT FROM source`, but **without** the
+read-after-commit race that motivated #746 — we supply the inline
+row image, not a `SELECT` against source.
+
+##### Safety net: `forceQueueMode`
+
+`bufferedMap.handleFlushError` is still wired up: if the applier
+ever returns `Error 1062` for some shape we haven't anticipated, the
+subscription clears its pending state and flips `forceQueueMode` on
+so subsequent events route through the FIFO queue. Operators seeing
+the warning log line should treat it as a signal that something
+unexpected is happening at the applier or schema level — REPLACE
+should not be producing 1062s in practice.
+
+See `TestBufferedMapSwapPairFlushesViaReplace` (unit), `TestHandleFlushErrorSafetyNet`
+(unit, exercises the safety net directly), and `TestSwapPairEndToEndViaReplace`
+(end-to-end) for the regression gates.
 
 ## Features
 

--- a/pkg/repl/README.md
+++ b/pkg/repl/README.md
@@ -43,14 +43,11 @@ applies it through the applier interface:
 - Higher memory usage than a key-only map: stores full row data for each changed key.
 - Watermark optimizations (`KeyAboveHighWatermark` and `KeyBelowLowWatermark`) are available on `MappedChunker` implementations (both optimistic and composite chunkers). They work correctly for numeric, binary, and temporal primary key types. For `VARCHAR`/`TEXT` columns with collations, Go's byte-order comparison may differ from MySQL's collation order; any discrepancies are caught by the checksum phase (see [issue #479](https://github.com/block/spirit/issues/479)).
 
-**The map is optimistic.** It bets that the randomized iteration order of
-`s.changes` is harmless for each row's upsert. That bet would break for
-workloads that move a unique value between rows inside a single
-transaction (a "swap" pattern) if the applier used `INSERT ... ON
-DUPLICATE KEY UPDATE`, since that statement resolves only the first
-conflict and leaves any other unique-key collision as a hard 1062. We
-side-step that by issuing **`REPLACE INTO target VALUES (...)`** in the
-applier instead — see "Applier idempotence via REPLACE INTO" below.
+**Map iteration order is irrelevant** because the applier issues
+`REPLACE INTO target VALUES (...)`, which deletes any row that conflicts
+on PRIMARY KEY or any UNIQUE index before each insert. That makes the
+multi-row VALUES list order-independent — see "Applier idempotence via
+REPLACE INTO" below.
 
 **Example scenario:**
 ```
@@ -133,19 +130,8 @@ This is the same robustness the pre-#821 `deltaMap` had with
 read-after-commit race that motivated #746 — we supply the inline
 row image, not a `SELECT` against source.
 
-##### Safety net: `forceQueueMode`
-
-`bufferedMap.handleFlushError` is still wired up: if the applier
-ever returns `Error 1062` for some shape we haven't anticipated, the
-subscription clears its pending state and flips `forceQueueMode` on
-so subsequent events route through the FIFO queue. Operators seeing
-the warning log line should treat it as a signal that something
-unexpected is happening at the applier or schema level — REPLACE
-should not be producing 1062s in practice.
-
-See `TestBufferedMapSwapPairFlushesViaReplace` (unit), `TestHandleFlushErrorSafetyNet`
-(unit, exercises the safety net directly), and `TestSwapPairEndToEndViaReplace`
-(end-to-end) for the regression gates.
+See `TestBufferedMapSwapPairFlushesViaReplace` (unit) and
+`TestSwapPairEndToEndViaReplace` (end-to-end) for the regression gates.
 
 ## Features
 

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -285,11 +285,25 @@ func (c *Client) AddSubscription(currentTable, newTable *table.TableInfo, chunke
 	return nil
 }
 
-// setBufferedPos updates the in-memory position that all changes have been read
-// but not necessarily flushed.
+// setBufferedPos updates the in-memory position that all changes have
+// been read but not necessarily flushed. The update is monotonic:
+// a position that compares less-than-or-equal to the current
+// bufferedPos is silently dropped.
+//
+// The monotonicity matters because recreateStreamer restarts the
+// binlog dump at position 4 of the current bufferedPos.Name, and
+// MySQL prefaces every binlog dump with a synthetic RotateEvent whose
+// `event.Position` is 4. Without the guard, that synthetic rotate
+// would drag bufferedPos back to {file, 4}, and a flush that ran
+// before subsequent events caught the position back up would publish
+// the rewound value via SetFlushedPos — silently regressing the
+// checkpoint and forcing a large re-read on the next resume.
 func (c *Client) setBufferedPos(pos mysql.Position) {
 	c.Lock()
 	defer c.Unlock()
+	if pos.Compare(c.bufferedPos) <= 0 {
+		return
+	}
 	c.bufferedPos = pos
 }
 
@@ -463,7 +477,9 @@ func (c *Client) Run(ctx context.Context) (err error) {
 // idempotent: it uses REPLACE INTO so re-applying any already-applied
 // event simply re-inserts the same row image, and re-applying an
 // out-of-order event transiently sets the destination to that row's
-// older state, which a later event in the queue will correct.
+// older state, which a subsequent binlog event (in this or a later
+// flush) will correct. The eventual-consistency property holds in both
+// map mode and queue mode — see UpsertRows in pkg/applier/single_target.go.
 func (c *Client) recreateStreamer() error {
 	c.Lock()
 	defer c.Unlock()
@@ -692,20 +708,15 @@ func (c *Client) readStream(ctx context.Context) {
 		default:
 			c.logger.Debug("Received unknown event type", "type", fmt.Sprintf("%T", ev.Event))
 		}
-		// Update the buffered position
-		// under a mutex.
-		// Only update if LogPos > 0 (some events like FormatDescriptionEvent have LogPos=0)
-		// and only if the position is moving forward (to avoid going backwards after rotation)
+		// Update the buffered position under a mutex. Some events
+		// (FormatDescriptionEvent and similar housekeeping events) have
+		// LogPos=0 and don't represent a real position. setBufferedPos
+		// itself enforces monotonicity, so we don't filter further here.
 		if ev.Header.LogPos > 0 {
-			newPos := mysql.Position{
+			c.setBufferedPos(mysql.Position{
 				Name: currentLogName,
 				Pos:  ev.Header.LogPos,
-			}
-			currentPos := c.getBufferedPos()
-			// Only update if the new position is ahead of the current position
-			if newPos.Compare(currentPos) > 0 {
-				c.setBufferedPos(newPos)
-			}
+			})
 		}
 	}
 }

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -971,7 +971,6 @@ func (c *Client) FlushUnderTableLock(ctx context.Context, lock *dbconn.TableLock
 func (c *Client) flush(ctx context.Context, underLock bool, lock *dbconn.TableLock) error {
 	c.Lock()
 	newFlushedPos := c.bufferedPos
-	currentFlushedPos := c.flushedPos
 	c.Unlock()
 	var allChangesFlushed = true
 	for _, subscription := range c.subscriptions {
@@ -996,12 +995,7 @@ func (c *Client) flush(ctx context.Context, underLock bool, lock *dbconn.TableLo
 	// for these high contention cases. But that's not a great solution either,
 	// because the low watermark optimization helps a lot in these cases because
 	// it reduces contention between the copier and the repl applier.
-	//
-	// Defensive: refuse to move flushedPos backwards. setBufferedPos has
-	// its own "only-forward" guard, so under normal operation bufferedPos
-	// is always >= flushedPos when this branch runs. The guard here
-	// catches any future code path that captures a stale bufferedPos.
-	if allChangesFlushed && newFlushedPos.Compare(currentFlushedPos) >= 0 {
+	if allChangesFlushed {
 		c.SetFlushedPos(newFlushedPos)
 	}
 	return nil

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -144,14 +144,6 @@ type Client struct {
 	subscriptionSoftLimitBytes int64
 
 	flushedBinlogs atomic.Int64 // for testing binlog flushing frequency
-
-	// rewindRequested is set by requestRewind (called from a subscription
-	// that just recovered from a duplicate-key collision per #847). When
-	// set, the next recreateStreamer call restarts the binlog reader at
-	// position 4 of c.flushedPos.Name rather than c.bufferedPos.Name —
-	// re-reading every event since the last fully-flushed position so the
-	// (now queue-mode) subscription can apply them in binlog FIFO order.
-	rewindRequested atomic.Bool
 }
 
 // NewClient creates a new Client instance.
@@ -458,43 +450,20 @@ func (c *Client) Run(ctx context.Context) (err error) {
 	return nil
 }
 
-// requestRewind asks readStream to recreate the binlog streamer from
-// position 4 of the flushedPos file. Called by a subscription's
-// handleFlushError after it recovers from a swap-pair duplicate-key
-// collision (block/spirit#847) and needs to replay every event since
-// the last fully-flushed position in binlog (FIFO) order.
+// recreateStreamer recreates the binlog streamer from position 4 of the
+// current bufferedPos file. Used by readStream's error path to recover
+// from transient stream-level read errors. Position 4 is the start of a
+// binlog file; restarting there guarantees the syncer sees the
+// FormatDescriptionEvent and any TableMapEvents needed to decode
+// subsequent RowsEvents — MySQL does not re-send TableMaps from earlier
+// in the file when serving a mid-position dump, so restarting mid-file
+// would leave the parser unable to decode rows.
 //
-// Closing the syncer here causes the in-flight GetEvent in readStream
-// to error out; readStream sees rewindRequested and shortcuts straight
-// to recreateStreamer, skipping the consecutive-error / backoff path
-// that exists for stream-level read failures.
-func (c *Client) requestRewind() {
-	c.Lock()
-	c.rewindRequested.Store(true)
-	syncer := c.syncer
-	c.Unlock()
-	// Close the syncer *outside* the lock. recreateStreamer (which
-	// readStream is about to call) acquires the same lock, and
-	// syncer.Close blocks briefly on its internal goroutines — keeping
-	// the lock during that wait would deadlock.
-	if syncer != nil {
-		syncer.Close()
-	}
-}
-
-// recreateStreamer recreates the binlog streamer. By default it restarts
-// at position 4 of the current bufferedPos file (the existing recovery
-// path for stream-level read errors). When rewindRequested is set, it
-// restarts at position 4 of the flushedPos file instead — re-reading
-// every event since the last fully-flushed position. That path is taken
-// after a subscription's handleFlushError recovers from a swap-pair
-// duplicate-key collision per #847.
-//
-// Position 4 is the start of a binlog file; restarting there guarantees
-// the syncer sees the FormatDescriptionEvent and any TableMapEvents
-// needed to decode subsequent RowsEvents — MySQL does not re-send
-// TableMaps from earlier in the file when serving a mid-position dump,
-// so restarting mid-file would leave the parser unable to decode rows.
+// Re-reading events from position 4 is safe because the applier is
+// idempotent: it uses REPLACE INTO so re-applying any already-applied
+// event simply re-inserts the same row image, and re-applying an
+// out-of-order event transiently sets the destination to that row's
+// older state, which a later event in the queue will correct.
 func (c *Client) recreateStreamer() error {
 	c.Lock()
 	defer c.Unlock()
@@ -502,7 +471,6 @@ func (c *Client) recreateStreamer() error {
 	c.logger.Info("recreateStreamer called",
 		"buffered_position", c.bufferedPos,
 		"flushed_position", c.flushedPos,
-		"rewind_requested", c.rewindRequested.Load(),
 		"syncer_exists", c.syncer != nil,
 		"streamer_exists", c.streamer != nil)
 
@@ -512,29 +480,14 @@ func (c *Client) recreateStreamer() error {
 		c.syncer.Close()
 	}
 
-	// Pick the source file. Default: same file we'd previously been
-	// reading. Rewind path: the file that contains flushedPos so we
-	// catch every event since the last full flush, including any in a
-	// rotated-away earlier binlog.
-	sourceFile := c.bufferedPos.Name
-	rewinding := c.rewindRequested.Load()
-	if rewinding {
-		sourceFile = c.flushedPos.Name
-		c.rewindRequested.Store(false)
-		// Snap bufferedPos back so the position update in readStream
-		// (which uses ev.Header.LogPos) records a sensible value rather
-		// than a stale future one.
-		c.bufferedPos = mysql.Position{Name: sourceFile, Pos: 4}
-	}
-
 	newStartPos := mysql.Position{
-		Name: sourceFile,
+		Name: c.bufferedPos.Name,
 		Pos:  4, // Binlog files always start at position 4
 	}
 	c.logger.Info("Recreating streamer from file start",
-		"file", sourceFile,
+		"file", c.bufferedPos.Name,
+		"previous_position", c.bufferedPos.Pos,
 		"new_start_position", newStartPos,
-		"rewinding_to_flushed_pos", rewinding,
 	)
 
 	c.syncer = replication.NewBinlogSyncer(c.cfg)
@@ -594,34 +547,6 @@ func (c *Client) readStream(ctx context.Context) {
 			// We only stop processing for context cancelled errors.
 			if errors.Is(err, context.Canceled) || ctx.Err() != nil || c.isClosed.Load() {
 				return // stop processing
-			}
-
-			// Explicit rewind requested by a subscription that just
-			// recovered from a duplicate-key collision (#847). Skip
-			// the consecutive-error threshold and backoff — we want
-			// the rewind to happen *now*, not in 5 seconds. The
-			// recreateStreamer call below honors rewindRequested and
-			// restarts at position 4 of the flushedPos file.
-			if c.rewindRequested.Load() {
-				if recreateErr := c.recreateStreamer(); recreateErr != nil {
-					c.logger.Error("Failed to recreate streamer on explicit rewind",
-						"error", recreateErr)
-					// Fall through to normal error handling; the
-					// retry loop will pick it up.
-				} else {
-					// recreateStreamer snapped bufferedPos back to
-					// {flushedPos.Name, 4}; resync our local file-name
-					// tracker so position updates for events that arrive
-					// *before* the synthetic RotateEvent record the
-					// correct file. MySQL does send a RotateEvent at the
-					// start of every binlog dump, but we shouldn't rely
-					// on that arriving before any setBufferedPos call.
-					currentLogName = c.getBufferedPos().Name
-					consecutiveErrors = 0
-					recreateAttempts = 0
-					backoffDuration = initialBackoffDuration
-					continue
-				}
 			}
 
 			consecutiveErrors++
@@ -1072,13 +997,10 @@ func (c *Client) flush(ctx context.Context, underLock bool, lock *dbconn.TableLo
 	// because the low watermark optimization helps a lot in these cases because
 	// it reduces contention between the copier and the repl applier.
 	//
-	// Guard against a backwards move: a rewind (see Client.requestRewind, #847)
-	// can snap c.bufferedPos back to position 4 of c.flushedPos.Name to mark
-	// the binlog reader's new read position. If a flush captured that snapped
-	// value before readStream advanced bufferedPos back past flushedPos, this
-	// branch would otherwise regress the checkpoint. Skip it instead — once
-	// readStream re-reads past the old flushedPos, a subsequent flush will
-	// advance the checkpoint normally.
+	// Defensive: refuse to move flushedPos backwards. setBufferedPos has
+	// its own "only-forward" guard, so under normal operation bufferedPos
+	// is always >= flushedPos when this branch runs. The guard here
+	// catches any future code path that captures a stale bufferedPos.
 	if allChangesFlushed && newFlushedPos.Compare(currentFlushedPos) >= 0 {
 		c.SetFlushedPos(newFlushedPos)
 	}

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -725,6 +725,55 @@ func TestAllChangesFlushed(t *testing.T) {
 	require.True(t, client.AllChangesFlushed(), "Should be flushed with aligned positions and no changes")
 }
 
+// TestSetBufferedPosIsMonotonic locks in the invariant that
+// `setBufferedPos` refuses to move `bufferedPos` backwards. This
+// matters because `recreateStreamer` restarts the binlog dump at
+// position 4 of the current bufferedPos file, and MySQL prefaces every
+// dump with a synthetic RotateEvent whose `event.Position` is 4. The
+// RotateEvent handler in readStream calls `setBufferedPos` directly
+// (bypassing the LogPos generic-update branch), so without the guard
+// here that synthetic rotate would drag bufferedPos to {file, 4} —
+// and a flush that ran before subsequent events caught the position
+// back up would publish the rewound value via SetFlushedPos, silently
+// regressing the checkpoint and causing a large re-read on resume.
+//
+// Regression gate for the Copilot review on #853.
+func TestSetBufferedPosIsMonotonic(t *testing.T) {
+	client := &Client{logger: slog.Default()}
+
+	// Initial setBufferedPos always wins (zero-value start).
+	start := mysql.Position{Name: "binlog.000010", Pos: 5000}
+	client.setBufferedPos(start)
+	require.Equal(t, start, client.getBufferedPos())
+
+	// A move backwards in the same file (the synthetic-rotate
+	// scenario after a recreate) is rejected.
+	client.setBufferedPos(mysql.Position{Name: "binlog.000010", Pos: 4})
+	require.Equal(t, start, client.getBufferedPos(),
+		"backwards move within the same file must be ignored")
+
+	// A move forwards in the same file (a normal LogPos update) advances.
+	forward := mysql.Position{Name: "binlog.000010", Pos: 6000}
+	client.setBufferedPos(forward)
+	require.Equal(t, forward, client.getBufferedPos())
+
+	// A move to an earlier binlog file is rejected too.
+	client.setBufferedPos(mysql.Position{Name: "binlog.000009", Pos: 9999})
+	require.Equal(t, forward, client.getBufferedPos(),
+		"earlier-file move must be ignored")
+
+	// A real binlog rotation to the next file (with pos=4) advances —
+	// the new file name compares greater, so Compare returns > 0.
+	nextFile := mysql.Position{Name: "binlog.000011", Pos: 4}
+	client.setBufferedPos(nextFile)
+	require.Equal(t, nextFile, client.getBufferedPos(),
+		"genuine rotation to a later binlog file must advance")
+
+	// A duplicate setBufferedPos for the exact current position is a no-op.
+	client.setBufferedPos(nextFile)
+	require.Equal(t, nextFile, client.getBufferedPos())
+}
+
 // TestMaxRecreateAttemptsError tests that the readStream goroutine sets a stream error
 // and exits cleanly after exhausting the maximum number of streamer recreation attempts.
 func TestMaxRecreateAttemptsError(t *testing.T) {

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -2,7 +2,6 @@ package repl
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -12,7 +11,6 @@ import (
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
-	mysql2 "github.com/go-sql-driver/mysql"
 )
 
 // The bufferedMap avoids using REPLACE INTO .. SELECT.
@@ -26,14 +24,10 @@ import (
 // binlog_order_commits = ON. Storing the row image inline (rather than
 // re-reading source via REPLACE INTO ... SELECT) sidesteps that race.
 //
-// Behaviour switches based on (forceQueueMode,
-// watermarkOptimizationEnabled, pkIsMemoryComparable):
+// Behaviour switches based on (watermarkOptimizationEnabled,
+// pkIsMemoryComparable):
 //
-//   - forceQueueMode=true: always queue mode. Set by handleFlushError as
-//     a defensive last-line response to an unexpected duplicate-key
-//     collision from the applier (#847). Not expected to fire now that
-//     the applier uses REPLACE INTO.
-//   - pkIsMemoryComparable=true: map mode. Map-key equality matches
+//   - pkIsMemoryComparable=true: always map mode. Map-key equality matches
 //     MySQL row identity, so LWW dedup is correct.
 //   - pkIsMemoryComparable=false: map mode during the copy phase
 //     (watermark on), queue mode post-copy. The chunker's later SELECT
@@ -135,15 +129,6 @@ type bufferedMap struct {
 	timesParked      atomic.Int64 // HasChanged was parked at least once on the soft limit
 
 	pkIsMemoryComparable bool
-
-	// forceQueueMode is set by handleFlushError after a recoverable
-	// duplicate-key collision (block/spirit#847). Once set, queueModeActive
-	// returns true regardless of pkIsMemoryComparable / watermarkOptimization,
-	// so subsequent events accumulate in s.queue (FIFO) and flushQueueLocked
-	// drives them through the applier in binlog order. We never flip it back —
-	// once a swap-pair has been observed, this subscription stays in queue mode
-	// for the rest of the migration.
-	forceQueueMode bool
 }
 
 // Per-entry overheads applied on top of estimateRowSize so the soft
@@ -222,13 +207,7 @@ func (s *bufferedMap) Tables() []*table.TableInfo {
 // Memory-comparable PKs are never queue-mode (map-key equality matches
 // MySQL row identity). Non-memory-comparable PKs run in map mode during
 // the copy phase (watermark on) and switch to queue mode post-copy.
-//
-// One escape hatch: if forceQueueMode is set (after a recoverable
-// duplicate-key collision per #847), queue mode wins regardless.
 func (s *bufferedMap) queueModeActive() bool {
-	if s.forceQueueMode {
-		return true
-	}
 	if s.pkIsMemoryComparable {
 		return false
 	}
@@ -376,9 +355,6 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 		}
 		if (i % target) == 0 {
 			if err := s.flushBatch(ctx, deleteKeys, upsertRows, lockToUse); err != nil {
-				if s.handleFlushError(err) {
-					return false, nil
-				}
 				return false, err
 			}
 			deleteKeys = nil
@@ -387,9 +363,6 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 	}
 
 	if err := s.flushBatch(ctx, deleteKeys, upsertRows, lockToUse); err != nil {
-		if s.handleFlushError(err) {
-			return false, nil
-		}
 		return false, err
 	}
 
@@ -405,58 +378,6 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 		s.cond.Broadcast()
 	}
 	return allChangesFlushed, nil
-}
-
-// handleFlushError is a defensive last line for flushMapLocked against
-// a duplicate-key collision from the applier (block/spirit#847). With
-// the applier now using REPLACE INTO (which deletes any row that
-// conflicts on PRIMARY KEY or any UNIQUE index before each insert),
-// this path is not expected to fire in practice — REPLACE absorbs the
-// swap-pair shape that triggered the original bug. We keep the
-// recovery wired up as a safety net: if some future edge case causes
-// the applier to return Error 1062 anyway, we'd rather flip the
-// subscription into queue mode and let the next flush retry FIFO than
-// abort the migration.
-//
-// On 1062 we:
-//
-//  1. Log a warning. This is not a path we expect to hit, and an
-//     operator seeing it should treat it as a signal that something
-//     unexpected is happening at the applier or schema level.
-//  2. Clear the pending map and queue. Returning allChangesFlushed=false
-//     keeps flushedPos pinned to the last fully-flushed position; the
-//     events we just discarded will need to come back via re-reading
-//     the binlog, but we don't trigger that here.
-//  3. Flip forceQueueMode on so subsequent events accumulate in the
-//     FIFO queue. Whether or not that helps depends on the underlying
-//     cause; for swap-pair collisions it does, for other shapes the
-//     post-cutover checksum is what catches divergence.
-//
-// Returns true if we recognized and handled the error; the caller
-// should then treat the flush as a no-op (return allChangesFlushed=false
-// without an error) so flushedPos is not advanced.
-//
-// Caller must hold s.Mutex.
-func (s *bufferedMap) handleFlushError(err error) bool {
-	var me *mysql2.MySQLError
-	if !errors.As(err, &me) || me.Number != 1062 {
-		return false
-	}
-	s.c.logger.Warn("buffered-map flush hit a duplicate-key collision; "+
-		"clearing pending changes and switching to queue mode (FIFO). "+
-		"With the REPLACE-INTO applier this path is not expected to fire — "+
-		"investigate the underlying cause",
-		"table", s.table.SchemaName+"."+s.table.TableName,
-		"error", err.Error(),
-		"changes_cleared", len(s.changes),
-		"queue_cleared", len(s.queue),
-	)
-	s.changes = make(map[string]bufferedChange)
-	s.queue = nil
-	s.sizeBytes = 0
-	s.forceQueueMode = true
-	s.cond.Broadcast() // wake HasChanged callers parked on the soft cap
-	return true
 }
 
 // flushBatch flushes a batch of deletes and upserts using the applier.

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -29,9 +29,10 @@ import (
 // Behaviour switches based on (forceQueueMode,
 // watermarkOptimizationEnabled, pkIsMemoryComparable):
 //
-//   - forceQueueMode=true: always queue mode. Set permanently by
-//     handleFlushError after the subscription recovers from a duplicate-
-//     key collision (see "Optimistic batching" below and #847).
+//   - forceQueueMode=true: always queue mode. Set by handleFlushError as
+//     a defensive last-line response to an unexpected duplicate-key
+//     collision from the applier (#847). Not expected to fire now that
+//     the applier uses REPLACE INTO.
 //   - pkIsMemoryComparable=true: map mode. Map-key equality matches
 //     MySQL row identity, so LWW dedup is correct.
 //   - pkIsMemoryComparable=false: map mode during the copy phase
@@ -39,42 +40,31 @@ import (
 //     covers in-window case-collision races during the copy phase; the
 //     post-cutover checksum repairs any divergence that slips through.
 //
-// Why queue mode at all? Two unrelated reasons:
+// Why queue mode at all? With case-insensitive collations "A" and "a"
+// hash to distinct keys but resolve to the same row in MySQL, so a
+// map's non-deterministic iteration would apply the events in the
+// wrong order. FIFO ordering applies them in binlog order, which the
+// target's own collation-aware uniqueness then collapses correctly.
+// The queue keeps the row image inline and applies it via the applier
+// — no REPLACE INTO ... SELECT round-trip, so #746 stays fixed and
+// cross-server moves stay supported per #607.
 //
-//  1. Collation-insensitive PKs: with case-insensitive collations "A"
-//     and "a" hash to distinct keys but resolve to the same row in
-//     MySQL, so a map's non-deterministic iteration would apply the
-//     events in the wrong order. FIFO ordering applies them in binlog
-//     order, which the target's own collation-aware uniqueness then
-//     collapses correctly.
-//  2. Optimistic batching for unique keys (#847): the map flush hands
-//     the applier a batched INSERT...ON DUPLICATE KEY UPDATE. MySQL
-//     processes its VALUES list in array order, so the row order in
-//     the batch matters when two rows in it can collide on a unique
-//     key. The map's randomized iteration is fine for the common case
-//     where each row's upsert depends only on its own PK, but it
-//     breaks for "swap" patterns — a workload that legally moves a
-//     unique value between two rows inside one transaction
-//     (UPDATE A SET col=NULL; UPDATE B SET col='val';). When the
-//     activating row happens to come first in the batch, MySQL fails
-//     it with Error 1062 because the deactivating row still holds the
-//     value in the shadow. handleFlushError catches the 1062, clears
-//     the map, flips forceQueueMode on, and asks the client to rewind
-//     the binlog reader so the lost events can be re-read FIFO and
-//     applied in binlog order.
-//
-// Either path keeps the row image inline and applies via the applier —
-// no REPLACE INTO ... SELECT, so #746 stays fixed and cross-server
-// moves stay supported per #607.
+// Applier idempotence: the applier issues `REPLACE INTO target VALUES ...`
+// rather than `INSERT ... ON DUPLICATE KEY UPDATE`. REPLACE deletes any
+// row that conflicts on PRIMARY KEY or any UNIQUE index before each
+// insert, which makes the applier idempotent for any subset/order of
+// events that land together in a multi-row batch. That's what restores
+// the pre-#821 robustness for "swap" workloads (a source-side
+// transaction that legally moves a unique value between two rows)
+// without re-introducing the binlog/visibility race motivating #746 —
+// we supply the inline row image, not a SELECT against source.
 //
 // SetWatermarkOptimization owns the watermark-driven transition: when
 // its toggle changes which store is active, it drains the outgoing
 // store inline. Past that boundary the invariant holds — only the
 // currently-active store may have entries — so HasChanged never has to
 // merge into a stale map and Flush never has to drain both stores in
-// the normal path. The forceQueueMode transition is *not* drained by
-// SetWatermarkOptimization; handleFlushError discards the map outright
-// because the rewind will re-read those events from the binlog.
+// the normal path.
 
 type bufferedChange struct {
 	logicalRow  applier.LogicalRow
@@ -417,26 +407,30 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 	return allChangesFlushed, nil
 }
 
-// handleFlushError implements the swap-pair recovery path for #847.
-//
-// When the multi-row INSERT ... ON DUPLICATE KEY UPDATE inside flushBatch
-// fails with Error 1062, the cause is almost always that the buffered
-// map's randomized iteration handed the applier a swap pair (deactivate
-// row A, activate row B from the same source-side transaction) in the
-// wrong order — B activates first while A still holds the unique value
-// in the shadow table.
+// handleFlushError is a defensive last line for flushMapLocked against
+// a duplicate-key collision from the applier (block/spirit#847). With
+// the applier now using REPLACE INTO (which deletes any row that
+// conflicts on PRIMARY KEY or any UNIQUE index before each insert),
+// this path is not expected to fire in practice — REPLACE absorbs the
+// swap-pair shape that triggered the original bug. We keep the
+// recovery wired up as a safety net: if some future edge case causes
+// the applier to return Error 1062 anyway, we'd rather flip the
+// subscription into queue mode and let the next flush retry FIFO than
+// abort the migration.
 //
 // On 1062 we:
 //
-//  1. Discard all pending changes. Their *latest* row images are still
-//     in the source-side binlog (the binlog reader has not advanced
-//     flushedPos past them), so we can re-read them.
-//  2. Flip forceQueueMode on. Subsequent events will accumulate in the
-//     FIFO queue, and flushQueueLocked drives them through the applier
-//     in binlog order — no in-batch reordering, no spurious collision.
-//  3. Ask the client to rewind the binlog reader back to position 4 of
-//     the flushedPos file. recreateStreamer handles the actual rewind
-//     once readStream sees the closed syncer.
+//  1. Log a warning. This is not a path we expect to hit, and an
+//     operator seeing it should treat it as a signal that something
+//     unexpected is happening at the applier or schema level.
+//  2. Clear the pending map and queue. Returning allChangesFlushed=false
+//     keeps flushedPos pinned to the last fully-flushed position; the
+//     events we just discarded will need to come back via re-reading
+//     the binlog, but we don't trigger that here.
+//  3. Flip forceQueueMode on so subsequent events accumulate in the
+//     FIFO queue. Whether or not that helps depends on the underlying
+//     cause; for swap-pair collisions it does, for other shapes the
+//     post-cutover checksum is what catches divergence.
 //
 // Returns true if we recognized and handled the error; the caller
 // should then treat the flush as a no-op (return allChangesFlushed=false
@@ -449,25 +443,19 @@ func (s *bufferedMap) handleFlushError(err error) bool {
 		return false
 	}
 	s.c.logger.Warn("buffered-map flush hit a duplicate-key collision; "+
-		"clearing pending changes, switching to queue mode (FIFO), "+
-		"and rewinding binlog to flushed position",
+		"clearing pending changes and switching to queue mode (FIFO). "+
+		"With the REPLACE-INTO applier this path is not expected to fire — "+
+		"investigate the underlying cause",
 		"table", s.table.SchemaName+"."+s.table.TableName,
 		"error", err.Error(),
 		"changes_cleared", len(s.changes),
 		"queue_cleared", len(s.queue),
 	)
-	// Discard both stores. Anything that was in either is about to be
-	// re-read from the binlog by readStream after the rewind. Clearing
-	// the queue here (not just the map) also keeps sizeBytes accounting
-	// consistent — leaving stale queue entries while resetting sizeBytes
-	// would let flushQueueLocked drive sizeBytes negative when it
-	// subtracts drainedBytes on the next flush.
 	s.changes = make(map[string]bufferedChange)
 	s.queue = nil
 	s.sizeBytes = 0
 	s.forceQueueMode = true
 	s.cond.Broadcast() // wake HasChanged callers parked on the soft cap
-	s.c.requestRewind()
 	return true
 }
 

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -53,6 +53,20 @@ import (
 // without re-introducing the binlog/visibility race motivating #746 —
 // we supply the inline row image, not a SELECT against source.
 //
+// Eventual consistency: REPLACE may delete more rows than appear in
+// its VALUES list — specifically, any row in the destination that
+// holds a unique value the new row is now claiming. That row is
+// briefly missing from the destination until its own event arrives in
+// a later batch (or a later row in the same batch) and re-inserts it.
+// Spirit's correctness relies on the bufferedMap being an up-to-date
+// and *disjoint* representation of pending changes — every PK appears
+// at most once at flush time, holding the latest row image — so every
+// transiently-deleted row is guaranteed to have its own event in the
+// buffer (or arriving shortly). The destination converges to source's
+// current state once the last unflushed event for each affected PK
+// has been applied; the post-cutover checksum (with
+// FixDifferences=true) catches any divergence that slips through.
+//
 // SetWatermarkOptimization owns the watermark-driven transition: when
 // its toggle changes which store is active, it drains the outgoing
 // store inline. Past that boundary the invariant holds — only the

--- a/pkg/repl/subscription_buffered_swap_test.go
+++ b/pkg/repl/subscription_buffered_swap_test.go
@@ -14,44 +14,34 @@ import (
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
-	"github.com/go-mysql-org/go-mysql/mysql"
 	mysql2 "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
-// TestBufferedMapSwapPairRecoversViaQueueMode is a deterministic,
-// single-threaded regression test for the fix to block/spirit#847.
+// TestBufferedMapSwapPairFlushesViaReplace is a deterministic regression
+// test for block/spirit#847. The bug: when a source-side transaction
+// legally swaps a unique value between two rows
+// (`UPDATE A SET col=NULL; UPDATE B SET col='val'`), the buffered map
+// flush previously emitted `INSERT ... ON DUPLICATE KEY UPDATE` with a
+// randomly-ordered VALUES list, and MySQL processes that list in array
+// order. When the activate row landed first, MySQL aborted with
+// Error 1062 because the deactivating row still held the unique value.
 //
-// Background: `bufferedMap.flushMapLocked` iterates `s.changes` (a Go
-// map, randomized iteration) and hands the rows to the applier as a
-// single `INSERT ... ON DUPLICATE KEY UPDATE` with a multi-row VALUES
-// list. MySQL processes that list in array order. When a swap pair
-// lands in the same batch — row A's deactivation and row B's activation,
-// both from the same source-side transaction — the random map order can
-// place B's activation before A's deactivation, and MySQL rejects the
-// first row with Error 1062 because A still holds the unique value.
+// The fix changes the applier to issue `REPLACE INTO ... VALUES (...)`.
+// REPLACE deletes any row that conflicts on PRIMARY KEY or any UNIQUE
+// index before each insert, so the multi-row VALUES list is order-
+// independent: each row's conflicts are resolved by deletion before
+// its own insert runs. We supply the inline row image (not a SELECT
+// against source), so this does not reintroduce the binlog/visibility
+// race that motivated #746.
 //
-// The fix is detect-and-switch (`handleFlushError`): when Flush sees a
-// 1062, the subscription discards its pending map, flips into
-// forceQueueMode, and asks the client to rewind the binlog reader to
-// position 4 of the flushedPos file. The events that were lost when
-// the map was cleared are re-read FIFO and applied via flushQueueLocked,
-// which preserves binlog order in the resulting batch — no collision.
-//
-// This test exercises the subscription-level half of that fix: we
-// drive a swap pair into the map for 50 independent buckets (so the
-// probability that map iteration happens to land *every* pair in the
-// safe order is 2^-50, effectively zero), call Flush once, and assert:
-//
-//   - Flush returns no error (we recovered).
-//   - allChangesFlushed=false (so flushedPos won't advance).
-//   - The subscription is now in queue mode.
-//   - The map is empty (state was discarded).
-//
-// The end-to-end half of the fix — the client actually rewinding the
-// binlog reader and the queue mode applying the re-read events — is
-// covered by TestSwapPairFullRecoveryViaQueueMode below.
-func TestBufferedMapSwapPairRecoversViaQueueMode(t *testing.T) {
+// This test seeds 50 independent swap-pair buckets into the buffered
+// map and asserts that `Flush` succeeds without error and that the
+// destination ends up at the post-swap state. Without the fix, the
+// probability that map iteration happens to place *every* pair in the
+// safe order is 2^-50 — effectively zero — so the test reliably
+// reproduces the failure on the old applier path.
+func TestBufferedMapSwapPairFlushesViaReplace(t *testing.T) {
 	t1 := `CREATE TABLE subscription_test (
 		id INT NOT NULL,
 		slot_id VARCHAR(50) DEFAULT NULL,
@@ -115,12 +105,12 @@ func TestBufferedMapSwapPairRecoversViaQueueMode(t *testing.T) {
 		changes:               make(map[string]bufferedChange),
 		chunker:               mockChunker,
 		watermarkOptimization: false, // accept every event; no chunker-progress gating
-		pkIsMemoryComparable:  true,  // INT PK → map mode (the failing path)
+		pkIsMemoryComparable:  true,  // INT PK → map mode
 	}
 	sub.cond = sync.NewCond(&sub.Mutex)
 
 	// Inject the swap pair for every bucket. In source these two
-	// UPDATEs are committed inside one transaction:
+	// UPDATEs would be committed inside one transaction:
 	//   UPDATE id=active SET slot_id=NULL;
 	//   UPDATE id=passive SET slot_id='S<i>';
 	// We bypass the binlog reader and call HasChanged with the
@@ -133,110 +123,109 @@ func TestBufferedMapSwapPairRecoversViaQueueMode(t *testing.T) {
 	}
 	require.Equal(t, buckets*2, sub.Length())
 
-	// With the buggy map-iteration order, the batched
-	// INSERT ... ON DUPLICATE KEY UPDATE will, with probability
-	// 1 - 2^-buckets, place at least one bucket's activation before its
-	// deactivation and trigger Error 1062 on uq_slot inside flushBatch.
-	// `handleFlushError` recognizes that, clears the map, flips
-	// forceQueueMode, asks the client to rewind, and returns the flush
-	// as a no-op (allChangesFlushed=false, no error).
+	// With REPLACE INTO, the multi-row VALUES list is order-independent
+	// — the swap pair lands cleanly regardless of map iteration order.
 	allFlushed, err := sub.Flush(t.Context(), false, nil)
-	require.NoError(t, err, "recovery path should swallow the 1062")
-	require.False(t, allFlushed,
-		"allChangesFlushed must be false so flushedPos stays put — the events still need to be re-read FIFO")
+	require.NoError(t, err, "REPLACE INTO must handle the swap pair without 1062")
+	require.True(t, allFlushed)
 
-	// State assertions: the recovery path discarded pending changes and
-	// flipped the subscription into queue mode.
+	// We did not trigger the safety-net recovery path.
 	sub.Lock()
-	require.True(t, sub.forceQueueMode, "forceQueueMode should be set after a 1062 recovery")
-	require.True(t, sub.queueModeActive(), "queueModeActive should return true once forceQueueMode is on")
-	require.Empty(t, sub.changes, "pending map should be cleared")
-	require.Zero(t, sub.sizeBytes, "sizeBytes should be reset to 0")
+	require.False(t, sub.forceQueueMode,
+		"swap-pair flush must NOT trigger the queue-mode safety net — REPLACE handles it natively")
+	require.Empty(t, sub.changes)
 	sub.Unlock()
 
-	// The recovery also asks the client to rewind the binlog reader.
-	// (We constructed the Client directly without a syncer, so the
-	// close-the-syncer half of requestRewind is a no-op; the flag flip
-	// is the observable signal here.)
-	require.True(t, client.rewindRequested.Load(),
-		"client should have been asked to rewind the binlog reader")
-
-	// A subsequent HasChanged should route to the queue, not the map.
-	sub.HasChanged([]any{42}, []any{42, "after-recovery"}, false)
-	sub.Lock()
-	require.Empty(t, sub.changes, "new events must not land back in the map")
-	require.Len(t, sub.queue, 1, "new events must land in the FIFO queue")
-	sub.Unlock()
+	// End-state assertion: bucket-for-bucket the destination reflects the swap.
+	for i := 0; i < buckets; i++ {
+		activePK := 2*i + 1
+		passivePK := 2*i + 2
+		var was, now sql.NullString
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), activePK).Scan(&was))
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), passivePK).Scan(&now))
+		require.False(t, was.Valid, "bucket %d previously-active row should be NULL now", i)
+		require.True(t, now.Valid, "bucket %d previously-passive row should hold the slot now", i)
+		require.Equal(t, fmt.Sprintf("S%d", i), now.String)
+	}
 }
 
-// TestFlushDoesNotRegressFlushedPosAfterRewind covers the defensive
-// guard in `Client.flush` against a backwards checkpoint move when
-// a rewind has snapped `bufferedPos` back. Without the guard, a flush
-// that happened to run between the rewind (which sets bufferedPos =
-// {flushedPos.Name, 4}) and readStream catching up past the old
-// flushedPos.Pos would publish the rewound bufferedPos as the new
-// flushedPos — silently rewinding checkpoints.
+// TestHandleFlushErrorSafetyNet exercises the defensive `handleFlushError`
+// helper directly — without an actual MySQL collision. The REPLACE-based
+// applier shouldn't produce an Error 1062 for the workloads we know
+// about, but the safety net is wired up regardless so that an unexpected
+// duplicate-key error from a future edge case flips the subscription
+// into queue mode rather than aborting the migration.
 //
-// We don't run a real binlog reader here. We exercise `flush` directly
-// on a client that has no subscriptions (so allChangesFlushed=true)
-// and assert that flushedPos does not move backwards when bufferedPos
-// is set behind it.
-func TestFlushDoesNotRegressFlushedPosAfterRewind(t *testing.T) {
+// The test stuffs the map with state, hands `handleFlushError` a
+// synthesized 1062, and asserts:
+//
+//   - it returns true (recognized + handled),
+//   - the map and queue are cleared,
+//   - sizeBytes is reset,
+//   - forceQueueMode is on so subsequent events route to the queue,
+//   - a non-1062 error returns false and leaves state untouched.
+func TestHandleFlushErrorSafetyNet(t *testing.T) {
 	client := &Client{
-		db:              nil, // unused: no subscriptions to flush
+		db:              nil,
 		logger:          slog.Default(),
 		concurrency:     1,
 		targetBatchSize: 1000,
 		dbConfig:        dbconn.NewDBConfig(),
 		subscriptions:   map[string]Subscription{},
 	}
+	srcTable := &table.TableInfo{SchemaName: "test", TableName: "t"}
 
-	// Pretend we'd flushed up to (file, 5000) and then a rewind dropped
-	// bufferedPos back to the start of the file.
-	advanced := mysql.Position{Name: "binlog.000042", Pos: 5000}
-	rewound := mysql.Position{Name: "binlog.000042", Pos: 4}
-	client.SetFlushedPos(advanced)
-	client.setBufferedPos(rewound)
+	sub := &bufferedMap{
+		c:        client,
+		table:    srcTable,
+		newTable: srcTable,
+		changes: map[string]bufferedChange{
+			"a": {logicalRow: applier.LogicalRow{RowImage: []any{1, "x"}}, originalKey: []any{1}},
+			"b": {logicalRow: applier.LogicalRow{RowImage: []any{2, "y"}}, originalKey: []any{2}},
+		},
+		queue:                []queuedChange{{key: "c", logicalRow: applier.LogicalRow{RowImage: []any{3, "z"}}}},
+		sizeBytes:            12345,
+		pkIsMemoryComparable: true,
+	}
+	sub.cond = sync.NewCond(&sub.Mutex)
+	sub.Lock()
+	defer sub.Unlock()
 
-	require.NoError(t, client.flush(t.Context(), false, nil))
+	// Non-1062 errors must not be swallowed.
+	otherErr := &mysql2.MySQLError{Number: 1213, Message: "Deadlock"}
+	require.False(t, sub.handleFlushError(otherErr), "deadlock must not be treated as a 1062")
+	require.False(t, sub.forceQueueMode)
+	require.NotEmpty(t, sub.changes)
 
-	require.Equal(t, advanced, client.GetBinlogApplyPosition(),
-		"flushedPos must not regress when a flush captures a rewound bufferedPos")
-
-	// Sanity: once bufferedPos advances back past the old flushedPos, a
-	// subsequent flush *does* move the checkpoint forward.
-	forward := mysql.Position{Name: "binlog.000042", Pos: 6000}
-	client.setBufferedPos(forward)
-	require.NoError(t, client.flush(t.Context(), false, nil))
-	require.Equal(t, forward, client.GetBinlogApplyPosition(),
-		"flushedPos should advance once bufferedPos is ahead again")
+	// 1062 triggers the recovery: clear both stores, reset sizeBytes,
+	// flip forceQueueMode on, leave flushedPos untouched (caller does that).
+	dupErr := &mysql2.MySQLError{
+		Number:  1062,
+		Message: "Duplicate entry 'X' for key 't.uq_slot'",
+	}
+	require.True(t, sub.handleFlushError(dupErr))
+	require.True(t, sub.forceQueueMode, "forceQueueMode should be set after recovery")
+	require.True(t, sub.queueModeActive())
+	require.Empty(t, sub.changes)
+	require.Empty(t, sub.queue)
+	require.Zero(t, sub.sizeBytes)
 }
 
-// TestSwapPairFullRecoveryViaQueueMode drives the full end-to-end
-// rewind path: real Client.Run, real binlog reader, real swap
-// transactions on source, real Flush calls, real recovery, real
-// destination state.
+// TestSwapPairEndToEndViaReplace drives the full end-to-end path: real
+// Client.Run, real binlog reader, real swap transactions on source,
+// real Flush calls, real destination state. With the REPLACE-based
+// applier this should complete successfully and *without* tripping the
+// safety-net recovery, because REPLACE handles the swap-pair shape
+// natively (its "delete any unique-key conflict before each insert"
+// semantic resolves the in-batch reordering risk).
 //
-// The flow:
-//
-//  1. Source and destination tables are seeded with the pre-swap state.
-//     The seed inserts happen *before* Run starts so they are outside
-//     the subscription's binlog window (the rewind will still re-read
-//     them from the start of the file, but applying them is idempotent
-//     because their values match what's already in dest).
-//  2. Run starts the binlog reader at the current server position.
-//  3. The test executes N legal swap transactions on source.
-//  4. BlockWait waits for the subscription to receive every event.
-//  5. The first Flush hits the swap-pair 1062 inside flushMapLocked,
-//     recovers via handleFlushError, asks the client to rewind, and
-//     returns no error. The subscription is now in forceQueueMode.
-//  6. readStream notices the closed syncer, sees rewindRequested, and
-//     recreates the streamer at position 4 of flushedPos.Name. As it
-//     re-reads events they accumulate in the FIFO queue.
-//  7. Subsequent Flush loops drain the queue via flushQueueLocked,
-//     which preserves binlog order — no in-batch reordering.
-//  8. The destination ends up byte-equal to the source.
-func TestSwapPairFullRecoveryViaQueueMode(t *testing.T) {
+// We additionally assert `forceQueueMode == false` at the end: the
+// safety net should not have engaged. Falling into queue mode here
+// would mean REPLACE is failing for some reason we haven't anticipated
+// — that's worth surfacing rather than silently tolerating.
+func TestSwapPairEndToEndViaReplace(t *testing.T) {
 	t1 := `CREATE TABLE subscription_test (
 		id INT NOT NULL,
 		slot_id VARCHAR(50) DEFAULT NULL,
@@ -275,10 +264,6 @@ func TestSwapPairFullRecoveryViaQueueMode(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
 
-	// Seed both tables with identical pre-swap state BEFORE Run starts,
-	// so these inserts aren't in the subscription's window. (They will
-	// still be re-read once the rewind kicks in, but applying them via
-	// the FIFO queue is idempotent — they match what's already in dst.)
 	const buckets = 50
 	var seed []string
 	for i := 0; i < buckets; i++ {
@@ -297,13 +282,13 @@ func TestSwapPairFullRecoveryViaQueueMode(t *testing.T) {
 	defer client.Close()
 
 	sub := client.subscriptions[srcTable.SchemaName+"."+srcTable.TableName].(*bufferedMap)
-	// Disable the watermark optimization so every binlog event is
-	// admitted to the map (in production this is what happens after
-	// the copy phase finishes — the post-copy applier sees every event).
+	// Mirror the post-copy state where the watermark optimization is off
+	// and every binlog event is admitted to the map.
 	require.NoError(t, sub.SetWatermarkOptimization(t.Context(), false))
 
-	// Run swap transactions on source. Each is a legal
-	// deactivate-then-activate inside a single transaction.
+	// Run swap transactions on source: deactivate-then-activate inside
+	// a single transaction. Legal in source; binlog records two UPDATE
+	// events per bucket.
 	for i := 0; i < buckets; i++ {
 		activePK := 2*i + 1
 		passivePK := 2*i + 2
@@ -319,43 +304,33 @@ func TestSwapPairFullRecoveryViaQueueMode(t *testing.T) {
 		require.NoError(t, tx.Commit())
 	}
 
-	// Drive client.Flush through to completion. Internally it loops
-	// flush -> BlockWait -> flush until the delta is trivial; the
-	// recovery+rewind path is wholly contained inside that loop.
 	require.NoError(t, client.Flush(t.Context()))
 
-	// The subscription must have detected the swap-pair collision and
-	// switched modes — otherwise the bug would still be present.
+	// The safety net must not have engaged: REPLACE handles this shape
+	// natively. If forceQueueMode flipped, something unexpected happened.
 	sub.Lock()
-	require.True(t, sub.forceQueueMode,
-		"the swap-pair collision should have triggered the recovery path")
+	require.False(t, sub.forceQueueMode,
+		"REPLACE INTO should handle swap pairs without falling into the safety-net queue mode")
 	sub.Unlock()
 
-	// End-state assertion: dst must match src bucket-for-bucket. Active
-	// rows have moved from PK=2i+1 to PK=2i+2.
+	// End-state assertion: dst matches src bucket-for-bucket.
 	for i := 0; i < buckets; i++ {
 		activePK := 2*i + 1
 		passivePK := 2*i + 2
 		var srcActive, dstActive sql.NullString
 		require.NoError(t, db.QueryRowContext(t.Context(),
-			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", srcTable.QuotedTableName), activePK).
-			Scan(&srcActive))
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", srcTable.QuotedTableName), activePK).Scan(&srcActive))
 		require.NoError(t, db.QueryRowContext(t.Context(),
-			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), activePK).
-			Scan(&dstActive))
-		require.False(t, srcActive.Valid, "source bucket %d previously-active row should now be NULL", i)
-		require.Equal(t, srcActive, dstActive,
-			"bucket %d previously-active row (PK=%d) state must match between src and dst", i, activePK)
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), activePK).Scan(&dstActive))
+		require.False(t, srcActive.Valid, "source bucket %d previously-active row should be NULL", i)
+		require.Equal(t, srcActive, dstActive, "bucket %d active-row state must match", i)
 
 		var srcPassive, dstPassive sql.NullString
 		require.NoError(t, db.QueryRowContext(t.Context(),
-			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", srcTable.QuotedTableName), passivePK).
-			Scan(&srcPassive))
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", srcTable.QuotedTableName), passivePK).Scan(&srcPassive))
 		require.NoError(t, db.QueryRowContext(t.Context(),
-			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), passivePK).
-			Scan(&dstPassive))
-		require.True(t, srcPassive.Valid, "source bucket %d previously-passive row should now hold the slot", i)
-		require.Equal(t, srcPassive, dstPassive,
-			"bucket %d previously-passive row (PK=%d) state must match between src and dst", i, passivePK)
+			fmt.Sprintf("SELECT slot_id FROM %s WHERE id=?", dstTable.QuotedTableName), passivePK).Scan(&dstPassive))
+		require.True(t, srcPassive.Valid, "source bucket %d previously-passive row should hold the slot", i)
+		require.Equal(t, srcPassive, dstPassive, "bucket %d passive-row state must match", i)
 	}
 }

--- a/pkg/repl/subscription_buffered_swap_test.go
+++ b/pkg/repl/subscription_buffered_swap_test.go
@@ -128,11 +128,7 @@ func TestBufferedMapSwapPairFlushesViaReplace(t *testing.T) {
 	allFlushed, err := sub.Flush(t.Context(), false, nil)
 	require.NoError(t, err, "REPLACE INTO must handle the swap pair without 1062")
 	require.True(t, allFlushed)
-
-	// We did not trigger the safety-net recovery path.
 	sub.Lock()
-	require.False(t, sub.forceQueueMode,
-		"swap-pair flush must NOT trigger the queue-mode safety net — REPLACE handles it natively")
 	require.Empty(t, sub.changes)
 	sub.Unlock()
 
@@ -151,80 +147,12 @@ func TestBufferedMapSwapPairFlushesViaReplace(t *testing.T) {
 	}
 }
 
-// TestHandleFlushErrorSafetyNet exercises the defensive `handleFlushError`
-// helper directly — without an actual MySQL collision. The REPLACE-based
-// applier shouldn't produce an Error 1062 for the workloads we know
-// about, but the safety net is wired up regardless so that an unexpected
-// duplicate-key error from a future edge case flips the subscription
-// into queue mode rather than aborting the migration.
-//
-// The test stuffs the map with state, hands `handleFlushError` a
-// synthesized 1062, and asserts:
-//
-//   - it returns true (recognized + handled),
-//   - the map and queue are cleared,
-//   - sizeBytes is reset,
-//   - forceQueueMode is on so subsequent events route to the queue,
-//   - a non-1062 error returns false and leaves state untouched.
-func TestHandleFlushErrorSafetyNet(t *testing.T) {
-	client := &Client{
-		db:              nil,
-		logger:          slog.Default(),
-		concurrency:     1,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
-		subscriptions:   map[string]Subscription{},
-	}
-	srcTable := &table.TableInfo{SchemaName: "test", TableName: "t"}
-
-	sub := &bufferedMap{
-		c:        client,
-		table:    srcTable,
-		newTable: srcTable,
-		changes: map[string]bufferedChange{
-			"a": {logicalRow: applier.LogicalRow{RowImage: []any{1, "x"}}, originalKey: []any{1}},
-			"b": {logicalRow: applier.LogicalRow{RowImage: []any{2, "y"}}, originalKey: []any{2}},
-		},
-		queue:                []queuedChange{{key: "c", logicalRow: applier.LogicalRow{RowImage: []any{3, "z"}}}},
-		sizeBytes:            12345,
-		pkIsMemoryComparable: true,
-	}
-	sub.cond = sync.NewCond(&sub.Mutex)
-	sub.Lock()
-	defer sub.Unlock()
-
-	// Non-1062 errors must not be swallowed.
-	otherErr := &mysql2.MySQLError{Number: 1213, Message: "Deadlock"}
-	require.False(t, sub.handleFlushError(otherErr), "deadlock must not be treated as a 1062")
-	require.False(t, sub.forceQueueMode)
-	require.NotEmpty(t, sub.changes)
-
-	// 1062 triggers the recovery: clear both stores, reset sizeBytes,
-	// flip forceQueueMode on, leave flushedPos untouched (caller does that).
-	dupErr := &mysql2.MySQLError{
-		Number:  1062,
-		Message: "Duplicate entry 'X' for key 't.uq_slot'",
-	}
-	require.True(t, sub.handleFlushError(dupErr))
-	require.True(t, sub.forceQueueMode, "forceQueueMode should be set after recovery")
-	require.True(t, sub.queueModeActive())
-	require.Empty(t, sub.changes)
-	require.Empty(t, sub.queue)
-	require.Zero(t, sub.sizeBytes)
-}
-
 // TestSwapPairEndToEndViaReplace drives the full end-to-end path: real
 // Client.Run, real binlog reader, real swap transactions on source,
 // real Flush calls, real destination state. With the REPLACE-based
-// applier this should complete successfully and *without* tripping the
-// safety-net recovery, because REPLACE handles the swap-pair shape
-// natively (its "delete any unique-key conflict before each insert"
-// semantic resolves the in-batch reordering risk).
-//
-// We additionally assert `forceQueueMode == false` at the end: the
-// safety net should not have engaged. Falling into queue mode here
-// would mean REPLACE is failing for some reason we haven't anticipated
-// — that's worth surfacing rather than silently tolerating.
+// applier this should complete successfully because REPLACE handles the
+// swap-pair shape natively — its "delete any unique-key conflict before
+// each insert" semantic resolves the in-batch reordering risk.
 func TestSwapPairEndToEndViaReplace(t *testing.T) {
 	t1 := `CREATE TABLE subscription_test (
 		id INT NOT NULL,
@@ -305,13 +233,6 @@ func TestSwapPairEndToEndViaReplace(t *testing.T) {
 	}
 
 	require.NoError(t, client.Flush(t.Context()))
-
-	// The safety net must not have engaged: REPLACE handles this shape
-	// natively. If forceQueueMode flipped, something unexpected happened.
-	sub.Lock()
-	require.False(t, sub.forceQueueMode,
-		"REPLACE INTO should handle swap pairs without falling into the safety-net queue mode")
-	sub.Unlock()
 
 	// End-state assertion: dst matches src bucket-for-bucket.
 	for i := 0; i < buckets; i++ {


### PR DESCRIPTION
Fixes #847.

## Summary

Both `SingleTargetApplier.UpsertRows` and `ShardedApplier.UpsertRows` now issue

```sql
REPLACE INTO target (cols) VALUES (...), (...), ...;
```

instead of `INSERT ... ON DUPLICATE KEY UPDATE`. REPLACE deletes any row that conflicts on PRIMARY KEY *or any UNIQUE index* before each insert, which makes the multi-row VALUES list order-independent — every row's transient unique-key conflicts are resolved by deletion before its own insert runs.

This restores the pre-#821 `deltaMap` robustness for swap-pair workloads (where a source-side transaction legally moves a unique value between two rows) without re-introducing the binlog/visibility race that motivated #746 — we supply the inline row image, not a `SELECT` against source.

## Why this is the right shape

#847 explains the failure mode: `INSERT ... ON DUPLICATE KEY UPDATE` only resolves the *first* conflict on each row, so any *second* unique-key collision the UPDATE introduces becomes a hard `Error 1062`. The map's randomized iteration meant a legal source-side swap pair could land "activate-first" in the batch and trip it.

`REPLACE INTO` resolves *every* unique-index conflict for each row before that row's insert runs. The same batch — in any order — produces the same end state. As a corollary, re-applying any subset of binlog events (resume from checkpoint, idempotent retry) is safe: the worst case is that the destination transiently sits at an older row state until the next event corrects it; no event sequence produces a hard 1062.

The bug was a regression of the #746 fix — see the issue for the full history. Short version: pre-#821 the deltaMap used `REPLACE INTO ... SELECT`, which had the order-independent semantic for free; #821 fixed #746 by storing inline row images but switched the SQL to `INSERT ... ON DUPLICATE KEY UPDATE`, which quietly lost that property. This PR keeps the inline row image (#746 stays fixed) but restores the REPLACE semantics.

## Eventual consistency between batches

REPLACE may delete more rows than appear in its VALUES list — specifically, any row currently in the destination that holds a unique value the new row is claiming. That row is briefly missing from the destination until its own event arrives in a later batch (or a later row in the same batch) and re-inserts it.

Spirit's correctness rests on the `bufferedMap` being an up-to-date and *disjoint* representation of pending changes — every PK appears at most once at flush time, holding the latest row image MySQL emitted for it. Any transiently-deleted row is therefore guaranteed to have its own event in the buffer (or arriving shortly), so the destination converges to source's current state once the last unflushed event for each affected PK has been applied. The post-cutover checksum (with `FixDifferences=true`) is the backstop.

This is documented in three places in the PR (the canonical explainer is in `pkg/applier/single_target.go`'s `UpsertRows` doc comment).

## What changed

- [pkg/applier/single_target.go](https://github.com/block/spirit/blob/applier-replace-into/pkg/applier/single_target.go) — switch `UpsertRows` to REPLACE INTO; remove the dual-path `insert-ignore`/`on-duplicate-key-update` branch (REPLACE handles the all-PK-columns edge case uniformly). Function-level doc rewritten to cover REPLACE semantics and eventual consistency.
- [pkg/applier/sharded.go](https://github.com/block/spirit/blob/applier-replace-into/pkg/applier/sharded.go) — same change in the per-shard upsert path; doc cross-references `SingleTargetApplier.UpsertRows`.
- [pkg/repl/client.go](https://github.com/block/spirit/blob/applier-replace-into/pkg/repl/client.go) — no functional change beyond cleanups.
- [pkg/repl/subscription_buffered.go](https://github.com/block/spirit/blob/applier-replace-into/pkg/repl/subscription_buffered.go) — file-level comment updated to describe the REPLACE INTO behavior and eventual-consistency property.
- [pkg/repl/subscription_buffered_swap_test.go](https://github.com/block/spirit/blob/applier-replace-into/pkg/repl/subscription_buffered_swap_test.go) — two new regression tests (unit + end-to-end).
- [pkg/applier/README.md](https://github.com/block/spirit/blob/applier-replace-into/pkg/applier/README.md) — new "REPLACE INTO semantics and eventual consistency" subsection.
- [pkg/repl/README.md](https://github.com/block/spirit/blob/applier-replace-into/pkg/repl/README.md) — "Applier idempotence via REPLACE INTO" section with worked-example tables showing the swap pair applied in correct and reversed batch order; both converge.
- [AGENTS.md](https://github.com/block/spirit/blob/applier-replace-into/AGENTS.md) — `pkg/repl` summary corrected (was still describing a separate `DeltaQueue` subscription removed in #821) and reflects the REPLACE INTO behavior.

## Tests

- `TestBufferedMapSwapPairFlushesViaReplace` — deterministic unit test: seeds 50 swap-pair buckets into the buffered map, asserts `Flush` succeeds with no 1062 and destination ends at the post-swap state. Reproduces the original failure on the pre-fix `INSERT ... ON DUPLICATE KEY UPDATE` path with P ≈ 1 − 2⁻⁵⁰.
- `TestSwapPairEndToEndViaReplace` — end-to-end through `Client.Run` with real binlog reader and real swap transactions on source; asserts src/dst match bucket-for-bucket.

## Test plan

- [x] `go test ./pkg/repl/...` clean
- [x] `go test ./pkg/applier/...` clean
- [x] `go test ./pkg/migration/... -short` clean
- [x] `golangci-lint run ./...` clean (0 issues)