### PR TITLE
fix(#854): redundant_indexes — never flag PRIMARY KEY as redundant

### DIFF
--- a/pkg/lint/lint_redundant_indexes.go
+++ b/pkg/lint/lint_redundant_indexes.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/block/spirit/pkg/statement"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
 func init() {
@@ -14,13 +13,22 @@ func init() {
 
 // RedundantIndexLinter checks for redundant indexes in tables.
 // An index is considered redundant if:
-// 1. Its columns are a prefix of the PRIMARY KEY columns
-// 2. Another index's column list starts with this index's columns (prefix match)
-// 3. Another index has exactly the same columns in the same order (duplicate)
-// 4. The index ends with PRIMARY KEY columns (suffix redundancy)
+//  1. Its columns are a prefix of the PRIMARY KEY columns
+//  2. Another index's column list starts with this index's columns (prefix match)
+//  3. Another index has exactly the same columns in the same order (duplicate)
+//  4. The index ends with PRIMARY KEY columns (suffix redundancy) — InnoDB
+//     auto-appends PK columns to secondary indexes, so spelling them out is
+//     wasteful.
+//  5. The index starts with the full PRIMARY KEY (prefix redundancy) — point
+//     and equality lookups by PK are already served by the clustered index,
+//     so the leading PK columns add no capability that a non-PK-leading
+//     variant of the index wouldn't already provide.
 //
-// In InnoDB, secondary indexes automatically include PRIMARY KEY columns as a suffix,
-// making certain index patterns redundant and wasteful.
+// The linter evaluates the *post-state* of the schema (existing tables with
+// CREATE TABLE / ALTER TABLE changes applied) so warnings fire when a
+// redundant index is being introduced, and stay silent when it is being
+// removed — matching the post-state convention established for other linters
+// in #840.
 type RedundantIndexLinter struct{}
 
 func (l *RedundantIndexLinter) Name() string {
@@ -28,20 +36,14 @@ func (l *RedundantIndexLinter) Name() string {
 }
 
 func (l *RedundantIndexLinter) Description() string {
-	return "Detects redundant indexes including duplicates, prefix matches, and unnecessary PRIMARY KEY suffixes"
+	return "Detects redundant indexes including duplicates, prefix matches, and unnecessary PRIMARY KEY suffixes or prefixes"
 }
 
 func (l *RedundantIndexLinter) Lint(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) []Violation {
 	var violations []Violation
-
-	// Check both existing tables and CREATE TABLE statements in changes
-	for table := range CreateTableStatements(existingTables, changes) {
+	for _, table := range PostState(existingTables, changes) {
 		violations = append(violations, l.checkTableIndexes(table)...)
 	}
-
-	// Check ALTER TABLE statements that add indexes
-	violations = append(violations, l.checkAlterTableStatements(existingTables, changes)...)
-
 	return violations
 }
 
@@ -64,9 +66,14 @@ func (l *RedundantIndexLinter) checkTableIndexes(table *statement.CreateTable) [
 			continue
 		}
 
-		// Check 1: Redundant PK suffix (can coexist with other issues)
-		// This checks if the index explicitly includes PK columns at the end
-		if primaryKey != nil {
+		// PRIMARY KEY itself never participates in suffix/prefix-of-PK checks
+		// against itself, and the checks below are only meaningful for
+		// secondary indexes.
+		if primaryKey != nil && index.Type != "PRIMARY KEY" {
+			// Check: Redundant PK suffix
+			// The index explicitly includes PK columns at its end. InnoDB
+			// already appends PK columns to secondary indexes, so spelling
+			// them out wastes space.
 			if hasRedundant, colCount := hasRedundantPKSuffix(index, *primaryKey); hasRedundant {
 				violations = append(violations, createPKSuffixViolation(
 					table.GetTableName(),
@@ -76,9 +83,22 @@ func (l *RedundantIndexLinter) checkTableIndexes(table *statement.CreateTable) [
 				))
 				// Continue checking - index might also be fully redundant
 			}
+
+			// Check: Redundant PK prefix
+			// The index leads with the full PK. Point and equality lookups by
+			// PK are already served by the clustered index, and a non-PK-leading
+			// variant of this index would auto-append PK anyway.
+			if hasRedundant, colCount := hasRedundantPKPrefix(index, *primaryKey); hasRedundant {
+				violations = append(violations, createPKPrefixViolation(
+					table.GetTableName(),
+					index,
+					*primaryKey,
+					colCount,
+				))
+			}
 		}
 
-		// Check 2: Redundant to another index
+		// Check: Redundant to another index
 		for _, otherIndex := range indexes {
 			if index.Name == otherIndex.Name {
 				continue
@@ -152,6 +172,35 @@ func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 	// - A duplicate of indexB (len(indexA) == len(indexB))
 	// Both cases are redundant!
 	return true
+}
+
+// hasRedundantPKPrefix checks if a secondary index leads with the full
+// PRIMARY KEY. Returns true and the count of leading PK columns if so.
+//
+// Rationale: InnoDB's PRIMARY KEY is the clustered index, so point and
+// equality lookups by PK are best served by PK directly. A secondary index
+// of the form INDEX (pk, x, y) covers no lookup that either PK alone or
+// INDEX (x, y) (with PK auto-appended) cannot already serve. The leading
+// PK columns are therefore redundant.
+//
+// Unlike the suffix check, this only matches the *full* PK at the start —
+// a partial PK prefix at the start is a defensible covering index pattern.
+// The index must have additional columns beyond the PK (an index that *is*
+// the PK is caught by the duplicate / prefix-of-PK rules instead).
+func hasRedundantPKPrefix(index statement.Index, primaryKey statement.Index) (bool, int) {
+	pkLen := len(primaryKey.Columns)
+	if pkLen == 0 {
+		return false, 0
+	}
+	if len(index.Columns) <= pkLen {
+		return false, 0
+	}
+	for i := range pkLen {
+		if index.Columns[i] != primaryKey.Columns[i] {
+			return false, 0
+		}
+	}
+	return true, pkLen
 }
 
 // hasRedundantPKSuffix checks if an index has a redundant PRIMARY KEY suffix.
@@ -341,156 +390,41 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 	}
 }
 
-// checkAlterTableStatements checks ALTER TABLE statements that add indexes
-// for potential redundancy with existing indexes or other indexes being added.
-func (l *RedundantIndexLinter) checkAlterTableStatements(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) []Violation {
-	var violations []Violation
+// createPKPrefixViolation creates a violation for a secondary index that
+// leads with the full PRIMARY KEY.
+func createPKPrefixViolation(tableName string, index statement.Index, primaryKey statement.Index, redundantColCount int) Violation {
+	redundantPrefix := index.Columns[:redundantColCount]
+	usefulSuffix := index.Columns[redundantColCount:]
 
-	// Build a map of existing tables for quick lookup
-	existingTableMap := make(map[string]*statement.CreateTable)
-	for _, table := range existingTables {
-		existingTableMap[table.GetTableName()] = table
-	}
+	message := fmt.Sprintf(
+		"Index '%s' on columns (%s) leads with PRIMARY KEY columns (%s). "+
+			"Point and equality lookups by PRIMARY KEY are served by the clustered index directly, "+
+			"and InnoDB appends PK columns to secondary indexes — the leading PK columns add no capability.",
+		index.Name,
+		strings.Join(index.Columns, ", "),
+		strings.Join(redundantPrefix, ", "),
+	)
+	suggestion := fmt.Sprintf(
+		"Redefine index '%s' as INDEX (%s) — InnoDB will append PRIMARY KEY (%s) internally — "+
+			"or drop it entirely if the PRIMARY KEY alone covers the queries that use it.",
+		index.Name,
+		strings.Join(usefulSuffix, ", "),
+		strings.Join(primaryKey.Columns, ", "),
+	)
 
-	// Process each ALTER TABLE statement
-	for _, change := range changes {
-		alterStmt, ok := change.AsAlterTable()
-		if !ok {
-			continue
-		}
-
-		tableName := change.Table
-
-		// Get the existing table definition (if it exists)
-		existingTable := existingTableMap[tableName]
-		if existingTable == nil {
-			// Table doesn't exist yet - might be created in this batch of changes
-			// For now, we'll skip checking ALTER on non-existent tables
-			continue
-		}
-
-		// Extract indexes being added in this ALTER TABLE
-		newIndexes := l.extractIndexesFromAlter(alterStmt)
-		if len(newIndexes) == 0 {
-			continue
-		}
-
-		// Get existing indexes from the table
-		existingIndexes := existingTable.GetIndexes()
-		primaryKey := existingIndexes.ByName("PRIMARY")
-
-		// Check each new index for redundancy
-		for i, newIndex := range newIndexes {
-			// Check against existing indexes
-			if v := l.checkIndexRedundancy(tableName, newIndex, existingIndexes, primaryKey); v != nil {
-				violations = append(violations, *v)
-			}
-
-			// Check against other new indexes being added in the same ALTER
-			// (only check against indexes that come before this one to avoid duplicates)
-			for j := range i {
-				otherNewIndex := newIndexes[j]
-
-				// Check if newIndex is redundant to otherNewIndex
-				if isRedundantToIndex(newIndex, otherNewIndex) {
-					isDuplicate := len(newIndex.Columns) == len(otherNewIndex.Columns)
-					violations = append(violations, createRedundancyViolation(
-						tableName,
-						newIndex,
-						otherNewIndex,
-						isDuplicate,
-						false, // not redundant to PK
-					))
-					break // Only report first redundancy
-				}
-			}
-		}
-	}
-
-	return violations
-}
-
-// checkIndexRedundancy checks if a single index is redundant to any index in the provided list.
-// Returns a violation if redundancy is found, nil otherwise.
-func (l *RedundantIndexLinter) checkIndexRedundancy(tableName string, index statement.Index, existingIndexes statement.Indexes, primaryKey *statement.Index) *Violation {
-	// Check for redundant PK suffix first
-	if primaryKey != nil {
-		if hasRedundant, colCount := hasRedundantPKSuffix(index, *primaryKey); hasRedundant {
-			v := createPKSuffixViolation(tableName, index, *primaryKey, colCount)
-			return &v
-		}
-	}
-
-	// Check if redundant to any existing index
-	for _, existingIndex := range existingIndexes {
-		if isRedundantToIndex(index, existingIndex) {
-			isDuplicate := len(index.Columns) == len(existingIndex.Columns)
-			v := createRedundancyViolation(
-				tableName,
-				index,
-				existingIndex,
-				isDuplicate,
-				existingIndex.Type == "PRIMARY KEY",
-			)
-			return &v
-		}
-	}
-
-	return nil
-}
-
-// extractIndexesFromAlter extracts index definitions from an ALTER TABLE statement
-func (l *RedundantIndexLinter) extractIndexesFromAlter(alterStmt *ast.AlterTableStmt) []statement.Index {
-	var indexes []statement.Index
-
-	for _, spec := range alterStmt.Specs {
-		if spec.Tp == ast.AlterTableAddConstraint && spec.Constraint != nil {
-			index := l.constraintToIndex(spec.Constraint)
-			if index != nil {
-				indexes = append(indexes, *index)
-			}
-		}
-	}
-
-	return indexes
-}
-
-// constraintToIndex converts an ast.Constraint to a statement.Index
-func (l *RedundantIndexLinter) constraintToIndex(constraint *ast.Constraint) *statement.Index {
-	// Extract column names from the constraint
-	var columns []string
-	for _, key := range constraint.Keys {
-		if key.Column != nil {
-			columns = append(columns, key.Column.Name.O)
-		}
-	}
-
-	if len(columns) == 0 {
-		return nil
-	}
-
-	// Determine the index type
-	var indexType string
-	switch constraint.Tp { //nolint:exhaustive
-	case ast.ConstraintPrimaryKey:
-		indexType = "PRIMARY KEY"
-	case ast.ConstraintUniq, ast.ConstraintUniqKey, ast.ConstraintUniqIndex:
-		indexType = "UNIQUE"
-	case ast.ConstraintKey, ast.ConstraintIndex:
-		indexType = "INDEX"
-	case ast.ConstraintFulltext:
-		indexType = "FULLTEXT"
-	case ast.ConstraintSpatial:
-		indexType = "SPATIAL"
-	default:
-		// Not an index constraint (e.g., foreign key, check)
-		return nil
-	}
-
-	return &statement.Index{
-		Name:    constraint.Name,
-		Type:    indexType,
-		Columns: columns,
-		Raw:     constraint,
+	return Violation{
+		Linter:     &RedundantIndexLinter{},
+		Severity:   SeverityWarning,
+		Message:    message,
+		Location:   &Location{Table: tableName, Index: &index.Name},
+		Suggestion: &suggestion,
+		Context: map[string]any{
+			"index_name":          index.Name,
+			"full_columns":        index.Columns,
+			"redundant_prefix":    redundantPrefix,
+			"useful_columns":      usefulSuffix,
+			"primary_key_columns": primaryKey.Columns,
+			"redundant_col_count": redundantColCount,
+		},
 	}
 }

--- a/pkg/lint/lint_redundant_indexes.go
+++ b/pkg/lint/lint_redundant_indexes.go
@@ -103,16 +103,41 @@ func (l *RedundantIndexLinter) checkTableIndexes(table *statement.CreateTable) [
 }
 
 // isRedundantToIndex checks if indexA is redundant to indexB.
-// Returns true if indexA is a prefix of indexB OR if they're duplicates.
+// Returns true if indexA is a prefix of indexB OR if they're duplicates,
+// AND any constraint indexA enforces is also enforced by indexB.
 func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
-	// Type compatibility check
-	if !canMakeRedundant(indexB, indexA) {
+	// FULLTEXT and SPATIAL indexes serve specialized purposes and are not
+	// interchangeable with B-tree indexes (or each other).
+	if indexA.Type == "FULLTEXT" || indexA.Type == "SPATIAL" ||
+		indexB.Type == "FULLTEXT" || indexB.Type == "SPATIAL" {
+		return false
+	}
+
+	// PRIMARY KEY is a table-level constraint (clustered key, uniqueness,
+	// implicit NOT NULL) that cannot be dropped in favor of another index —
+	// not even a column-for-column duplicate. Reporting it as redundant
+	// would suggest an unsafe rewrite, so never flag it.
+	if indexA.Type == "PRIMARY KEY" {
 		return false
 	}
 
 	// indexA cannot be redundant if it has MORE columns than indexB
 	if len(indexA.Columns) > len(indexB.Columns) {
 		return false
+	}
+
+	// A UNIQUE index enforces uniqueness over its exact column set. A wider
+	// covering index (UNIQUE or PK on more columns) enforces a *different*
+	// uniqueness scope and so does not subsume the constraint. UNIQUE is
+	// therefore only redundant when an exact-column-set duplicate also
+	// enforces uniqueness over those columns.
+	if indexA.Type == "UNIQUE" {
+		if len(indexA.Columns) != len(indexB.Columns) {
+			return false
+		}
+		if indexB.Type != "UNIQUE" && indexB.Type != "PRIMARY KEY" {
+			return false
+		}
 	}
 
 	// Check if all columns of indexA match the prefix of indexB in exact order
@@ -126,30 +151,6 @@ func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 	// - A prefix of indexB (len(indexA) < len(indexB)), OR
 	// - A duplicate of indexB (len(indexA) == len(indexB))
 	// Both cases are redundant!
-	return true
-}
-
-// canMakeRedundant checks if the covering index can make the redundant index redundant
-// based on their types. Different index types serve different purposes.
-func canMakeRedundant(covering statement.Index, redundant statement.Index) bool {
-	// FULLTEXT and SPATIAL indexes serve special purposes
-	// Regular indexes cannot make them redundant, and they can't make others redundant
-	if redundant.Type == "FULLTEXT" || redundant.Type == "SPATIAL" ||
-		covering.Type == "FULLTEXT" || covering.Type == "SPATIAL" {
-		return false
-	}
-
-	// PRIMARY KEY can make most indexes redundant (it acts like a UNIQUE index)
-	if covering.Type == "PRIMARY KEY" {
-		return true
-	}
-
-	// UNIQUE indexes provide additional constraints beyond lookup
-	// A non-unique index cannot make a UNIQUE index redundant
-	if redundant.Type == "UNIQUE" && covering.Type != "UNIQUE" {
-		return false
-	}
-
 	return true
 }
 

--- a/pkg/lint/lint_redundant_indexes_test.go
+++ b/pkg/lint/lint_redundant_indexes_test.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/block/spirit/pkg/statement"
@@ -895,16 +896,23 @@ func TestRedundantIndexLinter_AlterTableOnNonExistentTable(t *testing.T) {
 	require.Empty(t, violations)
 }
 
-// TestRedundantIndexLinter_PKNotFlaggedAsRedundant is a regression test for the
-// case where a secondary index whose leading columns match the PRIMARY KEY
-// caused the PRIMARY KEY itself to be reported as redundant. The PRIMARY KEY
-// is a constraint (clustered key + uniqueness + NOT NULL) that cannot be
-// dropped in favor of another index, so it must never be flagged as redundant.
+// TestRedundantIndexLinter_PKNotFlaggedAsRedundant is a regression test for
+// two issues reported together:
+//
+//  1. A secondary index whose leading columns match the PRIMARY KEY caused
+//     the PRIMARY KEY itself to be reported as redundant. The PRIMARY KEY is
+//     a constraint (clustered key + uniqueness + NOT NULL) and cannot be
+//     dropped in favor of another index, so it must never be flagged.
+//  2. The leading-PK secondary index itself should be flagged as redundant —
+//     in InnoDB the PK is the clustered key and secondary indexes auto-append
+//     PK columns, so a leading PK column contributes no lookup capability
+//     that the PK or a non-PK-leading variant of the index wouldn't already
+//     provide.
 //
 // Scenario: a table is left with both PRIMARY KEY (id) and a secondary index
-// (id, parent_id, created_at). When the secondary index is about to be dropped,
-// the existing-table view of the schema still contains both, and the old
-// behavior emitted a misleading "drop PRIMARY KEY in favor of 'id'" warning.
+// (id, parent_id, created_at). The linter should fire on the secondary index
+// (not on the PRIMARY KEY), and only when the redundant index is present in
+// the post-state.
 func TestRedundantIndexLinter_PKNotFlaggedAsRedundant(t *testing.T) {
 	createTable := `CREATE TABLE t1 (
 		id INT NOT NULL AUTO_INCREMENT,
@@ -924,13 +932,180 @@ func TestRedundantIndexLinter_PKNotFlaggedAsRedundant(t *testing.T) {
 
 	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
 
+	flagged := make(map[string]string)
 	for _, v := range violations {
 		if v.Location == nil || v.Location.Index == nil {
 			continue
 		}
 		require.NotEqual(t, "PRIMARY", *v.Location.Index,
 			"PRIMARY KEY must never be flagged as redundant; got: %s", v.Message)
+		flagged[*v.Location.Index] = v.Message
 	}
+
+	require.Contains(t, flagged, "id_parent_created",
+		"leading-PK secondary index should be flagged as redundant")
+	require.Contains(t, flagged["id_parent_created"], "leads with PRIMARY KEY")
+}
+
+// TestRedundantIndexLinter_PKPrefixRedundancy covers the leading-PK rule.
+func TestRedundantIndexLinter_PKPrefixRedundancy(t *testing.T) {
+	tests := []struct {
+		name           string
+		createTable    string
+		expectViolated bool
+		violatedIndex  string
+	}{
+		{
+			name: "INDEX (id, a, b) leading single-column PK is redundant",
+			createTable: `CREATE TABLE t1 (
+				id INT PRIMARY KEY,
+				a INT,
+				b INT,
+				INDEX idx (id, a, b)
+			)`,
+			expectViolated: true,
+			violatedIndex:  "idx",
+		},
+		{
+			name: "INDEX (a, b, c) leading composite PK is redundant",
+			createTable: `CREATE TABLE t1 (
+				a INT,
+				b INT,
+				c INT,
+				PRIMARY KEY (a, b),
+				INDEX idx (a, b, c)
+			)`,
+			expectViolated: true,
+			violatedIndex:  "idx",
+		},
+		{
+			name: "INDEX (a, c) with PK (a, b) — only partial PK at start, not flagged",
+			createTable: `CREATE TABLE t1 (
+				a INT,
+				b INT,
+				c INT,
+				PRIMARY KEY (a, b),
+				INDEX idx (a, c)
+			)`,
+			expectViolated: false,
+		},
+		{
+			name: "INDEX (a, b) with PK (a, b) is a duplicate, not a PK-prefix violation",
+			createTable: `CREATE TABLE t1 (
+				a INT,
+				b INT,
+				PRIMARY KEY (a, b),
+				INDEX idx (a, b)
+			)`,
+			expectViolated: false, // duplicate-of-PK rule fires instead
+		},
+		{
+			name: "INDEX (b, a, c) with PK (a, b) — different order, not flagged",
+			createTable: `CREATE TABLE t1 (
+				a INT,
+				b INT,
+				c INT,
+				PRIMARY KEY (a, b),
+				INDEX idx (b, a, c)
+			)`,
+			expectViolated: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := &RedundantIndexLinter{}
+			ct, err := statement.ParseCreateTable(tt.createTable)
+			require.NoError(t, err)
+
+			violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+
+			found := false
+			for _, v := range violations {
+				if v.Location != nil && v.Location.Index != nil && *v.Location.Index == tt.violatedIndex {
+					if strings.Contains(v.Message, "leads with PRIMARY KEY") {
+						found = true
+						break
+					}
+				}
+			}
+			if tt.expectViolated {
+				require.True(t, found, "Expected PK-prefix violation for index %s", tt.violatedIndex)
+			} else {
+				require.False(t, found, "Did not expect PK-prefix violation, got violations: %v", violations)
+			}
+		})
+	}
+}
+
+// TestRedundantIndexLinter_PostStateEvaluation verifies that the linter
+// evaluates the post-state of the schema (existing tables with pending
+// changes applied), matching the convention from #840. ADD INDEX should
+// surface redundancies as they are introduced, and DROP INDEX should
+// silence redundancies that are being removed.
+func TestRedundantIndexLinter_PostStateEvaluation(t *testing.T) {
+	existing := `CREATE TABLE t1 (
+		id INT NOT NULL AUTO_INCREMENT,
+		parent_id INT NOT NULL,
+		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		PRIMARY KEY (id),
+		KEY id_parent_created (id, parent_id, created_at),
+		KEY parent_id (parent_id),
+		KEY created_at (created_at)
+	)`
+
+	existingCT, err := statement.ParseCreateTable(existing)
+	require.NoError(t, err)
+	linter := &RedundantIndexLinter{}
+
+	// With no pending changes, the redundant index in the table should be
+	// flagged.
+	violations := linter.Lint([]*statement.CreateTable{existingCT}, nil)
+	flagged := false
+	for _, v := range violations {
+		if v.Location != nil && v.Location.Index != nil && *v.Location.Index == "id_parent_created" {
+			flagged = true
+		}
+	}
+	require.True(t, flagged, "should flag the redundant index in pre-state when no DROP is pending")
+
+	// Pending ALTER DROP INDEX should remove the redundant index from the
+	// post-state, silencing the warning.
+	dropStmts, err := statement.New("ALTER TABLE t1 DROP INDEX id_parent_created")
+	require.NoError(t, err)
+
+	violations = linter.Lint([]*statement.CreateTable{existingCT}, dropStmts)
+	for _, v := range violations {
+		if v.Location != nil && v.Location.Index != nil {
+			require.NotEqual(t, "id_parent_created", *v.Location.Index,
+				"DROP INDEX should silence the warning, got: %s", v.Message)
+		}
+	}
+
+	// Inverse: starting from a clean table, ALTER ADD INDEX that introduces a
+	// leading-PK index should surface the warning at ADD time.
+	cleanExisting := `CREATE TABLE t1 (
+		id INT NOT NULL AUTO_INCREMENT,
+		parent_id INT NOT NULL,
+		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		PRIMARY KEY (id),
+		KEY parent_id (parent_id),
+		KEY created_at (created_at)
+	)`
+	cleanCT, err := statement.ParseCreateTable(cleanExisting)
+	require.NoError(t, err)
+
+	addStmts, err := statement.New("ALTER TABLE t1 ADD INDEX id_parent_created (id, parent_id, created_at)")
+	require.NoError(t, err)
+
+	violations = linter.Lint([]*statement.CreateTable{cleanCT}, addStmts)
+	flaggedAtAdd := false
+	for _, v := range violations {
+		if v.Location != nil && v.Location.Index != nil && *v.Location.Index == "id_parent_created" {
+			flaggedAtAdd = true
+		}
+	}
+	require.True(t, flaggedAtAdd, "ADD INDEX should surface the leading-PK warning at the time the index is introduced")
 }
 
 // TestRedundantIndexLinter_AlterTableComplex tests a complex scenario

--- a/pkg/lint/lint_redundant_indexes_test.go
+++ b/pkg/lint/lint_redundant_indexes_test.go
@@ -463,7 +463,10 @@ func TestRedundantIndexLinter_TypeCompatibility(t *testing.T) {
 			expectViolated: false,
 		},
 		{
-			name: "UNIQUE (a) redundant to UNIQUE (a, b)",
+			// UNIQUE (a) and UNIQUE (a, b) enforce different uniqueness scopes:
+			// the former forbids duplicate values of `a`, the latter only forbids
+			// duplicate (a, b) pairs. Dropping UNIQUE (a) would weaken the schema.
+			name: "UNIQUE (a) NOT redundant to UNIQUE (a, b)",
 			createTable: `CREATE TABLE t1 (
 				id INT PRIMARY KEY,
 				a INT,
@@ -471,18 +474,20 @@ func TestRedundantIndexLinter_TypeCompatibility(t *testing.T) {
 				UNIQUE idx_a (a),
 				UNIQUE idx_ab (a, b)
 			)`,
-			expectViolated: true,
+			expectViolated: false,
 			violatedIndex:  "idx_a",
 		},
 		{
-			name: "UNIQUE (a) redundant to PK (a, b)",
+			// PRIMARY KEY (a, b) only forbids duplicate (a, b) pairs; it does
+			// not subsume the stricter UNIQUE (a) constraint.
+			name: "UNIQUE (a) NOT redundant to PK (a, b)",
 			createTable: `CREATE TABLE t1 (
 				a INT,
 				b INT,
 				PRIMARY KEY (a, b),
 				UNIQUE idx_a (a)
 			)`,
-			expectViolated: true,
+			expectViolated: false,
 			violatedIndex:  "idx_a",
 		},
 		{
@@ -735,17 +740,30 @@ func TestRedundantIndexLinter_AlterTableAddRedundantIndex(t *testing.T) {
 			messageContains: "PRIMARY KEY",
 		},
 		{
-			name: "ADD UNIQUE redundant to existing UNIQUE",
+			// Adding UNIQUE (a) alongside UNIQUE (a, b) is *not* redundant —
+			// the two enforce different uniqueness scopes.
+			name: "ADD UNIQUE NOT redundant to wider existing UNIQUE",
 			existingTable: `CREATE TABLE t1 (
 				id INT PRIMARY KEY,
 				a INT,
 				b INT,
 				UNIQUE KEY idx_ab (a, b)
 			)`,
-			alterSQL:        "ALTER TABLE t1 ADD UNIQUE KEY idx_a (a)",
+			alterSQL:       "ALTER TABLE t1 ADD UNIQUE KEY idx_a (a)",
+			expectViolated: false,
+		},
+		{
+			name: "ADD UNIQUE duplicate of existing UNIQUE",
+			existingTable: `CREATE TABLE t1 (
+				id INT PRIMARY KEY,
+				a INT,
+				b INT,
+				UNIQUE KEY idx_ab (a, b)
+			)`,
+			alterSQL:        "ALTER TABLE t1 ADD UNIQUE KEY idx_ab_dup (a, b)",
 			expectViolated:  true,
-			violatedIndex:   "idx_a",
-			messageContains: "redundant",
+			violatedIndex:   "idx_ab_dup",
+			messageContains: "duplicate",
 		},
 		{
 			name: "ADD INDEX with PK suffix redundancy",
@@ -875,6 +893,44 @@ func TestRedundantIndexLinter_AlterTableOnNonExistentTable(t *testing.T) {
 
 	// Should not crash and should return no violations
 	require.Empty(t, violations)
+}
+
+// TestRedundantIndexLinter_PKNotFlaggedAsRedundant is a regression test for the
+// case where a secondary index whose leading columns match the PRIMARY KEY
+// caused the PRIMARY KEY itself to be reported as redundant. The PRIMARY KEY
+// is a constraint (clustered key + uniqueness + NOT NULL) that cannot be
+// dropped in favor of another index, so it must never be flagged as redundant.
+//
+// Scenario: a table is left with both PRIMARY KEY (id) and a secondary index
+// (id, parent_id, created_at). When the secondary index is about to be dropped,
+// the existing-table view of the schema still contains both, and the old
+// behavior emitted a misleading "drop PRIMARY KEY in favor of 'id'" warning.
+func TestRedundantIndexLinter_PKNotFlaggedAsRedundant(t *testing.T) {
+	createTable := `CREATE TABLE t1 (
+		id INT NOT NULL AUTO_INCREMENT,
+		parent_id INT NOT NULL,
+		payload LONGTEXT,
+		note TEXT,
+		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		PRIMARY KEY (id),
+		KEY id_parent_created (id, parent_id, created_at),
+		KEY parent_id (parent_id),
+		KEY created_at (created_at)
+	)`
+
+	linter := &RedundantIndexLinter{}
+	ct, err := statement.ParseCreateTable(createTable)
+	require.NoError(t, err)
+
+	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+
+	for _, v := range violations {
+		if v.Location == nil || v.Location.Index == nil {
+			continue
+		}
+		require.NotEqual(t, "PRIMARY", *v.Location.Index,
+			"PRIMARY KEY must never be flagged as redundant; got: %s", v.Message)
+	}
 }
 
 // TestRedundantIndexLinter_AlterTableComplex tests a complex scenario


### PR DESCRIPTION
Closes #854.

## Summary

Two fixes for the `redundant_indexes` linter, addressing both halves of the original report.

### 1. PRIMARY KEY / narrower UNIQUE never redundant

Tighten `isRedundantToIndex` so:
- `PRIMARY KEY` is never flagged as redundant — it's a constraint (clustered key, uniqueness, implicit `NOT NULL`) that cannot be replaced by another index, even a column-for-column duplicate.
- A `UNIQUE` index is only redundant to a same-column-set `UNIQUE` or `PRIMARY KEY`. A wider covering enforces a *different* uniqueness scope (e.g. `UNIQUE (a, b)` does not subsume `UNIQUE (a)`).
- Type compatibility was previously a separate `canMakeRedundant(covering, redundant)` helper; folded inline so the column-length and prefix checks only run for combinations that are actually substitutable.

### 2. Post-state evaluation + leading-PK detection

The linter previously walked the pre-ALTER schema (`CreateTableStatements`), so an `ALTER DROP INDEX` made the linter see the still-present redundant index and fire — at the wrong time. Two changes:

- Switch to `PostState` (the helper [#840](https://github.com/block/spirit/pull/840) introduced for the column-based linters). Warnings now surface when a redundant index is being introduced, and stay silent when it is being removed.
- Add `hasRedundantPKPrefix` mirroring the existing `hasRedundantPKSuffix` check: a secondary index that leads with the full PRIMARY KEY is flagged. The leading PK column(s) add no lookup capability that the clustered index — or a non-PK-leading variant of the same index, with PK auto-appended — wouldn't already provide. Narrowed to *full* PK at the start so it does not false-positive on partial-PK-prefix indexes that are legitimate covering indexes.

The dedicated ALTER-handling path (`checkAlterTableStatements` and its `extractIndexesFromAlter` / `constraintToIndex` / `checkIndexRedundancy` helpers, ~120 lines) becomes redundant once `PostState` applies ALTER specs into the table view, and is removed.

The follow-on migration of the remaining linters to `PostState` lives in #856 as its own PR.

## Repro before this PR

```sql
CREATE TABLE t1 (
  id INT NOT NULL AUTO_INCREMENT,
  parent_id INT NOT NULL,
  payload LONGTEXT,
  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
  PRIMARY KEY (id),
  KEY id_parent_created (id, parent_id, created_at),
  KEY parent_id (parent_id),
  KEY created_at (created_at)
);
```

Old behavior:
- Adding `KEY (id, parent_id, created_at)`: **no warning**.
- Dropping it later: warned that `PRIMARY` was redundant to `id_parent_created` — backwards.

New behavior:
- Adding `KEY (id, parent_id, created_at)`: warns that the index leads with PRIMARY KEY columns.
- Dropping it later: silent.

## Test plan

- [x] `go test ./pkg/lint/ -count=1` — passes
- [x] `go test ./pkg/migration/ -run TestLint -count=1` — passes
- [x] `TestRedundantIndexLinter_PKNotFlaggedAsRedundant` — exact reproducer; asserts `PRIMARY` is *not* flagged and the leading-PK secondary *is*.
- [x] `TestRedundantIndexLinter_PKPrefixRedundancy` — table-driven coverage for the new rule: full-PK at start flagged, partial-PK at start not flagged, duplicate-of-PK deferred to the duplicate rule, out-of-order PK columns not flagged.
- [x] `TestRedundantIndexLinter_PostStateEvaluation` — `ALTER DROP INDEX` silences the warning, `ALTER ADD INDEX` introduces it.
- [x] Three pre-existing test cases that asserted `UNIQUE (a)` was redundant to `UNIQUE (a, b)` / `PRIMARY KEY (a, b)` updated to assert the correct (constraint-aware) behavior, with a new positive case for an exact-duplicate `UNIQUE` so coverage isn't lost.