### PR TITLE
Fix critical bug on checksum failure

### DIFF
--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -261,10 +261,21 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	// If you look at standard packages like wordpress, drupal etc.
 	// they all change the SQL mode. If you look at mysqldump, etc.
 	// they all unset the SQL mode just like this.
+	//
+	// NO_AUTO_VALUE_ON_ZERO is the one mode we *do* want enabled. Without it,
+	// MySQL rewrites a literal 0 in an AUTO_INCREMENT column to the next
+	// sequence value on INSERT/REPLACE. That silently corrupts a MODIFY ...
+	// AUTO_INCREMENT migration of a column whose source data already contains
+	// 0: the row at pk=0 ends up at a different pk in the new table, and
+	// neither the copier's INSERT IGNORE SELECT nor the checksum recopy can
+	// undo it (each retry re-allocates a fresh auto-inc value). Setting
+	// NO_AUTO_VALUE_ON_ZERO is a no-op for tables without AUTO_INCREMENT and
+	// for inserts that supply non-zero values, so it is safe to enable for
+	// all connections (copier, checksum recopy, binlog applier).
 	if cfg.Params == nil {
 		cfg.Params = make(map[string]string)
 	}
-	cfg.Params["sql_mode"] = `""`
+	cfg.Params["sql_mode"] = `"NO_AUTO_VALUE_ON_ZERO"`
 	cfg.Params["time_zone"] = `"+00:00"`
 	cfg.Params["innodb_lock_wait_timeout"] = strconv.Itoa(config.InnodbLockWaitTimeout)
 	cfg.Params["lock_wait_timeout"] = strconv.Itoa(config.LockWaitTimeout)

--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -254,24 +254,26 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	} // end if cfg.TLSConfig == ""
 
 	// Set session variables via Params map.
-	// Setting sql_mode looks ill-advised, but unfortunately it's required.
-	// A user might have set their SQL mode to empty even if the
-	// server has it enabled. After they've inserted data,
-	// we need to be able to produce the same when copying.
-	// If you look at standard packages like wordpress, drupal etc.
-	// they all change the SQL mode. If you look at mysqldump, etc.
-	// they all unset the SQL mode just like this.
 	//
-	// NO_AUTO_VALUE_ON_ZERO is the one mode we *do* want enabled. Without it,
-	// MySQL rewrites a literal 0 in an AUTO_INCREMENT column to the next
-	// sequence value on INSERT/REPLACE. That silently corrupts a MODIFY ...
-	// AUTO_INCREMENT migration of a column whose source data already contains
-	// 0: the row at pk=0 ends up at a different pk in the new table, and
-	// neither the copier's INSERT IGNORE SELECT nor the checksum recopy can
-	// undo it (each retry re-allocates a fresh auto-inc value). Setting
-	// NO_AUTO_VALUE_ON_ZERO is a no-op for tables without AUTO_INCREMENT and
-	// for inserts that supply non-zero values, so it is safe to enable for
-	// all connections (copier, checksum recopy, binlog applier).
+	// Spirit overrides sql_mode on every connection. This looks ill-advised
+	// at first glance — but the user may have inserted data with a more
+	// permissive mode than the server's current default, and we need to be
+	// able to reproduce that data exactly when copying. Standard tools take
+	// the same approach: WordPress / Drupal change sql_mode, mysqldump
+	// overrides it, etc. Historically Spirit set it to the empty string for
+	// the most permissive copy possible.
+	//
+	// We now set it to exactly one mode: NO_AUTO_VALUE_ON_ZERO. Without
+	// this mode, MySQL rewrites a literal 0 in an AUTO_INCREMENT column to
+	// the next sequence value on INSERT/REPLACE. That silently corrupts a
+	// MODIFY ... AUTO_INCREMENT migration of a column whose source data
+	// already contains 0: the row at pk=0 ends up at a different pk in the
+	// new table, and neither the copier's INSERT IGNORE SELECT nor the
+	// checksum recopy can undo it (each retry re-allocates a fresh
+	// auto-inc value). NO_AUTO_VALUE_ON_ZERO is otherwise a no-op (it
+	// only affects literal-0 inserts into AUTO_INCREMENT columns), so it
+	// is safe to enable on every connection — copier, checksum recopy,
+	// binlog applier.
 	if cfg.Params == nil {
 		cfg.Params = make(map[string]string)
 	}

--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -29,7 +29,7 @@ func assertDSNConfig(t *testing.T, dsnStr string, user, password, addr, dbName, 
 	require.Equal(t, true, cfg.RejectReadOnly)
 	require.Equal(t, interpolateParams, cfg.InterpolateParams)
 	require.Equal(t, "utf8mb4_bin", cfg.Collation)
-	require.Equal(t, `""`, cfg.Params["sql_mode"])
+	require.Equal(t, `"NO_AUTO_VALUE_ON_ZERO"`, cfg.Params["sql_mode"])
 	require.Equal(t, `"+00:00"`, cfg.Params["time_zone"])
 	require.Equal(t, `"read-committed"`, cfg.Params["transaction_isolation"])
 }

--- a/pkg/migration/change_test.go
+++ b/pkg/migration/change_test.go
@@ -231,6 +231,51 @@ func TestAutoIncrementWithRows(t *testing.T) {
 	require.GreaterOrEqual(t, autoIncValue.Int64, int64(2979719), "Final AUTO_INCREMENT should be >= 2979719")
 }
 
+// TestModifyAddAutoIncrementPreservesZeroPK regresses a silent-data-loss bug
+// where MODIFY-ing a column to add AUTO_INCREMENT caused the row with pk=0
+// to be lost during the copy. MySQL substitutes the next auto-increment value
+// for a literal 0 unless NO_AUTO_VALUE_ON_ZERO is set in sql_mode. Spirit
+// sets sql_mode on the connection to opt in to NO_AUTO_VALUE_ON_ZERO so the
+// copier, checksum recopy, and binlog applier all preserve a literal 0.
+func TestModifyAddAutoIncrementPreservesZeroPK(t *testing.T) {
+	t.Parallel()
+
+	tableName := "test_modify_autoinc_zero"
+	testutils.RunSQL(t, fmt.Sprintf(`DROP TABLE IF EXISTS %s, _%s_new, _%s_old`, tableName, tableName, tableName))
+	t.Cleanup(func() {
+		testutils.RunSQL(t, fmt.Sprintf(`DROP TABLE IF EXISTS %s, _%s_new, _%s_old`, tableName, tableName, tableName))
+	})
+
+	// Source schema mirrors the production case: gid is BIGINT NOT NULL but
+	// not yet AUTO_INCREMENT, and the table contains a row at gid=0.
+	testutils.RunSQL(t, fmt.Sprintf(`
+		CREATE TABLE %s (
+			gid BIGINT NOT NULL,
+			groupname VARCHAR(255) NOT NULL,
+			PRIMARY KEY (gid)
+		) ENGINE=InnoDB`, tableName))
+	testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO %s (gid, groupname) VALUES (0, 'zero'), (1, 'one'), (2, 'two')`, tableName))
+
+	r := NewTestRunner(t, tableName, "MODIFY gid BIGINT NOT NULL AUTO_INCREMENT")
+	defer utils.CloseAndLog(r)
+	require.NoError(t, r.Run(t.Context()))
+
+	testDB, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(testDB)
+
+	var ids []int64
+	rows, err := testDB.QueryContext(t.Context(), fmt.Sprintf("SELECT gid FROM %s ORDER BY gid", tableName))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+	for rows.Next() {
+		var id int64
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.Equal(t, []int64{0, 1, 2}, ids, "row with gid=0 must survive the MODIFY ... AUTO_INCREMENT migration")
+}
+
 func TestOldTableNameTruncation(t *testing.T) {
 	t.Parallel()
 	startTime := time.Date(2025, 6, 15, 10, 30, 45, 0, time.UTC)

--- a/pkg/migration/checksum_invalidation_test.go
+++ b/pkg/migration/checksum_invalidation_test.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -28,6 +29,55 @@ func (f *failingChecker) StartTime() time.Time          { return time.Now() }
 func (f *failingChecker) ExecTime() time.Duration       { return 0 }
 func (f *failingChecker) DifferencesFound() uint64      { return 0 }
 
+// setupRunnerForChecksumTest creates a real table, runs the runner setup as
+// far as creating the checkpoint table on disk, and returns a Runner that can
+// have its checker swapped and r.checksum() called directly. It deliberately
+// stops short of starting the binlog feed (replClient.Run) — these tests
+// short-circuit the checker, so the binlog is unnecessary.
+func setupRunnerForChecksumTest(t *testing.T, tableName string) *Runner {
+	t.Helper()
+	dropStmt := fmt.Sprintf("DROP TABLE IF EXISTS %s, %s, %s",
+		tableName,
+		utils.NewTableName(tableName),
+		utils.CheckpointTableName(tableName),
+	)
+	testutils.RunSQL(t, dropStmt)
+	t.Cleanup(func() { testutils.RunSQL(t, dropStmt) })
+	testutils.RunSQL(t, "CREATE TABLE "+tableName+" (id INT NOT NULL PRIMARY KEY)")
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	r, err := NewRunner(&Migration{
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: &cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  1,
+		Table:    tableName,
+		Alter:    "ENGINE=InnoDB",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(r) })
+
+	// Reuse one DBConfig so the *sql.DB pool sizing and the runner's view of
+	// it agree if their defaults ever drift.
+	dbCfg := dbconn.NewDBConfig()
+	r.db, err = dbconn.New(testutils.DSN(), dbCfg)
+	require.NoError(t, err)
+	r.dbConfig = dbCfg
+	r.changes[0].table = table.NewTableInfo(r.db, r.migration.Database, r.migration.Table)
+	require.NoError(t, r.changes[0].table.SetInfo(t.Context()))
+	require.NoError(t, r.changes[0].dropOldTable(t.Context()))
+	require.NoError(t, r.changes[0].createNewTable(t.Context()))
+	require.NoError(t, r.changes[0].alterNewTable(t.Context()))
+	require.NoError(t, r.createCheckpointTable(t.Context()))
+	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, r.checkpointTableName())
+
+	require.True(t, checkpointTableExists(t, r),
+		"checkpoint table must exist after setup")
+	return r
+}
+
 // TestChecksumFailureInvalidatesCheckpoint pins the invariant that when the
 // initial checksum exhausts retries, the runner invalidates the checkpoint
 // table before returning. Without this, a supervisor restart would resume
@@ -39,54 +89,11 @@ func (f *failingChecker) DifferencesFound() uint64      { return 0 }
 // fatalError in (*Runner).checksum.
 func TestChecksumFailureInvalidatesCheckpoint(t *testing.T) {
 	t.Parallel()
-	tableName := "chkpt_invalidation"
-	testutils.RunSQL(t, "DROP TABLE IF EXISTS "+tableName+", _"+tableName+"_new, _"+tableName+"_chkpnt")
-	t.Cleanup(func() {
-		testutils.RunSQL(t, "DROP TABLE IF EXISTS "+tableName+", _"+tableName+"_new, _"+tableName+"_chkpnt")
-	})
-	testutils.RunSQL(t, "CREATE TABLE "+tableName+" (id INT NOT NULL PRIMARY KEY)")
+	r := setupRunnerForChecksumTest(t, "chkpt_invalidation")
 
-	cfg, err := mysql.ParseDSN(testutils.DSN())
-	require.NoError(t, err)
-
-	r, err := NewRunner(&Migration{
-		Host:     cfg.Addr,
-		Username: cfg.User,
-		Password: &cfg.Passwd,
-		Database: cfg.DBName,
-		Threads:  1,
-		Table:    tableName,
-		Alter:    "ENGINE=InnoDB",
-	})
-	require.NoError(t, err)
-	defer utils.CloseAndLog(r)
-
-	// Step through the runner's setup far enough to have a real checkpoint
-	// table on disk. We deliberately stop short of starting the binlog feed
-	// (replClient.Run) because we don't need it — we'll short-circuit the
-	// checker.
-	r.db, err = dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	require.NoError(t, err)
-	r.dbConfig = dbconn.NewDBConfig()
-	r.changes[0].table = table.NewTableInfo(r.db, r.migration.Database, r.migration.Table)
-	require.NoError(t, r.changes[0].table.SetInfo(t.Context()))
-	require.NoError(t, r.changes[0].dropOldTable(t.Context()))
-	require.NoError(t, r.changes[0].createNewTable(t.Context()))
-	require.NoError(t, r.changes[0].alterNewTable(t.Context()))
-	require.NoError(t, r.createCheckpointTable(t.Context()))
-	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, r.checkpointTableName())
-
-	// Confirm the checkpoint table is actually present before we run the
-	// failing checksum, so the post-condition is meaningful.
-	require.True(t, checkpointTableExists(t, r),
-		"checkpoint table must exist before invoking the failing checksum")
-
-	// Install a runner-cancel hook so we can assert fatalError fired.
 	var cancelled bool
 	ctx, cancel := context.WithCancel(t.Context())
 	r.cancelFunc = func() { cancelled = true; cancel() }
-
-	// Substitute the real checker with one that simulates max-retries-exhausted.
 	r.checker = &failingChecker{err: errors.New("simulated checksum failure")}
 
 	checksumErr := r.checksum(ctx)
@@ -97,6 +104,33 @@ func TestChecksumFailureInvalidatesCheckpoint(t *testing.T) {
 		"fatalError must transition status to ErrCleanup")
 	require.False(t, checkpointTableExists(t, r),
 		"checkpoint table must be dropped after a permanent checksum failure")
+}
+
+// TestChecksumCancellationPreservesCheckpoint pins the complementary
+// invariant: a checker error returned because the parent context was
+// cancelled (operator Ctrl-C, deadline, supervisor stop) must NOT
+// invalidate the checkpoint. The persisted checksum_watermark is the
+// legitimate progress of a partial pass and the next run should be free
+// to resume from it.
+func TestChecksumCancellationPreservesCheckpoint(t *testing.T) {
+	t.Parallel()
+	r := setupRunnerForChecksumTest(t, "chkpt_cancel_preserves")
+
+	var cancelled bool
+	ctx, cancel := context.WithCancel(t.Context())
+	r.cancelFunc = func() { cancelled = true; cancel() }
+	// Mimic the checker returning ctx.Err() after the parent was cancelled.
+	r.checker = &failingChecker{err: context.Canceled}
+	cancel()
+
+	checksumErr := r.checksum(ctx)
+	require.Error(t, checksumErr, "r.checksum must propagate the cancellation error")
+	require.False(t, cancelled,
+		"runner cancelFunc must NOT fire on a parent-context cancellation")
+	require.NotEqual(t, status.ErrCleanup, r.status.Get(),
+		"status must not transition to ErrCleanup on cancellation")
+	require.True(t, checkpointTableExists(t, r),
+		"checkpoint table must be preserved when checksum exits due to cancellation")
 }
 
 func checkpointTableExists(t *testing.T, r *Runner) bool {

--- a/pkg/migration/checksum_invalidation_test.go
+++ b/pkg/migration/checksum_invalidation_test.go
@@ -1,0 +1,110 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// failingChecker is a checksum.Checker that always returns the configured
+// error from Run. Used to drive the runner.checksum() error path without
+// needing to fabricate a real source/target divergence.
+type failingChecker struct {
+	err error
+}
+
+func (f *failingChecker) Run(ctx context.Context) error { return f.err }
+func (f *failingChecker) GetProgress() string           { return "failing" }
+func (f *failingChecker) StartTime() time.Time          { return time.Now() }
+func (f *failingChecker) ExecTime() time.Duration       { return 0 }
+func (f *failingChecker) DifferencesFound() uint64      { return 0 }
+
+// TestChecksumFailureInvalidatesCheckpoint pins the invariant that when the
+// initial checksum exhausts retries, the runner invalidates the checkpoint
+// table before returning. Without this, a supervisor restart would resume
+// at the partial checksum_watermark persisted by the periodic dumper, skip
+// any chunk the failed run could not reconcile, and — if the remaining
+// range happens to pass — cut over on top of a corrupt _new table.
+//
+// See the silent-data-loss story documented at the call site of
+// fatalError in (*Runner).checksum.
+func TestChecksumFailureInvalidatesCheckpoint(t *testing.T) {
+	t.Parallel()
+	tableName := "chkpt_invalidation"
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS "+tableName+", _"+tableName+"_new, _"+tableName+"_chkpnt")
+	t.Cleanup(func() {
+		testutils.RunSQL(t, "DROP TABLE IF EXISTS "+tableName+", _"+tableName+"_new, _"+tableName+"_chkpnt")
+	})
+	testutils.RunSQL(t, "CREATE TABLE "+tableName+" (id INT NOT NULL PRIMARY KEY)")
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	r, err := NewRunner(&Migration{
+		Host:     cfg.Addr,
+		Username: cfg.User,
+		Password: &cfg.Passwd,
+		Database: cfg.DBName,
+		Threads:  1,
+		Table:    tableName,
+		Alter:    "ENGINE=InnoDB",
+	})
+	require.NoError(t, err)
+	defer utils.CloseAndLog(r)
+
+	// Step through the runner's setup far enough to have a real checkpoint
+	// table on disk. We deliberately stop short of starting the binlog feed
+	// (replClient.Run) because we don't need it — we'll short-circuit the
+	// checker.
+	r.db, err = dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	r.dbConfig = dbconn.NewDBConfig()
+	r.changes[0].table = table.NewTableInfo(r.db, r.migration.Database, r.migration.Table)
+	require.NoError(t, r.changes[0].table.SetInfo(t.Context()))
+	require.NoError(t, r.changes[0].dropOldTable(t.Context()))
+	require.NoError(t, r.changes[0].createNewTable(t.Context()))
+	require.NoError(t, r.changes[0].alterNewTable(t.Context()))
+	require.NoError(t, r.createCheckpointTable(t.Context()))
+	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, r.checkpointTableName())
+
+	// Confirm the checkpoint table is actually present before we run the
+	// failing checksum, so the post-condition is meaningful.
+	require.True(t, checkpointTableExists(t, r),
+		"checkpoint table must exist before invoking the failing checksum")
+
+	// Install a runner-cancel hook so we can assert fatalError fired.
+	var cancelled bool
+	ctx, cancel := context.WithCancel(t.Context())
+	r.cancelFunc = func() { cancelled = true; cancel() }
+
+	// Substitute the real checker with one that simulates max-retries-exhausted.
+	r.checker = &failingChecker{err: errors.New("simulated checksum failure")}
+
+	checksumErr := r.checksum(ctx)
+	require.Error(t, checksumErr, "r.checksum must propagate the checker's error")
+	require.ErrorContains(t, checksumErr, "checksum failed")
+	require.True(t, cancelled, "fatalError must cancel the run context")
+	require.Equal(t, status.ErrCleanup, r.status.Get(),
+		"fatalError must transition status to ErrCleanup")
+	require.False(t, checkpointTableExists(t, r),
+		"checkpoint table must be dropped after a permanent checksum failure")
+}
+
+func checkpointTableExists(t *testing.T, r *Runner) bool {
+	t.Helper()
+	var n int
+	err := r.db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?",
+		r.checkpointTable.SchemaName, r.checkpointTable.TableName).Scan(&n)
+	require.NoError(t, err)
+	return n > 0
+}

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -1267,6 +1267,18 @@ func (r *Runner) checksum(ctx context.Context) error {
 
 	// Run the checksum with internal retry logic
 	if err := r.checker.Run(ctx); err != nil {
+		// Invalidate the checkpoint before returning. The periodic checkpoint
+		// dumper persists the checksum chunker's low-watermark while the
+		// checksum is running, so by the time max retries is exhausted the
+		// stored watermark is past every chunk that has been recopied —
+		// including chunks that "passed" only because the recopy reproduced
+		// the same defect (e.g. an AUTO_INCREMENT rewrite of a literal 0).
+		// If we left the checkpoint in place, the next run would resume
+		// checksumming from that watermark, skip the broken chunk entirely,
+		// pass, and cut over to a corrupt table. fatalError drops the
+		// checkpoint and cancels the run context (idempotent via fatalOnce)
+		// so the supervisor has to start from scratch.
+		r.fatalError()
 		if r.addsUniqueIndex() {
 			// Overwrite the error if we think it's because of a unique index addition
 			return errors.New("checksum failed after several attempts. This is likely related to your statement adding a UNIQUE index on non-unique data")

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -1267,7 +1267,8 @@ func (r *Runner) checksum(ctx context.Context) error {
 
 	// Run the checksum with internal retry logic
 	if err := r.checker.Run(ctx); err != nil {
-		// Invalidate the checkpoint before returning. The periodic checkpoint
+		// On a genuine checksum failure (not parent-context cancellation),
+		// invalidate the checkpoint before returning. The periodic checkpoint
 		// dumper persists the checksum chunker's low-watermark while the
 		// checksum is running, so by the time max retries is exhausted the
 		// stored watermark is past every chunk that has been recopied —
@@ -1278,7 +1279,17 @@ func (r *Runner) checksum(ctx context.Context) error {
 		// pass, and cut over to a corrupt table. fatalError drops the
 		// checkpoint and cancels the run context (idempotent via fatalOnce)
 		// so the supervisor has to start from scratch.
-		r.fatalError()
+		//
+		// We do NOT invalidate on parent-context cancellation (operator
+		// Ctrl-C, deadline exceeded, supervisor-initiated stop). In that
+		// case the persisted checksum_watermark is the legitimate progress
+		// of a partial pass and the next run should be free to resume
+		// from it. Distinguishing "checker returned cancellation" from
+		// "real failure" by inspecting ctx.Err() is sufficient — the
+		// checker treats a cancelled parent context as an immediate exit.
+		if ctx.Err() == nil {
+			r.fatalError()
+		}
 		if r.addsUniqueIndex() {
 			// Overwrite the error if we think it's because of a unique index addition
 			return errors.New("checksum failed after several attempts. This is likely related to your statement adding a UNIQUE index on non-unique data")

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1049,8 +1049,13 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 		// while a checksum is in flight, so a permanent failure after the
 		// configured retries would otherwise leave a watermark that lets the
 		// next run skip the broken chunks and cut over on top of corrupt
-		// data. Invalidate the checkpoint here too.
-		r.fatalError()
+		// data. Invalidate the checkpoint here too. As in the migration
+		// runner, we skip the invalidation when the parent context is
+		// cancelled — that case is operator-initiated stop / deadline, and
+		// the partial checksum_watermark is legitimate resume progress.
+		if ctx.Err() == nil {
+			r.fatalError()
+		}
 		return err
 	}
 	return nil

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1043,7 +1043,17 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 		return err
 	}
 	r.status.Set(status.Checksum)
-	return r.checker.Run(ctx)
+	if err := r.checker.Run(ctx); err != nil {
+		// See pkg/migration/runner.go (Runner.checksum) for the rationale:
+		// the periodic checkpoint dumper persists the checksum low-watermark
+		// while a checksum is in flight, so a permanent failure after the
+		// configured retries would otherwise leave a watermark that lets the
+		// next run skip the broken chunks and cut over on top of corrupt
+		// data. Invalidate the checkpoint here too.
+		r.fatalError()
+		return err
+	}
+	return nil
 }
 
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

This fixes a corruption issue discovered in production:

- Adding an auto_increment property to a table which had a row of "0" led to the checksum failing.
- This is because as "0" was inserted, it picked up the next auto_inc value, inserting to the end of the table.
- The checksum kept failing, and after 3 attempts aborted the migration.
- But when our scheduler picked up and auto-resumed, it finished the checksum from the checkpoint and allowed the cutover to happen (unsafe).

There are 2 fixes:

- Make "0" to not use the auto_increment value (via a SQL mode).
- Destroy the checkpoint on checksum failure. This was a regression introduced by  https://github.com/block/spirit/pull/344