### PR TITLE
enhance status API

### DIFF
--- a/pkg/migration/binlog_test.go
+++ b/pkg/migration/binlog_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/throttler"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -126,7 +127,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	m := NewTestRunner(t, "e2et1", "ENGINE=InnoDB", WithBuffered(false))
 	defer utils.CloseAndLog(m)
 	require.Equal(t, "initial", m.status.Get().String())
-	require.Equal(t, status.Progress{CurrentState: status.Initial, Summary: "", Tables: nil}, m.Progress())
+	require.Equal(t, status.Progress{CurrentState: status.Initial, Summary: "", Tables: nil, Throttler: &throttler.Noop{}}, m.Progress())
 
 	// Usually we would call m.Run() but we want to step through
 	// the migration process manually.
@@ -163,7 +164,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	require.NotNil(t, chunk)
 	require.Equal(t, "((`id1` < 1001)\n OR (`id1` = 1001 AND `id2` < 1))", chunk.String())
 	require.NoError(t, ccopier.CopyChunk(t.Context(), chunk))
-	require.Equal(t, status.Progress{CurrentState: status.CopyRows, Summary: "1000/1200 83.33% copyRows ETA TBD", Tables: []status.TableProgress{{TableName: "e2et1", RowsCopied: 1000, RowsTotal: 1200, IsComplete: false}}}, m.Progress())
+	require.Equal(t, status.Progress{CurrentState: status.CopyRows, Summary: "1000/1200 83.33% copyRows ETA TBD", Tables: []status.TableProgress{{TableName: "e2et1", RowsCopied: 1000, RowsTotal: 1200, IsComplete: false}}, Throttler: &throttler.Noop{}}, m.Progress())
 
 	// Now insert some data.
 	testutils.RunSQL(t, `insert into e2et1 (id1, id2) values (1002, 2)`)
@@ -178,7 +179,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "((`id1` > 1001)\n OR (`id1` = 1001 AND `id2` >= 1))", chunk.String())
 	require.NoError(t, ccopier.CopyChunk(t.Context(), chunk))
-	require.Equal(t, status.Progress{CurrentState: status.CopyRows, Summary: "1201/1200 100.08% copyRows ETA DUE", Tables: []status.TableProgress{{TableName: "e2et1", RowsCopied: 1201, RowsTotal: 1200, IsComplete: true}}}, m.Progress())
+	require.Equal(t, status.Progress{CurrentState: status.CopyRows, Summary: "1201/1200 100.08% copyRows ETA DUE", Tables: []status.TableProgress{{TableName: "e2et1", RowsCopied: 1201, RowsTotal: 1200, IsComplete: true}}, Throttler: &throttler.Noop{}}, m.Progress())
 
 	// Now insert some data.
 	// This should be picked up by the binlog subscription
@@ -208,7 +209,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 	m.dbConfig = dbconn.NewDBConfig()
 	require.NoError(t, m.checksum(t.Context()))
 	require.Equal(t, "postChecksum", m.status.Get().String())
-	require.Equal(t, status.Progress{CurrentState: status.PostChecksum, Summary: "Applying Changeset Deltas=0", Tables: []status.TableProgress{{TableName: "e2et1", RowsCopied: 1201, RowsTotal: 1200, IsComplete: true}}}, m.Progress())
+	require.Equal(t, status.Progress{CurrentState: status.PostChecksum, Summary: "Applying Changeset Deltas=0", Tables: []status.TableProgress{{TableName: "e2et1", RowsCopied: 1201, RowsTotal: 1200, IsComplete: true}}, Throttler: &throttler.Noop{}}, m.Progress())
 
 	// All done!
 	require.Equal(t, 0, m.db.Stats().InUse) // all connections are returned.

--- a/pkg/migration/resume-from-checkpoint.md
+++ b/pkg/migration/resume-from-checkpoint.md
@@ -28,12 +28,12 @@ When a new Runner starts (`Runner.Run()` → `setup()`), it always attempts `res
 
 1. **Check `_<table>_new` exists** — if the shadow table is gone, there's nothing to resume.
 2. **Read checkpoint table** — fetch the saved watermarks, position, statement, and `original_table_name`.
-3. **Validate DDL statement matches** — the checkpoint must be for the same alter. On a mismatch, Spirit discards the checkpoint and starts fresh.
+3. **Validate DDL statement matches** — the checkpoint must be for the same alter. On a mismatch, Spirit discards the checkpoint and starts fresh. The error reason is surfaced via `Runner.ResumeError()`.
 4. **Validate `original_table_name` matches** (single-table mode) — guards against the rare collision where two long table names truncate to the same checkpoint table name. A mismatch causes Spirit to discard the checkpoint and start fresh.
 5. **Set up copier, checker, and change source** — create the change source and add subscriptions for each table.
 6. **Resume streaming from the saved position** — `replClient.StartFromPosition(ctx, position)` primes the source's internal position and begins streaming. The source validates the position is still resumable; if it isn't (e.g. the MySQL binlog file has been purged), `change.ErrPositionNotFound` is returned and surfaces as `status.ErrBinlogNotFound`, causing Spirit to fall back to `newMigration()`.
 
-If any step fails, Spirit logs the reason and falls back to `newMigration()`, which starts the migration from scratch. This means resume is best-effort — Spirit will always make forward progress even if the checkpoint is unusable.
+If any step fails, Spirit logs the reason and falls back to `newMigration()`, which starts the migration from scratch. This means resume is best-effort — Spirit will always make forward progress even if the checkpoint is unusable. The error returned by the failed `resumeFromCheckpoint()` is preserved on the runner and accessible via `Runner.ResumeError()`.
 
 ## Background: how MySQL binary logs work
 
@@ -47,11 +47,12 @@ MySQL automatically deletes old binlog files based on `binlog_expire_logs_second
 
 One reason resume can fail is **binlog expiry**. If the checkpoint references a binlog file that has been purged, Spirit cannot resume because changes in the gap would be lost.
 
-The change source is responsible for detecting this when resume begins. The binlog implementation validates the position inside `StartFromPosition` (against `SHOW BINARY LOGS`) and returns `change.ErrPositionNotFound` if the file is gone; the migration runner translates that to `status.ErrBinlogNotFound`. Spirit logs the reason and falls back to `newMigration()`, restarting the copy from scratch. All checkpoint progress is lost.
+The change source is responsible for detecting this when resume begins. The binlog implementation validates the position inside `StartFromPosition` (against `SHOW BINARY LOGS`) and returns `change.ErrPositionNotFound` if the file is gone; the migration runner translates that to `status.ErrBinlogNotFound`. Spirit logs the reason and falls back to `newMigration()`, restarting the copy from scratch. All checkpoint progress is lost. The error is preserved on `Runner.ResumeError()` so callers can detect what happened.
 
 The tradeoff of falling back to `newMigration()` is that all copy progress is lost. For a large table this could mean hours of wasted work. To avoid this:
 
 - **Keep binlog retention longer than your longest expected migration pause.** If you expect to pause migrations for up to a week, make sure `binlog_expire_logs_seconds` is set to at least 7 days. The MySQL 8.0 default is 30 days (`2592000`), which is usually sufficient.
+- **Inspect `Runner.ResumeError()` after `Run()`** if you want to alert on lost progress. The typed errors (`status.ErrMismatchedAlter`, `status.ErrBinlogNotFound`, `status.ErrCheckpointTooOld`, `status.ErrCheckpointCollision`) work with `errors.Is()` for programmatic handling.
 - **Be aware of your binlog retention window.** If Spirit is paused longer than the retention period, the checkpoint's binlog file will be purged and resume will fail. Some managed MySQL services disable retention by default.
 
 ## Cross-version compatibility
@@ -62,7 +63,7 @@ Practical implications:
 
 - **Upgrading Spirit mid-migration** (older binary → newer binary). The newer binary's `Scan` expects a different number of columns than the on-disk checkpoint provides, so the read fails.
 - **Rolling back Spirit mid-migration** (newer binary → older binary). Same failure mode in reverse.
-- **Effect:** the read returns a generic `"could not read from table"` error wrapping the underlying `database/sql` scan error. Spirit logs the error and falls through to `newMigration()`. The copy restarts from scratch and all checkpoint progress is lost.
+- **Effect:** the read returns a generic `"could not read from table"` error wrapping the underlying `database/sql` scan error. Spirit logs the error and falls through to `newMigration()`. The copy restarts from scratch and all checkpoint progress is lost; the error is preserved on `Runner.ResumeError()`.
 
 Operational guidance:
 

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -82,7 +82,7 @@ func TestChangeIntToBigIntPKResumeFromChkPt(t *testing.T) {
 	// Start a new migration with the same parameters. Let it complete.
 	m2 := NewTestRunner(t, "bigintpk", alterSQL, WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint)
+	require.True(t, m2.UsedResumeFromCheckpoint())
 	require.NoError(t, m2.Close())
 }
 
@@ -310,7 +310,7 @@ func TestCheckpointRestore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, r2.Run(t.Context()))
-	require.True(t, r2.usedResumeFromCheckpoint)
+	require.True(t, r2.UsedResumeFromCheckpoint())
 	require.NoError(t, r2.Close())
 }
 
@@ -346,7 +346,7 @@ func TestCheckpointRestoreBinaryPK(t *testing.T) {
 	// Resume with a fresh runner and confirm it picked up from the checkpoint.
 	m2 := NewTestRunner(t, "binarypk", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint) // managed to resume.
+	require.True(t, m2.UsedResumeFromCheckpoint()) // managed to resume.
 	require.NoError(t, m2.Close())
 }
 
@@ -410,7 +410,7 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 		WithTargetChunkTime(100*time.Millisecond))
 	require.NoError(t, r2.Run(t.Context()))
 	defer utils.CloseAndLog(r2)
-	require.True(t, r2.usedResumeFromCheckpoint)
+	require.True(t, r2.UsedResumeFromCheckpoint())
 }
 
 func TestCheckpointDifferentRestoreOptions(t *testing.T) {
@@ -508,7 +508,7 @@ func TestResumeFromCheckpointE2E(t *testing.T) {
 	// Start a new migration with the same parameters. Let it complete.
 	m2 := NewTestRunner(t, "chkpresumetest", alterSQL, WithThreads(4))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint)
+	require.True(t, m2.UsedResumeFromCheckpoint())
 	require.NoError(t, m2.Close())
 }
 
@@ -563,7 +563,7 @@ FROM compositevarcharpk a WHERE version='1'`)
 
 	m2 := NewTestRunner(t, "compositevarcharpk", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint)
+	require.True(t, m2.UsedResumeFromCheckpoint())
 	require.NoError(t, m2.Close())
 }
 
@@ -815,7 +815,7 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 	m.Cancel()
 	err = <-c
 	require.Error(t, err)
-	require.True(t, m.usedResumeFromCheckpoint)
+	require.True(t, m.UsedResumeFromCheckpoint())
 	require.NoError(t, m.Close())
 }
 
@@ -871,7 +871,7 @@ func TestResumeFromCheckpointCleanupOnFailure(t *testing.T) {
 	// Resume falls back to newMigration and completes successfully.
 	m2 := NewTestRunner(t, "cleanup_test", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.False(t, m2.usedResumeFromCheckpoint) // Should NOT have resumed because binlog was invalid
+	require.False(t, m2.UsedResumeFromCheckpoint()) // Should NOT have resumed because binlog was invalid
 	require.NoError(t, m2.Close())
 }
 
@@ -911,7 +911,7 @@ func TestResumeFromCheckpointTooOld(t *testing.T) {
 	// Resume falls back to newMigration and completes successfully.
 	m2 := NewTestRunner(t, "chkpttooold", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.False(t, m2.usedResumeFromCheckpoint) // Should NOT have resumed because checkpoint was too old
+	require.False(t, m2.UsedResumeFromCheckpoint()) // Should NOT have resumed because checkpoint was too old
 	require.NoError(t, m2.Close())
 }
 
@@ -947,7 +947,7 @@ func TestResumeFromCheckpointNotTooOld(t *testing.T) {
 	// The migration should resume from checkpoint successfully.
 	m2 := NewTestRunner(t, "chkptnotold", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint) // Should have resumed because checkpoint is fresh
+	require.True(t, m2.UsedResumeFromCheckpoint()) // Should have resumed because checkpoint is fresh
 	require.NoError(t, m2.Close())
 }
 
@@ -987,7 +987,7 @@ func TestResumeRejectsCheckpointFromDifferentTable(t *testing.T) {
 	// Resume must refuse and fall back to a fresh migration.
 	m2 := NewTestRunner(t, "chkptmismatch", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.False(t, m2.usedResumeFromCheckpoint,
+	require.False(t, m2.UsedResumeFromCheckpoint(),
 		"resume should be skipped when checkpoint records a different original table name")
 	require.NoError(t, m2.Close())
 }

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -76,9 +76,19 @@ type Runner struct {
 
 	// Used by the test-suite and some post-migration output.
 	// Indicates if certain optimizations applied.
-	usedInstantDDL           bool
-	usedInplaceDDL           bool
+	usedInstantDDL bool
+	usedInplaceDDL bool
+
+	// resumeMu protects usedResumeFromCheckpoint and resumeErr, which are
+	// written from setup() (running on the Run() goroutine) and may be read
+	// concurrently via the exported UsedResumeFromCheckpoint/ResumeError
+	// getters before Run() returns.
+	resumeMu                 sync.RWMutex
 	usedResumeFromCheckpoint bool
+	// resumeErr captures the error from a failed resumeFromCheckpoint attempt.
+	// It is set only when resume was attempted and failed (causing fallback to a
+	// fresh migration); it remains nil when resume succeeded or was not attempted.
+	resumeErr error
 
 	// Attached logger
 	logger     *slog.Logger
@@ -121,6 +131,7 @@ func NewRunner(m *Migration) (*Runner, error) {
 		logger:      slog.Default(),
 		metricsSink: &metrics.NoopSink{},
 		changes:     changes,
+		throttler:   &throttler.Noop{},
 	}
 	for _, change := range changes {
 		change.runner = runner // link back.
@@ -134,6 +145,37 @@ func (r *Runner) SetMetricsSink(sink metrics.Sink) {
 
 func (r *Runner) SetLogger(logger *slog.Logger) {
 	r.logger = logger
+}
+
+// UsedResumeFromCheckpoint reports whether this migration resumed from an
+// existing checkpoint rather than starting fresh.
+func (r *Runner) UsedResumeFromCheckpoint() bool {
+	r.resumeMu.RLock()
+	defer r.resumeMu.RUnlock()
+	return r.usedResumeFromCheckpoint
+}
+
+// ResumeError returns the error from a failed resume-from-checkpoint attempt
+// that fell back to a fresh migration. Returns nil if resume succeeded or was
+// not attempted. The typed errors in the status package (ErrMismatchedAlter,
+// ErrBinlogNotFound, ErrCheckpointTooOld, ErrCheckpointCollision) are
+// preserved and can be matched with errors.Is.
+func (r *Runner) ResumeError() error {
+	r.resumeMu.RLock()
+	defer r.resumeMu.RUnlock()
+	return r.resumeErr
+}
+
+func (r *Runner) markResumed() {
+	r.resumeMu.Lock()
+	r.usedResumeFromCheckpoint = true
+	r.resumeMu.Unlock()
+}
+
+func (r *Runner) setResumeErr(err error) {
+	r.resumeMu.Lock()
+	r.resumeErr = err
+	r.resumeMu.Unlock()
 }
 
 // attemptMySQLDDL tries to perform the DDL using MySQL's built-in
@@ -817,6 +859,7 @@ func (r *Runner) setup(ctx context.Context) error {
 		// checkpoint, or truncation collision all mean the checkpoint can't be
 		// used. Spirit logs the reason and falls back to a fresh migration so
 		// it always makes forward progress.
+		r.setResumeErr(err)
 		r.logger.Info("could not resume from checkpoint",
 			"reason", err,
 		) // explain why it failed.
@@ -963,6 +1006,7 @@ func (r *Runner) Progress() status.Progress {
 		CurrentState: r.status.Get(),
 		Summary:      summary,
 		Tables:       tables,
+		Throttler:    r.throttler,
 	}
 }
 
@@ -1153,7 +1197,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 		"checksum-watermark", checksumWatermark,
 		"position", binlogPosition,
 	)
-	r.usedResumeFromCheckpoint = true
+	r.markResumed()
 	return nil
 }
 

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
@@ -75,10 +76,27 @@ type Runner struct {
 	checker           checksum.Checker
 	checksumWatermark string
 
+	// throttler is currently always a Noop in the move path (cross-server
+	// copy doesn't have a replica or commit-latency throttler wired in yet),
+	// but is surfaced on the runner so status.Progress can expose it
+	// uniformly with the migration runner.
+	throttler throttler.Throttler
+
 	// Track some key statistics.
-	startTime                time.Time
-	sentinelWaitStartTime    time.Time
+	startTime             time.Time
+	sentinelWaitStartTime time.Time
+
+	// resumeMu protects usedResumeFromCheckpoint and resumeErr, which are
+	// written from setup() (running on the Run() goroutine) and may be read
+	// concurrently via the exported UsedResumeFromCheckpoint/ResumeError
+	// getters before Run() returns.
+	resumeMu                 sync.RWMutex
 	usedResumeFromCheckpoint bool
+	// resumeErr captures the error from a failed resumeFromCheckpoint attempt.
+	// In the move path a failed resume is fatal (returned up from setup), so
+	// this is only observable in tests or via late inspection before the
+	// runner is closed.
+	resumeErr error
 
 	cutoverFunc func(ctx context.Context) error
 
@@ -96,10 +114,40 @@ var _ status.Task = (*Runner)(nil)
 
 func NewRunner(m *Move) (*Runner, error) {
 	r := &Runner{
-		move:   m,
-		logger: slog.Default(),
+		move:      m,
+		logger:    slog.Default(),
+		throttler: &throttler.Noop{},
 	}
 	return r, nil
+}
+
+// UsedResumeFromCheckpoint reports whether this move resumed from an existing
+// checkpoint rather than starting fresh.
+func (r *Runner) UsedResumeFromCheckpoint() bool {
+	r.resumeMu.RLock()
+	defer r.resumeMu.RUnlock()
+	return r.usedResumeFromCheckpoint
+}
+
+// ResumeError returns the error from a failed resume-from-checkpoint attempt.
+// Move treats resume failure as fatal (returned up from setup), so a non-nil
+// result here implies setup itself returned an error.
+func (r *Runner) ResumeError() error {
+	r.resumeMu.RLock()
+	defer r.resumeMu.RUnlock()
+	return r.resumeErr
+}
+
+func (r *Runner) markResumed() {
+	r.resumeMu.Lock()
+	r.usedResumeFromCheckpoint = true
+	r.resumeMu.Unlock()
+}
+
+func (r *Runner) setResumeErr(err error) {
+	r.resumeMu.Lock()
+	r.resumeErr = err
+	r.resumeMu.Unlock()
 }
 
 func (r *Runner) Close() error {
@@ -367,7 +415,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	}
 
 	r.checkpointTable = table.NewTableInfo(src0.db, src0.config.DBName, checkpointTableName)
-	r.usedResumeFromCheckpoint = true
+	r.markResumed()
 	return nil
 }
 
@@ -460,8 +508,9 @@ func (r *Runner) setup(ctx context.Context) error {
 			return fmt.Errorf("target state is invalid for both new copy and resume: new_copy_error=%w, resume_error=%w", err, resumeErr)
 		}
 		// We pass the pre-check for resume, so attempt it
-		if err := r.resumeFromCheckpoint(ctx); err != nil {
-			return fmt.Errorf("resume validation passed but checkpoint resume failed: %w", err)
+		if resumeErr := r.resumeFromCheckpoint(ctx); resumeErr != nil {
+			r.setResumeErr(resumeErr)
+			return fmt.Errorf("resume validation passed but checkpoint resume failed: %w", resumeErr)
 		}
 		r.logger.Info("Successfully resumed move from existing checkpoint")
 		return nil
@@ -1104,6 +1153,7 @@ func (r *Runner) Progress() status.Progress {
 	return status.Progress{
 		CurrentState: r.status.Get(),
 		Summary:      summary,
+		Throttler:    r.throttler,
 	}
 }
 

--- a/pkg/status/progress.go
+++ b/pkg/status/progress.go
@@ -1,5 +1,7 @@
 package status
 
+import "github.com/block/spirit/pkg/throttler"
+
 // Progress is returned as a struct because we may add more to it later.
 // It is designed for wrappers (like a GUI) to be able to summarize the
 // current status without parsing log output.
@@ -10,6 +12,15 @@ type Progress struct {
 	// Tables contains per-table progress for multi-table migrations.
 	// For single-table migrations, this will have one entry.
 	Tables []TableProgress
+
+	// Throttler is the active throttler. Always non-nil — when no throttler
+	// has been configured a Noop is supplied so callers can dispatch on it
+	// without nil checks. Use Throttler.IsThrottled() for the boolean state
+	// and Throttler.String() for a human-readable reason (empty when not
+	// throttled). Surfacing the throttler itself (rather than fields cherry-
+	// picked from it) lets callers reach future throttler-specific data
+	// without needing additions to this struct.
+	Throttler throttler.Throttler
 }
 
 // TableProgress tracks progress for a single table in the migration.

--- a/pkg/throttler/aurora_activethreads.go
+++ b/pkg/throttler/aurora_activethreads.go
@@ -192,6 +192,14 @@ func (a *ActiveThreads) IsThrottled() bool {
 	return a.isThrottled.Load()
 }
 
+func (a *ActiveThreads) String() string {
+	if !a.isThrottled.Load() {
+		return ""
+	}
+	return fmt.Sprintf("Aurora active threads %d exceed vCPUs %d",
+		a.lastActiveThreads.Load(), a.vCPUs)
+}
+
 // BlockWait blocks until active CPU threads fall to or below vCPUs, or up to
 // 60s. Matches the commit-latency throttler's loop shape so the multi-
 // throttler waits uniformly across signals.

--- a/pkg/throttler/aurora_commitlatency.go
+++ b/pkg/throttler/aurora_commitlatency.go
@@ -166,6 +166,14 @@ func (c *CommitLatency) BlockWait(ctx context.Context) {
 		"threshold", c.threshold)
 }
 
+func (c *CommitLatency) String() string {
+	if !c.isThrottled.Load() {
+		return ""
+	}
+	return fmt.Sprintf("Aurora commit latency %s exceeds threshold %s",
+		time.Duration(c.avgLatencyUs.Load())*time.Microsecond, c.threshold)
+}
+
 // UpdateLag samples the Aurora commit counters and updates the throttled
 // state. Exported (and named to match the Throttler interface) so multi-
 // throttler can drive an immediate refresh. Errors here are unexpected

--- a/pkg/throttler/mock.go
+++ b/pkg/throttler/mock.go
@@ -38,3 +38,7 @@ func (t *Mock) BlockWait(ctx context.Context) {
 func (t *Mock) UpdateLag(ctx context.Context) error {
 	return nil
 }
+
+func (t *Mock) String() string {
+	return "mock throttler (always throttled)"
+}

--- a/pkg/throttler/multi.go
+++ b/pkg/throttler/multi.go
@@ -3,6 +3,7 @@ package throttler
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 )
 
@@ -77,6 +78,18 @@ func (m *multiThrottler) BlockWait(ctx context.Context) {
 		}
 	}
 	wg.Wait()
+}
+
+// String joins non-empty child descriptions with "; ". Returns "" when no
+// child throttler is currently throttling.
+func (m *multiThrottler) String() string {
+	var parts []string
+	for _, t := range m.throttlers {
+		if s := t.String(); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 // UpdateLag updates lag on all child throttlers.

--- a/pkg/throttler/multi_test.go
+++ b/pkg/throttler/multi_test.go
@@ -67,6 +67,13 @@ func (t *testThrottler) UpdateLag(_ context.Context) error {
 	return t.updateLagErr
 }
 
+func (t *testThrottler) String() string {
+	if t.throttled.Load() {
+		return "test throttler"
+	}
+	return ""
+}
+
 func TestMultiThrottler_Open(t *testing.T) {
 	t1 := &testThrottler{}
 	t2 := &testThrottler{}

--- a/pkg/throttler/noop.go
+++ b/pkg/throttler/noop.go
@@ -30,3 +30,7 @@ func (t *Noop) BlockWait(ctx context.Context) {
 func (t *Noop) UpdateLag(ctx context.Context) error {
 	return nil
 }
+
+func (t *Noop) String() string {
+	return ""
+}

--- a/pkg/throttler/replica.go
+++ b/pkg/throttler/replica.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync/atomic"
 	"time"
@@ -107,6 +108,14 @@ func (l *Replica) BlockWait(ctx context.Context) {
 		}
 	}
 	l.logger.Warn("lag monitor timed out", "lag_ms", atomic.LoadInt64(&l.currentLagInMs), "tolerance", l.lagTolerance)
+}
+
+func (l *Replica) String() string {
+	if !l.IsThrottled() {
+		return ""
+	}
+	return fmt.Sprintf("replica lag %dms exceeds tolerance %s",
+		atomic.LoadInt64(&l.currentLagInMs), l.lagTolerance)
 }
 
 // UpdateLag is a MySQL 8.0+ implementation of lag that is a better approximation than "seconds_behind_source".

--- a/pkg/throttler/throttler.go
+++ b/pkg/throttler/throttler.go
@@ -14,6 +14,13 @@ type Throttler interface {
 	IsThrottled() bool
 	BlockWait(ctx context.Context)
 	UpdateLag(ctx context.Context) error
+
+	// String returns a human-readable description of why the throttler is
+	// currently throttling. It MUST return "" when the throttler is not
+	// currently throttled, so callers can use a non-empty result as a sign
+	// that throttling is active. The returned text is suitable for surfacing
+	// to a UI or log without further formatting.
+	String() string
 }
 
 // NewReplicationThrottler returns a Throttler for MySQL 8.0+ replicas.


### PR DESCRIPTION
Closes #844.

## Summary

Surfaces resume-from-checkpoint outcome and the active throttler on the runner/Progress API so external clients (GUIs, automation) can summarize migration state without scraping logs.

> **Note:** This branch originally also removed `--strict` mode, but that landed separately in #910. After rebasing onto `main`, this PR is scoped to the status-API enhancements only.

### Runner getters (migration + move)

- `UsedResumeFromCheckpoint() bool`
- `ResumeError() error` — preserves typed `status.Err*` values for `errors.Is` matching

Both fields are guarded by a `sync.RWMutex` so concurrent reads via the getters cannot race with the `setup()` goroutine's write.

### Throttler interface

`Throttler` gains a `String() string` method — empty when not throttled, descriptive when active. Implemented on:

- `Noop` → always `""`
- `Mock` → `"mock throttler (always throttled)"`
- `Replica` → `"replica lag %dms exceeds tolerance %s"`
- `CommitLatency` → `"Aurora commit latency %s exceeds threshold %s"`
- `ActiveThreads` → `"Aurora active threads %d exceed vCPUs %d"`
- `multiThrottler` → joins non-empty children with `; `

### Progress struct

`status.Progress` gains a `Throttler throttler.Throttler` field. Guaranteed non-nil — both runners initialize `r.throttler` to `&throttler.Noop{}` so callers can dispatch on it without nil checks. Surfacing the throttler itself (rather than cherry-picking fields) means future throttler-specific data is available without amending `Progress`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/throttler/...` — green
- [ ] CI to run the full `-race` suite against MySQL
- [ ] Reviewer to sanity-check that `Progress.Throttler` (interface value in a returned struct) is acceptable shape for downstream consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
