### PR TITLE
table: support read-only / Vitess sources in TableInfo introspection

### DIFF
--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -50,6 +50,15 @@ type TableInfo struct {
 	statisticsLock              sync.Mutex
 	DisableAutoUpdateStatistics atomic.Bool
 
+	// DisableAnalyze skips the ANALYZE TABLE that setRowEstimate would
+	// otherwise run to refresh the optimizer's row estimate. ANALYZE TABLE
+	// writes to the statistics tables, so it requires INSERT on the table
+	// and a writable server. Set this when reading from a least-privilege
+	// (SELECT-only) or read-only source — e.g. sync's Vitess/PlanetScale
+	// replica — so the row estimate comes straight from information_schema,
+	// which only needs SELECT. Set before calling SetInfo.
+	DisableAnalyze bool
+
 	// Host is an optional identifier for the MySQL server this table belongs to.
 	// It is used by MultiChunker to disambiguate tables with the same SchemaName
 	// and TableName on different servers (e.g., in N:M move operations).
@@ -136,11 +145,16 @@ func (t *TableInfo) SetInfo(ctx context.Context) error {
 // setRowEstimate is a separate function so it can be repeated continuously
 // Since if a schema migration takes 14 days, it could change.
 func (t *TableInfo) setRowEstimate(ctx context.Context) error {
-	_, err := t.db.ExecContext(ctx, "ANALYZE TABLE "+t.QuotedTableName)
-	if err != nil {
-		return err
+	// ANALYZE TABLE refreshes the optimizer's row estimate. It writes to the
+	// statistics tables, so it requires INSERT on the table and a writable
+	// server; callers reading from a least-privilege (SELECT-only) or
+	// read-only source set DisableAnalyze to skip it (see the field doc).
+	if !t.DisableAnalyze {
+		if _, err := t.db.ExecContext(ctx, "ANALYZE TABLE "+t.QuotedTableName); err != nil {
+			return err
+		}
 	}
-	err = t.db.QueryRowContext(ctx, "SELECT IFNULL(table_rows,0) FROM information_schema.tables WHERE table_schema=? AND table_name=?", t.SchemaName, t.TableName).Scan(&t.EstimatedRows)
+	err := t.db.QueryRowContext(ctx, "SELECT IFNULL(table_rows,0) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=?", t.TableName).Scan(&t.EstimatedRows)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("table %s.%s does not exist", t.SchemaName, t.TableName)
@@ -151,8 +165,7 @@ func (t *TableInfo) setRowEstimate(ctx context.Context) error {
 }
 
 func (t *TableInfo) setIndexes(ctx context.Context) error {
-	rows, err := t.db.QueryContext(ctx, "SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=? AND table_name=? AND index_name != 'PRIMARY'",
-		t.SchemaName,
+	rows, err := t.db.QueryContext(ctx, "SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND table_name=? AND index_name != 'PRIMARY'",
 		t.TableName,
 	)
 	if err != nil {
@@ -178,8 +191,7 @@ func (t *TableInfo) setIndexes(ctx context.Context) error {
 }
 
 func (t *TableInfo) setColumns(ctx context.Context) error {
-	rows, err := t.db.QueryContext(ctx, "SELECT column_name, column_type, GENERATION_EXPRESSION FROM information_schema.columns WHERE table_schema=? AND table_name=? ORDER BY ORDINAL_POSITION",
-		t.SchemaName,
+	rows, err := t.db.QueryContext(ctx, "SELECT column_name, column_type, GENERATION_EXPRESSION FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? ORDER BY ORDINAL_POSITION",
 		t.TableName,
 	)
 	if err != nil {
@@ -225,8 +237,7 @@ func (t *TableInfo) setColumns(ctx context.Context) error {
 func (t *TableInfo) DescIndex(keyName string) ([]string, error) {
 	cols := []string{}
 	//nolint: noctx // too much refactoring to add context here
-	rows, err := t.db.Query("SELECT column_name FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA=? AND TABLE_NAME=? AND index_name=? ORDER BY seq_in_index",
-		t.SchemaName,
+	rows, err := t.db.Query("SELECT column_name FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND TABLE_NAME=? AND index_name=? ORDER BY seq_in_index",
 		t.TableName,
 		keyName,
 	)
@@ -254,8 +265,7 @@ func (t *TableInfo) DescIndex(keyName string) ([]string, error) {
 // setPrimaryKey sets the primary key and also the primary key type.
 // A primary key can contain multiple columns.
 func (t *TableInfo) setPrimaryKey(ctx context.Context) error {
-	rows, err := t.db.QueryContext(ctx, "SELECT column_name FROM information_schema.key_column_usage WHERE table_schema=? and table_name=? and constraint_name='PRIMARY' ORDER BY ORDINAL_POSITION",
-		t.SchemaName,
+	rows, err := t.db.QueryContext(ctx, "SELECT column_name FROM information_schema.key_column_usage WHERE table_schema=DATABASE() and table_name=? and constraint_name='PRIMARY' ORDER BY ORDINAL_POSITION",
 		t.TableName,
 	)
 	if err != nil {
@@ -282,9 +292,9 @@ func (t *TableInfo) setPrimaryKey(ctx context.Context) error {
 	}
 	for i, col := range t.KeyColumns {
 		// Get primary key type and auto_inc info.
-		query := "SELECT column_type, extra FROM information_schema.columns WHERE table_schema=? AND table_name=? and column_name=?"
+		query := "SELECT column_type, extra FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? and column_name=?"
 		var extra, pkType string
-		err = t.db.QueryRowContext(ctx, query, t.SchemaName, t.TableName, col).Scan(&pkType, &extra)
+		err = t.db.QueryRowContext(ctx, query, t.TableName, col).Scan(&pkType, &extra)
 		if err != nil {
 			return err
 		}

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -106,6 +106,40 @@ func TestDiscovery(t *testing.T) {
 	require.Len(t, t1.Columns, 2)
 }
 
+// TestDiscoveryDisableAnalyze verifies that SetInfo works with DisableAnalyze
+// set: it must skip ANALYZE TABLE (which needs a writable server) and still
+// discover the schema and populate EstimatedRows straight from
+// information_schema. This is the path a read-only / replica source uses.
+func TestDiscoveryDisableAnalyze(t *testing.T) {
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS discoverynoanalyze`)
+	table := `CREATE TABLE discoverynoanalyze (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`
+	testutils.RunSQL(t, table)
+	testutils.RunSQL(t, `insert into discoverynoanalyze values (1, 'a'), (2, 'b'), (3, 'c')`)
+	// Refresh the optimizer stats up front (the writable path) so the estimate
+	// is populated; DisableAnalyze must then read it back without re-analyzing.
+	testutils.RunSQL(t, `ANALYZE TABLE discoverynoanalyze`)
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	t1 := NewTableInfo(db, "test", "discoverynoanalyze")
+	t1.DisableAnalyze = true
+	require.NoError(t, t1.SetInfo(t.Context()))
+
+	require.Equal(t, "id", t1.KeyColumns[0])
+	require.True(t, t1.KeyIsAutoInc)
+	require.Len(t, t1.Columns, 2)
+	require.Equal(t, "1", t1.minValue.String())
+	require.Equal(t, "3", t1.maxValue.String())
+}
+
 func TestDiscoveryUInt(t *testing.T) {
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS discoveryuintt1`)
 	table := `CREATE TABLE discoveryuintt1 (


### PR DESCRIPTION
## Summary

Groundwork for the `sync` subcommand (#893): let `TableInfo.SetInfo` run
against a strictly read-only source (a replica) and through a Vitess
shard-targeted connection. Two self-contained changes to `pkg/table`.

### 1. Scope information_schema lookups with `DATABASE()`
Every `information_schema` query in `tableinfo.go` filtered on a bound
`t.SchemaName` literal. Those now filter on `table_schema=DATABASE()`.

- **Normal connection:** `DATABASE()` equals the table's schema, so the
  result is identical — behavior unchanged.
- **Vitess connection:** `SchemaName` is a routing string like
  `keyspace:-80@primary`, not a physical schema, so the literal would never
  match the physical `vt_<keyspace>_<shard>` schema (and would be ambiguous
  across shards). `DATABASE()` is pushed down by vtgate to the underlying
  tablet, where it resolves to the physical schema and keeps the result
  shard-scoped.

### 2. Add a `DisableAnalyze` knob
`setRowEstimate` runs `ANALYZE TABLE` to refresh the optimizer's row
estimate, but `ANALYZE` writes the statistics tables and so needs `INSERT`
and a writable server. A read-only / replica / least-privilege (SELECT-only)
source sets `DisableAnalyze` before `SetInfo`; the estimate then comes
straight from `information_schema`, which only needs `SELECT`. Default is
unchanged (ANALYZE still runs).

Includes a regression test (`TestDiscoveryDisableAnalyze`).

## Context
Pulled out of a downstream branch so it can land independently. Part of the
`sync` subcommand work tracked in #893; the `DATABASE()` change also supports
the VStream change feed in #888.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./pkg/table/...`
- [x] `golangci-lint run ./pkg/table/...`