### PR TITLE
fix: cleanup of remaining review items (cutover retry, binlog disambiguation, ...)

### DIFF
--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -445,6 +445,10 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 			if err != nil {
 				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", columnNames[i], err)
 			}
+			// datum.String() returns a complete pre-escaped SQL literal
+			// (NULL, a numeric, 0x… hex, or a "..."-quoted string). Safe
+			// to concatenate into the VALUES clause as-is — see the
+			// contract on Datum.String.
 			values = append(values, datum.String())
 		}
 		valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
@@ -767,6 +771,10 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 						results <- result{err: fmt.Errorf("failed to convert value to datum for column %s: %w", col, err)}
 						return
 					}
+					// datum.String() returns a complete pre-escaped SQL
+					// literal (NULL, a numeric, 0x… hex, or a "..."-quoted
+					// string). Safe to concatenate into the VALUES clause
+					// as-is — see the contract on Datum.String.
 					values = append(values, datum.String())
 				}
 				valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -331,6 +331,10 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 			if err != nil {
 				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", columnNames[i], err)
 			}
+			// datum.String() returns a complete pre-escaped SQL literal
+			// (NULL, a numeric, 0x… hex, or a "..."-quoted string). Safe
+			// to concatenate into the VALUES clause as-is — see the
+			// contract on Datum.String.
 			values = append(values, datum.String())
 		}
 		valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
@@ -541,6 +545,10 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.Col
 			if err != nil {
 				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", sourceColumnNames[i], err)
 			}
+			// datum.String() returns a complete pre-escaped SQL literal
+			// (NULL, a numeric, 0x… hex, or a "..."-quoted string). Safe
+			// to concatenate into the VALUES clause as-is — see the
+			// contract on Datum.String.
 			values = append(values, datum.String())
 		}
 		valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -61,6 +61,9 @@ func (c *CutOver) Run(ctx context.Context) error {
 		// - The RENAME TABLE connection
 		// - The Flush() threads
 		// Because we want to safely flush quickly, we set the limit to 5.
+		// Pool size grows monotonically and is not restored — the
+		// migration ends after cutover, so there is nothing to shrink
+		// back for. See the MaxOpenConnections doc in (*Runner).Run.
 		c.db.SetMaxOpenConns(5)
 	}
 	for i := range c.dbConfig.MaxRetries {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -183,6 +183,14 @@ func (r *Runner) Run(ctx context.Context) error {
 	// means that the replication applier can always make progress immediately,
 	// and does not need to wait for free slots from the copier *until* it needs
 	// copy in more than 1 thread.
+	//
+	// Pool size grows monotonically across migration phases — later phases
+	// (checksum, cutover) ratchet the limit upward via SetMaxOpenConns but
+	// never shrink it. That is deliberate: each phase's increase reflects
+	// its own connection budget, and by the time we're past the copy phase
+	// the copier/applier backpressure that motivated the starting +1 no
+	// longer applies. There is no point past which a smaller pool would
+	// help, so there is nothing to restore.
 	r.dbConfig.MaxOpenConnections = r.migration.Threads + 1
 	if r.migration.Buffered {
 		// Buffered has many more connections because it fans out x8 more write threads
@@ -1235,7 +1243,13 @@ func (r *Runner) checksum(ctx context.Context) error {
 	// - background flushing
 	// - checkpoint thread
 	// - checksum "replaceChunk" DB connections
-	// Handle a case just in the tests not having a dbConfig
+	// Handle a case just in the tests not having a dbConfig.
+	//
+	// Not restored when checksum completes — by then we are past the copy
+	// phase, so the +1 backpressure between copier and applier no longer
+	// applies, and the only thing left is cutover, which itself wants at
+	// least 5 connections. Pool size grows monotonically; see the
+	// MaxOpenConnections doc in (*Runner).Run.
 	r.db.SetMaxOpenConns(r.dbConfig.MaxOpenConnections + 2)
 
 	// Run the checksum with internal retry logic

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -276,14 +276,30 @@ func (d Datum) Range(d2 Datum) (uint64, error) {
 	return d.Val.(uint64) - d2.Val.(uint64), nil
 }
 
-// String returns the datum as a SQL-escaped literal. It is also
-// fmt.Stringer for log / debug formatting. The previous form panicked
-// when a non-numeric datum's Val was not a string; this form coerces
-// via %v so a misconstructed datum still produces a valid SQL fragment
-// (correctly escaped/quoted below) rather than crashing the migration.
-// NewDatum always normalizes Val to string for binaryType/unknownType,
-// so this coercion only fires for datums built by hand with an
-// unexpected Val type.
+// String returns the datum as a complete, self-contained SQL literal.
+// Every return path is safe to inline directly into a SQL statement
+// without further quoting or escaping by the caller:
+//
+//   - NULL                            for IsNil()
+//   - the numeric literal (e.g. 42)   for IsNumeric()
+//   - 0x... hex literal               for IsBinaryString()
+//   - "..." with backslash escapes    for everything else
+//
+// The string-literal path runs sqlescape.EscapeString on the contents
+// and wraps in double quotes, so callers like Chunk.String /
+// expandRowConstructorComparison / applier UpsertRows can construct
+// SQL by simple fmt.Sprintf concatenation. New code that has explicit
+// error handling available may prefer a typed accessor, but the
+// pre-escaped contract here is load-bearing for the migration's SQL
+// emission paths.
+//
+// It is also fmt.Stringer for log / debug output. The previous form
+// panicked when a non-numeric datum's Val was not a string; this form
+// coerces via %v so a misconstructed datum still produces a valid SQL
+// fragment rather than crashing the migration. NewDatum always
+// normalizes Val to string for binaryType/unknownType, so this
+// coercion only fires for datums built by hand with an unexpected Val
+// type.
 func (d Datum) String() string {
 	if d.IsNil() {
 		return "NULL"

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -90,6 +90,12 @@ func QuoteColumns(cols []string) string {
 // not always optimizing conditions such as (a,b,c) > (1,2,3).
 // This limitation is still current in 8.0, and was not fixed
 // by the work in https://dev.mysql.com/worklog/task/?id=7019
+//
+// vals[i].String() is inlined directly into the SQL fragment because
+// Datum.String() returns a pre-escaped self-contained SQL literal
+// (see its doc comment for the contract). Don't change the format
+// strings below to add quoting or escaping — the values already carry
+// it.
 func expandRowConstructorComparison(cols []string, operator Operator, vals []Datum) string {
 	if len(cols) != len(vals) {
 		panic("cols should be same size as values")


### PR DESCRIPTION
## Summary

Sweep of the remaining smaller correctness + clarity items from the post-review backlog. Branch name says \"docs\" because that's where it started; scope grew. Commits are split so any subset can be pulled out into a separate PR if preferred — let me know.

### Higher-impact fixes

**Cutover retry backoff + error joining + ctx-safe unlock** ([`cutover.go`](pkg/migration/cutover.go))
- Exponential backoff (100ms doubling, capped at 10s) between cutover retry attempts. Previously a failed cutover re-attempted immediately, which under transient lock contention worsened it. Sleep is ctx-aware.
- Collect every attempt's error and join with \`errors.Join\` on exit. Previously only the last attempt's err survived.
- Run \`UNLOCK TABLES\` with \`context.WithoutCancel\` so a parent-ctx cancel still releases the lock cleanly.

**\`binlogPositionIsImpossible\` / \`binlogFileExists\` distinguish \"purged\" from \"could not check\"** ([`client.go`](pkg/repl/client.go), [`runner.go`](pkg/migration/runner.go))
- Both previously returned a single bool that conflated \"file definitely missing\" with \"query failed.\" A transient network blip surfaced as \"binlog purged\" and triggered a full re-copy on resume — discarding potentially days of progress for a recoverable error.
- Both now return \`(bool, error)\`. Callers propagate the new error rather than collapse it.

### Defensive / DX

**Un-embed \`sync.Mutex\` on \`Client\`** ([`client.go`](pkg/repl/client.go))
- Embedded mutex exposed public \`Lock\` / \`Unlock\` on every \`*Client\` consumer, inviting accidental self-deadlocks (\`sync.Mutex\` is not re-entrant) or external lock-holding with no idea what fields it protects.
- Renamed to \`mu sync.Mutex\` (package-internal) with a doc comment listing the protected fields.
- No external callers exist today; this is a pure internal rename.

**Document \`continuousFlushMu\` held across \`checker.Run\`** ([`runner.go`](pkg/migration/runner.go))
- The periodic flush is paused for the duration of each continuous-checksum iteration. The existing comment explained why; this expands it to call out the operational consequence (binlog deltas accumulate, cutover under-lock flush drains them).
- Adds a \`logger.Info\` that emits the held duration when it exceeds the periodic-flush interval, so operators picking a cutover window on a long migration can see the pause cost.

### Quick wins

**\`pkValueEqual\` boolean / string collision** ([`utils.go`](pkg/repl/utils.go))
- \`fmt.Sprintf(\"%v\", true)\` and \`fmt.Sprintf(\"%v\", \"true\")\` render the same. A TINYINT(1) PK surfaced as bool would compare equal to a VARCHAR PK with literal \"true\". Vanishingly rare in practice but worth a defensive type-check. Added a test case.

**\`sql.ErrNoRows\` distinguishing in \`resumeFromCheckpoint\`** ([`runner.go`](pkg/migration/runner.go))
- An empty checkpoint table now surfaces as \"checkpoint table is empty, nothing to resume from\" rather than \"could not read from table\" (which reads like a permission issue).

**\`Migration.Validate\` gaps** ([`migration.go`](pkg/migration/migration.go))
- Reject negative \`--threads\` / \`--target-chunk-time\` / \`--replica-max-lag\` / \`--checkpoint-max-age\` at parse time. Zero stays valid (means \"use the default\" via normalizeOptions).

### Documentation (the original scope)

**\`Datum.String()\` pre-escaped SQL contract** ([`datum.go`](pkg/table/datum.go) + 5 inlining sites)
- Documented the contract that \`Datum.String()\` returns a complete pre-escaped SQL literal (NULL / numeric / \`0x…\` hex / \`\"...\"\` with backslash escapes), and added pointer comments at every inlining site so future readers / static analysis don't flag the inlining as a missing-escape bug.

**\`SetMaxOpenConns\` monotone-grow convention** ([`runner.go`](pkg/migration/runner.go), [`cutover.go`](pkg/migration/cutover.go))
- Both \`SetMaxOpenConns\` call sites ratchet the pool size upward and never restore. That's intentional: each phase's increase reflects its own connection budget, and by the time a phase ends the previous-phase backpressure no longer applies. Documented on the original \`MaxOpenConnections\` assignment and at both ratcheting sites.

### Deferred

\`bumpWatermark\` panics in the chunkers, on hold until #867 merges (touches the same files).

## Test plan

- [x] \`go build ./... && go vet ./...\` clean
- [x] \`go test -race -count=1 ./pkg/repl/ ./pkg/table/ ./pkg/applier/\` (53s) — clean
- [ ] \`go test -race -count=1 ./pkg/migration/ ./pkg/move/ ./pkg/copier/ ./pkg/checksum/\` — running

🤖 Generated with [Claude Code](https://claude.com/claude-code)