### PR TITLE
change: public NewBufferedSubscription constructor + adopt it in the binlog client

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -126,22 +126,25 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 // Satisfies Source interface.
 func (c *binlogClient) AddSubscription(currentTable, newTable *table.TableInfo, chunker table.MappedChunker) error {
 	subKey := encodeSchemaTable(currentTable.SchemaName, currentTable.TableName)
-	// If the PK is not memory comparable we still use the buffered map, but it
-	// needs to know that when the watermark optimizations are disabled
-	// (i.e. we've finished copying and we're about to start checksum),
-	// that it needs to act like a FIFO queue. This is a requirement because of edge
-	// cases caused by collations since A == a, but in our map they would
-	// not compare as equal.
-	if !c.subs.AddBuffered(subKey, &bufferedMap{
-		table:                currentTable,
-		newTable:             newTable,
-		changes:              make(map[string]bufferedChange),
-		logger:               c.logger,
-		chunker:              chunker,
-		applier:              c.applier,
-		pkIsMemoryComparable: currentTable.PrimaryKeyIsMemoryComparable() == nil,
-		softLimitBytes:       c.subscriptionSoftLimitBytes,
-	}) {
+	// Build the buffered subscription via the shared public constructor so the
+	// in-tree binlog client and out-of-tree change.Source implementations
+	// (e.g. a VStream source) construct it the same way. The bufferedMap
+	// transparently handles a non-memory-comparable PK: once the watermark
+	// optimizations are disabled (copy done, checksum about to start) it acts
+	// like a FIFO queue, which is required because of collation edge cases
+	// (A == a on the server, but not in our map).
+	sub, err := NewBufferedSubscription(BufferedSubscriptionConfig{
+		CurrentTable:   currentTable,
+		NewTable:       newTable,
+		Applier:        c.applier,
+		Chunker:        chunker,
+		Logger:         c.logger,
+		SoftLimitBytes: c.subscriptionSoftLimitBytes,
+	})
+	if err != nil {
+		return fmt.Errorf("could not build subscription for table %s.%s: %w", currentTable.SchemaName, currentTable.TableName, err)
+	}
+	if !c.subs.Add(subKey, sub) {
 		return fmt.Errorf("subscription already exists for table %s.%s", currentTable.SchemaName, currentTable.TableName)
 	}
 	return nil

--- a/pkg/change/binlog_test.go
+++ b/pkg/change/binlog_test.go
@@ -687,7 +687,8 @@ func TestAllChangesFlushed(t *testing.T) {
 		changes:              make(map[string]bufferedChange),
 		pkIsMemoryComparable: true,
 	}
-	require.True(t, client.subs.AddBuffered(encodeSchemaTable(srcTable.SchemaName, srcTable.TableName), sub))
+	sub.cond = sync.NewCond(&sub.Mutex)
+	require.True(t, client.subs.Add(encodeSchemaTable(srcTable.SchemaName, srcTable.TableName), sub))
 	require.True(t, client.AllChangesFlushed(), "Should be flushed with empty subscription")
 
 	// Test 3: Add changes and verify not flushed
@@ -707,7 +708,8 @@ func TestAllChangesFlushed(t *testing.T) {
 		changes:              make(map[string]bufferedChange),
 		pkIsMemoryComparable: true,
 	}
-	require.True(t, client.subs.AddBuffered("test2", sub2))
+	sub2.cond = sync.NewCond(&sub2.Mutex)
+	require.True(t, client.subs.Add("test2", sub2))
 	sub2.HasChanged([]any{2}, nil, false)
 	require.False(t, client.AllChangesFlushed(), "Should not be flushed with changes in any subscription")
 
@@ -867,7 +869,8 @@ func TestProcessDDLNotification(t *testing.T) {
 			changes:  make(map[string]bufferedChange),
 			logger:   c.logger,
 		}
-		require.True(t, c.subs.AddBuffered(dbName+".orders", sub))
+		sub.cond = sync.NewCond(&sub.Mutex)
+		require.True(t, c.subs.Add(dbName+".orders", sub))
 
 		// DDL on the subscribed table should cancel.
 		c.processDDLNotification(dbName, "orders")

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -177,6 +177,72 @@ const (
 	queuedChangeOverhead = 48
 )
 
+// BufferedSubscriptionConfig configures NewBufferedSubscription.
+type BufferedSubscriptionConfig struct {
+	// CurrentTable is the source-side TableInfo. Required.
+	CurrentTable *table.TableInfo
+
+	// NewTable is the destination-side TableInfo. May be nil for
+	// MoveTables/import flows where source and destination share the
+	// same schema; in that case Subscription.Tables() returns
+	// [CurrentTable, nil].
+	NewTable *table.TableInfo
+
+	// Applier writes batched changes to the target. Required.
+	Applier applier.Applier
+
+	// Chunker provides the watermark filter + column mapping. Required.
+	Chunker table.MappedChunker
+
+	// Logger receives diagnostic events. Defaults to slog.Default()
+	// when nil.
+	Logger *slog.Logger
+
+	// SoftLimitBytes is the per-subscription byte cap before
+	// HasChanged blocks waiting on the flush path. Zero disables the
+	// cap. See bufferedMap.softLimitBytes for the semantics.
+	SoftLimitBytes int64
+}
+
+// NewBufferedSubscription constructs the default bufferedMap-backed
+// Subscription. It is the public counterpart to binlogClient's internal
+// AddSubscription helper: out-of-tree change.Source implementations
+// (e.g. strata's pkg/vstream) call this from their own AddSubscription to
+// build a Subscription the runner / copier can drive.
+//
+// The returned Subscription is not yet wired into a registry — the caller
+// is responsible for storing it and routing row events to its HasChanged
+// method. The internal sync.Cond is initialised before return (matching
+// subscriptionRegistry.AddBuffered) so HasChanged / Flush /
+// SetWatermarkOptimization are safe to call immediately.
+func NewBufferedSubscription(cfg BufferedSubscriptionConfig) (Subscription, error) {
+	if cfg.CurrentTable == nil {
+		return nil, fmt.Errorf("NewBufferedSubscription: CurrentTable is required")
+	}
+	if cfg.Applier == nil {
+		return nil, fmt.Errorf("NewBufferedSubscription: Applier is required")
+	}
+	if cfg.Chunker == nil {
+		return nil, fmt.Errorf("NewBufferedSubscription: Chunker is required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	sub := &bufferedMap{
+		table:                cfg.CurrentTable,
+		newTable:             cfg.NewTable,
+		changes:              make(map[string]bufferedChange),
+		logger:               logger,
+		chunker:              cfg.Chunker,
+		applier:              cfg.Applier,
+		pkIsMemoryComparable: cfg.CurrentTable.PrimaryKeyIsMemoryComparable() == nil,
+		softLimitBytes:       cfg.SoftLimitBytes,
+	}
+	sub.cond = sync.NewCond(&sub.Mutex)
+	return sub, nil
+}
+
 // estimateRowSize returns a rough byte estimate for a []any column slice
 // that bufferedMap holds in memory. The estimate is intentionally
 // approximate — we only use it to bound the buffer, not to report exact

--- a/pkg/change/subscription_registry.go
+++ b/pkg/change/subscription_registry.go
@@ -22,25 +22,20 @@ func newSubscriptionRegistry() *subscriptionRegistry {
 	return &subscriptionRegistry{subs: make(map[string]Subscription)}
 }
 
-// AddBuffered inserts sub under key. Returns false if a subscription with
-// this key already exists; the existing entry is left untouched and sub
-// is discarded by the caller.
+// Add inserts sub under key. Returns false if a subscription with this key
+// already exists; the existing entry is left untouched and sub is discarded
+// by the caller.
 //
-// Named AddBuffered (rather than Add) to flag the asymmetry with Get and
-// Snapshot: they return the Subscription interface, but this method takes
-// the concrete *bufferedMap so it can finish the two-step construction by
-// wiring sub.cond to sub.Mutex. That init can't live in a struct literal
-// because sync.NewCond needs the address of a field of the value being
-// constructed. If a second Subscription implementation is ever added,
-// introduce a sibling AddXxx for it, or switch to an interface-typed Add
-// and move the cond init into a type-specific constructor.
-func (r *subscriptionRegistry) AddBuffered(key string, sub *bufferedMap) bool {
+// sub must be fully constructed before it is added — in particular its
+// internal sync.Cond must already be wired (NewBufferedSubscription does
+// this). The registry only stores the value, so it is agnostic to the
+// concrete Subscription implementation.
+func (r *subscriptionRegistry) Add(key string, sub Subscription) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.subs[key]; exists {
 		return false
 	}
-	sub.cond = sync.NewCond(&sub.Mutex)
 	r.subs[key] = sub
 	return true
 }


### PR DESCRIPTION
## Summary

Groundwork for VStream / heterogeneous change feeds (#888): expose the
`bufferedMap`-backed subscription through a public constructor so out-of-tree
`change.Source` implementations can build the same subscription the in-tree
binlog client uses, and make the binlog client itself go through that
constructor so it isn't dead code.

### `NewBufferedSubscription` / `BufferedSubscriptionConfig`
A public constructor that builds the default `bufferedMap` `Subscription` from
a config (current/new table, applier, chunker, logger, soft byte limit) and
wires its internal `sync.Cond` before returning. An out-of-tree source calls
this from its own `AddSubscription` to build a `Subscription` the runner /
copier can drive.

### Adopt it in `binlogClient.AddSubscription`
The binlog client previously built a `bufferedMap` struct literal inline and
relied on the registry to finish the two-step `cond` init. It now builds the
subscription via `NewBufferedSubscription`, so in-tree and out-of-tree callers
share one construction path.

Because the constructor now owns the `cond` wiring, the registry no longer
needs the concrete type to finish construction: `subscriptionRegistry`'s
`AddBuffered(*bufferedMap)` becomes `Add(Subscription)`, which simply stores a
fully-constructed subscription (this is the interface-typed `Add` the old
`AddBuffered` doc comment anticipated). White-box tests that build a
`bufferedMap` directly now set `cond` themselves.

No behavior change — `bufferedMap`'s logic is untouched.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/change/...`
- [x] `golangci-lint run ./pkg/change/...`