### PR TITLE
fix(#861): allow `binary` charset by default in allow_charset linter

### DIFF
--- a/pkg/lint/README.md
+++ b/pkg/lint/README.md
@@ -180,7 +180,7 @@ Restricts which character sets are allowed for tables and columns. Helps enforce
 
 **Configuration Options:**
 
-- `charsets` (string): Comma-separated list of allowed character sets. Default: `"utf8mb4"`.
+- `charsets` (string): Comma-separated list of allowed character sets. Default: `"utf8mb4,binary"`. The `binary` charset covers JSON, BLOB, and spatial columns, which MySQL reports as having the `binary` character set.
 
 **Examples:**
 

--- a/pkg/lint/lint_allow_charset.go
+++ b/pkg/lint/lint_allow_charset.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	Register(&AllowCharset{
-		charsets: []string{"utf8mb4"},
+		charsets: []string{"utf8mb4", "binary"},
 	})
 }
 
@@ -45,7 +45,7 @@ func (l *AllowCharset) Configure(config map[string]string) error {
 
 func (l *AllowCharset) DefaultConfig() map[string]string {
 	return map[string]string{
-		"charsets": "utf8mb4",
+		"charsets": "utf8mb4,binary",
 	}
 }
 

--- a/pkg/lint/lint_allow_charset_test.go
+++ b/pkg/lint/lint_allow_charset_test.go
@@ -431,7 +431,7 @@ func TestDefaultConfig(t *testing.T) {
 	linter := AllowCharset{}
 	config := linter.DefaultConfig()
 	require.Contains(t, config, "charsets")
-	require.Equal(t, "utf8mb4", config["charsets"])
+	require.Equal(t, "utf8mb4,binary", config["charsets"])
 }
 
 // Tests for existing tables parameter


### PR DESCRIPTION
## Summary

- Adds `binary` to the default `allow_charset` allowlist (now `utf8mb4,binary`).
- MySQL reports JSON, BLOB, and spatial columns as having the `binary` character set, which produced unactionable warnings — those columns cannot be converted to `utf8mb4`.
- Updates `DefaultConfig()`, the test expectation, and the linter README.

Fixes #861.

## Test plan

- [x] `go test ./pkg/lint/` passes
- [x] Manually re-run `spirit lint` against a schema containing JSON / spatial / BLOB columns and confirm no `allow_charset` warnings fire
- [x] Confirm `latin1` / `utf8mb3` columns still warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)