### PR TITLE
Compare column names case-insensitively in CREATE TABLE diffs

### DIFF
--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -143,15 +143,17 @@ func (ct *CreateTable) buildAlterStatement(clauses []string) (*AbstractStatement
 func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 	var clauses []string
 
-	// Build maps for easier lookup
+	// Build maps for easier lookup. Keys are lowercased so identifier
+	// matching is case-insensitive — MySQL treats column names that
+	// differ only in case as the same column.
 	sourceColumns := make(map[string]*Column)
 	for i := range ct.Columns {
-		sourceColumns[ct.Columns[i].Name] = &ct.Columns[i]
+		sourceColumns[strings.ToLower(ct.Columns[i].Name)] = &ct.Columns[i]
 	}
 
 	targetColumns := make(map[string]*Column)
 	for i := range target.Columns {
-		targetColumns[target.Columns[i].Name] = &target.Columns[i]
+		targetColumns[strings.ToLower(target.Columns[i].Name)] = &target.Columns[i]
 	}
 
 	// Handle PRIMARY KEY changes (inline column-level PRIMARY KEY)
@@ -163,7 +165,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 	// Collect DROP operations and sort by name for deterministic output
 	var dropClauses []string
 	for _, sourceCol := range ct.Columns {
-		if _, exists := targetColumns[sourceCol.Name]; !exists {
+		if _, exists := targetColumns[strings.ToLower(sourceCol.Name)]; !exists {
 			dropClauses = append(dropClauses, fmt.Sprintf("DROP COLUMN %s", quoteIdent(sourceCol.Name)))
 		}
 	}
@@ -179,7 +181,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 	// Generate the ALTER clauses in target order
 	var prevColumn string
 	for i, targetCol := range target.Columns {
-		sourceCol, existsInSource := sourceColumns[targetCol.Name]
+		sourceCol, existsInSource := sourceColumns[strings.ToLower(targetCol.Name)]
 
 		if !existsInSource {
 			// ADD new column
@@ -202,7 +204,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 			// Also check if only nullability changed due to PK drop
 			// (PK columns are NOT NULL, dropping PK makes them NULL)
 			pkDroppedNullabilityChange := pkDropped &&
-				sourceCol.Name == pkColumn &&
+				strings.EqualFold(sourceCol.Name, pkColumn) &&
 				sourceCol.PrimaryKey && !targetCol.PrimaryKey &&
 				!sourceCol.Nullable && targetCol.Nullable
 
@@ -214,7 +216,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 
 			if needsModify {
 				clause := fmt.Sprintf("MODIFY COLUMN %s", formatColumnDefinition(&targetCol))
-				if needsExplicitPosition[targetCol.Name] {
+				if needsExplicitPosition[strings.ToLower(targetCol.Name)] {
 					if prevColumn == "" {
 						clause += " FIRST"
 					} else {
@@ -237,24 +239,26 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 }
 
 // calculateColumnPositioning determines which columns need explicit positioning (FIRST/AFTER).
-// Returns a map of column names that need explicit positioning.
+// Returns a map of column names (lowercased) that need explicit positioning.
+// Map keys are lowercased to match the source/target column maps built by
+// the caller, since column identifiers in MySQL are case-insensitive.
 func (ct *CreateTable) calculateColumnPositioning(target *CreateTable, sourceColumns, targetColumns map[string]*Column) map[string]bool {
 	needsExplicitPosition := make(map[string]bool)
 
 	var prevColumn string
 	for _, targetCol := range target.Columns {
-		_, existsInSource := sourceColumns[targetCol.Name]
+		_, existsInSource := sourceColumns[strings.ToLower(targetCol.Name)]
 
 		if !existsInSource {
 			// New columns always need explicit positioning
-			needsExplicitPosition[targetCol.Name] = true
+			needsExplicitPosition[strings.ToLower(targetCol.Name)] = true
 		} else {
 			// Existing column - check if its position changed
 			sourcePrevCol := getPreviousColumn(ct.Columns, targetCol.Name)
 
 			// Check if this is an implicit or explicit position change
-			_, prevColExistedInSource := sourceColumns[prevColumn]
-			_, sourcePrevColStillExists := targetColumns[sourcePrevCol]
+			_, prevColExistedInSource := sourceColumns[strings.ToLower(prevColumn)]
+			_, sourcePrevColStillExists := targetColumns[strings.ToLower(sourcePrevCol)]
 
 			implicitChange := false
 			switch {
@@ -267,12 +271,12 @@ func (ct *CreateTable) calculateColumnPositioning(target *CreateTable, sourceCol
 			case sourcePrevCol != "" && !sourcePrevColStillExists:
 				// Previous column was dropped, position change is implicit
 				implicitChange = true
-			case prevColumn == sourcePrevCol:
+			case strings.EqualFold(prevColumn, sourcePrevCol):
 				// Same previous column, check if we need cascading
 				// Cascading happens if the previous column was repositioned
-				if prevColumn != "" && needsExplicitPosition[prevColumn] && prevColExistedInSource {
+				if prevColumn != "" && needsExplicitPosition[strings.ToLower(prevColumn)] && prevColExistedInSource {
 					// Previous column was repositioned, so this column needs repositioning too
-					needsExplicitPosition[targetCol.Name] = true
+					needsExplicitPosition[strings.ToLower(targetCol.Name)] = true
 				}
 				implicitChange = true
 			default:
@@ -281,7 +285,7 @@ func (ct *CreateTable) calculateColumnPositioning(target *CreateTable, sourceCol
 			}
 
 			if !implicitChange {
-				needsExplicitPosition[targetCol.Name] = true
+				needsExplicitPosition[strings.ToLower(targetCol.Name)] = true
 			}
 		}
 
@@ -311,14 +315,17 @@ func (ct *CreateTable) diffPrimaryKey(target *CreateTable, sourceColumns, target
 
 	// If the PK columns are the same (regardless of inline vs table-level representation),
 	// no change is needed. MySQL normalizes inline PK to table-level PK in SHOW CREATE TABLE,
-	// so we need to compare semantically rather than syntactically.
-	if slices.Equal(sourcePKColumns, targetPKColumns) {
+	// so we need to compare semantically rather than syntactically. Column
+	// identifiers are case-insensitive in MySQL, so PK columns that differ
+	// only in case (e.g. `PRIMARY KEY (id)` vs `PRIMARY KEY (ID)`) are the
+	// same key.
+	if equalFoldStrings(sourcePKColumns, targetPKColumns) {
 		return "", "", false, ""
 	}
 
 	// Check for inline PK removal (column-level PRIMARY KEY)
 	for _, sourceCol := range ct.Columns {
-		targetCol, exists := targetColumns[sourceCol.Name]
+		targetCol, exists := targetColumns[strings.ToLower(sourceCol.Name)]
 		if exists && sourceCol.PrimaryKey && !targetCol.PrimaryKey {
 			// PRIMARY KEY was removed from this column (inline PK)
 			// But only drop it if there's no table-level PK in target
@@ -334,7 +341,7 @@ func (ct *CreateTable) diffPrimaryKey(target *CreateTable, sourceColumns, target
 
 	// Check for inline PK addition (column-level PRIMARY KEY)
 	for _, targetCol := range target.Columns {
-		sourceCol, exists := sourceColumns[targetCol.Name]
+		sourceCol, exists := sourceColumns[strings.ToLower(targetCol.Name)]
 		if exists && !sourceCol.PrimaryKey && targetCol.PrimaryKey {
 			// PRIMARY KEY was added to this column (inline PK)
 			// Add it if:
@@ -423,7 +430,8 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) []string {
 
 	// Only handle inline PK <-> table-level PK transitions if the PK columns actually changed.
 	// If the columns are the same, the representations are semantically equivalent.
-	pkColumnsEqual := slices.Equal(sourcePKColumns, targetPKColumns)
+	// Compare case-insensitively, matching MySQL's column-name semantics.
+	pkColumnsEqual := equalFoldStrings(sourcePKColumns, targetPKColumns)
 
 	if sourceHasInlinePK && targetPKIndex != nil && !pkColumnsEqual {
 		// Inline PK -> table-level PK with different columns: drop the inline PK
@@ -701,7 +709,9 @@ func (to *TableOptions) getAutoIncrement() *string {
 // If a column's charset is nil, it inherits from the table. If it's explicitly set to the same as the table,
 // it's considered equal to nil (no explicit charset needed).
 func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable) bool {
-	if a.Name != b.Name {
+	// Column names are case-insensitive in MySQL, so `id` and `ID` refer
+	// to the same column.
+	if !strings.EqualFold(a.Name, b.Name) {
 		return false
 	}
 	if a.Type != b.Type {
@@ -800,7 +810,8 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 
 // columnsEqualIgnorePK checks if two columns are equal, ignoring the PrimaryKey attribute
 func columnsEqualIgnorePK(a, b *Column) bool {
-	if a.Name != b.Name {
+	// Column names are case-insensitive in MySQL.
+	if !strings.EqualFold(a.Name, b.Name) {
 		return false
 	}
 	if a.Type != b.Type {
@@ -874,12 +885,14 @@ func indexesEqual(a, b *Index) bool {
 	if a.Type != b.Type {
 		return false
 	}
-	// Compare using ColumnList if available, otherwise fall back to Columns
+	// Compare using ColumnList if available, otherwise fall back to Columns.
+	// Referenced column names are matched case-insensitively to mirror
+	// MySQL's column-identifier semantics.
 	if len(a.ColumnList) > 0 && len(b.ColumnList) > 0 {
 		if !indexColumnListsEqual(a.ColumnList, b.ColumnList) {
 			return false
 		}
-	} else if !slices.Equal(a.Columns, b.Columns) {
+	} else if !equalFoldStrings(a.Columns, b.Columns) {
 		return false
 	}
 	if !ptrEqual(a.Invisible, b.Invisible) {
@@ -902,12 +915,13 @@ func indexesEqualIgnoreVisibility(a, b *Index) bool {
 	if a.Type != b.Type {
 		return false
 	}
-	// Compare using ColumnList if available, otherwise fall back to Columns
+	// Compare using ColumnList if available, otherwise fall back to Columns.
+	// Referenced column names are matched case-insensitively.
 	if len(a.ColumnList) > 0 && len(b.ColumnList) > 0 {
 		if !indexColumnListsEqual(a.ColumnList, b.ColumnList) {
 			return false
 		}
-	} else if !slices.Equal(a.Columns, b.Columns) {
+	} else if !equalFoldStrings(a.Columns, b.Columns) {
 		return false
 	}
 	// Skip Invisible comparison
@@ -935,7 +949,8 @@ func indexColumnListsEqual(a, b []IndexColumn) bool {
 
 // indexColumnsEqual checks if two index columns are equal
 func indexColumnsEqual(a, b *IndexColumn) bool {
-	if a.Name != b.Name {
+	// Column identifiers are case-insensitive in MySQL.
+	if !strings.EqualFold(a.Name, b.Name) {
 		return false
 	}
 	if !ptrEqual(a.Expression, b.Expression) {

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -211,8 +211,12 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 			// MODIFY existing column if:
 			// 1. Column definition changed (and not just PK-related changes)
 			// 2. Column needs explicit positioning
+			// needsExplicitPosition is keyed by lowercased column name, so
+			// look up with the same normalization to avoid missing a
+			// position-only change when the target's spelling is in mixed
+			// or upper case.
 			needsModify := (!ct.columnsEqualWithContext(sourceCol, &targetCol, target) && !pkOnlyChange && !pkDroppedNullabilityChange) ||
-				needsExplicitPosition[targetCol.Name]
+				needsExplicitPosition[strings.ToLower(targetCol.Name)]
 
 			if needsModify {
 				clause := fmt.Sprintf("MODIFY COLUMN %s", formatColumnDefinition(&targetCol))

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -883,6 +883,29 @@ func TestDiff(t *testing.T) {
 			) ENGINE InnoDB DEFAULT CHARSET utf8mb4`,
 			expected: "ALTER TABLE `t1` ADD COLUMN `extra` json NOT NULL DEFAULT (json_object())",
 		},
+		// MySQL column identifiers are case-insensitive — `id` and `ID`
+		// refer to the same column. A diff between two CREATE TABLE
+		// statements that differ only in column-name case should produce
+		// no ALTER. The PK case is the one gh-ost's `modify-change-case-pk`
+		// localtest exercises.
+		{
+			name:     "PrimaryKeyColumnCaseOnly",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c1 INT NOT NULL DEFAULT 0)",
+			target:   "CREATE TABLE t1 (ID INT PRIMARY KEY, c1 INT NOT NULL DEFAULT 0)",
+			expected: "",
+		},
+		{
+			name:     "NonPrimaryKeyColumnCaseOnly",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c2 INT NOT NULL DEFAULT 0)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, C2 INT NOT NULL DEFAULT 0)",
+			expected: "",
+		},
+		{
+			name:     "CompoundPrimaryKeyColumnCaseOnly",
+			source:   "CREATE TABLE t1 (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a, b))",
+			target:   "CREATE TABLE t1 (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (A, B))",
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -906,6 +906,16 @@ func TestDiff(t *testing.T) {
 			target:   "CREATE TABLE t1 (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (A, B))",
 			expected: "",
 		},
+		// Reordering with uppercase column names must still emit MODIFY
+		// AFTER clauses. Regression for a read against
+		// needsExplicitPosition that used the original (uppercase) name
+		// even though the map is keyed by lowercased identifier.
+		{
+			name:     "ReorderUppercaseColumns",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, A INT NOT NULL, B INT NOT NULL)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, B INT NOT NULL, A INT NOT NULL)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `B` int(11) NOT NULL AFTER `id`, MODIFY COLUMN `A` int(11) NOT NULL AFTER `B`",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/statement/utils.go
+++ b/pkg/statement/utils.go
@@ -82,10 +82,11 @@ func ptrEqual[T comparable](a, b *T) bool {
 // getPreviousColumn returns the name of the column directly before
 // `name` in the given slice, or "" if `name` is the first column or
 // not found. Used by diffColumns to decide whether an ADD COLUMN needs
-// an AFTER clause.
+// an AFTER clause. Matches `name` case-insensitively, since MySQL
+// column identifiers are case-insensitive.
 func getPreviousColumn(columns []Column, name string) string {
 	for i, col := range columns {
-		if col.Name == name {
+		if strings.EqualFold(col.Name, name) {
 			if i == 0 {
 				return ""
 			}
@@ -93,6 +94,22 @@ func getPreviousColumn(columns []Column, name string) string {
 		}
 	}
 	return ""
+}
+
+// equalFoldStrings reports whether two string slices are equal under
+// case-insensitive comparison, element-by-element. Used for comparing
+// lists of identifiers (column names, index column references) where
+// MySQL treats case differences as semantically identical.
+func equalFoldStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !strings.EqualFold(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // needsQuotes decides whether a column DEFAULT value needs to be wrapped


### PR DESCRIPTION
## Summary

- `spirit diff` between two CREATE TABLE statements that differ only in column-name case (e.g. `id` vs `ID`) now produces no ALTER. MySQL column identifiers are case-insensitive, so `MODIFY ID INT` on an `id` column is semantically a no-op.
- Surfaced while porting gh-ost's [localtests/modify-change-case](https://github.com/github/gh-ost/tree/master/localtests/modify-change-case) and [localtests/modify-change-case-pk](https://github.com/github/gh-ost/tree/master/localtests/modify-change-case-pk).
- Affects the `spirit diff` subcommand only. Runtime migrations are unaffected — their column lists come from `information_schema` on source and shadow tables, which share the same canonical casing.

## What changed

- New `equalFoldStrings` helper for case-insensitive `[]string` equality.
- Column maps in `diffColumns` / `calculateColumnPositioning` / `diffPrimaryKey` use lowercased keys.
- `getPreviousColumn`, `columnsEqualWithContext`, `columnsEqualIgnorePK`, `indexColumnsEqual` use `strings.EqualFold` for column identifier comparison.
- `indexesEqual` / `indexesEqualIgnoreVisibility` use `equalFoldStrings` for referenced column lists.
- Three new table-driven cases in `TestDiff`: `PrimaryKeyColumnCaseOnly`, `NonPrimaryKeyColumnCaseOnly`, `CompoundPrimaryKeyColumnCaseOnly`.

Out of scope (not currently exercised by tests): FK constraint referenced-column case-insensitivity, index/constraint name case-insensitivity. Easy follow-ups if desired.

## Test plan

- [x] `go test ./pkg/statement/...` — passes (full TestDiff suite + three new cases)
- [x] `go test -run TestLint ./pkg/migration/ ./pkg/lint/` — passes
- [x] `golangci-lint run ./pkg/statement/...` — 0 issues