### PR TITLE
Fix BIT column handling through copier and binlog applier

### DIFF
--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -822,3 +822,264 @@ ADD SPATIAL INDEX idx_points_of_interest (points_of_interest)`)
 	require.NoError(t, tt.DB.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM t1spatial`).Scan(&count))
 	require.Equal(t, 10, count)
 }
+
+// TestBinaryToVarbinaryConcurrentDML ports gh-ost's localtests/binary-to-varbinary
+// scenario (gh-ost issue #909) as positive regression coverage. A BINARY(N)
+// source column is migrated to VARBINARY(M) while concurrent DML touches
+// rows with trailing-zero values.
+//
+// Two write paths exist for these rows:
+//   - Rowcopy: INSERT IGNORE INTO new SELECT FROM source. MySQL handles the
+//     conversion server-side; the BINARY(N)'s right-padded value lands in
+//     VARBINARY verbatim.
+//   - Binlog replay: the applier reads the row image from the binlog and
+//     emits REPLACE INTO new VALUES (0x<bytes>). gh-ost's #909 was that
+//     trailing zeros were stripped from the row image, producing shorter
+//     VARBINARY values than the rowcopy path for the same source bytes.
+//
+// Spirit's current applier path (NewDatumFromValue with the BINARY source
+// type → forceHexEncode → %#x on the full byte string) does preserve the
+// 20-byte width, so this test passes on main. It exists to lock that
+// behavior in: any future change that drops the trailing zeros, switches
+// the source-type lookup, or changes how the binlog row image is shaped
+// would regress this test.
+func TestBinaryToVarbinaryConcurrentDML(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "bin2varbin", `CREATE TABLE bin2varbin (
+		id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		info VARCHAR(64) NOT NULL,
+		data BINARY(20) NOT NULL
+	)`)
+
+	// Seed rows that will be the targets of concurrent UPDATEs. Their
+	// initial data is non-zero-trailing so the binlog event during UPDATE
+	// produces a row image with trailing zeros — the failure mode.
+	_, err := tt.DB.ExecContext(t.Context(), `
+		INSERT INTO bin2varbin (info, data) VALUES
+		  ('pre-existing-1',  X'01020304050607080910111213141516171819ff'),
+		  ('pre-existing-2',  X'0102030405060708091011121314151617181900'),
+		  ('update-target-1', X'ffffffffffffffffffffffffffffffffffffffff'),
+		  ('update-target-2', X'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')`)
+	require.NoError(t, err)
+	// Add bulk rows so the copier actually has work to do and replay can
+	// race with rowcopy.
+	tt.SeedRows(t, "INSERT INTO bin2varbin (info, data) SELECT 'bulk', X'aabbccddeeff00000000000000000000000000ff'", 5000)
+
+	m := NewTestRunner(t, "bin2varbin", "MODIFY data VARBINARY(32) NOT NULL",
+		WithThreads(1),
+		WithTargetChunkTime(100*time.Millisecond),
+		WithBuffered(true),
+		WithTestThrottler())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dmlDone := make(chan struct{})
+	go func() {
+		defer close(dmlDone)
+		for m.status.Get() < status.CopyRows {
+			time.Sleep(time.Millisecond)
+			if ctx.Err() != nil {
+				return
+			}
+		}
+		for i := 0; i < 50; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			// INSERTs with trailing-zero data — exercise the binlog INSERT
+			// row image path.
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO bin2varbin (info, data) VALUES ('insert-during', X'aabbccdd00000000000000000000000000000000')`)
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO bin2varbin (info, data) VALUES ('insert-during', X'11223344556677889900000000000000000000ee')`)
+			// UPDATEs of pre-existing rows to trailing-zero values —
+			// exercise the binlog UPDATE row image path.
+			_, _ = tt.DB.ExecContext(ctx, `UPDATE bin2varbin SET data = X'ffeeddcc00000000000000000000000000000000' WHERE info = 'update-target-1'`)
+			_, _ = tt.DB.ExecContext(ctx, `UPDATE bin2varbin SET data = X'aabbccdd11111111111111111100000000000000' WHERE info = 'update-target-2'`)
+		}
+	}()
+
+	migrationErr := m.Run(ctx)
+	cancel()
+	<-dmlDone
+	require.NoError(t, m.Close())
+	require.NoError(t, migrationErr, "BINARY(N) → VARBINARY(M) with concurrent DML must preserve trailing zeros (gh-ost #909 analog)")
+
+	// Target column must now be varbinary.
+	var colType string
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT column_type FROM information_schema.columns
+		 WHERE table_schema=DATABASE() AND table_name='bin2varbin' AND column_name='data'`).Scan(&colType))
+	require.Contains(t, colType, "varbinary")
+
+	// The known update-target rows must have their full 20-byte values
+	// preserved (with trailing zeros).
+	var dataLen1, dataLen2 int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT OCTET_LENGTH(data) FROM bin2varbin WHERE info = 'update-target-1' LIMIT 1`).Scan(&dataLen1))
+	require.Equal(t, 20, dataLen1, "update-target-1 must keep full 20-byte width after binlog replay")
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT OCTET_LENGTH(data) FROM bin2varbin WHERE info = 'update-target-2' LIMIT 1`).Scan(&dataLen2))
+	require.Equal(t, 20, dataLen2, "update-target-2 must keep full 20-byte width after binlog replay")
+
+	// No row inserted during migration should be shorter than 20 bytes —
+	// every INSERT value above is exactly 20 bytes wide and BINARY(20) is
+	// the source column type.
+	var shortRows int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM bin2varbin WHERE info = 'insert-during' AND OCTET_LENGTH(data) <> 20`).Scan(&shortRows))
+	require.Zero(t, shortRows, "rows inserted during migration must keep their full 20-byte width")
+
+	// The bulk-seeded rows take the rowcopy path; they too should round-trip
+	// at their full 20-byte width. A regression in the rowcopy SELECT or in
+	// MySQL's BINARY→VARBINARY conversion would surface here, separately
+	// from the binlog-replay assertions above.
+	var bulkShortRows int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM bin2varbin WHERE info = 'bulk' AND OCTET_LENGTH(data) <> 20`).Scan(&bulkShortRows))
+	require.Zero(t, bulkShortRows, "rowcopied rows must keep their full 20-byte width")
+}
+
+// TestBitColumnDML ports gh-ost's localtests/bit-dml. The applier reads BIT
+// values from the binlog as int64 (per go-mysql's decodeBit) and feeds them
+// to Spirit's Datum, which has no specific BIT arm in mySQLTypeToDatumTp.
+// The int64 falls into the unknownType branch in NewDatum, gets formatted
+// with fmt.Sprint, and is then emitted as a *quoted SQL string literal* —
+// e.g. REPLACE INTO t (b) VALUES (..., "5", ...).
+//
+// MySQL interprets a string assigned to BIT(N) as the literal bit pattern
+// of the bytes, NOT as a numeric coercion. So `"5"` (a 1-byte string of
+// ASCII '5' = 0x35) lands in a BIT(8) column as bit pattern 0x35 (decimal
+// 53), and `"127"` (a 3-byte string) is 24 bits wide — wider than BIT(8) —
+// triggering MySQL's "Out of range value" warning that Spirit's strict
+// applier promotes to a fatal error.
+//
+// The failure mode is therefore:
+//   - For values whose textual representation in bytes is wider than N
+//     bits: Spirit aborts the migration with "Out of range value for
+//     column ...". Fail-loud, but blocks any concurrent-write workload
+//     from migrating a table with a BIT column.
+//   - For values that fit: the destination receives the wrong bit pattern.
+//     Caught by the checksum, also fail-loud.
+//
+// All three subtests fail on current main. The fix is to give BIT a
+// dedicated arm in mySQLTypeToDatumTp (most cleanly: unsignedType,
+// reinterpreting the int64 as uint64) so the SQL literal is emitted as
+// a numeric, not a quoted string.
+func TestBitColumnDML(t *testing.T) {
+	t.Parallel()
+	t.Run("BIT(1)", func(t *testing.T) {
+		t.Parallel()
+		runBitDMLTest(t, "bit1col", "BIT(1)", []uint64{0, 1}, "b1")
+	})
+
+	t.Run("BIT(8)", func(t *testing.T) {
+		t.Parallel()
+		runBitDMLTest(t, "bit8col", "BIT(8)", []uint64{0, 1, 127, 200, 255}, "b8")
+	})
+
+	t.Run("BIT(64) high bit set", func(t *testing.T) {
+		t.Parallel()
+		// Values with the top bit set become negative int64 after decoding,
+		// which is where the string-coercion path goes wrong.
+		runBitDMLTest(t, "bit64col", "BIT(64)",
+			[]uint64{0, 1, 1 << 63, (1 << 63) | 1, ^uint64(0)}, "b64")
+	})
+}
+
+func runBitDMLTest(t *testing.T, tableName, bitType string, values []uint64, colName string) {
+	tt := testutils.NewTestTable(t, tableName, fmt.Sprintf(`CREATE TABLE %s (
+		id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		v INT NOT NULL,
+		%s %s NOT NULL DEFAULT 0
+	)`, tableName, colName, bitType))
+
+	// Seed enough rows to give the chunker work; the bit value here doesn't
+	// matter — the assertions cover rows written during migration via the
+	// binlog path.
+	tt.SeedRows(t, fmt.Sprintf("INSERT INTO %s (v, %s) SELECT 0, 0", tableName, colName), 5000)
+
+	// One row per test value, inserted before migration starts. We update
+	// these mid-migration so the new value flows through the binlog
+	// applier rather than the chunker SELECT.
+	type marker struct {
+		id  int64
+		val uint64
+	}
+	markers := make([]marker, len(values))
+	for i, v := range values {
+		res, err := tt.DB.ExecContext(t.Context(),
+			fmt.Sprintf("INSERT INTO %s (v, %s) VALUES (?, ?)", tableName, colName), -1-i, v)
+		require.NoError(t, err)
+		id, err := res.LastInsertId()
+		require.NoError(t, err)
+		markers[i] = marker{id: id, val: v}
+	}
+
+	// Capture the row count before the migration starts so we can assert
+	// no rows are lost or duplicated. SeedRows reaches the target by
+	// doubling, so the actual seeded count is not the requested number.
+	var rowsBeforeMigration int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&rowsBeforeMigration))
+
+	m := NewTestRunner(t, tableName, "ENGINE=InnoDB",
+		WithThreads(1),
+		WithTargetChunkTime(100*time.Millisecond),
+		WithBuffered(true),
+		WithTestThrottler())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dmlDone := make(chan struct{})
+	go func() {
+		defer close(dmlDone)
+		for m.status.Get() < status.CopyRows {
+			time.Sleep(time.Millisecond)
+			if ctx.Err() != nil {
+				return
+			}
+		}
+		// UPDATE the marker rows mid-migration. Each update produces a
+		// binlog row image carrying the BIT value as int64; the applier
+		// REPLACEs the corresponding row in the shadow table.
+		for i := 0; i < 20; i++ {
+			if ctx.Err() != nil {
+				return
+			}
+			for _, mk := range markers {
+				_, _ = tt.DB.ExecContext(ctx,
+					fmt.Sprintf("UPDATE %s SET v = v + 1, %s = ? WHERE id = ?", tableName, colName),
+					mk.val, mk.id)
+			}
+		}
+	}()
+
+	migrationErr := m.Run(ctx)
+	cancel()
+	<-dmlDone
+	require.NoError(t, m.Close())
+	require.NoError(t, migrationErr, "BIT column DML migration must not fail checksum")
+
+	// Row count must match what was there before migration. The DML
+	// goroutine issues UPDATEs only — no inserts or deletes — so the
+	// count must be identical. INSERT IGNORE silently dropping a
+	// rowcopied row, or REPLACE INTO deleting one via a unique-key
+	// collision on a corrupted bit pattern, would surface here.
+	var rowsAfterMigration int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&rowsAfterMigration))
+	require.Equal(t, rowsBeforeMigration, rowsAfterMigration, "row count after migration must match")
+
+	// Each marker row's stored bit value must match what we wrote. We
+	// compare via CAST(... AS UNSIGNED) so we can read it back as uint64.
+	for _, mk := range markers {
+		var got uint64
+		require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT CAST(%s AS UNSIGNED) FROM %s WHERE id = ?", colName, tableName), mk.id).
+			Scan(&got))
+		require.Equalf(t, mk.val, got,
+			"marker id=%d expected %s value 0x%016x but got 0x%016x",
+			mk.id, bitType, mk.val, got)
+	}
+}

--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"sync"
 	"testing"
@@ -911,19 +912,32 @@ func TestBinaryToVarbinaryConcurrentDML(t *testing.T) {
 		 WHERE table_schema=DATABASE() AND table_name='bin2varbin' AND column_name='data'`).Scan(&colType))
 	require.Contains(t, colType, "varbinary")
 
-	// The known update-target rows must have their full 20-byte values
-	// preserved (with trailing zeros).
-	var dataLen1, dataLen2 int
+	// The known update-target rows must contain the post-UPDATE bytes
+	// (with their trailing zeros). Comparing the full 20-byte value — not
+	// just OCTET_LENGTH — ensures the binlog UPDATE path actually
+	// replayed: the rows started life with non-zero-trailing data, so a
+	// missed UPDATE leaves the rowcopied initial value behind and this
+	// assertion fails.
+	var data1, data2 []byte
 	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
-		`SELECT OCTET_LENGTH(data) FROM bin2varbin WHERE info = 'update-target-1' LIMIT 1`).Scan(&dataLen1))
-	require.Equal(t, 20, dataLen1, "update-target-1 must keep full 20-byte width after binlog replay")
+		`SELECT data FROM bin2varbin WHERE info = 'update-target-1' LIMIT 1`).Scan(&data1))
+	wantData1, err := hex.DecodeString("ffeeddcc00000000000000000000000000000000")
+	require.NoError(t, err)
+	require.Equal(t, wantData1, data1, "update-target-1 must hold its post-UPDATE 20-byte value")
 	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
-		`SELECT OCTET_LENGTH(data) FROM bin2varbin WHERE info = 'update-target-2' LIMIT 1`).Scan(&dataLen2))
-	require.Equal(t, 20, dataLen2, "update-target-2 must keep full 20-byte width after binlog replay")
+		`SELECT data FROM bin2varbin WHERE info = 'update-target-2' LIMIT 1`).Scan(&data2))
+	wantData2, err := hex.DecodeString("aabbccdd11111111111111111100000000000000")
+	require.NoError(t, err)
+	require.Equal(t, wantData2, data2, "update-target-2 must hold its post-UPDATE 20-byte value")
 
-	// No row inserted during migration should be shorter than 20 bytes —
-	// every INSERT value above is exactly 20 bytes wide and BINARY(20) is
-	// the source column type.
+	// At least one 'insert-during' row must exist — otherwise the binlog
+	// INSERT path was not exercised and the next assertion is vacuous.
+	var insertCount int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM bin2varbin WHERE info = 'insert-during'`).Scan(&insertCount))
+	require.Positive(t, insertCount, "no concurrent INSERTs reached the binlog path — test is vacuous")
+
+	// And every one of them must keep its full 20-byte width.
 	var shortRows int
 	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
 		`SELECT COUNT(*) FROM bin2varbin WHERE info = 'insert-during' AND OCTET_LENGTH(data) <> 20`).Scan(&shortRows))
@@ -998,9 +1012,15 @@ func runBitDMLTest(t *testing.T, tableName, bitType string, values []uint64, col
 	// binlog path.
 	tt.SeedRows(t, fmt.Sprintf("INSERT INTO %s (v, %s) SELECT 0, 0", tableName, colName), 5000)
 
-	// One row per test value, inserted before migration starts. We update
-	// these mid-migration so the new value flows through the binlog
-	// applier rather than the chunker SELECT.
+	// One row per test value, inserted before migration starts with the
+	// BIT column at 0 — a sentinel that's different from every non-zero
+	// test value. We then UPDATE these mid-migration to flip the BIT to
+	// `val` via the binlog applier. If the UPDATE never replays, the
+	// post-migration BIT value remains at the seed (0) instead of `val`,
+	// and the assertion at the bottom catches it. The companion `v=v+1`
+	// in the UPDATE statement gives us a second signal that's monotone
+	// regardless of the BIT value involved (covers the val=0 case where
+	// seed and target both happen to be zero).
 	type marker struct {
 		id  int64
 		val uint64
@@ -1008,7 +1028,7 @@ func runBitDMLTest(t *testing.T, tableName, bitType string, values []uint64, col
 	markers := make([]marker, len(values))
 	for i, v := range values {
 		res, err := tt.DB.ExecContext(t.Context(),
-			fmt.Sprintf("INSERT INTO %s (v, %s) VALUES (?, ?)", tableName, colName), -1-i, v)
+			fmt.Sprintf("INSERT INTO %s (v, %s) VALUES (?, 0)", tableName, colName), -1-i)
 		require.NoError(t, err)
 		id, err := res.LastInsertId()
 		require.NoError(t, err)
@@ -1071,13 +1091,21 @@ func runBitDMLTest(t *testing.T, tableName, bitType string, values []uint64, col
 		fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&rowsAfterMigration))
 	require.Equal(t, rowsBeforeMigration, rowsAfterMigration, "row count after migration must match")
 
-	// Each marker row's stored bit value must match what we wrote. We
-	// compare via CAST(... AS UNSIGNED) so we can read it back as uint64.
-	for _, mk := range markers {
+	// Each marker row must show two things: (1) at least one UPDATE
+	// replayed — `v` was seeded negative and is only ever incremented,
+	// so v > -1-i proves the UPDATE path fired; (2) the stored BIT value
+	// matches what the UPDATE wrote. The combination is what makes the
+	// test non-vacuous: a missed UPDATE leaves v at the seed; a buggy
+	// BIT serialization leaves a different bit pattern in the column.
+	for i, mk := range markers {
 		var got uint64
+		var v int
 		require.NoError(t, tt.DB.QueryRowContext(t.Context(),
-			fmt.Sprintf("SELECT CAST(%s AS UNSIGNED) FROM %s WHERE id = ?", colName, tableName), mk.id).
-			Scan(&got))
+			fmt.Sprintf("SELECT v, CAST(%s AS UNSIGNED) FROM %s WHERE id = ?", colName, tableName), mk.id).
+			Scan(&v, &got))
+		require.Greaterf(t, v, -1-i,
+			"marker id=%d: v stayed at seed (%d) — no UPDATE replayed for this row",
+			mk.id, -1-i)
 		require.Equalf(t, mk.val, got,
 			"marker id=%d expected %s value 0x%016x but got 0x%016x",
 			mk.id, bitType, mk.val, got)

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -27,6 +27,16 @@ type Datum struct {
 	forceHexEncode bool    // when true, always hex-encode the value in String()
 }
 
+// isBITType reports whether the given MySQL column type is a BIT(N) type.
+// Used to gate the BIT-specific []byte → uint64 decoding in NewDatumFromValue.
+func isBITType(mysqlTp string) bool {
+	baseType := strings.ToUpper(removeWidth(mysqlTp))
+	if before, _, found := strings.Cut(baseType, "("); found {
+		baseType = before
+	}
+	return baseType == "BIT"
+}
+
 func mySQLTypeToDatumTp(mysqlTp string) datumTp {
 	// Normalize to uppercase and remove width specifications
 	normalized := strings.ToUpper(removeWidth(mysqlTp))
@@ -41,6 +51,14 @@ func mySQLTypeToDatumTp(mysqlTp string) datumTp {
 	case "INT", "BIGINT", "SMALLINT", "TINYINT", "MEDIUMINT":
 		return signedType
 	case "INT UNSIGNED", "BIGINT UNSIGNED", "SMALLINT UNSIGNED", "TINYINT UNSIGNED", "MEDIUMINT UNSIGNED":
+		return unsignedType
+	case "BIT":
+		// BIT(N) arrives from the binlog as int64 (go-mysql's decodeBit).
+		// Classifying as unsignedType makes NewDatum reinterpret the int64
+		// bit pattern as uint64 — preserving BIT(64) values with the high
+		// bit set — and Datum.String() emits a bare numeric literal that
+		// MySQL coerces to a bit pattern, rather than a quoted string
+		// (which MySQL would otherwise interpret byte-by-byte as bits).
 		return unsignedType
 	case "FLOAT", "DOUBLE", "DECIMAL":
 		// Treat floats as unknownType so they get formatted as-is
@@ -170,6 +188,20 @@ func NewDatumFromValue(value any, mysqlType string) (Datum, error) {
 	}
 
 	tp := mySQLTypeToDatumTp(mysqlType)
+
+	// BIT(N) is classified as unsignedType, but its wire form depends on
+	// the source: the Go MySQL driver returns []byte (big-endian bit
+	// pattern); the binlog reader returns int64. Decode []byte to uint64
+	// here so the generic unsignedType path below sees a numeric value
+	// and doesn't try to ParseUint on raw bit bytes (which would fail on
+	// any byte that isn't an ASCII decimal digit).
+	if b, ok := value.([]byte); ok && isBITType(mysqlType) {
+		var u uint64
+		for _, by := range b {
+			u = (u << 8) | uint64(by)
+		}
+		value = u
+	}
 
 	// Convert []byte to string for non-numeric types
 	if b, ok := value.([]byte); ok {

--- a/pkg/table/datum_test.go
+++ b/pkg/table/datum_test.go
@@ -340,6 +340,49 @@ func TestNewDatumFromValue(t *testing.T) {
 	d, err = NewDatumFromValue("test", "CUSTOM_TYPE")
 	require.NoError(t, err)
 	require.Equal(t, "\"test\"", d.String())
+
+	// BIT(N) values: emitted as bare numeric literals so MySQL coerces them
+	// to bit patterns, not as quoted strings (which MySQL would interpret
+	// byte-by-byte as bits). The Go MySQL driver returns BIT as a raw
+	// big-endian byte slice; the binlog reader returns int64. Both must
+	// land on the same numeric literal.
+	//
+	// Driver path: []byte → uint64 (big-endian).
+	d, err = NewDatumFromValue([]byte{0x01}, "BIT(1)")
+	require.NoError(t, err)
+	require.Equal(t, "1", d.String())
+	d, err = NewDatumFromValue([]byte{0x35}, "BIT(8)")
+	require.NoError(t, err)
+	require.Equal(t, "53", d.String())
+	d, err = NewDatumFromValue([]byte{0x01, 0x02}, "BIT(16)")
+	require.NoError(t, err)
+	require.Equal(t, "258", d.String())
+	// BIT(64) with top bit set: bytes round-trip through uint64 without
+	// the sign-extension that an int64 path would introduce.
+	d, err = NewDatumFromValue(
+		[]byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, "BIT(64)")
+	require.NoError(t, err)
+	require.Equal(t, "9223372036854775808", d.String())
+
+	// Binlog path: int64 from go-mysql's decodeBit. Positive values are
+	// trivial; negative int64 (BIT(64) high bit set) must reinterpret bits
+	// as uint64 to round-trip correctly.
+	d, err = NewDatumFromValue(int64(5), "BIT(8)")
+	require.NoError(t, err)
+	require.Equal(t, "5", d.String())
+	d, err = NewDatumFromValue(int64(-1), "BIT(64)")
+	require.NoError(t, err)
+	require.Equal(t, "18446744073709551615", d.String())
+
+	// NULL BIT survives.
+	d, err = NewDatumFromValue(nil, "BIT(8)")
+	require.NoError(t, err)
+	require.Equal(t, "NULL", d.String())
+
+	// Case-insensitive on the type spelling.
+	d, err = NewDatumFromValue([]byte{0x07}, "bit(3)")
+	require.NoError(t, err)
+	require.Equal(t, "7", d.String())
 }
 
 // TestNewDatumFromValueBinaryString tests that binary strings are hex-encoded

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -310,6 +310,19 @@ func (t *TableInfo) PrimaryKeyIsMemoryComparable() error {
 	if slices.Contains(t.keyDatums, unknownType) {
 		return ErrUnsupportedPKType
 	}
+	// BIT is classified as unsignedType so the binlog applier emits the
+	// value as a numeric literal (see mySQLTypeToDatumTp), but BIT primary
+	// keys are not supported end-to-end: setMinMax issues a SELECT that
+	// returns BIT as raw big-endian bytes, and the chunker's
+	// newDatumFromMySQL path parses those as decimal strings — which
+	// fails or produces wrong bounds. Until the min/max read path knows
+	// how to decode BIT bytes, reject BIT PKs upfront with the same error
+	// they returned before BIT got its own datumTp.
+	for _, mysqlTp := range t.keyColumnsMySQLTp {
+		if isBITType(mysqlTp) {
+			return ErrUnsupportedPKType
+		}
+	}
 	return nil
 }
 
@@ -320,6 +333,15 @@ func (t *TableInfo) PrimaryKeyIsMemoryComparable() error {
 func (t *TableInfo) setMinMax(ctx context.Context) error {
 	if t.keyDatums[0] == binaryType {
 		return nil // we don't min/max binary types for now.
+	}
+	// BIT is classified as unsignedType so the applier emits the value as
+	// a numeric literal, but `SELECT min(bit_col)` returns raw big-endian
+	// bytes that newDatumFromMySQL can't parse as decimal. BIT primary
+	// keys are rejected upfront by PrimaryKeyIsMemoryComparable; skip
+	// here so SetInfo can complete and the rejection can fire on a
+	// well-formed TableInfo.
+	if isBITType(t.keyColumnsMySQLTp[0]) {
+		return nil
 	}
 	quotedKey := QuoteColumns(t.KeyColumns[:1])
 	query := fmt.Sprintf("SELECT IFNULL(min(%s),'0'), IFNULL(max(%s),'0') FROM %s", quotedKey, quotedKey, t.QuotedTableName)

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -212,6 +212,31 @@ func TestDiscoveryBalancesTable(t *testing.T) {
 	require.Equal(t, "0", t1.maxValue.String())
 }
 
+// TestPrimaryKeyIsMemoryComparableRejectsBIT regresses a gap exposed when
+// BIT was reclassified from unknownType to unsignedType in
+// mySQLTypeToDatumTp: the change makes BIT-keyed tables pass the original
+// unknownType check, but the chunker's setMinMax path returns BIT as raw
+// big-endian bytes that newDatumFromMySQL can't parse as decimal. Until
+// the min/max read path is BIT-aware, BIT primary keys must be rejected
+// upfront with ErrUnsupportedPKType.
+func TestPrimaryKeyIsMemoryComparableRejectsBIT(t *testing.T) {
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS bitpk`)
+	testutils.RunSQL(t, `CREATE TABLE bitpk (b BIT(8) NOT NULL, v INT NOT NULL, PRIMARY KEY (b))`)
+	testutils.RunSQL(t, `INSERT INTO bitpk (b, v) VALUES (b'00000001', 1), (b'00000010', 2)`)
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Logf("failed to close db: %v", err)
+		}
+	}()
+
+	t1 := NewTableInfo(db, "test", "bitpk")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	require.ErrorIs(t, t1.PrimaryKeyIsMemoryComparable(), ErrUnsupportedPKType)
+}
+
 func TestDiscoveryCompositeNonComparable(t *testing.T) {
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS compnoncomparable`)
 	table := `CREATE TABLE compnoncomparable (


### PR DESCRIPTION
## Summary

- `BIT(N)` columns were missing a case in `mySQLTypeToDatumTp`, so they fell through to `unknownType` and were emitted as quoted string literals. MySQL interprets a string assigned to `BIT` as the literal bit pattern of its bytes, not as a numeric value — so inserting `"5"` into `BIT(8)` stored `0x35` (= 53), and inserting `"127"` into `BIT(8)` hit `Out of range` (a 3-byte string is 24 bits, wider than the column). Any concurrent-write workload on a table with a BIT column would either silently corrupt rows (and trip the post-copy checksum) or fail-loud during binlog replay.
- Surfaced while porting [gh-ost localtests/bit-dml](https://github.com/github/gh-ost/tree/master/localtests/bit-dml).

## What changed

- `pkg/table/datum.go` — add a `BIT` arm to `mySQLTypeToDatumTp` that returns `unsignedType`. The binlog path (`go-mysql`'s `decodeBit` returns `int64`) flows through `NewDatum`'s existing int64 → uint64 reinterpretation, which preserves `BIT(64)` values with the high bit set. For the Go MySQL driver path (returns `[]byte` big-endian), decode the bytes to `uint64` before `NewDatum` sees them; the generic `unsignedType` `ParseUint` path can't parse raw bit bytes.
- `pkg/table/datum_test.go` — eight new cases in `TestNewDatumFromValue`: `[]byte` for `BIT(1)/(8)/(16)/(64)`, `int64` (incl. negative for `BIT(64)` high bit), `NULL`, and case-insensitive type spelling.
- `pkg/migration/datatype_test.go` — two new integration tests ported from gh-ost localtests:
  - `TestBitColumnDML` — `BIT(1)`, `BIT(8)`, `BIT(64) high bit set` subtests. UPDATEs marker rows mid-migration so values flow through the binlog applier; asserts every marker round-trips and overall row count is preserved.
  - `TestBinaryToVarbinaryConcurrentDML` — positive regression coverage for the `BINARY(20) → VARBINARY(32)` case (gh-ost #909 analog). Confirms both rowcopied bulk rows and binlog-replayed marker rows preserve their full 20-byte width with trailing zeros.

## Test plan

- [x] `go test ./pkg/table/...` — pass (incl. new `TestNewDatumFromValue` cases)
- [x] `go test -run 'TestBitColumnDML|TestBinaryToVarbinary' ./pkg/migration/` — pass
- [x] `golangci-lint run ./pkg/table/... ./pkg/migration/...` — 0 issues