### PR TITLE
Relax enum type changes

### DIFF
--- a/pkg/migration/check/enumsetremoval.go
+++ b/pkg/migration/check/enumsetremoval.go
@@ -91,7 +91,8 @@ func enumSetRemovalCheck(ctx context.Context, r Resources, logger *slog.Logger) 
 			return fmt.Errorf("unsafe %s to %s type conversion on column %q is not supported. "+
 				"%s values would be coerced from their string form to %s, "+
 				"which loses the original value (typically becomes 0). "+
-				"Keep %s as a string-typed column (VARCHAR, CHAR, TEXT, BLOB, etc.) if it must be converted",
+				"Use a string-typed target (VARCHAR, CHAR, TEXT, BLOB, etc.) instead, "+
+				"or keep the column as %s",
 				typeName, col.ColDef.Tp.String(), col.LookupName, typeName, col.ColDef.Tp.String(), typeName)
 		}
 	}

--- a/pkg/migration/check/enumsetremoval.go
+++ b/pkg/migration/check/enumsetremoval.go
@@ -15,17 +15,33 @@ func init() {
 
 // enumSetRemovalCheck prevents unsafe ENUM/SET type conversions.
 //
-// This covers two cases:
+// The binlog replay path receives ENUM/SET values as integer ordinals
+// or bitmasks from the go-mysql library. processRowsEvent decodes those
+// back to their string form before handing the row image to the
+// applier, so ENUM/SET → string-like target columns (VARCHAR, CHAR,
+// TEXT, BLOB, etc.) are now safe.
 //
-// 1. ENUM/SET → non-ENUM/SET (e.g., ENUM → VARCHAR): the binlog replay path
-// (bufferedMap) receives ENUM/SET values as integer ordinals/bitmasks from
-// the go-mysql library. If the target column has been changed to a
-// non-ENUM/SET type, those integers are inserted as literal values instead
-// of the original strings, causing data corruption.
+// ENUM → SET is also supported: each ENUM ordinal decodes to a
+// single-element string which the SET column accepts unchanged. We do
+// not require every existing ENUM element to appear in the new SET —
+// a defined-but-unused ENUM value is harmless, and the post-cutover
+// checksum catches any row whose ENUM value really is missing from
+// the new SET (it would land as the empty set and mismatch).
 //
-// 2. ENUM ↔ SET cross-conversions: ENUM uses ordinal integers while SET uses
-// bitmask integers. Converting between them would misinterpret the integer
-// encoding, causing data corruption.
+// What this check still blocks:
+//
+// 1. ENUM/SET → numeric (or any non-string type): even after string
+// decoding, the destination would coerce "red" → 0, which is almost
+// certainly not what the operator intended.
+//
+// 2. SET → ENUM: SET values can hold multiple elements (comma-joined)
+// which an ENUM column cannot represent. Supporting this would require
+// scanning the table to confirm every row has at most one element set;
+// not done here — block instead.
+//
+// 3. SET reorder is enforced separately by setReorderCheck, which
+// disallows it because the checksum compares CAST(col AS char) and the
+// string order changes when bits are reordered.
 func enumSetRemovalCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 	for _, col := range findModifiedColumns(*r.Statement.StmtNode) {
 		newTp := col.ColDef.Tp.GetType()
@@ -41,35 +57,60 @@ func enumSetRemovalCheck(ctx context.Context, r Resources, logger *slog.Logger) 
 			continue // existing column is not ENUM/SET; nothing to protect
 		}
 
-		// Case 1: ENUM/SET → non-ENUM/SET
-		if newTp != mysql.TypeEnum && newTp != mysql.TypeSet {
-			typeName := "ENUM"
-			if isSetType(existingType) {
-				typeName = "SET"
-			}
-			return fmt.Errorf("unsafe %s to non-%s type conversion on column %q is not supported. "+
-				"The binlog replay path uses integer encodings for %s values (ENUM ordinals / SET bitmasks), "+
-				"so converting to %s would insert those integer encodings instead of the original string values. "+
-				"Keep the column as %s type",
-				typeName, typeName, col.LookupName, typeName, col.ColDef.Tp.String(), typeName)
+		existingIsSet := isSetType(existingType)
+
+		// SET → ENUM is rejected: a SET row can hold N elements but an
+		// ENUM cell holds at most one. We don't scan to prove single-value
+		// usage, so we refuse the conversion outright.
+		if existingIsSet && newTp == mysql.TypeEnum {
+			return fmt.Errorf("unsafe SET to ENUM type conversion on column %q is not supported. "+
+				"SET columns can hold multiple elements per row, which ENUM cannot represent. "+
+				"Convert via an intermediate VARCHAR if you need to migrate the data manually",
+				col.LookupName)
 		}
 
-		// Case 2: ENUM ↔ SET cross-conversion
-		existingIsSet := isSetType(existingType)
-		newIsSet := newTp == mysql.TypeSet
-		if existingIsSet != newIsSet {
-			oldName := "ENUM"
-			newName := "SET"
+		// ENUM → SET: allowed unconditionally. Each ENUM ordinal decodes
+		// to a single-element string that the SET parses against its own
+		// element list; if a row's value isn't in the new SET it lands
+		// as the empty set, and the post-cutover checksum catches the
+		// mismatch. Pre-checking element membership would reject
+		// migrations that drop defined-but-unused ENUM values, which is
+		// a legitimate use case.
+		if !existingIsSet && newTp == mysql.TypeSet {
+			continue
+		}
+
+		// Decoding only helps when the destination accepts a string. For
+		// numeric (or other non-string) destinations the decoded value
+		// would be coerced — typically to 0 — silently corrupting data.
+		if newTp != mysql.TypeEnum && newTp != mysql.TypeSet && !isStringTargetType(newTp) {
+			typeName := "ENUM"
 			if existingIsSet {
-				oldName = "SET"
-				newName = "ENUM"
+				typeName = "SET"
 			}
 			return fmt.Errorf("unsafe %s to %s type conversion on column %q is not supported. "+
-				"ENUM values are replayed as ordinal integers and SET values as bitmask integers. "+
-				"Converting between them would misinterpret the encoding, causing data corruption. "+
-				"Avoid converting between ENUM and SET",
-				oldName, newName, col.LookupName)
+				"%s values would be coerced from their string form to %s, "+
+				"which loses the original value (typically becomes 0). "+
+				"Keep %s as a string-typed column (VARCHAR, CHAR, TEXT, BLOB, etc.) if it must be converted",
+				typeName, col.ColDef.Tp.String(), col.LookupName, typeName, col.ColDef.Tp.String(), typeName)
 		}
 	}
 	return nil
+}
+
+// isStringTargetType reports whether a MySQL type accepts a decoded
+// ENUM/SET string value without lossy coercion. CHAR/VARCHAR/TEXT and
+// the BLOB family all qualify (BLOB columns store bytes verbatim).
+func isStringTargetType(tp byte) bool {
+	switch tp {
+	case mysql.TypeVarchar,
+		mysql.TypeString,     // CHAR
+		mysql.TypeVarString,  // VAR_STRING (parser internal)
+		mysql.TypeTinyBlob,   // TINYTEXT/TINYBLOB
+		mysql.TypeMediumBlob, // MEDIUMTEXT/MEDIUMBLOB
+		mysql.TypeLongBlob,   // LONGTEXT/LONGBLOB
+		mysql.TypeBlob:       // TEXT/BLOB
+		return true
+	}
+	return false
 }

--- a/pkg/migration/check/enumsetremoval_test.go
+++ b/pkg/migration/check/enumsetremoval_test.go
@@ -28,22 +28,13 @@ func TestEnumSetRemovalCheckEnumToVarchar(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "enumremoval")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + ENUM→VARCHAR: should fail
+	// ENUM→VARCHAR is supported: processRowsEvent decodes the binlog
+	// ordinal into the element string before the applier sees it.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE enumremoval MODIFY COLUMN status VARCHAR(255) NOT NULL")[0],
-		Buffered:  true,
 	}
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe ENUM to non-ENUM")
-
-	// Unbuffered + ENUM→VARCHAR: should also fail — bufferedMap is now the
-	// binlog replay path for memory-comparable PKs regardless of the copy mode.
-	r.Buffered = false
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe ENUM to non-ENUM")
+	require.NoError(t, enumSetRemovalCheck(t.Context(), r, slog.Default()))
 }
 
 func TestEnumSetRemovalCheckEnumToText(t *testing.T) {
@@ -60,15 +51,12 @@ func TestEnumSetRemovalCheckEnumToText(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "enumremoval2")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + ENUM→TEXT: should fail
+	// ENUM→TEXT is supported for the same reason as ENUM→VARCHAR.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE enumremoval2 MODIFY COLUMN status TEXT NOT NULL")[0],
-		Buffered:  true,
 	}
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe ENUM to non-ENUM")
+	require.NoError(t, enumSetRemovalCheck(t.Context(), r, slog.Default()))
 }
 
 func TestEnumSetRemovalCheckEnumToInt(t *testing.T) {
@@ -85,15 +73,16 @@ func TestEnumSetRemovalCheckEnumToInt(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "enumremoval3")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + ENUM→INT: should fail
+	// ENUM→INT is still rejected: the decoded string would be coerced
+	// to 0, silently losing data.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE enumremoval3 MODIFY COLUMN status INT NOT NULL")[0],
-		Buffered:  true,
 	}
 	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
 	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe ENUM to non-ENUM")
+	require.ErrorContains(t, err, "ENUM")
+	require.ErrorContains(t, err, "string-typed column")
 }
 
 func TestEnumSetRemovalCheckSetToVarchar(t *testing.T) {
@@ -110,22 +99,13 @@ func TestEnumSetRemovalCheckSetToVarchar(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "setremoval")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + SET→VARCHAR: should fail
+	// SET→VARCHAR is supported: bitmask is decoded to a comma-joined
+	// string of element names before the applier sees it.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE setremoval MODIFY COLUMN flags VARCHAR(255) NOT NULL")[0],
-		Buffered:  true,
 	}
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe SET to non-SET")
-
-	// Unbuffered + SET→VARCHAR: should also fail — bufferedMap is now the
-	// binlog replay path for memory-comparable PKs regardless of the copy mode.
-	r.Buffered = false
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe SET to non-SET")
+	require.NoError(t, enumSetRemovalCheck(t.Context(), r, slog.Default()))
 }
 
 func TestEnumSetRemovalCheckChangeColumn(t *testing.T) {
@@ -142,15 +122,12 @@ func TestEnumSetRemovalCheckChangeColumn(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "enumremoval_change")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + CHANGE COLUMN ENUM→VARCHAR: should fail
+	// CHANGE COLUMN ENUM→VARCHAR is supported.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE enumremoval_change CHANGE COLUMN status status VARCHAR(255) NOT NULL")[0],
-		Buffered:  true,
 	}
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe ENUM to non-ENUM")
+	require.NoError(t, enumSetRemovalCheck(t.Context(), r, slog.Default()))
 }
 
 func TestEnumSetRemovalCheckEnumToEnum(t *testing.T) {
@@ -167,11 +144,10 @@ func TestEnumSetRemovalCheckEnumToEnum(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "enumremoval_safe")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + ENUM→ENUM (append): should pass (handled by enumReorderCheck, not this check)
+	// ENUM→ENUM (append): handled by enumReorderCheck, not this check.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE enumremoval_safe MODIFY COLUMN status ENUM('active', 'inactive', 'pending') NOT NULL")[0],
-		Buffered:  true,
 	}
 	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
 	require.NoError(t, err)
@@ -191,11 +167,10 @@ func TestEnumSetRemovalCheckNonEnumColumn(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "enumremoval_nochange")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + VARCHAR→TEXT: should pass (not an ENUM/SET removal)
+	// VARCHAR→TEXT: not an ENUM/SET removal.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE enumremoval_nochange MODIFY COLUMN name TEXT NOT NULL")[0],
-		Buffered:  true,
 	}
 	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
 	require.NoError(t, err)
@@ -215,22 +190,45 @@ func TestEnumSetRemovalCheckEnumToSet(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "enumtoset")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + ENUM→SET: should fail (ordinal vs bitmask mismatch)
+	// ENUM→SET with the same elements is supported: each decoded ENUM
+	// string is a single-element value the SET accepts unchanged.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE enumtoset MODIFY COLUMN status SET('active', 'inactive') NOT NULL")[0],
-		Buffered:  true,
 	}
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe ENUM to SET")
+	require.NoError(t, enumSetRemovalCheck(t.Context(), r, slog.Default()))
 
-	// Unbuffered + ENUM→SET: should also fail — bufferedMap is now the
-	// binlog replay path for memory-comparable PKs regardless of the copy mode.
-	r.Buffered = false
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe ENUM to SET")
+	// Element reordering or extra new elements is also fine — the
+	// destination SET parses the decoded string against its own element
+	// list, so any superset of the ENUM elements works.
+	r.Statement = statement.MustNew("ALTER TABLE enumtoset MODIFY COLUMN status SET('inactive', 'active', 'pending') NOT NULL")[0]
+	require.NoError(t, enumSetRemovalCheck(t.Context(), r, slog.Default()))
+}
+
+func TestEnumSetRemovalCheckEnumToSetMissingElement(t *testing.T) {
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS enumtoset_missing`)
+	testutils.RunSQL(t, `CREATE TABLE enumtoset_missing (
+		id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		status ENUM('active', 'inactive', 'pending') NOT NULL
+	)`)
+
+	tbl := table.NewTableInfo(db, "test", "enumtoset_missing")
+	require.NoError(t, tbl.SetInfo(t.Context()))
+
+	// The new SET drops 'pending'. We allow the check to pass — if
+	// 'pending' rows actually exist they land as the empty set and the
+	// post-cutover checksum will reject; if no row used 'pending', the
+	// migration succeeds. Rejecting at preflight would block legitimate
+	// schema cleanups that drop defined-but-unused ENUM values.
+	r := Resources{
+		Table:     tbl,
+		Statement: statement.MustNew("ALTER TABLE enumtoset_missing MODIFY COLUMN status SET('active', 'inactive') NOT NULL")[0],
+	}
+	require.NoError(t, enumSetRemovalCheck(t.Context(), r, slog.Default()))
 }
 
 func TestEnumSetRemovalCheckSetToEnum(t *testing.T) {
@@ -247,19 +245,12 @@ func TestEnumSetRemovalCheckSetToEnum(t *testing.T) {
 	tbl := table.NewTableInfo(db, "test", "settoenum")
 	require.NoError(t, tbl.SetInfo(t.Context()))
 
-	// Buffered + SET→ENUM: should fail (bitmask vs ordinal mismatch)
+	// SET→ENUM is rejected: SET cells can hold multiple elements that
+	// ENUM cannot represent.
 	r := Resources{
 		Table:     tbl,
 		Statement: statement.MustNew("ALTER TABLE settoenum MODIFY COLUMN flags ENUM('read', 'write') NOT NULL")[0],
-		Buffered:  true,
 	}
-	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsafe SET to ENUM")
-
-	// Unbuffered + SET→ENUM: should also fail — bufferedMap is now the
-	// binlog replay path for memory-comparable PKs regardless of the copy mode.
-	r.Buffered = false
 	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "unsafe SET to ENUM")

--- a/pkg/migration/check/enumsetremoval_test.go
+++ b/pkg/migration/check/enumsetremoval_test.go
@@ -82,7 +82,7 @@ func TestEnumSetRemovalCheckEnumToInt(t *testing.T) {
 	err = enumSetRemovalCheck(t.Context(), r, slog.Default())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "ENUM")
-	require.ErrorContains(t, err, "string-typed column")
+	require.ErrorContains(t, err, "string-typed target")
 }
 
 func TestEnumSetRemovalCheckSetToVarchar(t *testing.T) {

--- a/pkg/migration/check/rename.go
+++ b/pkg/migration/check/rename.go
@@ -15,10 +15,38 @@ func init() {
 }
 
 // renameCheck validates rename operations in ALTER TABLE statements.
-// Table renames are always blocked. Column renames are allowed for non-PK columns
-// in non-buffered mode, but blocked for PK columns and in buffered mode.
-// Additionally, it blocks dangerous patterns where a rename's old or new name
-// overlaps with an added column name, which could cause data corruption.
+// Table renames are always blocked. Column renames are allowed for
+// non-PK columns in the unbuffered copier path; PK renames and any
+// rename under the buffered copier are blocked. Additionally, it
+// blocks dangerous patterns where a rename's old or new name overlaps
+// with an added column name, which could cause data corruption.
+//
+// Why r.Buffered (the buffered *copier*, not the binlog subscription)
+// still gates column renames:
+//
+// Column renames go through ColumnMapping in every code path, so the
+// straight-line case works. The unsolved edges are in the buffered
+// copier's row-handling around generated/virtual columns:
+//
+//   - The buffered copier reads source rows by the intersected source
+//     column list and writes them to the target by the intersected
+//     target column list (renames applied). For tables with
+//     generated/virtual columns the row image and column lists drift
+//     from a plain CRUD layout in ways the unbuffered INSERT IGNORE
+//     ... SELECT doesn't have to deal with — the source SELECT and the
+//     destination INSERT are no longer "the same shape," and some
+//     rename + generated-column combinations have edge cases we
+//     haven't audited.
+//   - The unbuffered copier sidesteps this because SELECT and INSERT
+//     are wired with the same ColumnMapping at the SQL layer; MySQL
+//     does the column resolution.
+//   - The binlog replay path (always buffered) also uses ColumnMapping
+//     and is independent of this concern — that's why we don't gate on
+//     the subscription mode here.
+//
+// Plan: revisit once buffered-copier row handling has explicit
+// coverage for rename + generated/virtual columns. Tracking issue
+// TODO.
 func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 	alterStmt, ok := (*r.Statement.StmtNode).(*ast.AlterTableStmt)
 	if !ok {
@@ -48,8 +76,11 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 		}
 
 		if spec.Tp == ast.AlterTableRenameColumn {
+			// See function-level comment: gate is about the buffered
+			// *copier*'s row handling for generated/virtual columns,
+			// not about the always-buffered binlog subscription.
 			if r.Buffered {
-				return errors.New("column renames are not supported in buffered mode")
+				return errors.New("column renames are not supported with the buffered copier (--buffered); unaudited edge cases around generated/virtual columns in the buffered row-image path. Rerun without --buffered")
 			}
 			if spec.OldColumnName != nil {
 				if _, isPK := pkColumns[spec.OldColumnName.Name.O]; isPK {
@@ -68,8 +99,10 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 				oldName := spec.OldColumnName.Name.O
 				newName := spec.NewColumns[0].Name.Name.O
 				if oldName != newName {
+					// See function-level comment: buffered-copier gate
+					// only; the subscription path is fine.
 					if r.Buffered {
-						return errors.New("column renames are not supported in buffered mode")
+						return errors.New("column renames are not supported with the buffered copier (--buffered); unaudited edge cases around generated/virtual columns in the buffered row-image path. Rerun without --buffered")
 					}
 					if _, isPK := pkColumns[oldName]; isPK {
 						return fmt.Errorf("renaming primary key column %q is not supported", oldName)

--- a/pkg/migration/check/rename_test.go
+++ b/pkg/migration/check/rename_test.go
@@ -65,26 +65,29 @@ func TestRenamePKColumnBlocked(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRenameBlockedInBufferedMode(t *testing.T) {
+// TestRenameBlockedWithBufferedCopier covers the gate on column
+// renames when the buffered copier (--buffered) is opted in. The
+// always-buffered binlog subscription is not the concern — see the
+// renameCheck doc comment for the generated/virtual-column edge cases
+// that motivate the gate.
+func TestRenameBlockedWithBufferedCopier(t *testing.T) {
 	r := Resources{
 		Statement: statement.MustNew("ALTER TABLE t1 RENAME COLUMN c1 TO c2")[0],
 		Buffered:  true,
 	}
 	err := renameCheck(t.Context(), r, slog.Default())
 	require.Error(t, err)
-	require.ErrorContains(t, err, "not supported in buffered mode")
+	require.ErrorContains(t, err, "buffered copier")
 
-	// CHANGE COLUMN rename also blocked in buffered mode
+	// CHANGE COLUMN rename is also blocked under the buffered copier.
 	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c2 VARCHAR(100)")[0]
 	err = renameCheck(t.Context(), r, slog.Default())
 	require.Error(t, err)
-	require.ErrorContains(t, err, "not supported in buffered mode")
+	require.ErrorContains(t, err, "buffered copier")
 
-	// CHANGE COLUMN without rename is fine in buffered mode
+	// CHANGE COLUMN without a rename is fine under the buffered copier.
 	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c1 VARCHAR(100)")[0] //nolint: dupword
-	r.Buffered = true
-	err = renameCheck(t.Context(), r, slog.Default())
-	require.NoError(t, err)
+	require.NoError(t, renameCheck(t.Context(), r, slog.Default()))
 }
 
 func TestRenameColumnNameOverlap(t *testing.T) {

--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -303,6 +303,212 @@ func testSetReorder(t *testing.T, enableBuffered bool) {
 	require.ErrorContains(t, migrationErr, "unsafe SET value reorder")
 }
 
+// TestEnumToVarchar verifies that ENUM → VARCHAR migrations correctly
+// decode binlog ordinals into element strings so that buffered replay
+// writes the original values (e.g. "active") to the new VARCHAR column
+// rather than the raw int64 ordinal that the go-mysql binlog reader
+// emits. Regression test for the gap reported in
+// ppe-schema-change-development on Slack (2026-05-19).
+func TestEnumToVarchar(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "enumtovarchar", `CREATE TABLE enumtovarchar (
+		id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		status ENUM('active', 'inactive', 'pending') NOT NULL
+	)`)
+	// Seed with every ENUM value so we can assert on the full mapping.
+	tt.SeedRows(t, "INSERT INTO enumtovarchar (status) SELECT 'active'", 3000)
+	tt.SeedRows(t, "INSERT INTO enumtovarchar (status) SELECT 'inactive'", 3000)
+	tt.SeedRows(t, "INSERT INTO enumtovarchar (status) SELECT 'pending'", 3000)
+
+	m := NewTestRunner(t, "enumtovarchar", "MODIFY COLUMN status VARCHAR(32) NOT NULL",
+		WithThreads(1),
+		WithTargetChunkTime(100*time.Millisecond),
+		WithBuffered(true),
+		WithTestThrottler())
+
+	// Concurrent DML during the copy phase exercises the binlog replay
+	// path — the bug we're regression-testing only surfaces for rows that
+	// reach the target via the bufferedMap, not via the chunker's SELECT.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dmlDone := make(chan struct{})
+	go func() {
+		defer close(dmlDone)
+		for m.status.Get() < status.CopyRows {
+			time.Sleep(time.Millisecond)
+			if ctx.Err() != nil {
+				return
+			}
+		}
+		for i := 1; i <= 100; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO enumtovarchar (status) VALUES ('active')`)
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO enumtovarchar (status) VALUES ('inactive')`)
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO enumtovarchar (status) VALUES ('pending')`)
+			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE enumtovarchar SET status = 'pending' WHERE id = %d`, i))
+			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE enumtovarchar SET status = 'inactive' WHERE id = %d`, 3000+i))
+			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE enumtovarchar SET status = 'active' WHERE id = %d`, 6000+i))
+		}
+	}()
+
+	require.NoError(t, m.Run(ctx))
+	cancel()
+	<-dmlDone
+	require.NoError(t, m.Close())
+
+	// The column must now be VARCHAR and the values must be the original
+	// element strings — not their integer ordinals.
+	var colType string
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT column_type FROM information_schema.columns
+		 WHERE table_schema='test' AND table_name='enumtovarchar' AND column_name='status'`).Scan(&colType))
+	require.Contains(t, colType, "varchar")
+
+	// No row should have a numeric-looking status — that would mean the
+	// ordinal leaked through. Cast to numeric and look for any non-zero
+	// match; ENUM ordinals would all be 1/2/3.
+	var leaked int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM enumtovarchar WHERE status IN ('1','2','3')`).Scan(&leaked))
+	require.Zero(t, leaked, "binlog ENUM ordinals leaked into VARCHAR column")
+
+	// Every value should be one of the original element strings.
+	var nonString int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM enumtovarchar WHERE status NOT IN ('active','inactive','pending')`).Scan(&nonString))
+	require.Zero(t, nonString)
+}
+
+// TestSetToVarchar verifies that SET → VARCHAR migrations decode the
+// bitmask wire format into a comma-joined element string. Companion to
+// TestEnumToVarchar.
+func TestSetToVarchar(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "settovarchar", `CREATE TABLE settovarchar (
+		id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		perms SET('read', 'write', 'execute') NOT NULL
+	)`)
+	tt.SeedRows(t, "INSERT INTO settovarchar (perms) SELECT 'read,write'", 5000)
+	_, err := tt.DB.ExecContext(t.Context(), `INSERT INTO settovarchar (perms) VALUES ('read'),('write'),('execute'),('read,write,execute')`)
+	require.NoError(t, err)
+
+	m := NewTestRunner(t, "settovarchar", "MODIFY COLUMN perms VARCHAR(64) NOT NULL",
+		WithThreads(1),
+		WithTargetChunkTime(100*time.Millisecond),
+		WithBuffered(true),
+		WithTestThrottler())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dmlDone := make(chan struct{})
+	go func() {
+		defer close(dmlDone)
+		for m.status.Get() < status.CopyRows {
+			time.Sleep(time.Millisecond)
+			if ctx.Err() != nil {
+				return
+			}
+		}
+		for i := 1; i <= 50; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO settovarchar (perms) VALUES ('execute')`)
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO settovarchar (perms) VALUES ('read,execute')`)
+			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE settovarchar SET perms = 'read,write,execute' WHERE id = %d`, i))
+		}
+	}()
+
+	require.NoError(t, m.Run(ctx))
+	cancel()
+	<-dmlDone
+	require.NoError(t, m.Close())
+
+	var colType string
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT column_type FROM information_schema.columns
+		 WHERE table_schema='test' AND table_name='settovarchar' AND column_name='perms'`).Scan(&colType))
+	require.Contains(t, colType, "varchar")
+
+	// No row should contain a numeric-looking bitmask value. Any bitmask
+	// leaking through would render as a decimal string like "1", "3", "7".
+	var leaked int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM settovarchar WHERE perms REGEXP '^[0-9]+$'`).Scan(&leaked))
+	require.Zero(t, leaked, "binlog SET bitmask leaked into VARCHAR column")
+}
+
+// TestEnumToSet verifies that ENUM → SET migrations work end-to-end.
+// Each ENUM ordinal decodes to a single-element string which the
+// destination SET column accepts unchanged. Companion to
+// TestEnumToVarchar; covers the same binlog replay path with a SET
+// target instead of VARCHAR.
+func TestEnumToSet(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "enumtoset_mig", `CREATE TABLE enumtoset_mig (
+		id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		status ENUM('active', 'inactive', 'pending') NOT NULL
+	)`)
+	tt.SeedRows(t, "INSERT INTO enumtoset_mig (status) SELECT 'active'", 3000)
+	tt.SeedRows(t, "INSERT INTO enumtoset_mig (status) SELECT 'inactive'", 3000)
+	tt.SeedRows(t, "INSERT INTO enumtoset_mig (status) SELECT 'pending'", 3000)
+
+	m := NewTestRunner(t, "enumtoset_mig",
+		"MODIFY COLUMN status SET('active', 'inactive', 'pending') NOT NULL",
+		WithThreads(1),
+		WithTargetChunkTime(100*time.Millisecond),
+		WithBuffered(true),
+		WithTestThrottler())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dmlDone := make(chan struct{})
+	go func() {
+		defer close(dmlDone)
+		for m.status.Get() < status.CopyRows {
+			time.Sleep(time.Millisecond)
+			if ctx.Err() != nil {
+				return
+			}
+		}
+		for i := 1; i <= 100; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO enumtoset_mig (status) VALUES ('active')`)
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO enumtoset_mig (status) VALUES ('inactive')`)
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO enumtoset_mig (status) VALUES ('pending')`)
+			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE enumtoset_mig SET status = 'pending' WHERE id = %d`, i))
+			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE enumtoset_mig SET status = 'inactive' WHERE id = %d`, 3000+i))
+		}
+	}()
+
+	require.NoError(t, m.Run(ctx))
+	cancel()
+	<-dmlDone
+	require.NoError(t, m.Close())
+
+	var colType string
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT column_type FROM information_schema.columns
+		 WHERE table_schema='test' AND table_name='enumtoset_mig' AND column_name='status'`).Scan(&colType))
+	require.Contains(t, colType, "set(")
+
+	// Every row must hold one of the three known element strings. A
+	// failed decode would render as an integer-looking value, or the
+	// empty SET if an ordinal pointed at a missing element.
+	var bad int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM enumtoset_mig
+		 WHERE status NOT IN ('active','inactive','pending')`).Scan(&bad))
+	require.Zero(t, bad)
+}
+
 // TestBufferedMigrationFailsGracefullyWithMinimalRBR verifies that a buffered
 // migration fails gracefully when it receives minimal RBR events from a rogue session.
 func TestBufferedMigrationFailsGracefullyWithMinimalRBR(t *testing.T) {

--- a/pkg/repl/client.go
+++ b/pkg/repl/client.go
@@ -650,6 +650,19 @@ func (c *Client) processRowsEvent(ev *replication.BinlogEvent, e *replication.Ro
 	tbl := sub.Tables()[0]
 	eventType := parseEventType(ev.Header.EventType)
 
+	// Decode ENUM ordinals / SET bitmasks back to their string form before
+	// we hand the row image to the subscription. The binlog reader yields
+	// them as int64s; if the target column has been migrated to a non-ENUM
+	// type (e.g. VARCHAR) the applier would otherwise insert those integers
+	// as literal values. See TableInfo.DecodeBinlogRow.
+	if tbl.HasEnumOrSetColumns() {
+		for _, row := range e.Rows {
+			if err := tbl.DecodeBinlogRow(row); err != nil {
+				return fmt.Errorf("decoding binlog row for %s.%s: %w", tbl.SchemaName, tbl.TableName, err)
+			}
+		}
+	}
+
 	if eventType == eventTypeUpdate {
 		// UPDATE events always carry before/after image pairs.
 		for i := 0; i < len(e.Rows); i += 2 {

--- a/pkg/table/enumset.go
+++ b/pkg/table/enumset.go
@@ -122,17 +122,22 @@ func decodeEnumOrdinal(ordinal int64, elements []string) (string, error) {
 // decodeSetBitmask converts a SET bitmask into a comma-joined string of
 // the elements whose bits are set. Bit i (0-indexed) corresponds to
 // elements[i]. Bits set above len(elements) are an error.
+//
+// The bitmask arrives from the go-mysql binlog reader as int64 because
+// that is what its decodeValue() path returns, but MySQL SET supports
+// up to 64 members — a value with bit 63 set (or all 64 bits set,
+// which surfaces as -1) is valid. We reinterpret the int64 as uint64
+// to walk the bits; out-of-range bits are caught by the
+// i >= len(elements) guard rather than by a sign check.
 func decodeSetBitmask(bitmask int64, elements []string) (string, error) {
 	if bitmask == 0 {
 		return "", nil
 	}
-	if bitmask < 0 {
-		return "", fmt.Errorf("SET bitmask %d is negative", bitmask)
-	}
+	bits := uint64(bitmask)
 	maxBits := len(elements)
 	var parts []string
 	for i := 0; i < 64; i++ {
-		if bitmask&(int64(1)<<i) == 0 {
+		if bits&(uint64(1)<<i) == 0 {
 			continue
 		}
 		if i >= maxBits {

--- a/pkg/table/enumset.go
+++ b/pkg/table/enumset.go
@@ -1,0 +1,144 @@
+package table
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ENUM/SET binlog decoding.
+//
+// The go-mysql binlog reader returns ENUM values as int64 ordinals
+// (1-indexed) and SET values as int64 bitmasks. To replay those values
+// onto a target column that has been migrated to a string type (e.g.
+// VARCHAR), we need the original string elements. They are not carried
+// in the binlog stream, so we recover them by parsing the column's
+// `column_type` text from information_schema, which TableInfo already
+// caches in columnsMySQLTps.
+
+// isEnumColumnType reports whether a column_type string from
+// information_schema is an ENUM, e.g. "enum('a','b','c')".
+func isEnumColumnType(mysqlType string) bool {
+	return strings.HasPrefix(strings.ToLower(mysqlType), "enum(")
+}
+
+// isSetColumnType reports whether a column_type string from
+// information_schema is a SET, e.g. "set('a','b','c')".
+func isSetColumnType(mysqlType string) bool {
+	return strings.HasPrefix(strings.ToLower(mysqlType), "set(")
+}
+
+// parseEnumSetElements extracts the element list from a column_type
+// string like "enum('a','b','c')" or "set('x','y','z')". It is
+// fail-closed: malformed input returns an error so callers never
+// silently bypass the decoder. Duplicated intentionally from
+// pkg/migration/check/enumsetutil.go to avoid an import cycle; the
+// two parsers are covered by their respective tests.
+func parseEnumSetElements(mysqlType string) ([]string, error) {
+	if !isEnumColumnType(mysqlType) && !isSetColumnType(mysqlType) {
+		return nil, fmt.Errorf("not an enum/set type: %q", mysqlType)
+	}
+
+	start := strings.IndexByte(mysqlType, '(')
+	if start < 0 {
+		return nil, fmt.Errorf("missing opening parenthesis in type: %q", mysqlType)
+	}
+	end := strings.LastIndexByte(mysqlType, ')')
+	if end <= start {
+		return nil, fmt.Errorf("missing closing parenthesis in type: %q", mysqlType)
+	}
+	inner := mysqlType[start+1 : end]
+	if len(inner) == 0 {
+		return nil, nil
+	}
+
+	var elems []string
+	i := 0
+	n := len(inner)
+	expectValue := true
+	for {
+		for i < n && (inner[i] == ' ' || inner[i] == '\t') {
+			i++
+		}
+		if expectValue {
+			if i >= n {
+				if len(elems) == 0 {
+					return nil, fmt.Errorf("empty quoted list %q", inner)
+				}
+				return nil, fmt.Errorf("trailing delimiter in quoted list %q", inner)
+			}
+			if inner[i] != '\'' {
+				return nil, fmt.Errorf("unexpected character %q at position %d in quoted list %q", inner[i], i, inner)
+			}
+			i++
+			var buf strings.Builder
+			closed := false
+			for i < n {
+				if inner[i] == '\'' {
+					if i+1 < n && inner[i+1] == '\'' {
+						buf.WriteByte('\'')
+						i += 2
+						continue
+					}
+					i++
+					closed = true
+					break
+				}
+				buf.WriteByte(inner[i])
+				i++
+			}
+			if !closed {
+				return nil, fmt.Errorf("unterminated quoted string in quoted list %q", inner)
+			}
+			elems = append(elems, buf.String())
+			expectValue = false
+		} else {
+			if i >= n {
+				break
+			}
+			if inner[i] != ',' {
+				return nil, fmt.Errorf("unexpected character %q at position %d in quoted list %q", inner[i], i, inner)
+			}
+			i++
+			expectValue = true
+		}
+	}
+	return elems, nil
+}
+
+// decodeEnumOrdinal converts a 1-indexed ENUM ordinal into the matching
+// element string. Ordinal 0 is MySQL's empty-string sentinel (”) for an
+// invalid value and is preserved as "". Out-of-range ordinals are an
+// error rather than a silent miscoding.
+func decodeEnumOrdinal(ordinal int64, elements []string) (string, error) {
+	if ordinal == 0 {
+		return "", nil
+	}
+	if ordinal < 0 || int(ordinal) > len(elements) {
+		return "", fmt.Errorf("ENUM ordinal %d out of range for %d elements", ordinal, len(elements))
+	}
+	return elements[ordinal-1], nil
+}
+
+// decodeSetBitmask converts a SET bitmask into a comma-joined string of
+// the elements whose bits are set. Bit i (0-indexed) corresponds to
+// elements[i]. Bits set above len(elements) are an error.
+func decodeSetBitmask(bitmask int64, elements []string) (string, error) {
+	if bitmask == 0 {
+		return "", nil
+	}
+	if bitmask < 0 {
+		return "", fmt.Errorf("SET bitmask %d is negative", bitmask)
+	}
+	maxBits := len(elements)
+	var parts []string
+	for i := 0; i < 64; i++ {
+		if bitmask&(int64(1)<<i) == 0 {
+			continue
+		}
+		if i >= maxBits {
+			return "", fmt.Errorf("SET bitmask bit %d set but only %d elements defined", i, maxBits)
+		}
+		parts = append(parts, elements[i])
+	}
+	return strings.Join(parts, ","), nil
+}

--- a/pkg/table/enumset_test.go
+++ b/pkg/table/enumset_test.go
@@ -1,6 +1,9 @@
 package table
 
 import (
+	"fmt"
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -115,6 +118,41 @@ func TestDecodeSetBitmask(t *testing.T) {
 
 	_, err = decodeSetBitmask(8, elements) // bit 3, no element
 	require.Error(t, err)
+	// -1 (all 64 bits) is rejected here because elements only defines 3.
+	// The 64-element case is covered separately below.
 	_, err = decodeSetBitmask(-1, elements)
 	require.Error(t, err)
+}
+
+// TestDecodeSetBitmask64Elements covers the upper edge of MySQL SET:
+// 64 members means valid bitmasks can use bit 63, which surfaces as a
+// negative int64 from the go-mysql binlog reader. Regression test for
+// the earlier check that rejected any negative input outright.
+func TestDecodeSetBitmask64Elements(t *testing.T) {
+	elements := make([]string, 64)
+	for i := range elements {
+		elements[i] = fmt.Sprintf("e%d", i)
+	}
+
+	// Bit 63 alone — int64 representation is math.MinInt64 (negative).
+	// Build via math.MinInt64 to avoid constant-overflow rules around
+	// 1 << 63 in either signed or unsigned form.
+	bit63 := int64(math.MinInt64)
+	got, err := decodeSetBitmask(bit63, elements)
+	require.NoError(t, err)
+	require.Equal(t, "e63", got)
+
+	// All 64 bits set — int64 representation is -1.
+	got, err = decodeSetBitmask(-1, elements)
+	require.NoError(t, err)
+	expectedParts := make([]string, 64)
+	for i := range expectedParts {
+		expectedParts[i] = fmt.Sprintf("e%d", i)
+	}
+	require.Equal(t, strings.Join(expectedParts, ","), got)
+
+	// Mixed: bit 0 + bit 63.
+	got, err = decodeSetBitmask(int64(1)|bit63, elements)
+	require.NoError(t, err)
+	require.Equal(t, "e0,e63", got)
 }

--- a/pkg/table/enumset_test.go
+++ b/pkg/table/enumset_test.go
@@ -1,0 +1,120 @@
+package table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsEnumColumnType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"enum('a','b','c')", true},
+		{"ENUM('a')", true},
+		{"set('a','b')", false},
+		{"varchar(255)", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		require.Equalf(t, c.want, isEnumColumnType(c.in), "input=%q", c.in)
+	}
+}
+
+func TestIsSetColumnType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"set('a','b','c')", true},
+		{"SET('a')", true},
+		{"enum('a','b')", false},
+		{"varchar(255)", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		require.Equalf(t, c.want, isSetColumnType(c.in), "input=%q", c.in)
+	}
+}
+
+func TestParseEnumSetElements(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{"enum('active','inactive','pending')", []string{"active", "inactive", "pending"}, false},
+		{"set('read','write','execute')", []string{"read", "write", "execute"}, false},
+		{"enum('a','b,c','d')", []string{"a", "b,c", "d"}, false},
+		{"enum('it''s','fine')", []string{"it's", "fine"}, false},
+		{"enum()", nil, false},
+		{"varchar(255)", nil, true},
+		{"enum('unterminated", nil, true},
+		{"enum('a',,'b')", nil, true},
+	}
+	for _, c := range cases {
+		got, err := parseEnumSetElements(c.in)
+		if c.wantErr {
+			require.Errorf(t, err, "input=%q", c.in)
+			continue
+		}
+		require.NoErrorf(t, err, "input=%q", c.in)
+		require.Equalf(t, c.want, got, "input=%q", c.in)
+	}
+}
+
+func TestDecodeEnumOrdinal(t *testing.T) {
+	elements := []string{"active", "inactive", "pending"}
+
+	got, err := decodeEnumOrdinal(1, elements)
+	require.NoError(t, err)
+	require.Equal(t, "active", got)
+
+	got, err = decodeEnumOrdinal(2, elements)
+	require.NoError(t, err)
+	require.Equal(t, "inactive", got)
+
+	got, err = decodeEnumOrdinal(3, elements)
+	require.NoError(t, err)
+	require.Equal(t, "pending", got)
+
+	// 0 is MySQL's "invalid value" sentinel; preserved as empty string.
+	got, err = decodeEnumOrdinal(0, elements)
+	require.NoError(t, err)
+	require.Equal(t, "", got)
+
+	_, err = decodeEnumOrdinal(4, elements)
+	require.Error(t, err)
+	_, err = decodeEnumOrdinal(-1, elements)
+	require.Error(t, err)
+}
+
+func TestDecodeSetBitmask(t *testing.T) {
+	elements := []string{"read", "write", "execute"}
+
+	got, err := decodeSetBitmask(0, elements)
+	require.NoError(t, err)
+	require.Equal(t, "", got)
+
+	got, err = decodeSetBitmask(1, elements) // read
+	require.NoError(t, err)
+	require.Equal(t, "read", got)
+
+	got, err = decodeSetBitmask(3, elements) // read | write
+	require.NoError(t, err)
+	require.Equal(t, "read,write", got)
+
+	got, err = decodeSetBitmask(5, elements) // read | execute
+	require.NoError(t, err)
+	require.Equal(t, "read,execute", got)
+
+	got, err = decodeSetBitmask(7, elements) // all
+	require.NoError(t, err)
+	require.Equal(t, "read,write,execute", got)
+
+	_, err = decodeSetBitmask(8, elements) // bit 3, no element
+	require.Error(t, err)
+	_, err = decodeSetBitmask(-1, elements)
+	require.Error(t, err)
+}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -39,6 +39,7 @@ type TableInfo struct {
 	NonGeneratedColumns         []string          // all the non-generated column names
 	Indexes                     []string          // all the index names
 	columnsMySQLTps             map[string]string // map from column name to MySQL type
+	enumSetElements             map[int][]string  // parsed ENUM/SET element list, keyed by column ordinal; only present for ENUM/SET columns
 	KeyColumns                  []string          // the column names of the primaryKey
 	keyColumnsMySQLTp           []string          // the MySQL types of the primaryKey
 	KeyIsAutoInc                bool              // if pk[0] is an auto_increment column
@@ -192,6 +193,7 @@ func (t *TableInfo) setColumns(ctx context.Context) error {
 	t.Columns = []string{}
 	t.NonGeneratedColumns = []string{}
 	t.columnsMySQLTps = make(map[string]string)
+	t.enumSetElements = nil
 	for rows.Next() {
 		var col, tp, expression string
 		if err := rows.Scan(&col, &tp, &expression); err != nil {
@@ -201,6 +203,16 @@ func (t *TableInfo) setColumns(ctx context.Context) error {
 		t.columnsMySQLTps[col] = tp
 		if expression == "" {
 			t.NonGeneratedColumns = append(t.NonGeneratedColumns, col)
+		}
+		if isEnumColumnType(tp) || isSetColumnType(tp) {
+			elements, perr := parseEnumSetElements(tp)
+			if perr != nil {
+				return fmt.Errorf("parsing ENUM/SET elements for %s.%s.%s: %w", t.SchemaName, t.TableName, col, perr)
+			}
+			if t.enumSetElements == nil {
+				t.enumSetElements = make(map[int][]string)
+			}
+			t.enumSetElements[len(t.Columns)-1] = elements
 		}
 	}
 	if rows.Err() != nil {
@@ -419,6 +431,64 @@ func (t *TableInfo) datumTp(col string) (datumTp, error) {
 func (t *TableInfo) GetColumnMySQLType(col string) (string, bool) {
 	tp, ok := t.columnsMySQLTps[col]
 	return tp, ok
+}
+
+// HasEnumOrSetColumns reports whether any column on this table is an
+// ENUM or SET. Used to skip the per-row decoding hot path when there's
+// nothing to decode.
+func (t *TableInfo) HasEnumOrSetColumns() bool {
+	return len(t.enumSetElements) > 0
+}
+
+// DecodeBinlogRow converts ENUM and SET values in a binlog row image
+// from their integer wire format (ENUM ordinal / SET bitmask) back to
+// the string form. Mutates the slice in place.
+//
+// Why: the go-mysql binlog reader yields ENUM as int64 ordinals and SET
+// as int64 bitmasks. Spirit's buffered replay path takes the row image
+// verbatim and feeds it to the applier as a REPLACE INTO ... VALUES.
+// If the target column has been migrated to a non-ENUM type
+// (e.g. VARCHAR), MySQL inserts those integers as literal values
+// instead of the original strings, corrupting data. Decoding here
+// restores the string form before the applier sees it.
+//
+// nil values (NULL columns) and rows with no ENUM/SET columns are a
+// no-op. If the table has no ENUM/SET columns at all, callers should
+// gate with HasEnumOrSetColumns and skip the call entirely.
+func (t *TableInfo) DecodeBinlogRow(row []any) error {
+	if len(t.enumSetElements) == 0 {
+		return nil
+	}
+	for ord, elements := range t.enumSetElements {
+		if ord >= len(row) {
+			continue
+		}
+		raw := row[ord]
+		if raw == nil {
+			continue
+		}
+		intVal, ok := raw.(int64)
+		if !ok {
+			continue
+		}
+		colName := ""
+		if ord < len(t.Columns) {
+			colName = t.Columns[ord]
+		}
+		mysqlType := t.columnsMySQLTps[colName]
+		var decoded string
+		var derr error
+		if isSetColumnType(mysqlType) {
+			decoded, derr = decodeSetBitmask(intVal, elements)
+		} else {
+			decoded, derr = decodeEnumOrdinal(intVal, elements)
+		}
+		if derr != nil {
+			return fmt.Errorf("decoding %s.%s column %q: %w", t.SchemaName, t.TableName, colName, derr)
+		}
+		row[ord] = decoded
+	}
+	return nil
 }
 
 // GetColumnOrdinal returns the ordinal position (0-indexed) of a column by name.


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

This relaxes a requirement where buffered subscriptions could not handle enum changes, such as enum->varchar.

This required supporting work to decode ENUM/SET values in the binary log stream. Unit tests and explicit integration tests for common cases (ENUM-> SET, ENUM->VARCHAR) are added.