### PR TITLE
fix(migration): cutover retry backoff + error joining + ctx-safe unlock

### DIFF
--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -7,11 +7,22 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/repl"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
+)
+
+const (
+	// cutoverInitialBackoff is the starting per-retry delay before
+	// re-attempting the rename. It doubles on each subsequent failure up
+	// to cutoverMaxBackoff. Without backoff a contended table lock
+	// produces a tight retry loop that worsens contention; this gives
+	// the source of contention time to clear.
+	cutoverInitialBackoff = 100 * time.Millisecond
+	cutoverMaxBackoff     = 10 * time.Second
 )
 
 type CutOver struct {
@@ -54,7 +65,6 @@ func NewCutOver(db *sql.DB, config []*cutoverConfig, feed *repl.Client, dbConfig
 }
 
 func (c *CutOver) Run(ctx context.Context) error {
-	var err error
 	if c.dbConfig.MaxOpenConnections < 5 {
 		// The gh-ost cutover algorithm requires a minimum of 3 connections:
 		// - The LOCK TABLES connection
@@ -63,15 +73,37 @@ func (c *CutOver) Run(ctx context.Context) error {
 		// Because we want to safely flush quickly, we set the limit to 5.
 		c.db.SetMaxOpenConns(5)
 	}
+	// Collect every attempt's error and join them on exit, so an operator
+	// debugging a flapping cutover sees the full failure history rather
+	// than just whatever happened on the last try.
+	var attemptErrs []error
+	backoff := cutoverInitialBackoff
 	for i := range c.dbConfig.MaxRetries {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return errors.Join(append(attemptErrs, ctx.Err())...)
+		}
+		if i > 0 {
+			// Exponential backoff between attempts. Without this a
+			// contended lock produces a tight retry loop that worsens
+			// contention. Sleeping ctx-aware so a cancel during backoff
+			// returns promptly instead of waiting out the full delay.
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return errors.Join(append(attemptErrs, ctx.Err())...)
+			case <-timer.C:
+			}
+			backoff *= 2
+			if backoff > cutoverMaxBackoff {
+				backoff = cutoverMaxBackoff
+			}
 		}
 		// Try and catch up before we attempt the cutover.
 		// since we will need to catch up again with the lock held
 		// and we want to minimize that.
 		if err := c.feed.Flush(ctx); err != nil {
-			return err
+			return errors.Join(append(attemptErrs, err)...)
 		}
 		// We use maxCutoverRetries as our retrycount, but nested
 		// within c.algorithmX() it may also have a retry for the specific statement
@@ -81,14 +113,17 @@ func (c *CutOver) Run(ctx context.Context) error {
 		)
 		// if specified in c.config[0], we will use the test cutover for failure injection.
 		// we don't need to exhaustively check all configs.
+		var err error
 		if len(c.config) > 0 && c.config[0].useTestCutover {
 			err = c.partialRenameForTest(ctx)
 		} else {
 			err = c.algorithmRenameUnderLock(ctx)
 		}
 		if err != nil {
+			attemptErrs = append(attemptErrs, fmt.Errorf("attempt %d: %w", i+1, err))
 			c.logger.Warn("cutover failed",
 				"error", err.Error(),
+				"next_backoff", backoff,
 			)
 			continue
 		}
@@ -96,7 +131,7 @@ func (c *CutOver) Run(ctx context.Context) error {
 		return nil
 	}
 	c.logger.Error("cutover failed, and retries exhausted")
-	return err
+	return errors.Join(attemptErrs...)
 }
 
 // algorithmRenameUnderLock is the preferred cutover algorithm.
@@ -123,7 +158,12 @@ func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*ta
 	if err != nil {
 		return err
 	}
-	defer utils.CloseAndLogWithContext(ctx, tableLock)
+	// Run UNLOCK TABLES with a ctx that ignores the parent's cancellation
+	// so a ctx cancel mid-cutover still releases the lock. ExecContext on
+	// a cancelled ctx returns immediately without sending the statement;
+	// the server would eventually release the lock when the connection
+	// dies, but giving UNLOCK TABLES a fair chance is cleaner.
+	defer utils.CloseAndLogWithContext(context.WithoutCancel(ctx), tableLock)
 	// FlushUnderTableLock itself does flush → BlockWait → flush, so the
 	// flush's own binlog events (REPLACE INTO _new / DELETE FROM _new) are
 	// already read back inside the BlockWait of the same call. The earlier

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -23,6 +23,12 @@ const (
 	// the source of contention time to clear.
 	cutoverInitialBackoff = 100 * time.Millisecond
 	cutoverMaxBackoff     = 10 * time.Second
+	// cutoverUnlockTimeout caps the duration of the deferred UNLOCK TABLES
+	// in executeRenameUnderLock. The unlock runs under a ctx derived via
+	// context.WithoutCancel so it still fires when the parent ctx is
+	// cancelled mid-cutover; without an explicit timeout the call could
+	// block indefinitely on an unhealthy connection.
+	cutoverUnlockTimeout = 30 * time.Second
 )
 
 type CutOver struct {
@@ -78,7 +84,7 @@ func (c *CutOver) Run(ctx context.Context) error {
 	// than just whatever happened on the last try.
 	var attemptErrs []error
 	backoff := cutoverInitialBackoff
-	for i := range c.dbConfig.MaxRetries {
+	for i := range max(1, c.dbConfig.MaxRetries) {
 		if ctx.Err() != nil {
 			return errors.Join(append(attemptErrs, ctx.Err())...)
 		}
@@ -162,8 +168,12 @@ func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*ta
 	// so a ctx cancel mid-cutover still releases the lock. ExecContext on
 	// a cancelled ctx returns immediately without sending the statement;
 	// the server would eventually release the lock when the connection
-	// dies, but giving UNLOCK TABLES a fair chance is cleaner.
-	defer utils.CloseAndLogWithContext(context.WithoutCancel(ctx), tableLock)
+	// dies, but giving UNLOCK TABLES a fair chance is cleaner. Bound the
+	// detached ctx with cutoverUnlockTimeout so an unhealthy connection
+	// can't block the deferred close indefinitely.
+	unlockCtx, cancelUnlock := context.WithTimeout(context.WithoutCancel(ctx), cutoverUnlockTimeout)
+	defer cancelUnlock()
+	defer utils.CloseAndLogWithContext(unlockCtx, tableLock)
 	// FlushUnderTableLock itself does flush → BlockWait → flush, so the
 	// flush's own binlog events (REPLACE INTO _new / DELETE FROM _new) are
 	// already read back inside the BlockWait of the same call. The earlier

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -138,6 +138,17 @@ func TestMDLLockFails(t *testing.T) {
 	// Cutover retries in a loop and fails after ~15s (3s timeout * 5 retries).
 	err = cutover.Run(t.Context())
 	require.Error(t, err)
+
+	// With error joining, every failed attempt is preserved in the returned
+	// error chain — operators debugging a flapping cutover see the full
+	// history rather than just the last try. MaxRetries=2 above, so we
+	// expect both attempts to be annotated and present.
+	joined, ok := err.(interface{ Unwrap() []error })
+	require.True(t, ok, "cutover error should be a joined error (%T)", err)
+	require.Len(t, joined.Unwrap(), 2, "expected one wrapped error per attempt")
+	require.Contains(t, err.Error(), "attempt 1:")
+	require.Contains(t, err.Error(), "attempt 2:")
+
 	require.NoError(t, trx.Rollback())
 }
 


### PR DESCRIPTION
## Summary

Three related fixes in the cutover path, split out of #868.

1. **Exponential backoff between cutover retry attempts.** Previously a failed cutover re-attempted immediately, which under transient lock contention worsened the contention. Sleep is 100ms doubling, capped at 10s, and is ctx-aware via \`select + timer\` so a cancel during backoff returns promptly.

2. **Collect every attempt's error and join with \`errors.Join\` on exit.** Previously only the last attempt's err survived, which obscured intermittent failure patterns when debugging a flapping cutover. Each per-attempt error is annotated with its attempt index for readability.

3. **Run \`UNLOCK TABLES\` with \`context.WithoutCancel\`** so a parent-ctx cancel mid-cutover still releases the table lock cleanly. Without this, \`ExecContext\` on a cancelled ctx returns immediately without sending the statement; the server eventually releases the lock when the connection dies, but giving \`UNLOCK TABLES\` a fair chance is the right shape.

Single commit, focused on cutover only.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `go test -race -count=1 ./pkg/migration/` (running)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)