### PR TITLE
support RENAME operations for buffered copies

### DIFF
--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -310,26 +310,33 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 		return 0, nil
 	}
 
-	// Get the intersected column names to match with the values
-	columnList, _ := chunkletData.chunk.ColumnMapping.Columns()
-	columnNames, _ := chunkletData.chunk.ColumnMapping.ColumnsSlice()
+	// The intersected source and target column lists are parallel — row.values[i]
+	// is a value for source column sourceColumnNames[i], which corresponds to
+	// target column at the same ordinal in targetColumnList. With column renames
+	// the two lists differ; without renames they are identical.
+	mapping := chunkletData.chunk.ColumnMapping
+	_, targetColumnList := mapping.Columns()
+	sourceColumnNames, _ := mapping.ColumnsSlice()
 
 	// Build VALUES clauses for all rows in the chunklet
 	var valuesClauses []string
 	for _, row := range chunkletData.rows {
-		if len(columnNames) != len(row.values) {
+		if len(sourceColumnNames) != len(row.values) {
 			return 0, fmt.Errorf("column count mismatch: chunk %s has %d columns, but chunklet has %d values",
-				chunkletData.chunk.String(), len(columnNames), len(row.values))
+				chunkletData.chunk.String(), len(sourceColumnNames), len(row.values))
 		}
 		var values []string
 		for i, value := range row.values {
-			columnType, ok := chunkletData.chunk.ColumnMapping.TargetTable().GetColumnMySQLType(columnNames[i])
+			// Type lookup uses the source table by the source column name —
+			// the value came from a source SELECT, and MySQL coerces on the
+			// destination INSERT if the target column type has widened.
+			columnType, ok := mapping.SourceTable().GetColumnMySQLType(sourceColumnNames[i])
 			if !ok {
-				return 0, fmt.Errorf("column %s not found in table info", columnNames[i])
+				return 0, fmt.Errorf("column %s not found in source table info", sourceColumnNames[i])
 			}
 			datum, err := table.NewDatumFromValue(value, columnType)
 			if err != nil {
-				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", columnNames[i], err)
+				return 0, fmt.Errorf("failed to convert value to datum for column %s: %w", sourceColumnNames[i], err)
 			}
 			// datum.String() returns a complete pre-escaped SQL literal
 			// (NULL, a numeric, 0x… hex, or a "..."-quoted string). Safe
@@ -340,10 +347,10 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 		valuesClauses = append(valuesClauses, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
 	}
 
-	// Build the INSERT statement
+	// Build the INSERT statement — target columns, with renames applied.
 	query := fmt.Sprintf("INSERT IGNORE INTO %s (%s) VALUES %s",
-		chunkletData.chunk.ColumnMapping.TargetTable().QuotedTableName,
-		columnList,
+		mapping.TargetTable().QuotedTableName,
+		targetColumnList,
 		strings.Join(valuesClauses, ", "),
 	)
 

--- a/pkg/migration/check/rename.go
+++ b/pkg/migration/check/rename.go
@@ -16,37 +16,10 @@ func init() {
 
 // renameCheck validates rename operations in ALTER TABLE statements.
 // Table renames are always blocked. Column renames are allowed for
-// non-PK columns in the unbuffered copier path; PK renames and any
-// rename under the buffered copier are blocked. Additionally, it
-// blocks dangerous patterns where a rename's old or new name overlaps
-// with an added column name, which could cause data corruption.
-//
-// Why r.Buffered (the buffered *copier*, not the binlog subscription)
-// still gates column renames:
-//
-// Column renames go through ColumnMapping in every code path, so the
-// straight-line case works. The unsolved edges are in the buffered
-// copier's row-handling around generated/virtual columns:
-//
-//   - The buffered copier reads source rows by the intersected source
-//     column list and writes them to the target by the intersected
-//     target column list (renames applied). For tables with
-//     generated/virtual columns the row image and column lists drift
-//     from a plain CRUD layout in ways the unbuffered INSERT IGNORE
-//     ... SELECT doesn't have to deal with — the source SELECT and the
-//     destination INSERT are no longer "the same shape," and some
-//     rename + generated-column combinations have edge cases we
-//     haven't audited.
-//   - The unbuffered copier sidesteps this because SELECT and INSERT
-//     are wired with the same ColumnMapping at the SQL layer; MySQL
-//     does the column resolution.
-//   - The binlog replay path (always buffered) also uses ColumnMapping
-//     and is independent of this concern — that's why we don't gate on
-//     the subscription mode here.
-//
-// Plan: revisit once buffered-copier row handling has explicit
-// coverage for rename + generated/virtual columns. Tracking issue
-// TODO.
+// non-PK columns in both the buffered and unbuffered copier paths.
+// PK renames are blocked. Additionally, it blocks dangerous patterns
+// where a rename's old or new name overlaps with an added column
+// name, which could cause data corruption.
 func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 	alterStmt, ok := (*r.Statement.StmtNode).(*ast.AlterTableStmt)
 	if !ok {
@@ -76,12 +49,6 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 		}
 
 		if spec.Tp == ast.AlterTableRenameColumn {
-			// See function-level comment: gate is about the buffered
-			// *copier*'s row handling for generated/virtual columns,
-			// not about the always-buffered binlog subscription.
-			if r.Buffered {
-				return errors.New("column renames are not supported with the buffered copier (--buffered); unaudited edge cases around generated/virtual columns in the buffered row-image path. Rerun without --buffered")
-			}
 			if spec.OldColumnName != nil {
 				if _, isPK := pkColumns[spec.OldColumnName.Name.O]; isPK {
 					return fmt.Errorf("renaming primary key column %q is not supported", spec.OldColumnName.Name.O)
@@ -99,11 +66,6 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 				oldName := spec.OldColumnName.Name.O
 				newName := spec.NewColumns[0].Name.Name.O
 				if oldName != newName {
-					// See function-level comment: buffered-copier gate
-					// only; the subscription path is fine.
-					if r.Buffered {
-						return errors.New("column renames are not supported with the buffered copier (--buffered); unaudited edge cases around generated/virtual columns in the buffered row-image path. Rerun without --buffered")
-					}
 					if _, isPK := pkColumns[oldName]; isPK {
 						return fmt.Errorf("renaming primary key column %q is not supported", oldName)
 					}

--- a/pkg/migration/check/rename_test.go
+++ b/pkg/migration/check/rename_test.go
@@ -65,27 +65,21 @@ func TestRenamePKColumnBlocked(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestRenameBlockedWithBufferedCopier covers the gate on column
-// renames when the buffered copier (--buffered) is opted in. The
-// always-buffered binlog subscription is not the concern — see the
-// renameCheck doc comment for the generated/virtual-column edge cases
-// that motivate the gate.
-func TestRenameBlockedWithBufferedCopier(t *testing.T) {
+// TestRenameAllowedWithBufferedCopier covers that column renames are
+// permitted under the buffered copier (--buffered). The buffered copier
+// uses the same ColumnMapping intersection as the unbuffered path, so
+// renames flow through identically; generated/virtual columns are
+// excluded from the intersection on both source and target.
+func TestRenameAllowedWithBufferedCopier(t *testing.T) {
 	r := Resources{
 		Statement: statement.MustNew("ALTER TABLE t1 RENAME COLUMN c1 TO c2")[0],
 		Buffered:  true,
 	}
-	err := renameCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "buffered copier")
+	require.NoError(t, renameCheck(t.Context(), r, slog.Default()))
 
-	// CHANGE COLUMN rename is also blocked under the buffered copier.
 	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c2 VARCHAR(100)")[0]
-	err = renameCheck(t.Context(), r, slog.Default())
-	require.Error(t, err)
-	require.ErrorContains(t, err, "buffered copier")
+	require.NoError(t, renameCheck(t.Context(), r, slog.Default()))
 
-	// CHANGE COLUMN without a rename is fine under the buffered copier.
 	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 c1 VARCHAR(100)")[0] //nolint: dupword
 	require.NoError(t, renameCheck(t.Context(), r, slog.Default()))
 }

--- a/pkg/migration/rename_column_test.go
+++ b/pkg/migration/rename_column_test.go
@@ -11,7 +11,7 @@ import (
 
 // runRenameTest is a helper that creates a table, inserts data, runs a migration with the given
 // ALTER statement, and then verifies the data in the resulting table matches expectations.
-func runRenameTest(t *testing.T, tableName, createTable, insertData, alter string, verifyFunc func(t *testing.T, db *sql.DB)) {
+func runRenameTest(t *testing.T, enableBuffered bool, tableName, createTable, insertData, alter string, verifyFunc func(t *testing.T, db *sql.DB)) {
 	t.Helper()
 	dbName, _ := testutils.CreateUniqueTestDatabase(t)
 	testutils.RunSQLInDatabase(t, dbName, createTable)
@@ -19,7 +19,7 @@ func runRenameTest(t *testing.T, tableName, createTable, insertData, alter strin
 		testutils.RunSQLInDatabase(t, dbName, insertData)
 	}
 
-	m := NewTestMigration(t, WithDBName(dbName), WithTable(tableName), WithAlter(alter))
+	m := NewTestMigration(t, WithDBName(dbName), WithTable(tableName), WithAlter(alter), WithBuffered(enableBuffered))
 	require.NoError(t, m.Run())
 
 	if verifyFunc != nil {
@@ -33,7 +33,16 @@ func runRenameTest(t *testing.T, tableName, createTable, insertData, alter strin
 // TestRenameColumnSimple tests a simple column rename (RENAME COLUMN syntax).
 func TestRenameColumnSimple(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnSimple(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnSimple(t, true)
+	})
+}
+
+func testRenameColumnSimple(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_simple",
 		`CREATE TABLE rcol_simple (
 			id int NOT NULL AUTO_INCREMENT,
@@ -55,7 +64,16 @@ func TestRenameColumnSimple(t *testing.T) {
 // TestRenameColumnChangeType tests CHANGE COLUMN with rename and type change.
 func TestRenameColumnChangeType(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnChangeType(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnChangeType(t, true)
+	})
+}
+
+func testRenameColumnChangeType(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_chtype",
 		`CREATE TABLE rcol_chtype (
 			id int NOT NULL AUTO_INCREMENT,
@@ -83,7 +101,16 @@ func TestRenameColumnChangeType(t *testing.T) {
 // TestRenameColumnMultiple tests multiple column renames in a single ALTER.
 func TestRenameColumnMultiple(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnMultiple(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnMultiple(t, true)
+	})
+}
+
+func testRenameColumnMultiple(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_multi",
 		`CREATE TABLE rcol_multi (
 			id int NOT NULL AUTO_INCREMENT,
@@ -111,7 +138,16 @@ func TestRenameColumnMultiple(t *testing.T) {
 // (MySQL blocks renaming columns that have generated column dependencies.)
 func TestRenameColumnWithGeneratedColumnEnd(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnWithGeneratedColumnEnd(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnWithGeneratedColumnEnd(t, true)
+	})
+}
+
+func testRenameColumnWithGeneratedColumnEnd(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_genend",
 		`CREATE TABLE rcol_genend (
 			id int NOT NULL AUTO_INCREMENT,
@@ -139,7 +175,16 @@ func TestRenameColumnWithGeneratedColumnEnd(t *testing.T) {
 // (MySQL blocks renaming columns that have generated column dependencies.)
 func TestRenameColumnWithGeneratedColumnMiddle(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnWithGeneratedColumnMiddle(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnWithGeneratedColumnMiddle(t, true)
+	})
+}
+
+func testRenameColumnWithGeneratedColumnMiddle(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_genmid",
 		`CREATE TABLE rcol_genmid (
 			id int NOT NULL AUTO_INCREMENT,
@@ -168,7 +213,16 @@ func TestRenameColumnWithGeneratedColumnMiddle(t *testing.T) {
 // TestRenameColumnWithAddColumn tests rename combined with adding a new column.
 func TestRenameColumnWithAddColumn(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnWithAddColumn(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnWithAddColumn(t, true)
+	})
+}
+
+func testRenameColumnWithAddColumn(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_addcol",
 		`CREATE TABLE rcol_addcol (
 			id int NOT NULL AUTO_INCREMENT,
@@ -192,7 +246,16 @@ func TestRenameColumnWithAddColumn(t *testing.T) {
 // TestRenameColumnWithDropColumn tests rename combined with dropping a column.
 func TestRenameColumnWithDropColumn(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnWithDropColumn(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnWithDropColumn(t, true)
+	})
+}
+
+func testRenameColumnWithDropColumn(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_dropcol",
 		`CREATE TABLE rcol_dropcol (
 			id int NOT NULL AUTO_INCREMENT,
@@ -221,6 +284,15 @@ func TestRenameColumnWithDropColumn(t *testing.T) {
 // TestRenameColumnLargerDataset tests rename with enough data to exercise chunking.
 func TestRenameColumnLargerDataset(t *testing.T) {
 	t.Parallel()
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnLargerDataset(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnLargerDataset(t, true)
+	})
+}
+
+func testRenameColumnLargerDataset(t *testing.T, enableBuffered bool) {
 	dbName, _ := testutils.CreateUniqueTestDatabase(t)
 	tableName := "rcol_large"
 	testutils.RunSQLInDatabase(t, dbName, fmt.Sprintf("DROP TABLE IF EXISTS %s, _%s_new", tableName, tableName))
@@ -238,7 +310,8 @@ func TestRenameColumnLargerDataset(t *testing.T) {
 	}
 	// Should have 16 rows now
 
-	m := NewTestMigration(t, WithDBName(dbName), WithTable(tableName), WithAlter("RENAME COLUMN old_name TO new_name"))
+	m := NewTestMigration(t, WithDBName(dbName), WithTable(tableName),
+		WithAlter("RENAME COLUMN old_name TO new_name"), WithBuffered(enableBuffered))
 	require.NoError(t, m.Run())
 
 	db, err := sql.Open("mysql", testutils.DSNForDatabase(dbName))
@@ -287,7 +360,16 @@ func TestRenameColumnPKBlocked(t *testing.T) {
 // TestRenameColumnChangeColumnWithTypeChange tests CHANGE COLUMN that renames + changes type on multiple columns.
 func TestRenameColumnChangeColumnWithTypeChange(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnChangeColumnWithTypeChange(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnChangeColumnWithTypeChange(t, true)
+	})
+}
+
+func testRenameColumnChangeColumnWithTypeChange(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_chg_tp",
 		`CREATE TABLE rcol_chg_tp (
 			id int NOT NULL AUTO_INCREMENT,
@@ -312,7 +394,16 @@ func TestRenameColumnChangeColumnWithTypeChange(t *testing.T) {
 // TestRenameColumnWithNullableColumns tests rename with nullable columns containing NULLs.
 func TestRenameColumnWithNullableColumns(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnWithNullableColumns(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnWithNullableColumns(t, true)
+	})
+}
+
+func testRenameColumnWithNullableColumns(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_null",
 		`CREATE TABLE rcol_null (
 			id int NOT NULL AUTO_INCREMENT,
@@ -344,7 +435,16 @@ func TestRenameColumnWithNullableColumns(t *testing.T) {
 // TestRenameColumnCompositeKey tests rename on a table with a composite primary key.
 func TestRenameColumnCompositeKey(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnCompositeKey(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnCompositeKey(t, true)
+	})
+}
+
+func testRenameColumnCompositeKey(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_compkey",
 		`CREATE TABLE rcol_compkey (
 			tenant_id int NOT NULL,
@@ -368,7 +468,16 @@ func TestRenameColumnCompositeKey(t *testing.T) {
 // drop column, and generated columns present (but not depending on the renamed column).
 func TestRenameColumnAllCombined(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnAllCombined(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnAllCombined(t, true)
+	})
+}
+
+func testRenameColumnAllCombined(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_combo",
 		`CREATE TABLE rcol_combo (
 			id int NOT NULL AUTO_INCREMENT,
@@ -399,6 +508,15 @@ func TestRenameColumnAllCombined(t *testing.T) {
 // the rename works through the full copy+checksum+binlog replay path.
 func TestRenameColumnForceCopyPath(t *testing.T) {
 	t.Parallel()
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnForceCopyPath(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnForceCopyPath(t, true)
+	})
+}
+
+func testRenameColumnForceCopyPath(t *testing.T, enableBuffered bool) {
 	dbName, _ := testutils.CreateUniqueTestDatabase(t)
 	tableName := "rcol_forcecopy"
 	testutils.RunSQLInDatabase(t, dbName, fmt.Sprintf("DROP TABLE IF EXISTS %s, _%s_new", tableName, tableName))
@@ -418,7 +536,8 @@ func TestRenameColumnForceCopyPath(t *testing.T) {
 
 	// CHANGE COLUMN with type change forces the copy algorithm
 	m := NewTestMigration(t, WithDBName(dbName), WithTable(tableName),
-		WithAlter("CHANGE COLUMN old_name new_name varchar(200) NOT NULL"))
+		WithAlter("CHANGE COLUMN old_name new_name varchar(200) NOT NULL"),
+		WithBuffered(enableBuffered))
 	require.NoError(t, m.Run())
 
 	db, err := sql.Open("mysql", testutils.DSNForDatabase(dbName))
@@ -447,7 +566,16 @@ func TestRenameColumnForceCopyPath(t *testing.T) {
 // TestRenameColumnEmpty tests rename on an empty table.
 func TestRenameColumnEmpty(t *testing.T) {
 	t.Parallel()
-	runRenameTest(t,
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnEmpty(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnEmpty(t, true)
+	})
+}
+
+func testRenameColumnEmpty(t *testing.T, enableBuffered bool) {
+	runRenameTest(t, enableBuffered,
 		"rcol_empty",
 		`CREATE TABLE rcol_empty (
 			id int NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

This adds support for RENAME operations to the single target applier, and removes the check that was gating that.
