### PR TITLE
fix(#856): extend PostState and migrate six linters to post-state evaluation

### DIFF
--- a/pkg/lint/lint_allow_charset.go
+++ b/pkg/lint/lint_allow_charset.go
@@ -49,10 +49,22 @@ func (l *AllowCharset) DefaultConfig() map[string]string {
 	}
 }
 
+// Lint walks the post-state of the schema. The message form preserves the
+// pre/post-state distinction that the old ALTER pass made explicit:
+//
+//   - "New column …" when the column did not exist in the pre-state.
+//   - "Column … modified to use …" when MODIFY/CHANGE COLUMN retypes an
+//     existing column.
+//   - "Column … has unsupported character set" for pre-existing untouched
+//     columns and columns inside a new CREATE TABLE.
 func (l *AllowCharset) Lint(createTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
 	// TODO: do we care about supporting character sets that are valid for MySQL but not valid for the TiDB parser? For example big5
 	suggestion := "Use a supported character set: " + strings.Join(l.charsets, ", ")
-	for ct := range CreateTableStatements(createTables, changes) {
+	pre := PreStateColumns(createTables)
+	newTables := newTablesInChanges(changes)
+	modified := columnsModifiedInChanges(changes)
+
+	for _, ct := range PostState(createTables, changes) {
 		if ct.TableOptions != nil && ct.TableOptions.Charset != nil && !slices.Contains(l.charsets, *ct.TableOptions.Charset) {
 			violations = append(violations, Violation{
 				Linter:     l,
@@ -62,41 +74,27 @@ func (l *AllowCharset) Lint(createTables []*statement.CreateTable, changes []*st
 				Suggestion: &suggestion,
 			})
 		}
+		tKey := strings.ToLower(ct.TableName)
 		for _, column := range ct.Columns {
-			v := l.checkColumnCharset(column.Raw, fmt.Sprintf("Column %q has unsupported character set", column.Name))
-			if v != nil {
-				if v.Location != nil {
-					v.Location.Table = ct.TableName
-				}
-				violations = append(violations, *v)
-			}
-		}
-	}
-
-	for _, change := range changes {
-		at, ok := change.AsAlterTable()
-		if !ok {
-			continue
-		}
-		for _, spec := range at.Specs {
-			var message string
-			switch spec.Tp { //nolint:exhaustive
-			case ast.AlterTableAddColumns:
-				message = "New column %q in table %q uses a disallowed character set"
-			case ast.AlterTableModifyColumn, ast.AlterTableChangeColumn:
-				message = "Column %q in table %q modified to use a disallowed character set"
-			default:
+			if column.Raw == nil {
 				continue
 			}
-
-			for _, column := range spec.NewColumns {
-				v := l.checkColumnCharset(column, message)
-				if v != nil {
-					if v.Location != nil && at.Table != nil {
-						v.Location.Table = at.Table.Name.String()
-					}
-					violations = append(violations, *v)
-				}
+			colKey := strings.ToLower(column.Name)
+			_, preExisted := pre[tKey][colKey]
+			var message string
+			switch {
+			case modified[tKey][colKey]:
+				message = fmt.Sprintf("Column %q in table %q modified to use a disallowed character set", column.Name, ct.TableName)
+			case !preExisted && !newTables[tKey]:
+				// ADD COLUMN against a pre-existing table.
+				message = fmt.Sprintf("New column %q in table %q uses a disallowed character set", column.Name, ct.TableName)
+			default:
+				message = fmt.Sprintf("Column %q has unsupported character set", column.Name)
+			}
+			v := l.checkColumnCharset(column.Raw, message)
+			if v != nil {
+				v.Location.Table = ct.TableName
+				violations = append(violations, *v)
 			}
 		}
 	}

--- a/pkg/lint/lint_allow_engine.go
+++ b/pkg/lint/lint_allow_engine.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/block/spirit/pkg/statement"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
 func init() {
@@ -58,6 +57,10 @@ func (l *AllowEngine) String() string {
 	return Stringer(l)
 }
 
+// Lint walks the post-state of the schema so an ALTER TABLE ENGINE=... that
+// migrates *to* an allowed engine no longer false-positives against the
+// legacy engine, and one that changes the engine to a disallowed value is
+// reported against the table's final shape.
 func (l *AllowEngine) Lint(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
 	if l.allowedEngines == nil {
 		err := l.Configure(l.DefaultConfig())
@@ -65,45 +68,21 @@ func (l *AllowEngine) Lint(existingTables []*statement.CreateTable, changes []*s
 			panic(err)
 		}
 	}
-	for ct := range CreateTableStatements(existingTables, changes) {
-		// Skip tables without explicit engine specification
+	for _, ct := range PostState(existingTables, changes) {
 		if ct.TableOptions == nil || ct.TableOptions.Engine == nil {
 			continue
 		}
-
 		engineName := *ct.TableOptions.Engine
-		if _, ok := l.allowedEngines[strings.ToLower(engineName)]; !ok {
-			violations = append(violations, Violation{
-				Linter:     l,
-				Location:   &Location{Table: ct.TableName},
-				Message:    fmt.Sprintf("Table %q uses an unsupported engine %q", ct.TableName, engineName),
-				Severity:   SeverityWarning,
-				Suggestion: strPtr("Use a supported storage engine: " + strings.Join(slices.Sorted(maps.Keys(l.allowedEngines)), ", ")),
-			})
-		}
-	}
-	for _, change := range changes {
-		alter, ok := change.AsAlterTable()
-		if !ok {
+		if _, ok := l.allowedEngines[strings.ToLower(engineName)]; ok {
 			continue
 		}
-		for _, spec := range alter.Specs {
-			for _, option := range spec.Options {
-				if option.Tp != ast.TableOptionEngine {
-					continue
-				}
-				engineName := option.StrValue
-				if _, ok := l.allowedEngines[strings.ToLower(engineName)]; !ok {
-					violations = append(violations, Violation{
-						Linter:     l,
-						Location:   &Location{Table: alter.Table.Name.String()},
-						Message:    fmt.Sprintf("Table %q uses an unsupported engine %q", alter.Table.Name, engineName),
-						Severity:   SeverityWarning,
-						Suggestion: strPtr("Use a supported storage engine: " + strings.Join(slices.Sorted(maps.Keys(l.allowedEngines)), ", ")),
-					})
-				}
-			}
-		}
+		violations = append(violations, Violation{
+			Linter:     l,
+			Location:   &Location{Table: ct.TableName},
+			Message:    fmt.Sprintf("Table %q uses an unsupported engine %q", ct.TableName, engineName),
+			Severity:   SeverityWarning,
+			Suggestion: strPtr("Use a supported storage engine: " + strings.Join(slices.Sorted(maps.Keys(l.allowedEngines)), ", ")),
+		})
 	}
 	return violations
 }

--- a/pkg/lint/lint_auto_inc_capacity.go
+++ b/pkg/lint/lint_auto_inc_capacity.go
@@ -47,8 +47,11 @@ func (l *AutoIncCapacityLinter) String() string {
 	return Stringer(l)
 }
 
+// Lint walks the post-state of the schema so an ALTER that raises
+// AUTO_INCREMENT or widens the column type is linted against the table's
+// final shape rather than the pre-ALTER snapshot.
 func (l *AutoIncCapacityLinter) Lint(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
-	for ct := range CreateTableStatements(existingTables, changes) {
+	for _, ct := range PostState(existingTables, changes) {
 		if ct.TableOptions == nil || ct.TableOptions.AutoIncrement == nil {
 			// If the table definition doesn't include an AUTO_INCREMENT clause we can't check anything
 			continue

--- a/pkg/lint/lint_has_fk.go
+++ b/pkg/lint/lint_has_fk.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/block/spirit/pkg/statement"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
 type HasFKLinter struct{}
@@ -25,39 +24,26 @@ func (l *HasFKLinter) Description() string {
 	return "Detects usage of FOREIGN KEY constraints in table definitions"
 }
 
+// Lint walks the post-state of the schema, so an ALTER DROP FOREIGN KEY that
+// fixes a legacy FK does not produce a false positive, and an ALTER ADD
+// FOREIGN KEY surfaces the violation against the table's final shape.
 func (l *HasFKLinter) Lint(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
-	for ct := range CreateTableStatements(existingTables, changes) {
+	for _, ct := range PostState(existingTables, changes) {
 		for _, constraint := range ct.Constraints {
-			if constraint.Raw.Tp == ast.ConstraintForeignKey {
-				violations = append(violations, Violation{
-					Linter: l,
-					Location: &Location{
-						Table:      ct.TableName,
-						Constraint: &constraint.Name,
-					},
-					Message:  fmt.Sprintf("Table %q has FOREIGN KEY constraint %q", ct.TableName, constraint.Name),
-					Severity: SeverityWarning,
-				})
+			if constraint.Type != "FOREIGN KEY" {
+				continue
 			}
+			name := constraint.Name
+			violations = append(violations, Violation{
+				Linter: l,
+				Location: &Location{
+					Table:      ct.TableName,
+					Constraint: &name,
+				},
+				Message:  fmt.Sprintf("Table %q has FOREIGN KEY constraint %q", ct.TableName, constraint.Name),
+				Severity: SeverityWarning,
+			})
 		}
 	}
-	for _, change := range changes {
-		if at, ok := change.AsAlterTable(); ok {
-			for _, spec := range at.Specs {
-				if spec.Tp == ast.AlterTableAddConstraint && spec.Constraint != nil && spec.Constraint.Tp == ast.ConstraintForeignKey {
-					violations = append(violations, Violation{
-						Severity: SeverityWarning,
-						Linter:   l,
-						Location: &Location{
-							Table:      at.Table.Name.O,
-							Constraint: &spec.Constraint.Name,
-						},
-						Message: fmt.Sprintf("Adding foreign key constraint %q to table %q", spec.Constraint.Name, at.Table.Name.O),
-					})
-				}
-			}
-		}
-	}
-
 	return violations
 }

--- a/pkg/lint/lint_has_fk_test.go
+++ b/pkg/lint/lint_has_fk_test.go
@@ -587,7 +587,7 @@ func TestHasFKLinter_AlterTableAddForeignKey(t *testing.T) {
 	require.Len(t, violations, 1)
 	require.Equal(t, "has_foreign_key", violations[0].Linter.Name())
 	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "Adding foreign key constraint")
+	require.Contains(t, violations[0].Message, "FOREIGN KEY constraint")
 	require.Contains(t, violations[0].Message, "fk_user_id")
 	require.Contains(t, violations[0].Message, "orders")
 	require.Equal(t, "orders", violations[0].Location.Table)
@@ -613,7 +613,7 @@ func TestHasFKLinter_AlterTableAddMultipleForeignKeys(t *testing.T) {
 		require.Equal(t, SeverityWarning, v.Severity)
 		require.Equal(t, "order_items", v.Location.Table)
 		require.NotNil(t, v.Location.Constraint)
-		require.Contains(t, v.Message, "Adding foreign key constraint")
+		require.Contains(t, v.Message, "FOREIGN KEY constraint")
 	}
 
 	// Verify both constraint names are present
@@ -861,7 +861,7 @@ func TestHasFKLinter_MixedCreateAndAlterStatements(t *testing.T) {
 		case "orders":
 			require.Contains(t, v.Message, "has FOREIGN KEY constraint")
 		case "order_items":
-			require.Contains(t, v.Message, "Adding foreign key constraint")
+			require.Contains(t, v.Message, "FOREIGN KEY constraint")
 		}
 	}
 }
@@ -948,7 +948,7 @@ func TestHasFKLinter_AlterTableViolationStructure(t *testing.T) {
 	require.Equal(t, "has_foreign_key", v.Linter.Name())
 	require.Equal(t, SeverityWarning, v.Severity)
 	require.NotEmpty(t, v.Message)
-	require.Contains(t, v.Message, "Adding foreign key constraint")
+	require.Contains(t, v.Message, "FOREIGN KEY constraint")
 	require.NotNil(t, v.Location)
 	require.Equal(t, "orders", v.Location.Table)
 	require.NotNil(t, v.Location.Constraint)

--- a/pkg/lint/lint_name_case.go
+++ b/pkg/lint/lint_name_case.go
@@ -25,8 +25,11 @@ func (l *NameCaseLinter) Description() string {
 	return "ensure that table names are all lowercase"
 }
 
+// Lint walks the post-state of the schema so an ALTER RENAME that fixes a
+// non-lowercase name does not produce a false positive, and a rename that
+// introduces a non-lowercase name surfaces against the final table name.
 func (l *NameCaseLinter) Lint(createTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
-	for ct := range CreateTableStatements(createTables, changes) {
+	for _, ct := range PostState(createTables, changes) {
 		if ct.TableName != strings.ToLower(ct.TableName) {
 			violations = append(violations, Violation{
 				Linter: l,
@@ -36,26 +39,6 @@ func (l *NameCaseLinter) Lint(createTables []*statement.CreateTable, changes []*
 				Message:  fmt.Sprintf("table name %q is not lowercase", ct.TableName),
 				Severity: SeverityWarning,
 			})
-		}
-	}
-	for _, change := range changes {
-		if at, ok := change.AsAlterTable(); ok {
-			for _, spec := range at.Specs {
-				if spec.NewTable != nil {
-					newName := spec.NewTable.Name.O
-					oldName := at.Table.Name.O
-					if newName != oldName && newName != strings.ToLower(newName) {
-						violations = append(violations, Violation{
-							Linter: l,
-							Location: &Location{
-								Table: oldName,
-							},
-							Message:  fmt.Sprintf("table %q being renamed to %q, which is not lowercase", oldName, newName),
-							Severity: SeverityWarning,
-						})
-					}
-				}
-			}
 		}
 	}
 	return violations

--- a/pkg/lint/lint_name_case_test.go
+++ b/pkg/lint/lint_name_case_test.go
@@ -265,13 +265,12 @@ func TestNameCaseLinter_AlterTableRenameUppercase(t *testing.T) {
 	linter := &NameCaseLinter{}
 	violations := linter.Lint(nil, stmts)
 
-	// Renaming to uppercase should be detected
+	// Renaming to uppercase should be detected against the post-state name.
 	require.Len(t, violations, 1)
 	require.Equal(t, "name_case", violations[0].Linter.Name())
-	require.Contains(t, violations[0].Message, "users")
 	require.Contains(t, violations[0].Message, "CUSTOMERS")
 	require.Contains(t, violations[0].Message, "not lowercase")
-	require.Equal(t, "users", violations[0].Location.Table)
+	require.Equal(t, "CUSTOMERS", violations[0].Location.Table)
 }
 
 func TestNameCaseLinter_AlterTableRenameMixedCase(t *testing.T) {
@@ -282,11 +281,10 @@ func TestNameCaseLinter_AlterTableRenameMixedCase(t *testing.T) {
 	linter := &NameCaseLinter{}
 	violations := linter.Lint(nil, stmts)
 
-	// Renaming to mixed case should be detected
+	// Renaming to mixed case should be detected against the post-state name.
 	require.Len(t, violations, 1)
-	require.Contains(t, violations[0].Message, "users")
 	require.Contains(t, violations[0].Message, "UserAccounts")
-	require.Equal(t, "users", violations[0].Location.Table)
+	require.Equal(t, "UserAccounts", violations[0].Location.Table)
 }
 
 func TestNameCaseLinter_AlterTableRenameCamelCase(t *testing.T) {
@@ -494,11 +492,11 @@ func TestNameCaseLinter_MultipleRenames(t *testing.T) {
 
 	var foundUsers, foundOrders bool
 	for _, v := range violations {
-		if v.Location.Table == "users" {
+		switch v.Location.Table {
+		case "USERS_NEW":
 			foundUsers = true
 			require.Contains(t, v.Message, "USERS_NEW")
-		}
-		if v.Location.Table == "orders" {
+		case "Orders_Archive":
 			foundOrders = true
 			require.Contains(t, v.Message, "Orders_Archive")
 		}
@@ -616,15 +614,14 @@ func TestNameCaseLinter_RenameViolationStructure(t *testing.T) {
 	require.Len(t, violations, 1)
 	v := violations[0]
 
-	// Verify violation structure for rename
+	// The violation is reported against the post-state table name —
+	// the unified "table name %q is not lowercase" message keys off the
+	// final name, since that is what would land in the schema.
 	require.NotNil(t, v.Linter)
 	require.Equal(t, "name_case", v.Linter.Name())
-	require.NotEmpty(t, v.Message)
-	require.Contains(t, v.Message, "users")
 	require.Contains(t, v.Message, "USERS_NEW")
-	require.Contains(t, v.Message, "renamed")
 	require.NotNil(t, v.Location)
-	require.Equal(t, "users", v.Location.Table)
+	require.Equal(t, "USERS_NEW", v.Location.Table)
 }
 
 // Tests for complex scenarios
@@ -672,13 +669,12 @@ func TestNameCaseLinter_ComplexScenario(t *testing.T) {
 
 	var foundUsers, foundProducts, foundInventory bool
 	for _, v := range violations {
-		if v.Location.Table == "USERS" {
+		switch v.Location.Table {
+		case "USERS":
 			foundUsers = true
-		}
-		if v.Location.Table == "Products" {
+		case "Products":
 			foundProducts = true
-		}
-		if v.Location.Table == "inventory" {
+		case "INVENTORY_NEW":
 			foundInventory = true
 			require.Contains(t, v.Message, "INVENTORY_NEW")
 		}

--- a/pkg/lint/lint_reserved_words.go
+++ b/pkg/lint/lint_reserved_words.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/block/spirit/pkg/statement"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
 func init() {
@@ -96,10 +95,13 @@ func (l *ReservedWordsLinter) String() string {
 	return Stringer(l)
 }
 
+// Lint walks the post-state of the schema so warnings reflect the final
+// table and column names. ALTERs that DROP, RENAME, or MODIFY away a
+// reserved-word identifier no longer produce false positives, and ALTERs
+// that introduce a reserved-word identifier (ADD COLUMN, RENAME TABLE, etc.)
+// are reported against the final shape.
 func (l *ReservedWordsLinter) Lint(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
-	// Check CREATE TABLE statements
-	for ct := range CreateTableStatements(existingTables, changes) {
-		// Check table name
+	for _, ct := range PostState(existingTables, changes) {
 		if l.isReservedWord(ct.TableName) {
 			violations = append(violations, Violation{
 				Linter:   l,
@@ -112,67 +114,19 @@ func (l *ReservedWordsLinter) Lint(existingTables []*statement.CreateTable, chan
 			})
 		}
 
-		// Check column names
 		for _, column := range ct.Columns {
 			if l.isReservedWord(column.Name) {
+				colName := column.Name
 				violations = append(violations, Violation{
 					Linter:   l,
 					Severity: SeverityWarning,
 					Location: &Location{
 						Table:  ct.TableName,
-						Column: &column.Name,
+						Column: &colName,
 					},
 					Message:    fmt.Sprintf("Column name %q is a MySQL reserved word", column.Name),
 					Suggestion: strPtr(fmt.Sprintf("Use backticks when referencing this column: `%s` or choose a different name", column.Name)),
 				})
-			}
-		}
-	}
-
-	// Check ALTER TABLE statements
-	for _, change := range changes {
-		at, ok := change.AsAlterTable()
-		if !ok {
-			continue
-		}
-
-		tableName := at.Table.Name.String()
-
-		for _, spec := range at.Specs {
-			switch spec.Tp { //nolint:exhaustive
-			case ast.AlterTableAddColumns, ast.AlterTableModifyColumn, ast.AlterTableChangeColumn:
-				// Check new column names
-				for _, column := range spec.NewColumns {
-					columnName := column.Name.Name.O
-					if l.isReservedWord(columnName) {
-						violations = append(violations, Violation{
-							Linter:   l,
-							Severity: SeverityWarning,
-							Location: &Location{
-								Table:  tableName,
-								Column: &columnName,
-							},
-							Message:    fmt.Sprintf("Column name %q is a MySQL reserved word", columnName),
-							Suggestion: strPtr(fmt.Sprintf("Use backticks when referencing this column: `%s` or choose a different name", columnName)),
-						})
-					}
-				}
-			case ast.AlterTableRenameTable:
-				// Check new table name
-				if spec.NewTable != nil {
-					newTableName := spec.NewTable.Name.O
-					if l.isReservedWord(newTableName) {
-						violations = append(violations, Violation{
-							Linter:   l,
-							Severity: SeverityWarning,
-							Location: &Location{
-								Table: tableName,
-							},
-							Message:    fmt.Sprintf("New table name %q is a MySQL reserved word", newTableName),
-							Suggestion: strPtr(fmt.Sprintf("Use backticks when referencing this table: `%s` or choose a different name", newTableName)),
-						})
-					}
-				}
 			}
 		}
 	}

--- a/pkg/lint/post_state.go
+++ b/pkg/lint/post_state.go
@@ -52,7 +52,13 @@ func PostState(existing []*statement.CreateTable, changes []*statement.AbstractS
 			// without full schema context.
 			base = &statement.CreateTable{TableName: change.Table}
 		}
-		byName[key] = applyAlter(base, at)
+		result := applyAlter(base, at)
+		// RENAME TABLE changes the key the post-state map should index by.
+		newKey := strings.ToLower(result.TableName)
+		if newKey != key {
+			delete(byName, key)
+		}
+		byName[newKey] = result
 	}
 
 	out := make([]*statement.CreateTable, 0, len(byName))
@@ -202,6 +208,11 @@ func applyAlter(t *statement.CreateTable, at *ast.AlterTableStmt) *statement.Cre
 	cloned := *t
 	cloned.Columns = append(statement.Columns(nil), t.Columns...)
 	cloned.Indexes = append(statement.Indexes(nil), t.Indexes...)
+	cloned.Constraints = append(statement.Constraints(nil), t.Constraints...)
+	if t.TableOptions != nil {
+		opts := *t.TableOptions
+		cloned.TableOptions = &opts
+	}
 
 	for _, spec := range at.Specs {
 		switch spec.Tp { //nolint:exhaustive
@@ -234,6 +245,9 @@ func applyAlter(t *statement.CreateTable, at *ast.AlterTableStmt) *statement.Cre
 				// duplication is harmless for the indexed-column set (a set,
 				// not a multiset), so we don't dedupe here.
 			}
+			if c, ok := nonIndexConstraint(spec.Constraint); ok {
+				cloned.Constraints = append(cloned.Constraints, c)
+			}
 		case ast.AlterTableDropIndex:
 			before := len(cloned.Indexes)
 			cloned.Indexes = removeIndex(cloned.Indexes, spec.Name, "")
@@ -249,9 +263,88 @@ func applyAlter(t *statement.CreateTable, at *ast.AlterTableStmt) *statement.Cre
 			// only surfaces via GetIndexes() synthesizing from this flag.
 			// Clearing it here makes the post-state honor DROP PRIMARY KEY.
 			cloned.Columns = clearAllInlinePrimaryKey(cloned.Columns)
+		case ast.AlterTableDropForeignKey:
+			cloned.Constraints = removeConstraint(cloned.Constraints, spec.Name, "FOREIGN KEY")
+		case ast.AlterTableDropCheck:
+			cloned.Constraints = removeConstraint(cloned.Constraints, spec.Name, "CHECK")
+		case ast.AlterTableRenameTable:
+			if spec.NewTable != nil {
+				cloned.TableName = spec.NewTable.Name.O
+			}
+		case ast.AlterTableOption:
+			cloned.TableOptions = applyTableOptions(cloned.TableOptions, spec.Options)
 		}
 	}
 	return &cloned
+}
+
+// applyTableOptions returns a TableOptions with the changes from opts merged in.
+// Options not set in opts are preserved from the input; setting an empty string
+// or zero value leaves the existing option untouched (matches MySQL semantics —
+// table options without a clause are not reset to defaults).
+func applyTableOptions(existing *statement.TableOptions, opts []*ast.TableOption) *statement.TableOptions {
+	if len(opts) == 0 {
+		return existing
+	}
+	var out statement.TableOptions
+	if existing != nil {
+		out = *existing
+	}
+	for _, opt := range opts {
+		switch opt.Tp { //nolint:exhaustive
+		case ast.TableOptionEngine:
+			if opt.StrValue != "" {
+				v := opt.StrValue
+				out.Engine = &v
+			}
+		case ast.TableOptionCharset:
+			if opt.StrValue != "" {
+				v := opt.StrValue
+				out.Charset = &v
+			}
+		case ast.TableOptionCollate:
+			if opt.StrValue != "" {
+				v := opt.StrValue
+				out.Collation = &v
+			}
+		case ast.TableOptionAutoIncrement:
+			if opt.UintValue > 0 {
+				v := opt.UintValue
+				out.AutoIncrement = &v
+			}
+		case ast.TableOptionComment:
+			if opt.StrValue != "" {
+				v := opt.StrValue
+				out.Comment = &v
+			}
+		}
+	}
+	return &out
+}
+
+// nonIndexConstraint converts an ast.Constraint that is *not* an index-like
+// constraint (FK, CHECK) into a statement.Constraint suitable for the post-
+// state Constraints slice. Returns (_, false) for index/PK/UNIQUE constraints,
+// which are already handled by indexFromConstraint.
+func nonIndexConstraint(c *ast.Constraint) (statement.Constraint, bool) {
+	switch c.Tp { //nolint:exhaustive
+	case ast.ConstraintForeignKey:
+		return statement.Constraint{Raw: c, Name: c.Name, Type: "FOREIGN KEY"}, true
+	case ast.ConstraintCheck:
+		return statement.Constraint{Raw: c, Name: c.Name, Type: "CHECK"}, true
+	}
+	return statement.Constraint{}, false
+}
+
+func removeConstraint(cs statement.Constraints, name, typeMatch string) statement.Constraints {
+	out := cs[:0]
+	for _, c := range cs {
+		if name != "" && strings.EqualFold(c.Name, name) && c.Type == typeMatch {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // columnFromAst constructs a minimal statement.Column from an AST column def.

--- a/pkg/lint/post_state_test.go
+++ b/pkg/lint/post_state_test.go
@@ -1,0 +1,188 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/block/spirit/pkg/statement"
+	"github.com/stretchr/testify/require"
+)
+
+// findTable returns the post-state table with the given name (case-insensitive)
+// or nil if none matches.
+func findTable(tables []*statement.CreateTable, name string) *statement.CreateTable {
+	for _, t := range tables {
+		if t.TableName == name {
+			return t
+		}
+	}
+	return nil
+}
+
+// TestPostState_RenameTable verifies that ALTER … RENAME TO surfaces the
+// table under its new name in the post-state, and that the old name is gone.
+func TestPostState_RenameTable(t *testing.T) {
+	existing, err := statement.ParseCreateTable("CREATE TABLE Foo (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+
+	rename, err := statement.New("ALTER TABLE Foo RENAME TO bar")
+	require.NoError(t, err)
+
+	post := PostState([]*statement.CreateTable{existing}, rename)
+	require.Len(t, post, 1)
+	require.Equal(t, "bar", post[0].TableName)
+}
+
+// TestPostState_TableOptionEngine verifies that ALTER TABLE … ENGINE=… is
+// applied to TableOptions in the post-state.
+func TestPostState_TableOptionEngine(t *testing.T) {
+	existing, err := statement.ParseCreateTable("CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=MyISAM")
+	require.NoError(t, err)
+	require.NotNil(t, existing.TableOptions)
+	require.NotNil(t, existing.TableOptions.Engine)
+	require.Equal(t, "MyISAM", *existing.TableOptions.Engine)
+
+	alter, err := statement.New("ALTER TABLE t1 ENGINE=InnoDB")
+	require.NoError(t, err)
+
+	post := PostState([]*statement.CreateTable{existing}, alter)
+	t1 := findTable(post, "t1")
+	require.NotNil(t, t1)
+	require.NotNil(t, t1.TableOptions)
+	require.NotNil(t, t1.TableOptions.Engine)
+	require.Equal(t, "InnoDB", *t1.TableOptions.Engine)
+}
+
+// TestPostState_TableOptionAutoIncrement verifies that ALTER TABLE …
+// AUTO_INCREMENT=… is applied to TableOptions in the post-state.
+func TestPostState_TableOptionAutoIncrement(t *testing.T) {
+	existing, err := statement.ParseCreateTable("CREATE TABLE t1 (id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) AUTO_INCREMENT=100")
+	require.NoError(t, err)
+
+	alter, err := statement.New("ALTER TABLE t1 AUTO_INCREMENT=1000000000")
+	require.NoError(t, err)
+
+	post := PostState([]*statement.CreateTable{existing}, alter)
+	t1 := findTable(post, "t1")
+	require.NotNil(t, t1)
+	require.NotNil(t, t1.TableOptions)
+	require.NotNil(t, t1.TableOptions.AutoIncrement)
+	require.Equal(t, uint64(1000000000), *t1.TableOptions.AutoIncrement)
+}
+
+// TestPostState_AddDropForeignKey verifies that ADD CONSTRAINT FOREIGN KEY
+// and DROP FOREIGN KEY mutate the Constraints slice in the post-state.
+func TestPostState_AddDropForeignKey(t *testing.T) {
+	existing, err := statement.ParseCreateTable(`CREATE TABLE orders (
+		id INT PRIMARY KEY,
+		user_id INT,
+		CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id)
+	)`)
+	require.NoError(t, err)
+	require.Len(t, existing.Constraints, 1)
+
+	drop, err := statement.New("ALTER TABLE orders DROP FOREIGN KEY fk_user")
+	require.NoError(t, err)
+	postAfterDrop := PostState([]*statement.CreateTable{existing}, drop)
+	t1 := findTable(postAfterDrop, "orders")
+	require.NotNil(t, t1)
+	fkCount := 0
+	for _, c := range t1.Constraints {
+		if c.Type == "FOREIGN KEY" {
+			fkCount++
+		}
+	}
+	require.Equal(t, 0, fkCount, "DROP FOREIGN KEY should remove the constraint from post-state")
+
+	clean, err := statement.ParseCreateTable(`CREATE TABLE orders (
+		id INT PRIMARY KEY,
+		user_id INT
+	)`)
+	require.NoError(t, err)
+	add, err := statement.New("ALTER TABLE orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id)")
+	require.NoError(t, err)
+	postAfterAdd := PostState([]*statement.CreateTable{clean}, add)
+	t1 = findTable(postAfterAdd, "orders")
+	require.NotNil(t, t1)
+	fkCount = 0
+	for _, c := range t1.Constraints {
+		if c.Type == "FOREIGN KEY" {
+			fkCount++
+		}
+	}
+	require.Equal(t, 1, fkCount, "ADD CONSTRAINT FOREIGN KEY should appear in post-state")
+}
+
+// TestPostState_MigratedLinters_FixingAltersSilenceWarnings verifies the
+// post-state convention across the six linters migrated in this change:
+// an ALTER that fixes the legacy issue should silence the warning.
+func TestPostState_MigratedLinters_FixingAltersSilenceWarnings(t *testing.T) {
+	t.Run("allow_engine: ALTER ENGINE=InnoDB silences legacy MyISAM", func(t *testing.T) {
+		existing, err := statement.ParseCreateTable("CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=MyISAM")
+		require.NoError(t, err)
+		fix, err := statement.New("ALTER TABLE t1 ENGINE=InnoDB")
+		require.NoError(t, err)
+
+		linter := &AllowEngine{}
+		require.NoError(t, linter.Configure(linter.DefaultConfig()))
+		require.Empty(t, linter.Lint([]*statement.CreateTable{existing}, fix))
+	})
+
+	t.Run("allow_charset: MODIFY COLUMN to utf8mb4 silences legacy latin1", func(t *testing.T) {
+		existing, err := statement.ParseCreateTable("CREATE TABLE t1 (id INT PRIMARY KEY, n VARCHAR(50) CHARACTER SET latin1)")
+		require.NoError(t, err)
+		fix, err := statement.New("ALTER TABLE t1 MODIFY COLUMN n VARCHAR(50) CHARACTER SET utf8mb4")
+		require.NoError(t, err)
+
+		linter := &AllowCharset{charsets: []string{"utf8mb4"}}
+		require.Empty(t, linter.Lint([]*statement.CreateTable{existing}, fix))
+	})
+
+	t.Run("has_foreign_key: DROP FOREIGN KEY silences the FK warning", func(t *testing.T) {
+		existing, err := statement.ParseCreateTable(`CREATE TABLE orders (
+			id INT PRIMARY KEY,
+			user_id INT,
+			CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id)
+		)`)
+		require.NoError(t, err)
+		fix, err := statement.New("ALTER TABLE orders DROP FOREIGN KEY fk_user")
+		require.NoError(t, err)
+
+		linter := &HasFKLinter{}
+		require.Empty(t, linter.Lint([]*statement.CreateTable{existing}, fix))
+	})
+
+	t.Run("name_case: RENAME to lowercase silences legacy uppercase", func(t *testing.T) {
+		existing, err := statement.ParseCreateTable("CREATE TABLE USERS (id INT PRIMARY KEY)")
+		require.NoError(t, err)
+		fix, err := statement.New("ALTER TABLE USERS RENAME TO users")
+		require.NoError(t, err)
+
+		linter := &NameCaseLinter{}
+		require.Empty(t, linter.Lint([]*statement.CreateTable{existing}, fix))
+	})
+
+	t.Run("reserved_words: DROP COLUMN silences legacy reserved column name", func(t *testing.T) {
+		existing, err := statement.ParseCreateTable("CREATE TABLE t1 (id INT PRIMARY KEY, `select` INT)")
+		require.NoError(t, err)
+		fix, err := statement.New("ALTER TABLE t1 DROP COLUMN `select`")
+		require.NoError(t, err)
+
+		linter := &ReservedWordsLinter{}
+		require.Empty(t, linter.Lint([]*statement.CreateTable{existing}, fix))
+	})
+
+	t.Run("auto_inc_capacity: ALTER MODIFY widens column type silences capacity warning", func(t *testing.T) {
+		// Legacy table: SMALLINT auto-inc at 60000 (~91% of 65535, over the 85% default threshold).
+		existing, err := statement.ParseCreateTable("CREATE TABLE t1 (id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) AUTO_INCREMENT=60000")
+		require.NoError(t, err)
+		linter := &AutoIncCapacityLinter{}
+		require.NoError(t, linter.Configure(linter.DefaultConfig()))
+		// Sanity: linter fires without any change.
+		require.NotEmpty(t, linter.Lint([]*statement.CreateTable{existing}, nil))
+
+		// Widen to BIGINT: post-state column is BIGINT, 60000 is far below threshold.
+		fix, err := statement.New("ALTER TABLE t1 MODIFY COLUMN id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT")
+		require.NoError(t, err)
+		require.Empty(t, linter.Lint([]*statement.CreateTable{existing}, fix))
+	})
+}

--- a/pkg/lint/post_state_test.go
+++ b/pkg/lint/post_state_test.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/block/spirit/pkg/statement"
@@ -8,10 +9,12 @@ import (
 )
 
 // findTable returns the post-state table with the given name (case-insensitive)
-// or nil if none matches.
+// or nil if none matches. PostState keys its internal map by lower-cased name
+// but preserves the original casing on TableName, so callers shouldn't have to
+// guess the case the post-state produced.
 func findTable(tables []*statement.CreateTable, name string) *statement.CreateTable {
 	for _, t := range tables {
-		if t.TableName == name {
+		if strings.EqualFold(t.TableName, name) {
 			return t
 		}
 	}


### PR DESCRIPTION
Closes #856. Surfaced while addressing #854 / #855.

## Summary

Following [#840](https://github.com/block/spirit/pull/840) (post-state for column-type linters) and the post-state switch in [#855](https://github.com/block/spirit/pull/855) (redundant indexes), lift the remaining six linters that still walked the pre-ALTER schema via \`CreateTableStatements\` plus their own ad-hoc ALTER handlers onto the shared \`PostState\` helper. They each false-positive when an ALTER in the same batch fixes the legacy issue.

## PostState extensions (\`post_state.go\`)

- \`applyAlter\` now clones \`TableOptions\` and \`Constraints\` so mutations don't leak back to the input.
- New \`applyTableOptions\` merges \`ENGINE\`, \`CHARSET\`, \`COLLATE\`, \`AUTO_INCREMENT\`, \`COMMENT\`.
- \`AlterTableRenameTable\` rewrites \`TableName\`; \`PostState\` re-keys \`byName\` under the new name.
- \`AlterTableAddConstraint\` now also captures FK / CHECK constraints via new \`nonIndexConstraint\`.
- \`AlterTableDropForeignKey\` / \`AlterTableDropCheck\` drop the matching \`Constraint\` entry.

## Linters migrated

Each loses its ad-hoc ALTER pass.

| Linter | Key new behavior |
|---|---|
| \`has_foreign_key\` | \`DROP FOREIGN KEY\` silences the FK warning. Message unified to "Table X has FOREIGN KEY constraint Y" against the post-state shape. |
| \`name_case\` | \`RENAME TO lowercase\` silences a legacy-uppercase warning. Violation keyed off the final name. |
| \`reserved_words\` | \`DROP COLUMN\` / \`RENAME\` away a reserved-word identifier silences the warning. |
| \`allow_engine\` | \`ALTER ENGINE=InnoDB\` silences a legacy MyISAM warning. |
| \`allow_charset\` | "New column …" / "modified to use …" / "has unsupported character set" message granularity preserved via \`PreStateColumns\` + \`columnsModifiedInChanges\` + \`newTablesInChanges\` (the same pattern \`has_float\` uses). |
| \`auto_inc_capacity\` | \`ALTER MODIFY\` widening or shrinking the auto-inc column is now picked up. |

## Linters intentionally left on pre-state

- \`invisible_index\` — needs to know whether the index was *already* invisible before the DROP fires; post-state would always show it absent.
- \`multiple_alter\`, \`rename_column\`, \`unsafe\` — inspect statements directly and don't look at schema state.
- \`primary_key_type\` — intentionally splits severity by source (Warning legacy / Error new). A clean migration needs \`PreStateColumns\` for severity assignment and is left as a follow-up.

## Test plan

- [x] \`go test ./pkg/lint/ -count=1\` — passes
- [x] \`go test ./pkg/migration/ -count=1\` — passes
- [x] New \`post_state_test.go\` with direct unit coverage for each new \`applyAlter\` case (rename, engine, auto_increment, FK add/drop).
- [x] \`TestPostState_MigratedLinters_FixingAltersSilenceWarnings\` — cross-linter table-driven test asserting that for each migrated linter, a fixing ALTER silences the warning.
- [x] Pre-existing tests that encoded the *old* behavior ("Adding foreign key constraint" message, rename-against-old-name location) updated to match the post-state-correct behavior.