### PR TITLE
Robustness fixes: copy error surfacing, binary-safe watermarks, configurable rejectReadOnly

### DIFF
--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -35,6 +35,8 @@ type buffered struct {
 	concurrency      int
 	rowsPerSecond    uint64
 	isInvalid        atomic.Bool
+	errMu            sync.Mutex // guards firstErr
+	firstErr         error      // first error that invalidated the copy (any goroutine)
 	startTime        time.Time
 	throttler        throttler.Throttler
 	dbConfig         *dbconn.DBConfig
@@ -148,8 +150,15 @@ func (c *buffered) Run(ctx context.Context) error {
 		err = closeErr
 	}
 
-	if c.isInvalid.Load() {
-		return errors.New("copy failed due to earlier errors")
+	// A failure inside an async applier callback (e.g. a chunklet the target
+	// rejected with a warning) is reported to the callback in the applier's own
+	// goroutine — it never flows through errGrp or applier.Wait, both of which
+	// return nil in that case. Surface the first captured error so callers get
+	// the real root cause instead of a generic "copy failed" message (or, worse,
+	// a nil error that looks like success). Read/apply errors that already came
+	// back through errGrp take precedence and leave this untouched.
+	if err == nil {
+		err = c.getFirstErr()
 	}
 	return err
 }
@@ -169,7 +178,7 @@ func (c *buffered) readWorker(ctx context.Context) error {
 				return nil
 			}
 			c.logger.Error("readWorker got error from chunker", "error", err)
-			c.setInvalid()
+			c.setInvalid(err)
 			return err
 		}
 		c.logger.Debug("readWorker got chunk", "chunk", chunk.String())
@@ -178,8 +187,9 @@ func (c *buffered) readWorker(ctx context.Context) error {
 		chunkStartTime := time.Now()
 		rows, err := c.readChunkData(ctx, chunk)
 		if err != nil {
-			c.setInvalid()
-			return fmt.Errorf("failed to read chunk data: %w", err)
+			readErr := fmt.Errorf("failed to read chunk data: %w", err)
+			c.setInvalid(readErr)
+			return readErr
 		}
 
 		// Handle empty chunks immediately
@@ -206,7 +216,7 @@ func (c *buffered) readWorker(ctx context.Context) error {
 		callback := func(affectedRows int64, err error) {
 			if err != nil {
 				c.logger.Error("applier callback received error", "chunk", capturedChunk.String(), "error", err)
-				c.setInvalid()
+				c.setInvalid(err)
 				return
 			}
 
@@ -229,8 +239,9 @@ func (c *buffered) readWorker(ctx context.Context) error {
 
 		// Apply the rows
 		if err := c.applier.Apply(ctx, chunk, rows, callback); err != nil {
-			c.setInvalid()
-			return fmt.Errorf("failed to apply rows: %w", err)
+			applyErr := fmt.Errorf("failed to apply rows: %w", err)
+			c.setInvalid(applyErr)
+			return applyErr
 		}
 	}
 
@@ -238,8 +249,25 @@ func (c *buffered) readWorker(ctx context.Context) error {
 	return nil
 }
 
-func (c *buffered) setInvalid() {
+// setInvalid marks the copy as failed and records the first error that caused
+// it. It is called from the read workers and from async applier callbacks, so
+// it captures only the first error and is safe for concurrent use.
+func (c *buffered) setInvalid(err error) {
+	if err != nil {
+		c.errMu.Lock()
+		if c.firstErr == nil {
+			c.firstErr = err
+		}
+		c.errMu.Unlock()
+	}
 	c.isInvalid.Store(true)
+}
+
+// getFirstErr returns the first error that invalidated the copy, or nil.
+func (c *buffered) getFirstErr() error {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+	return c.firstErr
 }
 
 func (c *buffered) SetThrottler(throttler throttler.Throttler) {

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -165,9 +165,15 @@ func TestBufferedCopierDataTypeConversionError(t *testing.T) {
 	copier, err := NewCopier(db, chunker, cfg)
 	require.NoError(t, err)
 
-	// Run the copier - should fail with conversion error
+	// Run the copier - should fail with conversion error.
 	err = copier.Run(t.Context())
 	require.Error(t, err, "Copier should return an error when data conversion fails")
+	// The failure happens in the applier's async callback, not on the errgroup
+	// path, so Run must surface that captured error rather than masking it with
+	// a generic "copy failed due to earlier errors" message.
+	require.ErrorContains(t, err, "unsafe warning",
+		"buffered copier must surface the real applier error, got: %v", err)
+	require.NotContains(t, err.Error(), "copy failed due to earlier errors")
 
 	// Verify early exit by checking how many chunks were processed
 	_, chunksCopied, _ := copier.GetChunker().Progress()

--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -292,7 +292,12 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	// So that we recycle the connection if we inadvertently connect to an old primary which is now a read only replica.
 	// This behaviour has been observed during blue/green upgrades and failover on AWS Aurora.
 	// See also: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#rejectreadonly
-	cfg.RejectReadOnly = true
+	//
+	// Disabled for an injected, read-only change.Source (a Vitess/PlanetScale
+	// VStream import) via DBConfig.RejectReadOnly: that source is a read-only
+	// replica on purpose, and rejectReadOnly would turn its read-only
+	// responses into "driver: bad connection".
+	cfg.RejectReadOnly = config.RejectReadOnly
 	cfg.InterpolateParams = config.InterpolateParams
 	// Allow cleartext password authentication only when TLS is configured
 	// (required for AWS RDS IAM auth, safe because the connection uses TLS).

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -36,6 +36,17 @@ type DBConfig struct {
 	RangeOptimizerMaxMemSize int64
 	InterpolateParams        bool
 	ForceKill                bool // If true, kill locking transactions to acquire metadata locks (default: true)
+	// RejectReadOnly maps to the go-sql-driver rejectReadOnly option: a
+	// statement that fails with a read-only error (1290/1792/1836) is turned
+	// into driver.ErrBadConn so database/sql throws the connection away and
+	// reconnects. This guards against landing on a demoted, now-read-only
+	// Aurora primary after a blue/green deploy or failover (default: true).
+	//
+	// An injected, read-only change.Source (e.g. a Vitess/PlanetScale VStream
+	// import) connects to a read-only replica on purpose. With this enabled,
+	// the replica's read-only responses would loop every source statement to
+	// "driver: bad connection", so the move runner disables it for that case.
+	RejectReadOnly bool
 	// TLS Configuration
 	TLSMode            string // TLS connection mode (DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY)
 	TLSCertificatePath string // Path to custom TLS certificate file
@@ -50,6 +61,7 @@ func NewDBConfig() *DBConfig {
 		RangeOptimizerMaxMemSize: 0,     // default is 8M, we set to unlimited. Not user configurable (may reconsider in the future).
 		InterpolateParams:        false, // default is false
 		ForceKill:                true,  // default is true
+		RejectReadOnly:           true,  // default is true (Aurora failover safety)
 		// TLS defaults
 		TLSMode:            "PREFERRED", // default to PREFERRED mode like MySQL
 		TLSCertificatePath: "",          // no custom certificate by default

--- a/pkg/dbconn/tls_mode_test.go
+++ b/pkg/dbconn/tls_mode_test.go
@@ -708,6 +708,7 @@ func TestPREFERREDModeDISABLEDFallback(t *testing.T) {
 		LockWaitTimeout:          60,
 		RangeOptimizerMaxMemSize: 8388608,
 		InterpolateParams:        true,
+		RejectReadOnly:           true, // production default (see NewDBConfig)
 	}
 
 	// Create a fallback config as done in the New() function

--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -98,23 +98,50 @@ func (b *Boundary) comparesTo(b2 *Boundary) bool {
 	return true
 }
 
-// valuesString uses only values and ignores inclusive operation,
-// to get a string representation of Values in Boundary.
+// valuesString renders the boundary values as a comma-separated list of JSON
+// string literals (used inside Boundary.JSON's "Value" array).
 func (b *Boundary) valuesString() string {
 	vals := make([]string, len(b.Value))
 	for i, v := range b.Value {
-		// We have to *also* quote numeric types to avoid JSON float behavior
-		// See Issue #125; this doesn't apply to string types
-		// because they are already quoted by datum.String()
-		// We also force-quote binary strings, because there is no JSON handling
-		// for a hex values, and it needs quoting in this context.
-		if v.IsNumeric() || v.IsBinaryString() {
-			vals[i] = fmt.Sprintf(`"%s"`, v)
-		} else {
-			vals[i] = v.String()
-		}
+		vals[i] = jsonQuoteDatum(v)
 	}
 	return strings.Join(vals, ",")
+}
+
+// jsonQuoteDatum renders a boundary datum as a JSON string literal (always
+// quoted, properly escaped). Numeric values are quoted to avoid JSON float
+// behavior (#125); binary values are hex-encoded ("0x...") so they round-trip
+// via datumValFromString. Crucially it uses json.Marshal rather than
+// Datum.String() (which SQL-escapes for WHERE clauses): a string value that is
+// valid in a MySQL string literal but not in JSON — e.g. a VARCHAR PK holding a
+// control byte like 0x16, or an embedded quote — must be JSON-escaped here, or
+// the checkpoint watermark becomes unparseable and resume fails permanently.
+func jsonQuoteDatum(v Datum) string {
+	var s string
+	switch {
+	case v.IsNumeric():
+		s = fmt.Sprintf("%v", v.Val)
+	case v.IsBinaryString():
+		bs, ok := v.Val.(string)
+		if !ok {
+			bs = fmt.Sprintf("%v", v.Val)
+		}
+		if len(bs) == 0 {
+			s = "0x00" // MySQL binary string needs at least one character
+		} else {
+			s = fmt.Sprintf("%#x", bs)
+		}
+	default:
+		var ok bool
+		if s, ok = v.Val.(string); !ok {
+			s = fmt.Sprintf("%v", v.Val)
+		}
+	}
+	// json.Marshal of a (valid-UTF8) string never errors and escapes anything
+	// JSON requires escaped; binary values took the hex branch above so they're
+	// ASCII here.
+	out, _ := json.Marshal(s)
+	return string(out)
 }
 
 type JSONChunk struct {

--- a/pkg/table/chunk_test.go
+++ b/pkg/table/chunk_test.go
@@ -1,10 +1,29 @@
 package table
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestBoundaryJSONControlChar guards against the watermark-corruption bug: a
+// string PK value containing a control byte (e.g. 0x16) that is valid in a
+// MySQL string literal but not in JSON must be JSON-escaped, so the checkpoint
+// watermark stays parseable and resume works.
+func TestBoundaryJSONControlChar(t *testing.T) {
+	b := &Boundary{
+		Value:     []Datum{{Val: "foo\x16bar", Tp: unknownType}},
+		Inclusive: true,
+	}
+	j := b.JSON()
+	require.True(t, json.Valid([]byte(j)), "boundary JSON must be valid: %q", j)
+
+	// And the value round-trips back through JSON unchanged.
+	var parsed JSONBoundary
+	require.NoError(t, json.Unmarshal([]byte(j), &parsed))
+	require.Equal(t, []string{"foo\x16bar"}, parsed.Value)
+}
 
 func TestChunk2String(t *testing.T) {
 	chunk := &Chunk{


### PR DESCRIPTION
## Summary

Three small, independent robustness fixes pulled out of a larger downstream
branch so they can land upstream on their own. Each is self-contained and
behavior-preserving for existing callers.

### 1. copier: surface the real buffered-copy error instead of masking it
In the buffered copier, a chunklet the target rejects is reported to the
applier **callback in the applier's own goroutine**. That error never flows
through the errgroup or `applier.Wait` (both return `nil` in that case), so
`Run` reached `if c.isInvalid.Load() { return errors.New("copy failed due to
earlier errors") }` and replaced the real cause with a generic string — e.g.
a strict-`sql_mode` `Out of range value for column ...` or `Incorrect integer
value ...` became an opaque `copy failed due to earlier errors`.

The first error from every invalidation path (`chunker.Next`, the chunk read,
`applier.Apply`, and the async callback) is now captured in a mutex-guarded
field, and `Run` returns it when the errgroup/applier path didn't already
produce one. Errors that do come back through the errgroup keep precedence.
`TestBufferedCopierDataTypeConversionError` now asserts the real applier error
is surfaced rather than only that *some* error occurred.

### 2. table: make boundary watermark JSON binary-safe
`Boundary.valuesString` rendered each datum with `Datum.String()`, which
SQL-escapes for WHERE clauses rather than JSON-escapes. A string PK value
that is valid in a MySQL string literal but not in JSON — e.g. a VARCHAR PK
holding a control byte like `0x16`, or an embedded quote — produced an
unparseable checkpoint watermark, so resume failed permanently with
`invalid character ... in string literal`.

Values are now rendered via `json.Marshal` (new `jsonQuoteDatum` helper):
numeric values stay quoted to avoid JSON float behavior (#125), binary
values are hex-encoded so they round-trip via `datumValFromString`, and
string values are properly JSON-escaped. Adds a regression test for a
control byte in a string PK.

### 3. dbconn: make `rejectReadOnly` configurable via `DBConfig`
`newDSN` hardcoded `rejectReadOnly=true`. That is the right default for
Aurora failover safety and stays the default via `NewDBConfig`, but it is
now exposed as a `DBConfig` field so a caller can opt out for a connection
that is read-only on purpose (e.g. an injected source that reads from a
replica, where `rejectReadOnly` would otherwise turn every read-only
response into `driver: bad connection`). All production code constructs
`DBConfig` via `NewDBConfig`, so behavior is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./pkg/copier/... ./pkg/dbconn/... ./pkg/table/...`
- [x] `golangci-lint run ./pkg/copier/... ./pkg/dbconn/... ./pkg/table/...`