### PR TITLE
docs: pre-escaped SQL contract on Datum.String + monotone-grow pool convention

### DIFF
--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -445,6 +445,10 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 			if err != nil {
 				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", columnNames[i], err)
 			}
+			// datum.String() returns a complete pre-escaped SQL literal
+			// (NULL, a numeric, 0x… hex, or a "..."-quoted string). Safe
+			// to concatenate into the VALUES clause as-is — see the
+			// contract on Datum.String.
 			values = append(values, datum.String())
 		}
 		valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
@@ -767,6 +771,10 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 						results <- result{err: fmt.Errorf("failed to convert value to datum for column %s: %w", col, err)}
 						return
 					}
+					// datum.String() returns a complete pre-escaped SQL
+					// literal (NULL, a numeric, 0x… hex, or a "..."-quoted
+					// string). Safe to concatenate into the VALUES clause
+					// as-is — see the contract on Datum.String.
 					values = append(values, datum.String())
 				}
 				valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -331,6 +331,10 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 			if err != nil {
 				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", columnNames[i], err)
 			}
+			// datum.String() returns a complete pre-escaped SQL literal
+			// (NULL, a numeric, 0x… hex, or a "..."-quoted string). Safe
+			// to concatenate into the VALUES clause as-is — see the
+			// contract on Datum.String.
 			values = append(values, datum.String())
 		}
 		valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
@@ -541,6 +545,10 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.Col
 			if err != nil {
 				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", sourceColumnNames[i], err)
 			}
+			// datum.String() returns a complete pre-escaped SQL literal
+			// (NULL, a numeric, 0x… hex, or a "..."-quoted string). Safe
+			// to concatenate into the VALUES clause as-is — see the
+			// contract on Datum.String.
 			values = append(values, datum.String())
 		}
 		valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -61,6 +61,9 @@ func (c *CutOver) Run(ctx context.Context) error {
 		// - The RENAME TABLE connection
 		// - The Flush() threads
 		// Because we want to safely flush quickly, we set the limit to 5.
+		// Pool size grows monotonically and is not restored — the
+		// migration ends after cutover, so there is nothing to shrink
+		// back for. See the MaxOpenConnections doc in (*Runner).Run.
 		c.db.SetMaxOpenConns(5)
 	}
 	for i := range c.dbConfig.MaxRetries {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -183,6 +183,14 @@ func (r *Runner) Run(ctx context.Context) error {
 	// means that the replication applier can always make progress immediately,
 	// and does not need to wait for free slots from the copier *until* it needs
 	// copy in more than 1 thread.
+	//
+	// Pool size grows monotonically across migration phases — later phases
+	// (checksum, cutover) ratchet the limit upward via SetMaxOpenConns but
+	// never shrink it. That is deliberate: each phase's increase reflects
+	// its own connection budget, and by the time we're past the copy phase
+	// the copier/applier backpressure that motivated the starting +1 no
+	// longer applies. There is no point past which a smaller pool would
+	// help, so there is nothing to restore.
 	r.dbConfig.MaxOpenConnections = r.migration.Threads + 1
 	if r.migration.Buffered {
 		// Buffered has many more connections because it fans out x8 more write threads
@@ -1232,7 +1240,13 @@ func (r *Runner) checksum(ctx context.Context) error {
 	// - background flushing
 	// - checkpoint thread
 	// - checksum "replaceChunk" DB connections
-	// Handle a case just in the tests not having a dbConfig
+	// Handle a case just in the tests not having a dbConfig.
+	//
+	// Not restored when checksum completes — by then we are past the copy
+	// phase, so the +1 backpressure between copier and applier no longer
+	// applies, and the only thing left is cutover, which itself wants at
+	// least 5 connections. Pool size grows monotonically; see the
+	// MaxOpenConnections doc in (*Runner).Run.
 	r.db.SetMaxOpenConns(r.dbConfig.MaxOpenConnections + 2)
 
 	// Run the checksum with internal retry logic

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -276,14 +276,30 @@ func (d Datum) Range(d2 Datum) (uint64, error) {
 	return d.Val.(uint64) - d2.Val.(uint64), nil
 }
 
-// String returns the datum as a SQL-escaped literal. It is also
-// fmt.Stringer for log / debug formatting. The previous form panicked
-// when a non-numeric datum's Val was not a string; this form coerces
-// via %v so a misconstructed datum still produces a valid SQL fragment
-// (correctly escaped/quoted below) rather than crashing the migration.
-// NewDatum always normalizes Val to string for binaryType/unknownType,
-// so this coercion only fires for datums built by hand with an
-// unexpected Val type.
+// String returns the datum as a complete, self-contained SQL literal.
+// Every return path is safe to inline directly into a SQL statement
+// without further quoting or escaping by the caller:
+//
+//   - NULL                            for IsNil()
+//   - the numeric literal (e.g. 42)   for IsNumeric()
+//   - 0x... hex literal               for IsBinaryString()
+//   - "..." with backslash escapes    for everything else
+//
+// The string-literal path runs sqlescape.EscapeString on the contents
+// and wraps in double quotes, so callers like Chunk.String /
+// expandRowConstructorComparison / applier UpsertRows can construct
+// SQL by simple fmt.Sprintf concatenation. New code that has explicit
+// error handling available may prefer a typed accessor, but the
+// pre-escaped contract here is load-bearing for the migration's SQL
+// emission paths.
+//
+// It is also fmt.Stringer for log / debug output. The previous form
+// panicked when a non-numeric datum's Val was not a string; this form
+// coerces via %v so a misconstructed datum still produces a valid SQL
+// fragment rather than crashing the migration. NewDatum always
+// normalizes Val to string for binaryType/unknownType, so this
+// coercion only fires for datums built by hand with an unexpected Val
+// type.
 func (d Datum) String() string {
 	if d.IsNil() {
 		return "NULL"

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -90,6 +90,12 @@ func QuoteColumns(cols []string) string {
 // not always optimizing conditions such as (a,b,c) > (1,2,3).
 // This limitation is still current in 8.0, and was not fixed
 // by the work in https://dev.mysql.com/worklog/task/?id=7019
+//
+// vals[i].String() is inlined directly into the SQL fragment because
+// Datum.String() returns a pre-escaped self-contained SQL literal
+// (see its doc comment for the contract). Don't change the format
+// strings below to add quoting or escaping — the values already carry
+// it.
 func expandRowConstructorComparison(cols []string, operator Operator, vals []Datum) string {
 	if len(cols) != len(vals) {
 		panic("cols should be same size as values")


### PR DESCRIPTION
## Summary

Two doc-only commits split out of #868.

- **`pkg/table/datum.go`, `pkg/table/utils.go`, `pkg/applier/{sharded,single_target}.go`** — document that `Datum.String()` is used in two distinct ways: as a `fmt.Stringer` for logs *and* as a direct SQL-fragment inlining by `Chunk.String` / `expandRowConstructorComparison` / applier `UpsertRows`. Use case 2 is safe because every return path is a self-contained SQL literal (NULL / numeric / `0x…` hex / escape-quoted string). The contract was already true in the code; the comments now reflect it so a future reader doesn't "fix" it into a string concatenation that smuggles a quote.

- **`pkg/migration/runner.go`** — document the monotone-grow `SetMaxOpenConns` convention at the original assignment and the two ratchet sites (checksum + cutover). The pool size is never restored because by the time those phases run there is no later phase that would benefit from a smaller pool. The original code was correct; the absence of restore now looks intentional instead of suspect.

No behaviour change. Comment edits only.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)