### PR TITLE
fix(repl): remove obsolete adaptive batch-size feedback machinery

### DIFF
--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
@@ -46,7 +45,6 @@ func TestFixCorruptWithApplier(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(dest, newDBName, "corruptt1")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 	target := applier.Target{
 		DB:       dest,
 		KeyRange: "0",
@@ -56,12 +54,7 @@ func TestFixCorruptWithApplier(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start the applier so its workers can process async Apply calls
-	feed := repl.NewClient(src, cfg.Addr, cfg.User, cfg.Passwd, applier, &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(src, cfg.Addr, cfg.User, cfg.Passwd, applier, repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -156,12 +149,7 @@ func TestDistributedChecksum(t *testing.T) {
 	// Create replication feed
 	// We're not going to do anything, but it's required by the distributed checker
 	logger := slog.Default()
-	feed := repl.NewClient(sourceDB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(sourceDB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, repl.NewClientDefaultConfig())
 	defer feed.Close()
 
 	// For distributed checksum, we only add one subscription for the source table
@@ -283,24 +271,14 @@ func TestDistributedChecksumNtoM(t *testing.T) {
 
 	// Create a repl client per source. Both share the same applier.
 	logger := slog.Default()
-	feed0 := repl.NewClient(src0DB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed0 := repl.NewClient(src0DB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, repl.NewClientDefaultConfig())
 	defer feed0.Close()
 	chunker0, err := table.NewChunker(src0Table, table.ChunkerConfig{NewTable: src0Table})
 	require.NoError(t, err)
 	require.NoError(t, feed0.AddSubscription(src0Table, src0Table, chunker0))
 	require.NoError(t, feed0.Run(t.Context()))
 
-	feed1 := repl.NewClient(src1DB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed1 := repl.NewClient(src1DB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, repl.NewClientDefaultConfig())
 	defer feed1.Close()
 	chunker1, err := table.NewChunker(src1Table, table.ChunkerConfig{Logger: logger})
 	require.NoError(t, err)

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -2,7 +2,6 @@ package checksum
 
 import (
 	"database/sql"
-	"log/slog"
 	"testing"
 	"time"
 
@@ -37,16 +36,10 @@ func TestBasicChecksum(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_basic_checksum_new")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -75,16 +68,10 @@ func TestBasicValidation(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "basic_validation2")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -132,16 +119,10 @@ func TestUnfixableUniqueChecksum(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "uniqfailuret2")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -179,16 +160,10 @@ func TestFixCorrupt(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_fixcorruption_t1_new")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -236,16 +211,10 @@ func TestCorruptChecksum(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_chkpcorruptt1_new")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -277,16 +246,10 @@ func TestBoundaryCases(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_checkert1_new")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -354,16 +317,10 @@ func TestChangeDataTypeDatetime(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_tdatetime_new")
 	require.NoError(t, t2.SetInfo(t.Context())) // fails
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -396,16 +353,10 @@ func TestYieldTimeout(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_yield_t1_new")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
@@ -448,16 +399,10 @@ func TestFromWatermark(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t2 := table.NewTableInfo(db, "test", "_tfromwatermark_new")
 	require.NoError(t, t2.SetInfo(t.Context()))
-	logger := slog.Default()
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -53,12 +53,7 @@ func TestCutOver(t *testing.T) {
 	t1new := table.NewTableInfo(db, cfg.DBName, "_cutovert1_new")
 	t1old := "_cutovert1_old"
 	logger := slog.Default()
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
 	require.NoError(t, err)
@@ -117,12 +112,7 @@ func TestMDLLockFails(t *testing.T) {
 	t1new := table.NewTableInfo(db, cfg.DBName, "_mdllocks_new")
 	t1old := "test_old"
 	logger := slog.Default()
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	defer feed.Close()
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
 	require.NoError(t, err)
@@ -180,12 +170,7 @@ func TestInvalidOptions(t *testing.T) {
 	require.NoError(t, t1.SetInfo(t.Context()))
 	t1new := table.NewTableInfo(db, cfg.DBName, "_invalid_t1_new")
 	t1old := "test_old"
-	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &repl.ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        repl.NewServerID(),
-	})
+	feed := repl.NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), repl.NewClientDefaultConfig())
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
 	require.NoError(t, err)
 	require.NoError(t, feed.AddSubscription(t1, t1new, chunker))

--- a/pkg/migration/replica_tls_test.go
+++ b/pkg/migration/replica_tls_test.go
@@ -209,11 +209,9 @@ func TestReplicationClientTLSConfig(t *testing.T) {
 			tlsConfig.TLSCertificatePath = tc.tlsCert
 
 			// Create replication client config with database config
-			clientConfig := &repl.ClientConfig{
-				Logger:   slog.Default(),
-				ServerID: repl.NewServerID(),
-				DBConfig: tlsConfig,
-			} // Create a mock database connection for testing
+			clientConfig := repl.NewClientDefaultConfig()
+			clientConfig.DBConfig = tlsConfig
+			// Create a mock database connection for testing
 			db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 			require.NoError(t, err)
 			defer utils.CloseAndLog(db)

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -575,14 +575,11 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 
 	// Set the binlog position.
 	// Create a binlog subscriber
-	r.replClient = repl.NewClient(r.db, r.migration.Host, r.migration.Username, *r.migration.Password, appl, &repl.ClientConfig{
-		Logger:          r.logger,
-		Concurrency:     r.migration.Threads,
-		TargetBatchTime: r.migration.TargetChunkTime,
-		CancelFunc:      r.fatalError,
-		ServerID:        repl.NewServerID(),
-		DBConfig:        r.dbConfig, // Pass database configuration to replication client
-	})
+	replConfig := repl.NewClientDefaultConfig()
+	replConfig.Logger = r.logger
+	replConfig.CancelFunc = r.fatalError
+	replConfig.DBConfig = r.dbConfig
+	r.replClient = repl.NewClient(r.db, r.migration.Host, r.migration.Username, *r.migration.Password, appl, replConfig)
 	// For each of the changes, we know the new table exists now
 	// So we should call SetInfo to populate the columns etc.
 	for _, change := range r.changes {

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -433,16 +433,13 @@ func (r *Runner) setup(ctx context.Context) error {
 	r.logger.Info("Setting up repl clients", "sourceCount", len(r.sources))
 	for i := range r.sources {
 		src := &r.sources[i]
-		src.replClient = repl.NewClient(src.db, src.config.Addr, src.config.User, src.config.Passwd, r.applier, &repl.ClientConfig{
-			Logger:          r.logger,
-			Concurrency:     r.move.Threads,
-			TargetBatchTime: r.move.TargetChunkTime,
-			CancelFunc:      r.fatalError,
-			DDLFilterSchema: src.config.DBName,
-			DDLFilterTables: r.move.SourceTables,
-			ServerID:        repl.NewServerID(),
-			DBConfig:        r.dbConfig,
-		})
+		replConfig := repl.NewClientDefaultConfig()
+		replConfig.Logger = r.logger
+		replConfig.CancelFunc = r.fatalError
+		replConfig.DDLFilterSchema = src.config.DBName
+		replConfig.DDLFilterTables = r.move.SourceTables
+		replConfig.DBConfig = r.dbConfig
+		src.replClient = repl.NewClient(src.db, src.config.Addr, src.config.User, src.config.Passwd, r.applier, replConfig)
 	}
 
 	// Run post-setup checks

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
-	"github.com/block/spirit/pkg/utils"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 )
@@ -367,7 +366,7 @@ func (c *Client) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to get binlog position, check binary is enabled: %w", err)
 		}
 	} else {
-		impossible, err := c.binlogPositionIsImpossible(ctx)
+		impossible, err := binlogPositionIsImpossible(ctx, c.db, c.flushedPos.Name)
 		if err != nil {
 			return fmt.Errorf("could not verify binlog position: %w", err)
 		}
@@ -763,40 +762,6 @@ func (c *Client) processRowsEvent(ev *replication.BinlogEvent, e *replication.Ro
 		}
 	}
 	return nil
-}
-
-// binlogPositionIsImpossible reports whether the configured flushedPos
-// names a binlog file that is no longer present on the server.
-//
-// Returns:
-//   - (true, nil)   — the file was definitely purged: resume from this
-//     position cannot succeed.
-//   - (false, nil)  — the file is present: the position is resumable.
-//   - (_, err)      — could not determine (query failed, scan failed,
-//     row iteration failed). Callers should surface
-//     this as a real error rather than treating it as
-//     "purged" — a network blip or auth hiccup is
-//     recoverable, while reporting "purged" abandons
-//     the checkpoint and forces a full re-copy.
-func (c *Client) binlogPositionIsImpossible(ctx context.Context) (bool, error) {
-	rows, err := c.db.QueryContext(ctx, "SHOW BINARY LOGS")
-	if err != nil {
-		return false, fmt.Errorf("query SHOW BINARY LOGS: %w", err)
-	}
-	defer utils.CloseAndLog(rows)
-	var logname, size, encrypted string
-	for rows.Next() {
-		if err := rows.Scan(&logname, &size, &encrypted); err != nil {
-			return false, fmt.Errorf("scan SHOW BINARY LOGS row: %w", err)
-		}
-		if logname == c.flushedPos.Name {
-			return false, nil // file present, position is resumable
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return false, fmt.Errorf("iterating SHOW BINARY LOGS: %w", err)
-	}
-	return true, nil // file definitely not in the result set
 }
 
 // fatalError is called from within the readStream goroutine when a truly fatal

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -19,67 +19,6 @@ import (
 	"github.com/go-mysql-org/go-mysql/replication"
 )
 
-const (
-	binlogTrivialThreshold = 10000
-	// DefaultBatchSize is the number of rows in each batched REPLACE/DELETE statement.
-	// Larger is better, but we need to keep the run-time of the statement well below
-	// dbconn.maximumLockTime so that it doesn't prevent copy-row tasks from failing.
-	// Since on some of our Aurora tables with out-of-cache workloads only copy ~300 rows per second,
-	// we probably shouldn't set this any larger than about 1K. It will also use
-	// multiple-flush-threads, which should help it group commit and still be fast.
-	// This is only used as an initial starting value. It will auto-scale based on the DefaultTargetBatchTime.
-	DefaultBatchSize = 1000
-	// minBatchSize is the minimum batch size that we will allow the targetBatchSize to be.
-	minBatchSize = 5
-	// DefaultTargetBatchTime is the target time for flushing REPLACE/DELETE statements.
-	DefaultTargetBatchTime = time.Millisecond * 500
-
-	// DefaultFlushInterval is the time that the client will flush all binlog changes to disk.
-	// Longer values require more memory, but permit more merging.
-	// I expect we will change this to 1hr-24hr in the future.
-	DefaultFlushInterval = 30 * time.Second
-	// DefaultSubscriptionSoftLimitBytes caps the approximate memory held
-	// per subscription before HasChanged starts blocking on the buffered
-	// map's condition variable. The cap is "soft": a single oversized
-	// row admitted when the buffer is empty will exceed the limit, and
-	// the next caller will park until that row drains. This keeps wide
-	// rows (LONGTEXT / BLOB / large JSON) from OOMing the migrator
-	// while still guaranteeing forward progress regardless of row width.
-	// See pkg/repl/subscription_buffered.go for the accounting model.
-	//
-	// Operators should be aware that pausing the binlog reader for an
-	// extended period risks falling past the source's binlog retention
-	// (binlog_expire_logs_seconds). Tune this value, or the source's
-	// retention, accordingly.
-	DefaultSubscriptionSoftLimitBytes = 256 << 20
-	// DefaultTimeout is how long BlockWait is supposed to wait before returning errors.
-	DefaultTimeout = 30 * time.Second
-	// Maximum number of consecutive errors before recreating the streamer
-	maxConsecutiveErrors = 5
-	// Initial backoff duration for streamer recreation
-	initialBackoffDuration = time.Second
-	// Maximum backoff duration
-	maxBackoffDuration = time.Minute
-	// Backoff multiplier
-	backoffMultiplier = 2
-	// Sleep time between position checks in BlockWait
-	blockWaitSleep = 100 * time.Millisecond
-	// Number of consecutive blockWaitSleep intervals where the buffered position
-	// hasn't advanced before BlockWait flushes binary logs to nudge the syncer.
-	// 3 * blockWaitSleep (~300ms) tolerates brief syncer lag (e.g. CI load) while
-	// remaining negligible relative to DefaultTimeout.
-	blockWaitStallThreshold = 3
-)
-
-var (
-	// maxRecreateAttempts is the maximum number of streamer recreation attempts before giving up.
-	// This is really a const, but set to var for testing.
-	maxRecreateAttempts = 10
-
-	// ErrChangesNotFlushed indicates that not all changes have been flushed from the replication feed.
-	ErrChangesNotFlushed = errors.New("not all changes flushed")
-)
-
 type Client struct {
 	// mu protects position fields (bufferedPos / flushedPos), the
 	// streamer / syncer / cancelFunc tuple, and the cached
@@ -99,9 +38,10 @@ type Client struct {
 	streamer *replication.BinlogStreamer
 
 	// The DB connection is used for queries like SHOW MASTER STATUS
-	db       *sql.DB
-	applier  applier.Applier
-	dbConfig *dbconn.DBConfig
+	db               *sql.DB
+	applier          applier.Applier
+	dbConfig         *dbconn.DBConfig
+	binlogStatusStmt string // cached: "SHOW MASTER STATUS" or "SHOW BINARY LOG STATUS"
 
 	// subs owns the table-keyed subscription set and its own lock. See
 	// subscriptionRegistry. The Client mutex above does NOT cover map
@@ -121,14 +61,6 @@ type Client struct {
 	serverID    uint32         // server ID for the binlog reader
 	bufferedPos mysql.Position // buffered position
 	flushedPos  mysql.Position // safely written to new table
-
-	statisticsLock  sync.Mutex
-	targetBatchTime time.Duration
-	targetBatchSize int64 // will auto-adjust over time, use atomic to read/set
-	timingHistory   []time.Duration
-	concurrency     int
-
-	binlogStatusStmt string // cached: "SHOW MASTER STATUS" or "SHOW BINARY LOG STATUS"
 
 	// The periodic flush lock is just used for ensuring only one periodic flush runs at a time,
 	// and when we disable it, no more periodic flushes will run. The actual flushing is protected
@@ -168,9 +100,6 @@ func NewClient(db *sql.DB, host string, username, password string, appl applier.
 		username:                   username,
 		password:                   password,
 		logger:                     config.Logger,
-		targetBatchTime:            config.TargetBatchTime,
-		targetBatchSize:            DefaultBatchSize, // initial starting value.
-		concurrency:                config.Concurrency,
 		subs:                       newSubscriptionRegistry(),
 		callerCancelFunc:           config.CancelFunc,
 		ddlFilterSchema:            config.DDLFilterSchema,
@@ -947,7 +876,7 @@ func (c *Client) StartPeriodicFlush(ctx context.Context, interval time.Duration)
 				c.logger.Error("error flushing binary log", "error", err)
 			}
 			c.periodicFlushLock.Unlock()
-			c.logger.Info("finished periodic flush of binary log", "total-duration", time.Since(startLoop), "batch-size", atomic.LoadInt64(&c.targetBatchSize))
+			c.logger.Info("finished periodic flush of binary log", "total-duration", time.Since(startLoop))
 		}
 	}
 }
@@ -1005,47 +934,6 @@ func (c *Client) BlockWait(ctx context.Context) error {
 			// We are not caught up yet, so we need to wait.
 			time.Sleep(blockWaitSleep)
 		}
-	}
-}
-
-// feedback provides feedback on the apply time of changesets.
-// We use this to refine the targetBatchSize. This is a little bit
-// different for feedback for the copier, because:
-//
-//  1. frequently the batches will not be full.
-//  2. feedback is (at least currently) global to all subscriptions,
-//     and does not take into account that inserting into a 2 col table
-//     with 0 indexes is much faster than inserting into a 10 col table with 5 indexes.
-//
-// We still need to use a p90-like mechanism though,
-// because the rows being changed are by definition more likely to be hotspots.
-// Hotspots == Lock Contention. This is one of the exact reasons why we are
-// chunking in the first place. The probability that the applier can cause
-// impact on OLTP workloads is much higher than the copier.
-func (c *Client) feedback(numberOfKeys int, d time.Duration) {
-	c.statisticsLock.Lock()
-	defer c.statisticsLock.Unlock()
-	if numberOfKeys == 0 {
-		return // can't calculate anything, just return
-	}
-	// For the p90-like mechanism rather than storing all the previous
-	// durations, because the numberOfKeys is variable we instead store
-	// the timePerKey. We then adjust the targetBatchSize based on this.
-	// This creates some skew because small batches will have a higher
-	// timePerKey, which can create a back log. Which results in a smaller
-	// timePerKey. So at least the skew *should* be self-correcting. This
-	// has not yet been proven though.
-	timePerKey := d / time.Duration(numberOfKeys)
-	c.timingHistory = append(c.timingHistory, timePerKey)
-
-	// If we have enough feedback re-evaluate the target batch size
-	// based on the p90 timePerKey.
-	if len(c.timingHistory) >= 10 {
-		timePerKey := table.LazyFindP90(c.timingHistory)
-		newBatchSize := int64(float64(c.targetBatchTime) / float64(timePerKey))
-		newBatchSize = max(newBatchSize, minBatchSize)
-		atomic.StoreInt64(&c.targetBatchSize, newBatchSize)
-		c.timingHistory = nil // reset
 	}
 }
 

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -82,7 +82,14 @@ var (
 )
 
 type Client struct {
-	sync.Mutex
+	// mu protects position fields (bufferedPos / flushedPos), the
+	// streamer / syncer / cancelFunc tuple, and the cached
+	// binlogStatusStmt. Subscriptions live in c.subs with its own
+	// RWMutex. Named (not embedded) so the lock surface stays
+	// package-internal: sync.Mutex is not re-entrant, and exposing
+	// public Lock/Unlock on an external API invites accidental
+	// self-deadlocks from a caller that doesn't know what's already held.
+	mu sync.Mutex
 
 	host     string
 	username string
@@ -214,8 +221,8 @@ func (c *Client) AddSubscription(currentTable, newTable *table.TableInfo, chunke
 // the rewound value via SetFlushedPos — silently regressing the
 // checkpoint and forcing a large re-read on the next resume.
 func (c *Client) setBufferedPos(pos mysql.Position) {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if pos.Compare(c.bufferedPos) <= 0 {
 		return
 	}
@@ -224,22 +231,22 @@ func (c *Client) setBufferedPos(pos mysql.Position) {
 
 // getBufferedPos returns the buffered position under a mutex.
 func (c *Client) getBufferedPos() mysql.Position {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.bufferedPos
 }
 
 // SetFlushedPos updates the known safe position that all changes have been flushed.
 // It is used for resuming from a checkpoint.
 func (c *Client) SetFlushedPos(pos mysql.Position) {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.flushedPos = pos
 }
 
 func (c *Client) AllChangesFlushed() bool {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.bufferedPos.Compare(c.flushedPos) > 0 {
 		c.logger.Warn("Binlog reader info flushed-pos buffered-pos. Discrepancies could be due to modifications on other tables.", "flushed-pos", c.flushedPos, "buffered-pos", c.bufferedPos)
 	}
@@ -255,8 +262,8 @@ func (c *Client) AllChangesFlushed() bool {
 }
 
 func (c *Client) GetBinlogApplyPosition() mysql.Position {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.flushedPos
 }
 
@@ -310,8 +317,8 @@ func (c *Client) getCurrentBinlogPosition(ctx context.Context) (mysql.Position, 
 // Run initializes the binlog syncer and starts the binlog reader.
 // It returns an error if the initialization fails.
 func (c *Client) Run(ctx context.Context) error {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	host, portStr, err := net.SplitHostPort(c.host)
 	if err != nil {
@@ -397,8 +404,8 @@ func (c *Client) Run(ctx context.Context) error {
 // flush) will correct. The eventual-consistency property holds in both
 // map mode and queue mode — see UpsertRows in pkg/applier/single_target.go.
 func (c *Client) recreateStreamer() error {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	c.logger.Info("recreateStreamer called",
 		"buffered_position", c.bufferedPos,
@@ -441,10 +448,10 @@ func (c *Client) recreateStreamer() error {
 func (c *Client) readStream(ctx context.Context) {
 	defer c.streamWG.Done() // Signal completion when goroutine exits
 
-	c.Lock()
+	c.mu.Lock()
 	currentLogName := c.flushedPos.Name
 	startPos := c.flushedPos // Copy while holding lock
-	c.Unlock()
+	c.mu.Unlock()
 
 	consecutiveErrors := 0
 	recreateAttempts := 0
@@ -795,9 +802,9 @@ func (c *Client) Close() {
 	// itself acquires c.Lock from inside its loop (setBufferedPos,
 	// recreateStreamer), and holding the lock during Wait would deadlock
 	// an in-flight lock acquisition there.
-	c.Lock()
+	c.mu.Lock()
 	cancel := c.cancelFunc
-	c.Unlock()
+	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
 	}
@@ -854,9 +861,9 @@ func (c *Client) FlushUnderTableLock(ctx context.Context, lock *dbconn.TableLock
 // the end of the flush. That's OK, we only set the flushed position to the known
 // safe buffered position taken at the start.
 func (c *Client) flush(ctx context.Context, underLock bool, lock *dbconn.TableLock) error {
-	c.Lock()
+	c.mu.Lock()
 	newFlushedPos := c.bufferedPos
-	c.Unlock()
+	c.mu.Unlock()
 	var allChangesFlushed = true
 	for _, subscription := range c.subs.Snapshot() {
 		flushed, err := subscription.Flush(ctx, underLock, lock)

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -366,8 +366,14 @@ func (c *Client) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to get binlog position, check binary is enabled: %w", err)
 		}
-	} else if c.binlogPositionIsImpossible(ctx) {
-		return errors.New("binlog position is impossible, the source may have already purged it")
+	} else {
+		impossible, err := c.binlogPositionIsImpossible(ctx)
+		if err != nil {
+			return fmt.Errorf("could not verify binlog position: %w", err)
+		}
+		if impossible {
+			return errors.New("binlog position is impossible, the source may have already purged it")
+		}
 	}
 	c.bufferedPos = c.flushedPos // set buffered to the initial flushed value
 	c.syncer = replication.NewBinlogSyncer(c.cfg)
@@ -759,25 +765,38 @@ func (c *Client) processRowsEvent(ev *replication.BinlogEvent, e *replication.Ro
 	return nil
 }
 
-func (c *Client) binlogPositionIsImpossible(ctx context.Context) bool {
+// binlogPositionIsImpossible reports whether the configured flushedPos
+// names a binlog file that is no longer present on the server.
+//
+// Returns:
+//   - (true, nil)   — the file was definitely purged: resume from this
+//     position cannot succeed.
+//   - (false, nil)  — the file is present: the position is resumable.
+//   - (_, err)      — could not determine (query failed, scan failed,
+//     row iteration failed). Callers should surface
+//     this as a real error rather than treating it as
+//     "purged" — a network blip or auth hiccup is
+//     recoverable, while reporting "purged" abandons
+//     the checkpoint and forces a full re-copy.
+func (c *Client) binlogPositionIsImpossible(ctx context.Context) (bool, error) {
 	rows, err := c.db.QueryContext(ctx, "SHOW BINARY LOGS")
 	if err != nil {
-		return true // if we can't get the logs, its already impossible
+		return false, fmt.Errorf("query SHOW BINARY LOGS: %w", err)
 	}
 	defer utils.CloseAndLog(rows)
 	var logname, size, encrypted string
 	for rows.Next() {
 		if err := rows.Scan(&logname, &size, &encrypted); err != nil {
-			return true
+			return false, fmt.Errorf("scan SHOW BINARY LOGS row: %w", err)
 		}
 		if logname == c.flushedPos.Name {
-			return false // We just need presence of the log file for success
+			return false, nil // file present, position is resumable
 		}
 	}
-	if rows.Err() != nil {
-		return true // can't determine.
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterating SHOW BINARY LOGS: %w", err)
 	}
-	return true
+	return true, nil // file definitely not in the result set
 }
 
 // fatalError is called from within the readStream goroutine when a truly fatal

--- a/pkg/repl/client_test.go
+++ b/pkg/repl/client_test.go
@@ -44,15 +44,9 @@ func TestReplClient(t *testing.T) {
 	t2 := table.NewTableInfo(db, "test", "replt2")
 	require.NoError(t, t2.SetInfo(t.Context()))
 
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(t1, t2, chunker))
@@ -187,15 +181,9 @@ func TestReplClientResumeFromImpossible(t *testing.T) {
 	t2 := table.NewTableInfo(db, "test", "replresumet2")
 	require.NoError(t, t2.SetInfo(t.Context()))
 
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(t1, t2, chunker))
@@ -221,15 +209,9 @@ func TestReplClientResumeFromPoint(t *testing.T) {
 	t2 := table.NewTableInfo(db, "test", "replresumepointt2")
 	require.NoError(t, t2.SetInfo(t.Context()))
 
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(t1, t2, chunker))
@@ -261,15 +243,9 @@ func TestReplClientOpts(t *testing.T) {
 	t2 := table.NewTableInfo(db, "test", "replclientoptst2")
 	require.NoError(t, t2.SetInfo(t.Context()))
 
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(t1, t2, chunker))
@@ -373,59 +349,6 @@ func TestReplClientQueue(t *testing.T) {
 	require.Equal(t, 0, client.GetDeltaLen())
 }
 
-func TestFeedback(t *testing.T) {
-	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	require.NoError(t, err)
-	defer utils.CloseAndLog(db)
-
-	testutils.RunSQL(t, "DROP TABLE IF EXISTS feedbackt1, feedbackt2, _feedbackt1_chkpnt")
-	testutils.RunSQL(t, "CREATE TABLE feedbackt1 (a VARCHAR(255) NOT NULL, b INT, c INT, PRIMARY KEY (a))")
-	testutils.RunSQL(t, "CREATE TABLE feedbackt2 (a VARCHAR(255) NOT NULL, b INT, c INT, PRIMARY KEY (a))")
-	testutils.RunSQL(t, "CREATE TABLE _feedbackt1_chkpnt (a int)") // just used to advance binlog
-
-	t1 := table.NewTableInfo(db, "test", "replqueuet1")
-	require.NoError(t, t1.SetInfo(t.Context()))
-	t2 := table.NewTableInfo(db, "test", "replqueuet2")
-	require.NoError(t, t2.SetInfo(t.Context()))
-
-	cfg, err := mysql2.ParseDSN(testutils.DSN())
-	require.NoError(t, err)
-
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
-	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
-	require.NoError(t, err)
-	require.NoError(t, client.AddSubscription(t1, t2, chunker))
-	require.NoError(t, client.Run(t.Context()))
-	defer client.Close()
-
-	// initial values expected:
-	require.Equal(t, time.Millisecond*500, client.targetBatchTime)
-	require.Equal(t, int64(1000), client.targetBatchSize)
-
-	// Make it complete 5 times faster than expected
-	// Run 9 times initially.
-	for range 9 {
-		client.feedback(1000, time.Millisecond*100)
-	}
-	require.Equal(t, int64(1000), client.targetBatchSize) // no change yet
-	client.feedback(0, time.Millisecond*100)              // no keys, should not cause change.
-	require.Equal(t, int64(1000), client.targetBatchSize) // no change yet
-	client.feedback(1000, time.Millisecond*100)           // 10th time.
-	require.Equal(t, int64(5000), client.targetBatchSize) // 5x more keys.
-
-	// test with slower chunk
-	for range 10 {
-		client.feedback(1000, time.Second)
-	}
-	require.Equal(t, int64(500), client.targetBatchSize) // less keys.
-
-	// Test with a way slower chunk.
-	for range 10 {
-		client.feedback(500, time.Second*100)
-	}
-	require.Equal(t, int64(5), client.targetBatchSize) // equals the minimum.
-}
-
 // TestBlockWait tests that the BlockWait function will:
 // - check the server's binary log position
 // - block waiting until the repl client is at that position.
@@ -447,15 +370,9 @@ func TestBlockWait(t *testing.T) {
 	t3 := table.NewTableInfo(db, "test", "blockwaitt3")
 	require.NoError(t, t3.SetInfo(t.Context()))
 
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(t1, t2, chunker))
@@ -515,22 +432,17 @@ func TestDDLNotification(t *testing.T) {
 	t2 := table.NewTableInfo(db, "test", "ddl_t2")
 	require.NoError(t, t2.SetInfo(t.Context()))
 
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
 
 	// Use a channel to track cancel calls from the CancelFunc callback.
 	cancelled := make(chan struct{}, 1)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		CancelFunc: func() bool {
-			cancelled <- struct{}{}
-			return true
-		},
-		ServerID: NewServerID(),
-	})
+	clientConfig := NewClientDefaultConfig()
+	clientConfig.CancelFunc = func() bool {
+		cancelled <- struct{}{}
+		return true
+	}
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), clientConfig)
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(t1, t2, chunker))
@@ -592,15 +504,9 @@ func TestCompositePKUpdate(t *testing.T) {
 	require.NoError(t, t2.SetInfo(t.Context()))
 
 	// Create replication client
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
 
 	// Add subscription - note that keyAboveWatermark is disabled for composite PKs
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
@@ -669,12 +575,10 @@ func TestAllChangesFlushed(t *testing.T) {
 	)`
 	srcTable, dstTable := setupTestTables(t, t1, t2)
 	client := &Client{
-		db:              nil,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
-		subs:            newSubscriptionRegistry(),
+		db:       nil,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
+		subs:     newSubscriptionRegistry(),
 	}
 
 	// Test 1: Initial state - should be flushed when no changes
@@ -797,13 +701,9 @@ func TestMaxRecreateAttemptsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), &ClientConfig{
-		Logger:          slog.Default(),
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-		CancelFunc:      func() bool { cancel(); return true },
-	})
+	clientConfig := NewClientDefaultConfig()
+	clientConfig.CancelFunc = func() bool { cancel(); return true }
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), clientConfig)
 	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(t1, t2, chunker))

--- a/pkg/repl/config.go
+++ b/pkg/repl/config.go
@@ -2,17 +2,14 @@ package repl
 
 import (
 	"log/slog"
-	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
 )
 
 type ClientConfig struct {
-	TargetBatchTime time.Duration
-	Concurrency     int
-	Logger          *slog.Logger
-	ServerID        uint32
-	DBConfig        *dbconn.DBConfig // Database configuration including TLS settings
+	Logger   *slog.Logger
+	ServerID uint32
+	DBConfig *dbconn.DBConfig // Database configuration including TLS settings
 
 	// CancelFunc is an optional callback from the caller (e.g. migration or move runner).
 	// It is called when a DDL change is detected on a subscribed table, or when a fatal
@@ -44,9 +41,7 @@ type ClientConfig struct {
 // NewClientDefaultConfig returns a default config for the copier.
 func NewClientDefaultConfig() *ClientConfig {
 	return &ClientConfig{
-		Concurrency:     4,
-		TargetBatchTime: DefaultTargetBatchTime,
-		Logger:          slog.Default(),
-		ServerID:        NewServerID(),
+		Logger:   slog.Default(),
+		ServerID: NewServerID(),
 	}
 }

--- a/pkg/repl/config_test.go
+++ b/pkg/repl/config_test.go
@@ -15,9 +15,6 @@ func TestNewClientDefaultConfig(t *testing.T) {
 	cfg := NewClientDefaultConfig()
 	require.NotNil(t, cfg)
 
-	require.Equal(t, 4, cfg.Concurrency, "default Concurrency is 4")
-	require.Equal(t, DefaultTargetBatchTime, cfg.TargetBatchTime,
-		"default TargetBatchTime matches DefaultTargetBatchTime")
 	require.NotNil(t, cfg.Logger, "Logger defaults to slog.Default(), not nil")
 	require.GreaterOrEqual(t, cfg.ServerID, uint32(1001),
 		"ServerID generated via NewServerID() must be in the safe range")

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -4,8 +4,74 @@ package repl
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"sync/atomic"
 	"time"
+)
+
+const (
+	binlogTrivialThreshold = 10000
+	// DefaultBatchSize is the fixed number of rows in each batched REPLACE/
+	// DELETE statement that the binlog applier emits against the _new
+	// table. Larger is better, but we need to keep the run-time of the
+	// statement well below dbconn.maximumLockTime so that it doesn't
+	// prevent copy-row tasks from failing. On Aurora tables with
+	// out-of-cache workloads that copy ~300 rows per second this is close
+	// to the safe ceiling.
+	//
+	// Was previously an initial value for an adaptive sizer (feedback()
+	// driven by p90 apply time). That mechanism was meaningful when the
+	// applier issued `REPLACE INTO _new ... SELECT FROM source` and S-locked
+	// rows on the live table, but after #853 the applier emits inline
+	// VALUES against _new only — no source-side locks — and the batches
+	// are strictly serial inside flushBatch. There's nothing left to
+	// throttle, so the batch size is just a constant. See issue #869.
+	DefaultBatchSize = 1000
+
+	// DefaultFlushInterval is the time that the client will flush all binlog changes to disk.
+	// Longer values require more memory, but permit more merging.
+	// I expect we will change this to 1hr-24hr in the future.
+	DefaultFlushInterval = 30 * time.Second
+	// DefaultSubscriptionSoftLimitBytes caps the approximate memory held
+	// per subscription before HasChanged starts blocking on the buffered
+	// map's condition variable. The cap is "soft": a single oversized
+	// row admitted when the buffer is empty will exceed the limit, and
+	// the next caller will park until that row drains. This keeps wide
+	// rows (LONGTEXT / BLOB / large JSON) from OOMing the migrator
+	// while still guaranteeing forward progress regardless of row width.
+	// See pkg/repl/subscription_buffered.go for the accounting model.
+	//
+	// Operators should be aware that pausing the binlog reader for an
+	// extended period risks falling past the source's binlog retention
+	// (binlog_expire_logs_seconds). Tune this value, or the source's
+	// retention, accordingly.
+	DefaultSubscriptionSoftLimitBytes = 256 << 20
+	// DefaultTimeout is how long BlockWait is supposed to wait before returning errors.
+	DefaultTimeout = 30 * time.Second
+	// Maximum number of consecutive errors before recreating the streamer
+	maxConsecutiveErrors = 5
+	// Initial backoff duration for streamer recreation
+	initialBackoffDuration = time.Second
+	// Maximum backoff duration
+	maxBackoffDuration = time.Minute
+	// Backoff multiplier
+	backoffMultiplier = 2
+	// Sleep time between position checks in BlockWait
+	blockWaitSleep = 100 * time.Millisecond
+	// Number of consecutive blockWaitSleep intervals where the buffered position
+	// hasn't advanced before BlockWait flushes binary logs to nudge the syncer.
+	// 3 * blockWaitSleep (~300ms) tolerates brief syncer lag (e.g. CI load) while
+	// remaining negligible relative to DefaultTimeout.
+	blockWaitStallThreshold = 3
+)
+
+var (
+	// maxRecreateAttempts is the maximum number of streamer recreation attempts before giving up.
+	// This is really a const, but set to var for testing.
+	maxRecreateAttempts = 10
+
+	// ErrChangesNotFlushed indicates that not all changes have been flushed from the replication feed.
+	ErrChangesNotFlushed = errors.New("not all changes flushed")
 )
 
 // serverIDCounter is an atomic counter used to help ensure unique server IDs

--- a/pkg/repl/subscription_buffered.go
+++ b/pkg/repl/subscription_buffered.go
@@ -351,9 +351,8 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 	var deleteKeys []string
 	var upsertRows []applier.LogicalRow
 	var keysFlushed []string
-	var i int64
+	var i int
 	allChangesFlushed := true
-	target := atomic.LoadInt64(&s.c.targetBatchSize)
 
 	var lockToUse *dbconn.TableLock
 	if underLock {
@@ -379,7 +378,7 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 		} else {
 			upsertRows = append(upsertRows, change.logicalRow)
 		}
-		if (i % target) == 0 {
+		if (i % DefaultBatchSize) == 0 {
 			if err := s.flushBatch(ctx, deleteKeys, upsertRows, lockToUse); err != nil {
 				return false, err
 			}
@@ -422,7 +421,6 @@ func (s *bufferedMap) flushBatch(ctx context.Context, deleteKeys []string, upser
 			return fmt.Errorf("failed to delete keys: %w", err)
 		}
 		deleteAffected = affectedRows
-		s.c.feedback(int(affectedRows), time.Since(startTime))
 	}
 
 	// Execute upserts
@@ -432,7 +430,6 @@ func (s *bufferedMap) flushBatch(ctx context.Context, deleteKeys []string, upser
 			return fmt.Errorf("failed to upsert rows: %w", err)
 		}
 		upsertAffected = affectedRows
-		s.c.feedback(int(affectedRows), time.Since(startTime))
 	}
 
 	s.c.logger.Debug("flushBatch executed",
@@ -468,7 +465,6 @@ func (s *bufferedMap) flushQueueLocked(ctx context.Context, underLock bool, lock
 	if underLock {
 		lockToUse = lock
 	}
-	target := int(atomic.LoadInt64(&s.c.targetBatchSize))
 
 	var deleteKeys []string
 	var upsertRows []applier.LogicalRow
@@ -485,7 +481,7 @@ func (s *bufferedMap) flushQueueLocked(ctx context.Context, underLock bool, lock
 	var drainedBytes int64
 	for _, change := range s.queue {
 		typeFlip := change.logicalRow.IsDeleted != prevIsDelete
-		batchFull := len(deleteKeys)+len(upsertRows) >= target
+		batchFull := len(deleteKeys)+len(upsertRows) >= DefaultBatchSize
 		if typeFlip || batchFull {
 			if err := flushSegment(); err != nil {
 				return err

--- a/pkg/repl/subscription_buffered_swap_test.go
+++ b/pkg/repl/subscription_buffered_swap_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
@@ -71,11 +70,9 @@ func TestBufferedMapSwapPairFlushesViaReplace(t *testing.T) {
 	require.NoError(t, err)
 
 	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	// Seed the pre-swap state in the destination table directly. The
@@ -182,12 +179,7 @@ func TestSwapPairEndToEndViaReplace(t *testing.T) {
 	applierInstance, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
 
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applierInstance, &ClientConfig{
-		Logger:          slog.Default(),
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applierInstance, NewClientDefaultConfig())
 	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))

--- a/pkg/repl/subscription_buffered_test.go
+++ b/pkg/repl/subscription_buffered_test.go
@@ -85,7 +85,6 @@ func TestBufferedMapVariableColumns(t *testing.T) {
 	srcTable, dstTable := setupTestTables(t, t1, t2)
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
 	target := applier.Target{
@@ -95,12 +94,7 @@ func TestBufferedMapVariableColumns(t *testing.T) {
 	}
 	applier, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier, &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier, NewClientDefaultConfig())
 	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
@@ -141,7 +135,6 @@ func TestBufferedMapIllegalValues(t *testing.T) {
 	srcTable, dstTable := setupTestTables(t, t1, t2)
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
 	target := applier.Target{
@@ -151,12 +144,7 @@ func TestBufferedMapIllegalValues(t *testing.T) {
 	}
 	applier, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier, &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier, NewClientDefaultConfig())
 	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
@@ -230,11 +218,9 @@ func TestBufferedMapFlushUnderLockBypassesWatermark(t *testing.T) {
 	require.NoError(t, err)
 
 	client := &Client{
-		db:              db,
-		logger:          logger,
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   logger,
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	// Create mock chunker with current position at 5
@@ -363,11 +349,9 @@ func TestBufferedMapFlushWithoutLockRespectsWatermark(t *testing.T) {
 	require.NoError(t, err)
 
 	client := &Client{
-		db:              db,
-		logger:          logger,
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   logger,
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	// Create mock chunker with current position at 5
@@ -462,10 +446,8 @@ func TestBufferedMapQueueModeRouting(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -534,11 +516,9 @@ func TestBufferedMapQueueModeFlush(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -617,11 +597,9 @@ func TestBufferedMapQueueModeFIFOOrder(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -685,11 +663,9 @@ func TestBufferedMapTransitionDrainsOutgoing(t *testing.T) {
 	mockChunker.MarkAsComplete()
 
 	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -762,10 +738,8 @@ func TestBufferedMapTogglePassthrough(t *testing.T) {
 	mockChunker.SimulateProgress(0.001)
 
 	client := &Client{
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -809,10 +783,8 @@ func TestBufferedMapConcurrentHasChanged(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -863,10 +835,8 @@ func TestBufferedMapKeyOverwriteDedupes(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -909,10 +879,8 @@ func TestBufferedMapHasChangedNilAndEmpty(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -958,10 +926,8 @@ func TestBufferedMapKeyAboveWatermarkCounters(t *testing.T) {
 	mockChunker.SimulateProgress(0.005) // Current position at 5
 
 	client := &Client{
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -1027,11 +993,9 @@ func TestBufferedMapQueueFlushEmpty(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -1049,71 +1013,6 @@ func TestBufferedMapQueueFlushEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, allFlushed)
 	require.Equal(t, 0, sub.Length())
-}
-
-// TestBufferedMapQueueFlushBatchSizeLimit drives the queue flush with a
-// targetBatchSize smaller than the queue length, so flushQueueLocked must
-// split a same-type segment across multiple applier calls. The end state in
-// the target must still be all rows applied.
-func TestBufferedMapQueueFlushBatchSizeLimit(t *testing.T) {
-	t1 := `CREATE TABLE subscription_test (
-		id VARCHAR(64) NOT NULL,
-		name VARCHAR(255) NOT NULL,
-		PRIMARY KEY (id)
-	)`
-	t2 := `CREATE TABLE _subscription_test_new (
-		id VARCHAR(64) NOT NULL,
-		name VARCHAR(255) NOT NULL,
-		PRIMARY KEY (id)
-	)`
-	srcTable, dstTable := setupTestTables(t, t1, t2)
-
-	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	require.NoError(t, err)
-	defer utils.CloseAndLog(db)
-
-	cfg, err := mysql2.ParseDSN(testutils.DSN())
-	require.NoError(t, err)
-	target := applier.Target{DB: db, KeyRange: "0", Config: cfg}
-	applierInstance, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
-	require.NoError(t, err)
-
-	mockChunker := table.NewMockChunker(srcTable.TableName, 1000)
-	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
-
-	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 2, // forces the same-type segment to split mid-flush
-		dbConfig:        dbconn.NewDBConfig(),
-	}
-
-	sub := &bufferedMap{
-		c:                    client,
-		applier:              applierInstance,
-		table:                srcTable,
-		newTable:             dstTable,
-		changes:              make(map[string]bufferedChange),
-		chunker:              mockChunker,
-		pkIsMemoryComparable: false,
-	}
-	sub.cond = sync.NewCond(&sub.Mutex)
-
-	for i := 1; i <= 5; i++ {
-		k := fmt.Sprintf("k%d", i)
-		sub.HasChanged([]any{k}, []any{k, "v"}, false)
-	}
-	require.Equal(t, 5, sub.Length())
-
-	allFlushed, err := sub.Flush(t.Context(), false, nil)
-	require.NoError(t, err)
-	require.True(t, allFlushed)
-
-	var count int
-	require.NoError(t, db.QueryRowContext(t.Context(),
-		fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable.QuotedTableName)).Scan(&count))
-	require.Equal(t, 5, count, "split across batches must still apply every row")
 }
 
 // TestBufferedMapQueueFlushUnderLock verifies that queue-mode flush works
@@ -1148,11 +1047,9 @@ func TestBufferedMapQueueFlushUnderLock(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -1228,11 +1125,9 @@ func TestBufferedMapQueueConcurrentFlush(t *testing.T) {
 	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
 
 	client := &Client{
-		db:              db,
-		logger:          slog.Default(),
-		concurrency:     2,
-		targetBatchSize: 1000,
-		dbConfig:        dbconn.NewDBConfig(),
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
 	}
 
 	sub := &bufferedMap{
@@ -1762,12 +1657,7 @@ func TestBufferedMapGeometry(t *testing.T) {
 	}
 	appl, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, appl, &ClientConfig{
-		Logger:          slog.Default(),
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, appl, NewClientDefaultConfig())
 	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))
@@ -1941,12 +1831,7 @@ func TestBufferedMapJSONNumberRoundTrip(t *testing.T) {
 			}
 			appl, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 			require.NoError(t, err)
-			client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, appl, &ClientConfig{
-				Logger:          slog.Default(),
-				Concurrency:     4,
-				TargetBatchTime: time.Second,
-				ServerID:        NewServerID(),
-			})
+			client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, appl, NewClientDefaultConfig())
 			chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
 			require.NoError(t, err)
 			require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))

--- a/pkg/repl/subscription_test.go
+++ b/pkg/repl/subscription_test.go
@@ -5,10 +5,8 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"log/slog"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
@@ -109,7 +107,6 @@ func setupBufferedTest(t *testing.T) (*sql.DB, *Client, *table.TableInfo, *table
 	srcTable, dstTable := setupTestTables(t, t1, t2)
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
-	logger := slog.Default()
 	cfg, err := mysql2.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
 	target := applier.Target{
@@ -119,12 +116,7 @@ func setupBufferedTest(t *testing.T) (*sql.DB, *Client, *table.TableInfo, *table
 	}
 	applier, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
 	require.NoError(t, err)
-	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier, &ClientConfig{
-		Logger:          logger,
-		Concurrency:     4,
-		TargetBatchTime: time.Second,
-		ServerID:        NewServerID(),
-	})
+	client := NewClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier, NewClientDefaultConfig())
 	chunker, err := table.NewChunker(srcTable, table.ChunkerConfig{NewTable: dstTable})
 	require.NoError(t, err)
 	require.NoError(t, client.AddSubscription(srcTable, dstTable, chunker))

--- a/pkg/repl/utils.go
+++ b/pkg/repl/utils.go
@@ -1,8 +1,11 @@
 package repl
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 
+	"github.com/block/spirit/pkg/utils"
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -166,4 +169,44 @@ func isMinimalRowImage(e *replication.RowsEvent) bool {
 		}
 	}
 	return false
+}
+
+// binlogPositionIsImpossible reports whether expectedLogName is no
+// longer present on the server (i.e. the binlog file the caller wants
+// to resume from has been purged).
+//
+// Returns:
+//   - (true, nil)   — the file is definitely absent: resume from this
+//     position cannot succeed.
+//   - (false, nil)  — the file is present: the position is resumable.
+//   - (_, err)      — could not determine (query / scan / iteration
+//     failed). Callers should surface this as a real
+//     error rather than treating it as "purged" — a
+//     network blip or auth hiccup is recoverable,
+//     while reporting "purged" abandons the checkpoint
+//     and forces a full re-copy.
+//
+// pkg/migration.Runner has a near-identical helper (binlogFileExists)
+// over the same SHOW BINARY LOGS query. Consolidating into a single
+// shared helper would mean exposing it from pkg/repl or pulling both
+// into a lower-level package; left as a follow-up.
+func binlogPositionIsImpossible(ctx context.Context, db *sql.DB, expectedLogName string) (bool, error) {
+	rows, err := db.QueryContext(ctx, "SHOW BINARY LOGS")
+	if err != nil {
+		return false, fmt.Errorf("query SHOW BINARY LOGS: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+	var logname, size, encrypted string
+	for rows.Next() {
+		if err := rows.Scan(&logname, &size, &encrypted); err != nil {
+			return false, fmt.Errorf("scan SHOW BINARY LOGS row: %w", err)
+		}
+		if logname == expectedLogName {
+			return false, nil // file present, position is resumable
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterating SHOW BINARY LOGS: %w", err)
+	}
+	return true, nil // file definitely not in the result set
 }

--- a/pkg/repl/utils.go
+++ b/pkg/repl/utils.go
@@ -144,6 +144,15 @@ func pkValueEqual(a, b any) bool {
 	if bb, ok := b.([]byte); ok {
 		b = string(bb)
 	}
+	// Booleans would otherwise collide with strings "true" / "false" under
+	// fmt.Sprintf("%v", ...). PK columns are rarely boolean (BIT or
+	// TINYINT(1) some drivers surface as bool), but if one is, exact
+	// type-and-value match is required.
+	aBool, aIsBool := a.(bool)
+	bBool, bIsBool := b.(bool)
+	if aIsBool || bIsBool {
+		return aIsBool && bIsBool && aBool == bBool
+	}
 	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }
 

--- a/pkg/repl/utils_test.go
+++ b/pkg/repl/utils_test.go
@@ -424,6 +424,19 @@ func TestPkChanged(t *testing.T) {
 		require.False(t, pkChanged([]any{nil}, []any{nil}))
 		require.True(t, pkChanged([]any{nil}, []any{int64(0)}))
 	})
+
+	t.Run("boolean and string-of-bool do not collide", func(t *testing.T) {
+		// fmt.Sprintf("%v", true) == "true" and fmt.Sprintf("%v", "true")
+		// == "true". Without the bool special-case, a TINYINT(1) PK
+		// column surfaced as bool would compare equal to a VARCHAR PK
+		// holding the literal string "true". Vanishingly rare in
+		// practice but worth a defensive test.
+		require.True(t, pkChanged([]any{true}, []any{"true"}))
+		require.True(t, pkChanged([]any{false}, []any{"false"}))
+		require.False(t, pkChanged([]any{true}, []any{true}))
+		require.False(t, pkChanged([]any{false}, []any{false}))
+		require.True(t, pkChanged([]any{true}, []any{false}))
+	})
 }
 
 // TestIsMinimalRowImage verifies the per-event detection used by the


### PR DESCRIPTION
## Summary

Closes #869. The branch is a focused cleanup of `pkg/repl/client.go` — both the obsolete adaptive batch-size machinery (the explicit ask of #869) and a few adjacent shape changes that fall out of looking at the same file. Net ~230 lines removed across `pkg/repl`.

### #869: remove the adaptive batch-size feedback loop

After #853 switched the binlog applier to emit inline `REPLACE INTO _new VALUES (...)` against the destination only, the source-side S-locks that motivated adaptive sizing disappeared and batches are now strictly serial inside `flushBatch` — there's nothing left for the p90-driven `feedback()` loop to throttle.

- Drop `Client.feedback()`, `Client.statisticsLock`, `Client.timingHistory`, `Client.targetBatchTime`, `Client.targetBatchSize`. The `flushMap` and `flushQueue` paths now just split on the package-level `DefaultBatchSize` constant.
- Drop `ClientConfig.TargetBatchTime` and `DefaultTargetBatchTime`. `pkg/migration.Runner` and `pkg/move.Runner` no longer propagate `TargetChunkTime` into a setting that does nothing.
- Drop `Client.concurrency` — the actual applier concurrency lives in `pkg/applier`, never on the repl `Client`.
- Refresh the `DefaultBatchSize` doc comment: it's no longer an "initial value," it's a fixed constant.

### Un-embed `sync.Mutex` on `Client`

`Client` embedded `sync.Mutex`, which exposed public `Lock()` / `Unlock()` on every `*Client` consumer:

- External code can call `c.Lock()` with no way to know what fields it protects. Future package-internal code that briefly takes the lock and the external caller can race, deadlock if the external caller forgets to unlock, or accidentally self-deadlock via a re-entrant call (`sync.Mutex` is not re-entrant).
- "What does `Client.Lock` protect?" is invisible at the type declaration — a reader has to grep the call sites to find out.

Renamed to a named, package-internal field `mu sync.Mutex` with a doc comment listing the fields it protects (positions, streamer/syncer/cancelFunc, the cached `binlogStatusStmt`). Updated all ~10 internal Lock/Unlock pairs. No external callers exist today, so this is a pure internal rename.

### Move free functions out of `Client` (shrink the god-struct)

`pkg/repl/utils.go` now holds the helpers that don't need any `Client` state:

- `binlogPositionIsImpossible(ctx, db, expectedLogName) (bool, error)` — was a `Client` method using only `c.db`. Parameterised on `db` so it's reusable.
- It also gained an honest signature: previously it returned a single `bool` that conflated "file definitely missing" with "the query failed." A transient network blip surfaced as "purged" and triggered a full re-copy on resume. Now: `(true, nil)` = purged, `(false, nil)` = resumable, `(_, err)` = couldn't tell — caller surfaces it as a real error.
- `pkValueEqual` now special-cases booleans so a `TINYINT(1)` PK surfaced as `bool` doesn't compare equal to a `VARCHAR` PK holding the literal string `"true"` (`fmt.Sprintf("%v", ...)` collapsed both to `"true"` previously). Vanishingly rare in practice, but the kind of thing a fuzz test would eventually find.

Package-level constants (`DefaultBatchSize`, `DefaultFlushInterval`, `DefaultSubscriptionSoftLimitBytes`, `DefaultTimeout`, the backoff knobs, `NewServerID`) move from `client.go` into `repl.go` so the `Client` type declaration in `client.go` reads as just the type and its methods.

### Use `NewClientDefaultConfig()` at the call sites

Collapsed ~25 `&ClientConfig{Logger: slog.Default(), ServerID: NewServerID()}` literals across tests and production callers to `NewClientDefaultConfig()` (with field overrides where needed for `CancelFunc` / `DBConfig` / a real logger). The two production sites (`pkg/migration/runner.go`, `pkg/move/runner.go`) use the same helper-and-override pattern instead of repeating the boilerplate. Default helper now actually has callers.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./pkg/repl/`
- [x] `go test -race -count=1 ./pkg/checksum/ ./pkg/migration/ ./pkg/move/`
- [x] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)