### PR TITLE
datasync: experimental `sync` subcommand (initial copy + continuous replication)

### DIFF
--- a/cmd/spirit/main.go
+++ b/cmd/spirit/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/alecthomas/kong"
 	"github.com/block/spirit/pkg/buildinfo"
+	"github.com/block/spirit/pkg/datasync"
 	spiritfmt "github.com/block/spirit/pkg/fmt"
 	"github.com/block/spirit/pkg/lint"
 	"github.com/block/spirit/pkg/migration"
@@ -21,6 +22,7 @@ var cli struct {
 	Version buildinfo.VersionFlag `name:"version" short:"v" help:"Show version information and exit."`
 	Migrate migration.Migration   `cmd:"" help:"Run an online schema change on a table."`
 	Move    move.Move             `cmd:"" help:"Move tables between MySQL servers."`
+	Sync    datasync.Sync         `cmd:"" help:"[EXPERIMENTAL] Continuously sync tables from a source to a target (initial copy, then stream changes until cancelled)."`
 	Lint    lint.LintCmd          `cmd:"" help:"Lint an entire MySQL schema."`
 	Diff    lint.DiffCmd          `cmd:"" help:"Diff two MySQL schemas and lint the changes."`
 	Fmt     spiritfmt.FmtCmd      `cmd:"" help:"Canonicalize CREATE TABLE .sql files by round-tripping through MySQL."`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Spirit is a single binary with subcommands for MySQL schema and data operations:
 |------------|---------|
 | [**`spirit migrate`**](migrate.md) | Online schema change tool — applies `ALTER TABLE` statements to large tables without blocking reads or writes |
 | [**`spirit move`**](move.md) | Logical table mover — copies whole schemas (or a subset of tables) between different MySQL servers |
+| [**`spirit sync`**](sync.md) | Continuous replicator (**experimental**) — initial copy then streams changes from a source to a target until interrupted; no cutover |
 | [**`spirit lint`**](lint.md) | Schema linter — validates an entire MySQL schema against built-in lint rules |
 | [**`spirit diff`**](diff.md) | Schema differ — compares two MySQL schemas and lints the changes |
 | [**`spirit fmt`**](fmt.md) | Schema file formatter — canonicalizes `CREATE TABLE` `.sql` files by round-tripping them through MySQL |

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -32,16 +32,26 @@ checkpoint rather than re-copying from scratch.
 | Cutover | atomic rename | none |
 | Source | MySQL | MySQL (a pluggable `change.Source` allows other producers) |
 
-The source is treated as **read-only**: `sync` needs only `SELECT` on the
-source schema (plus `REPLICATION SLAVE`/`REPLICATION CLIENT` for the binlog
-change feed), runs no `ANALYZE`, acquires no source locks, and performs no
-cutover, so it can run against a replica.
+`sync` never writes to the source, runs no `ANALYZE`, acquires no source
+locks, and performs no cutover, so it can run against a replica. The exact
+source privileges depend on the change feed:
+
+- **Built-in MySQL binlog source** (default, from `--source-dsn`): needs
+  `SELECT` on the source schema, `REPLICATION SLAVE` + `REPLICATION CLIENT`
+  for the binlog stream, and `RELOAD` — the binlog reader runs
+  `FLUSH BINARY LOGS` to establish/advance its start position, so it is not
+  a pure `SELECT`-only role even though it never modifies your data.
+- **Injected `change.Source`** (e.g. a Vitess/PlanetScale VStream supplied by
+  a programmatic caller): the feed is driven entirely by that source, so the
+  built-in binlog privileges (`REPLICATION *`, `RELOAD`) do not apply — only
+  `SELECT` on the source schema is required for the initial copy.
 
 ## Requirements
 
 - **MySQL 8.0+** on both ends
-- Source: `binlog_format=ROW`, `log_bin=ON`, and `REPLICATION SLAVE` /
-  `REPLICATION CLIENT` privileges for the change feed
+- Source (built-in binlog feed): `binlog_format=ROW`, `log_bin=ON`, and
+  `SELECT` + `REPLICATION SLAVE` + `REPLICATION CLIENT` + `RELOAD` privileges
+  (`RELOAD` is required for the `FLUSH BINARY LOGS` the reader issues)
 
 ## Configuration
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,0 +1,112 @@
+# Sync subcommand
+
+> **Experimental.** `spirit sync` is under active development. The flags,
+> behavior, and on-disk checkpoint format may change between releases. Today it
+> supports **MySQL → MySQL** only.
+
+The `sync` command performs an initial copy of a source schema into a target
+and then **continuously applies the source's change stream** to the target
+until it is interrupted (Ctrl-C / SIGTERM). Unlike [`move`](move.md), it does
+**not** cut over — it is meant for keeping a target continuously up to date
+(e.g. seeding and then tailing a replica of a dataset).
+
+Basic usage:
+
+```bash
+spirit sync --source-dsn "user:pass@tcp(source-host:3306)/mydb" \
+            --target-dsn "user:pass@tcp(target-host:3306)/mydb"
+```
+
+This copies all tables from the source database to the target database
+(creating the target database and tables if they do not exist), then streams
+changes until the process is signalled. On a clean shutdown it drains the
+outstanding changes and records a checkpoint; a re-run resumes from that
+checkpoint rather than re-copying from scratch.
+
+## How it differs from `move`
+
+| | `move` | `sync` |
+|---|---|---|
+| Initial copy | yes | yes |
+| Continuous replication | until cutover | until interrupted (no cutover) |
+| Cutover | atomic rename | none |
+| Source | MySQL | MySQL (a pluggable `change.Source` allows other producers) |
+
+The source is treated as **read-only**: `sync` needs only `SELECT` on the
+source schema (plus `REPLICATION SLAVE`/`REPLICATION CLIENT` for the binlog
+change feed), runs no `ANALYZE`, acquires no source locks, and performs no
+cutover, so it can run against a replica.
+
+## Requirements
+
+- **MySQL 8.0+** on both ends
+- Source: `binlog_format=ROW`, `log_bin=ON`, and `REPLICATION SLAVE` /
+  `REPLICATION CLIENT` privileges for the change feed
+
+## Configuration
+
+- [source-dsn](#source-dsn)
+- [target-dsn](#target-dsn)
+- [target-chunk-time](#target-chunk-time)
+- [threads](#threads)
+- [write-threads](#write-threads)
+- [flush-interval](#flush-interval)
+- [force](#force)
+
+### source-dsn
+
+- Type: String
+- Default value: `spirit:spirit@tcp(127.0.0.1:3306)/src`
+
+A Go MySQL DSN for the source database. All tables in this database are copied
+and then followed on the change stream.
+
+### target-dsn
+
+- Type: String
+- Default value: `spirit:spirit@tcp(127.0.0.1:3306)/dest`
+
+A Go MySQL DSN for the target database. The database and tables are created
+automatically from the source schema if they do not already exist.
+
+### target-chunk-time
+
+- Type: Duration
+- Default value: `5s`
+
+The target time for each chunk of rows to be copied during the initial copy.
+See the [migrate documentation](migrate.md#target-chunk-time) for how chunk
+timing adapts.
+
+### threads
+
+- Type: Integer
+- Default value: `4`
+
+How many chunks to copy in parallel from the source during the initial copy.
+
+### write-threads
+
+- Type: Integer
+- Default value: `4`
+
+How many concurrent write threads to use on the target.
+
+### flush-interval
+
+- Type: Duration
+- Default value: `30s`
+
+How often buffered changes are applied to the target during continuous sync —
+the replication-latency vs. batching trade-off.
+
+### force
+
+- Type: Boolean
+- Default value: `false`
+
+Drop and recreate the target database at startup **unless** a resumable
+checkpoint exists. A resumable run (checkpoint present) is left intact and
+resumes as normal; this only resets a target that is non-empty with no usable
+checkpoint, which would otherwise trip the fresh-sync target-empty guard.
+Intended for testing/iterating.

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -1,0 +1,1083 @@
+package datasync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/copier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/metrics"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/throttler"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+)
+
+// syncCheckpointTableName is the table, created on the target, that
+// records the source change-feed position so a restart can resume the
+// continuous stream instead of re-copying. It always lives on the target
+// because the source may be read-only (e.g. a Vitess/PlanetScale replica).
+const syncCheckpointTableName = "_spirit_sync_checkpoint"
+
+// errNoSuchTable is MySQL's ER_NO_SUCH_TABLE (1146).
+const errNoSuchTable = 1146
+
+// shutdownFlushTimeout bounds the best-effort final flush on a clean shutdown,
+// and shutdownCheckpointTimeout bounds the final checkpoint write (kept
+// independent so a slow flush can't starve the checkpoint). Both are short so
+// Ctrl-C / SIGTERM exits promptly even against a busy source whose change feed
+// never fully catches up; unflushed changes are re-applied on the next run from
+// the checkpoint.
+const (
+	shutdownFlushTimeout      = 10 * time.Second
+	shutdownCheckpointTimeout = 10 * time.Second
+)
+
+// sourceInfo holds the single source's connection state.
+type sourceInfo struct {
+	db     *sql.DB
+	config *mysql.Config
+	dsn    string
+}
+
+// Runner executes a Sync: an initial copy followed by continuous
+// replication that runs until the context is cancelled.
+type Runner struct {
+	sync *Sync
+
+	source sourceInfo
+	target applier.Target
+	// ownsTarget is true when the runner opened the target DB itself (from
+	// TargetDSN) and is therefore responsible for closing it. When the
+	// caller injected Sync.Target, it owns the DB's lifecycle.
+	ownsTarget bool
+
+	sourceTables []*table.TableInfo
+
+	applier     applier.Applier
+	replClient  change.Source
+	copyChunker table.Chunker
+	copier      copier.Copier
+
+	// resuming is set when a checkpoint was found on the target: the
+	// initial copy is skipped and the change feed is opened from the
+	// checkpointed position.
+	resuming bool
+
+	status    status.State
+	startTime time.Time
+
+	logger     *slog.Logger
+	cancelFunc context.CancelFunc
+	// sourceDBConfig connects to the read-only source: ForceKill and
+	// RejectReadOnly are disabled (see Run). targetDBConfig connects to the
+	// writable target and keeps the standard safe defaults — most importantly
+	// RejectReadOnly=true for Aurora-failover safety.
+	sourceDBConfig *dbconn.DBConfig
+	targetDBConfig *dbconn.DBConfig
+
+	// watchDone is closed when the status-logging goroutine exits.
+	watchDone chan struct{}
+
+	// checkpointDone is closed when the periodic checkpoint goroutine exits.
+	checkpointDone chan struct{}
+
+	// fatalErr records a fatal source-side event (e.g. DDL on a synced
+	// table) that should surface as the Run error rather than a clean
+	// cancellation. Guarded by fatalMu.
+	fatalMu  sync.Mutex
+	fatalErr error
+
+	// progMu guards the progress-related fields (copier, copyChunker,
+	// replClient, startTime, cancelFunc) that Run assigns during setup and
+	// that the status.Task accessors (Progress/Status/DumpCheckpoint/Cancel)
+	// read concurrently from a separate monitoring goroutine.
+	progMu sync.RWMutex
+}
+
+var _ status.Task = (*Runner)(nil)
+
+// NewRunner validates the Sync config and returns a Runner. The CLI
+// supplies defaults via kong; programmatic callers get the same defaults
+// applied here as a safety net.
+func NewRunner(s *Sync) (*Runner, error) {
+	if s.Source != nil && s.Applier == nil {
+		return nil, errors.New("Sync.Source requires Sync.Applier to also be set; the injected change.Source needs the same applier the copier uses")
+	}
+	if s.Threads <= 0 {
+		s.Threads = 4
+	}
+	if s.WriteThreads <= 0 {
+		s.WriteThreads = 4
+	}
+	if s.TargetChunkTime <= 0 {
+		s.TargetChunkTime = 5 * time.Second
+	}
+	if s.FlushInterval <= 0 {
+		s.FlushInterval = change.DefaultFlushInterval
+	}
+	return &Runner{sync: s, logger: slog.Default()}, nil
+}
+
+// SetLogger overrides the logger (used by programmatic callers to capture
+// progress output).
+func (r *Runner) SetLogger(logger *slog.Logger) {
+	r.logger = logger
+}
+
+// Run performs the initial copy and then streams changes continuously
+// until ctx is cancelled. A clean cancellation returns nil; a fatal
+// source event (e.g. DDL) returns an error.
+func (r *Runner) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	r.progMu.Lock()
+	r.cancelFunc = cancel
+	r.startTime = time.Now()
+	r.progMu.Unlock()
+	r.logger.Info("Starting sync", "source_dsn", redactDSN(r.sync.SourceDSN))
+
+	r.sourceDBConfig = dbconn.NewDBConfig()
+	// Sync only ever reads from the source (copy SELECTs + the change feed).
+	// It never writes to the source, acquires no source locks, and performs
+	// no cutover, so it needs only SELECT on the source schema (plus
+	// REPLICATION SLAVE/CLIENT when the change feed is the built-in MySQL
+	// binlog client, which that client validates on Start). Disable the two
+	// dbConfig behaviours that would otherwise demand more:
+	//   - ForceKill needs CONNECTION_ADMIN/PROCESS + performance_schema, and
+	//     is only used to break metadata locks during cutover — which sync
+	//     never does.
+	//   - RejectReadOnly is an Aurora-failover guard that turns a read-only
+	//     server error into driver.ErrBadConn; sync's source is read-only by
+	//     design (e.g. a Vitess/PlanetScale replica), so it must not fire.
+	r.sourceDBConfig.ForceKill = false
+	r.sourceDBConfig.RejectReadOnly = false
+	r.sourceDBConfig.MaxOpenConnections = 100
+
+	// The target is written to (table creation, the copy/apply, the
+	// checkpoint, and CREATE DATABASE on the admin connection), so it keeps the
+	// standard safe defaults — crucially RejectReadOnly=true, so that if the
+	// target Aurora fails over and we land on a demoted, now-read-only primary,
+	// writes turn into driver.ErrBadConn and the pool reconnects instead of
+	// silently erroring. Only the relaxations the target genuinely shares with
+	// the source are applied (no cutover here either, so ForceKill is left at
+	// its default but never fires).
+	r.targetDBConfig = dbconn.NewDBConfig()
+	r.targetDBConfig.MaxOpenConnections = 100
+
+	// Open the source SQL connection. Even when the change feed is an
+	// injected non-MySQL source, spirit still needs SQL access to the
+	// source for SHOW TABLES / SHOW CREATE TABLE and the initial-copy
+	// SELECTs.
+	db, err := dbconn.New(r.sync.SourceDSN, r.sourceDBConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to source: %w", err)
+	}
+	cfg, err := mysql.ParseDSN(r.sync.SourceDSN)
+	if err != nil {
+		return fmt.Errorf("failed to parse source DSN: %w", err)
+	}
+	r.source = sourceInfo{db: db, config: cfg, dsn: r.sync.SourceDSN}
+
+	// Resolve the single target. The target database is auto-created (if
+	// missing) on both paths — the import's per-shard target databases are
+	// not guaranteed to pre-exist on the destination cluster.
+	if r.sync.Target != nil {
+		r.target = *r.sync.Target
+		// The injected target DB connects lazily, so ensure its database
+		// exists before the first query (createTargetTables / checkpoint).
+		if err := r.ensureTargetDatabase(ctx, r.target.Config); err != nil {
+			return err
+		}
+	} else {
+		tcfg, terr := mysql.ParseDSN(r.sync.TargetDSN)
+		if terr != nil {
+			return fmt.Errorf("failed to parse target DSN: %w", terr)
+		}
+		// Create the database before opening — a DSN-scoped open pings it.
+		if err := r.ensureTargetDatabase(ctx, tcfg); err != nil {
+			return err
+		}
+		tdb, terr := dbconn.New(r.sync.TargetDSN, r.targetDBConfig)
+		if terr != nil {
+			return fmt.Errorf("failed to connect to target: %w", terr)
+		}
+		r.target = applier.Target{KeyRange: "0", DB: tdb, Config: tcfg}
+		r.ownsTarget = true
+	}
+
+	if err := r.setup(ctx); err != nil {
+		return err
+	}
+	if len(r.sourceTables) == 0 {
+		r.logger.Info("No tables to sync; nothing to do")
+		return nil
+	}
+
+	// Background routines: periodic flush keeps the target caught up; the
+	// status goroutine logs progress.
+	r.startBackgroundRoutines(ctx)
+
+	// Copy phase — runs for both a fresh sync and a resume. On a fresh sync
+	// the chunker starts at the beginning; on a resume it was opened at the
+	// checkpointed watermark (startResume), so the copier continues from there
+	// — and finishes immediately if the copy had already completed. The applier
+	// copies with INSERT IGNORE, so re-copying the chunks straddling the
+	// watermark is idempotent.
+	if !r.resuming {
+		// Watermark optimization ON during a fresh continuous copy: change
+		// events for keys the copier has not reached yet (above the watermark)
+		// are discarded, because the copier will copy those rows directly.
+		//
+		// CORRECTNESS CAVEAT — read replicas:
+		// keyAboveWatermark is only safe when the copier reads from a source
+		// that reflects every change the change feed has already delivered.
+		// That holds on a PRIMARY, but NOT on a lagging REPLICA: an update to
+		// an above-watermark key can be observed on the change stream — and
+		// discarded — while the copier's later read of that key on the replica
+		// still returns the pre-update (stale) value, silently losing it. The
+		// intended safety net is the post-copy checksum, which isn't usable on
+		// the read-only import source yet (it needs privileges that credential
+		// lacks). So a replica source (e.g. the strata import) gets only
+		// best-effort consistency. On resume we leave the optimization OFF
+		// (startResume) so every change applies.
+		if err := r.replClient.SetWatermarkOptimization(ctx, true); err != nil {
+			return err
+		}
+	}
+	r.status.Set(status.CopyRows)
+	r.logger.Info("Starting copy", "resuming", r.resuming)
+	if err := r.copier.Run(ctx); err != nil {
+		return fmt.Errorf("copy failed: %w", err)
+	}
+	if !r.resuming {
+		if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+			return err
+		}
+	}
+	// Drain the copy-phase backlog so every change observed so far is
+	// applied before steady-state streaming.
+	if err := r.replClient.Flush(ctx); err != nil {
+		return fmt.Errorf("failed to flush after copy: %w", err)
+	}
+
+	r.logger.Info("Copy complete; entering continuous sync")
+	return r.runContinuous(ctx)
+}
+
+// runContinuous creates/maintains the target checkpoint and blocks until
+// the context is cancelled, while the periodic flush (started in
+// startBackgroundRoutines) keeps applying buffered changes. On a clean
+// cancellation it drains the final backlog and returns nil; on a fatal
+// source event it returns that error.
+func (r *Runner) runContinuous(ctx context.Context) error {
+	// status moves off CopyRows so the status goroutine logs the continuous
+	// phase. The checkpoint table and the periodic checkpoint loop were already
+	// set up before the copy (createCheckpointTable in startFresh/startResume,
+	// the loop in startBackgroundRoutines), so a restart at any point — copy or
+	// continuous — resumes from the last checkpoint.
+	r.status.Set(status.ApplyChangeset)
+
+	r.logger.Info("Continuous sync running; will run until cancelled")
+	<-ctx.Done()
+
+	if ferr := r.fatal(); ferr != nil {
+		r.logger.Error("Sync stopping due to fatal source event", "error", ferr)
+		return ferr
+	}
+
+	r.logger.Info("Sync cancelled; draining final changes")
+	r.replClient.StopPeriodicFlush()
+	// Best-effort final flush, detached from the cancelled ctx with a short
+	// bound so shutdown is prompt. Flush retries until the change feed catches
+	// up to the source's *latest* position; against a busy source that never
+	// converges, so without a tight cap shutdown would spin for the whole
+	// budget (and a Ctrl-C / SIGTERM would feel hung). Whatever isn't flushed
+	// here is re-applied on the next run from the checkpoint below.
+	flushCtx, cancelFlush := context.WithTimeout(context.WithoutCancel(ctx), shutdownFlushTimeout)
+	defer cancelFlush()
+	if err := r.replClient.Flush(flushCtx); err != nil {
+		r.logger.Warn("Final flush failed; some recent changes may not have been applied", "error", err)
+	}
+	// Write the final checkpoint on its own independent budget. It records the
+	// copier watermark + change-feed position that let a restart resume instead
+	// of re-copying, so a slow or timed-out final flush above must not starve
+	// it of a shared deadline.
+	cpCtx, cancelCp := context.WithTimeout(context.WithoutCancel(ctx), shutdownCheckpointTimeout)
+	defer cancelCp()
+	if err := r.dumpCheckpoint(cpCtx); err != nil {
+		r.logger.Warn("Final checkpoint write failed", "error", err)
+	}
+	r.logger.Info("Sync stopped", "total_time", time.Since(r.startTime).Round(time.Second))
+	return nil
+}
+
+// setup discovers the source tables, builds the applier and change
+// source, and prepares either a fresh copy or a checkpoint resume.
+//
+// Sync deliberately runs no source privilege/configuration preflight: it
+// needs only SELECT on the source, and the change source validates any
+// feed-specific requirements itself (the MySQL binlog client checks
+// REPLICATION privileges + ROW binlog format on Start; a VStream
+// authenticates over gRPC). A table without a primary key surfaces a clear
+// error from getTables (SetInfo). The only target-side gate is that, for a
+// fresh sync, the target tables must be empty.
+func (r *Runner) setup(ctx context.Context) error {
+	r.logger.Info("Fetching source table list")
+	tables, err := r.getTables(ctx)
+	if err != nil {
+		return err
+	}
+	r.sourceTables = tables
+	if len(r.sourceTables) == 0 {
+		return nil
+	}
+
+	r.logger.Info("Creating applier")
+	r.applier, err = r.createApplier()
+	if err != nil {
+		return err
+	}
+
+	// Wire the change source: injected (e.g. VStream), or a built-in MySQL
+	// binlog client constructed from the source DSN. Sync replicates a whole
+	// schema, so the DDL filter is by schema only.
+	if r.sync.Source != nil {
+		r.setReplClient(r.sync.Source)
+	} else {
+		replConfig := change.NewClientDefaultConfig()
+		replConfig.Logger = r.logger
+		replConfig.CancelFunc = r.fatalError
+		replConfig.DDLFilterSchema = r.source.config.DBName
+		replConfig.DBConfig = r.sourceDBConfig
+		r.setReplClient(change.NewBinlogClient(r.source.db, r.source.config.Addr, r.source.config.User, r.source.config.Passwd, r.applier, replConfig))
+	}
+
+	// If a checkpoint exists on the target, resume: open the copier chunker at
+	// the saved watermark (continuing a partial copy) and open the change feed
+	// at the saved position — skipping the target-empty check. So a restarted
+	// sync resumes its partial copy instead of starting over.
+	watermark, pos, hasCheckpoint, err := r.readCheckpoint(ctx)
+	if err != nil {
+		return err
+	}
+	if hasCheckpoint {
+		r.resuming = true
+		r.logger.Info("Found checkpoint on target; resuming", "position", pos)
+		return r.startResume(ctx, watermark, pos)
+	}
+
+	// Fresh sync: the target tables must be empty so the copy can't clobber
+	// or duplicate existing data.
+	if err := r.checkTargetEmpty(ctx); err != nil {
+		return err
+	}
+	return r.startFresh(ctx)
+}
+
+// getTables discovers all tables in the source schema. Sync operates on a
+// whole schema at a time. Each table's metadata is populated via SetInfo.
+func (r *Runner) getTables(ctx context.Context) ([]*table.TableInfo, error) {
+	rows, err := r.source.db.QueryContext(ctx, "SHOW TABLES")
+	if err != nil {
+		return nil, err
+	}
+	defer utils.CloseAndLog(rows)
+
+	var tableName string
+	tables := make([]*table.TableInfo, 0)
+	for rows.Next() {
+		if err := rows.Scan(&tableName); err != nil {
+			return nil, err
+		}
+		// Skip the checkpoint table in case the source and target schemas
+		// coincide (e.g. local testing).
+		if tableName == syncCheckpointTableName {
+			continue
+		}
+		ti := table.NewTableInfo(r.source.db, r.source.config.DBName, tableName)
+		ti.Host = r.source.config.Addr
+		// Sync only needs SELECT on the source, so skip the ANALYZE TABLE
+		// (it needs INSERT + a writable server); the row estimate comes from
+		// information_schema instead.
+		ti.DisableAnalyze = true
+		if err := ti.SetInfo(ctx); err != nil {
+			return nil, err
+		}
+		tables = append(tables, ti)
+	}
+	return tables, rows.Err()
+}
+
+// checkTargetEmpty verifies that, for a fresh sync, none of the source
+// tables already exist with data on the target. A table that does not yet
+// exist is fine (startFresh will create it). Uses only SELECT on the
+// target.
+func (r *Runner) checkTargetEmpty(ctx context.Context) error {
+	for _, t := range r.sourceTables {
+		var dummy int
+		err := r.target.DB.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT 1 FROM `%s`.`%s` LIMIT 1", r.target.Config.DBName, t.TableName)).Scan(&dummy)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue // table exists but is empty
+		}
+		if err != nil {
+			// A missing target table is expected on a fresh sync.
+			var myErr *mysql.MySQLError
+			if errors.As(err, &myErr) && myErr.Number == errNoSuchTable {
+				continue
+			}
+			return fmt.Errorf("failed to check whether target table %q is empty: %w", t.TableName, err)
+		}
+		return fmt.Errorf("target table %q already exists and is not empty; sync requires an empty target (drop it, or start from a checkpoint)", t.TableName)
+	}
+	return nil
+}
+
+// createApplier returns the caller-injected applier, or constructs a
+// MySQL SingleTargetApplier for the target. The applier is not started
+// here — the copier starts its async workers for the initial copy and
+// stops them when it finishes; the subscription flush path uses the
+// applier's synchronous UpsertRows/DeleteKeys, which do not require the
+// workers, for steady-state streaming.
+func (r *Runner) createApplier() (applier.Applier, error) {
+	if r.sync.Applier != nil {
+		r.logger.Info("Using caller-provided applier")
+		return r.sync.Applier, nil
+	}
+	appl, err := applier.NewSingleTargetApplier(r.target, &applier.ApplierConfig{
+		DBConfig: r.targetDBConfig,
+		Logger:   r.logger,
+		Threads:  r.sync.WriteThreads,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SingleTargetApplier: %w", err)
+	}
+	return appl, nil
+}
+
+// ensureTargetDatabase creates the target database if it does not already
+// exist, by connecting to the target server (from the target's config)
+// without selecting a database. Used on both the injected-Target and
+// TargetDSN paths — the import's per-shard target databases are not
+// guaranteed to pre-exist on the destination cluster.
+func (r *Runner) ensureTargetDatabase(ctx context.Context, cfg *mysql.Config) error {
+	if cfg == nil {
+		return errors.New("target config is nil; cannot ensure target database")
+	}
+	if cfg.DBName == "" {
+		return errors.New("target must include a database name")
+	}
+	adminCfg := cfg.Clone()
+	adminCfg.DBName = ""
+	adminDB, err := dbconn.New(adminCfg.FormatDSN(), r.targetDBConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to target server to ensure database: %w", err)
+	}
+	defer utils.CloseAndLog(adminDB)
+	// Force: drop and recreate the target database unless a resumable
+	// checkpoint exists. We do this here, on the admin connection (no database
+	// selected) and before r.target.DB is ever queried, so no live connection
+	// has the database selected when it's dropped. A resumable run is left
+	// intact and resumes as normal.
+	if r.sync.Force {
+		resumable, rerr := r.hasResumableCheckpoint(ctx, adminDB, cfg.DBName)
+		if rerr != nil {
+			return rerr
+		}
+		if resumable {
+			r.logger.Info("force set, but a resumable checkpoint exists; keeping target and resuming", "database", cfg.DBName)
+		} else {
+			r.logger.Warn("force set and no resumable checkpoint; dropping and recreating target database", "database", cfg.DBName)
+			if err := dbconn.Exec(ctx, adminDB, "DROP DATABASE IF EXISTS %n", cfg.DBName); err != nil {
+				return fmt.Errorf("failed to drop target database %q: %w", cfg.DBName, err)
+			}
+		}
+	}
+	if err := dbconn.Exec(ctx, adminDB, "CREATE DATABASE IF NOT EXISTS %n", cfg.DBName); err != nil {
+		return fmt.Errorf("failed to create target database %q: %w", cfg.DBName, err)
+	}
+	r.logger.Info("ensured target database exists", "database", cfg.DBName)
+	return nil
+}
+
+// hasResumableCheckpoint reports whether the target database holds a sync
+// checkpoint that can be resumed from (a row carrying a copier watermark). It
+// runs on the passed connection (typically the no-database admin connection),
+// using fully-qualified names so it works without a selected database — and so
+// it can be called before r.target.DB is opened.
+func (r *Runner) hasResumableCheckpoint(ctx context.Context, db *sql.DB, dbName string) (bool, error) {
+	var exists int
+	e := db.QueryRowContext(ctx,
+		"SELECT 1 FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?",
+		dbName, syncCheckpointTableName).Scan(&exists)
+	if errors.Is(e, sql.ErrNoRows) {
+		return false, nil
+	}
+	if e != nil {
+		return false, fmt.Errorf("failed to check for checkpoint table: %w", e)
+	}
+	var watermark string
+	e = db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT IFNULL(copier_watermark, '') FROM `%s`.`%s` WHERE id = 1", dbName, syncCheckpointTableName)).Scan(&watermark)
+	if errors.Is(e, sql.ErrNoRows) {
+		return false, nil
+	}
+	if e != nil {
+		return false, fmt.Errorf("failed to read checkpoint: %w", e)
+	}
+	return watermark != "", nil
+}
+
+// createTargetTables creates each source table on the target using the
+// source's SHOW CREATE TABLE. Tables that already exist are skipped (they
+// were validated as empty + schema-compatible by the target_state check).
+//
+// This is MySQL→MySQL schema replication; a future heterogeneous target
+// (e.g. Postgres) would translate or pre-create the schema instead.
+//
+// The DDL runs with a relaxed sql_mode. The source's SHOW CREATE TABLE can
+// carry legacy column definitions — most commonly a TIMESTAMP/DATETIME with a
+// zero-date default ('0000-00-00 00:00:00') — that the target's strict
+// sql_mode (TRADITIONAL: NO_ZERO_DATE/NO_ZERO_IN_DATE/STRICT_*) rejects with
+// "Invalid default value" (error 1067). We recreate the tables exactly as the
+// source defines them, so we clear sql_mode for the CREATE statements. The DDL
+// runs on a single dedicated connection so the SET SESSION applies to it, and
+// we restore the mode before returning that connection to the pool (data
+// writes keep the strict mode).
+func (r *Runner) createTargetTables(ctx context.Context) error {
+	conn, err := r.target.DB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire target connection for DDL: %w", err)
+	}
+	defer utils.CloseAndLog(conn)
+
+	var prevSQLMode string
+	if err := conn.QueryRowContext(ctx, "SELECT @@SESSION.sql_mode").Scan(&prevSQLMode); err != nil {
+		return fmt.Errorf("failed to read target sql_mode: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "SET SESSION sql_mode = ''"); err != nil {
+		return fmt.Errorf("failed to relax sql_mode for table creation: %w", err)
+	}
+	defer func() {
+		// Restore before the connection returns to the pool so data writes
+		// aren't silently relaxed.
+		if _, err := conn.ExecContext(ctx, "SET SESSION sql_mode = ?", prevSQLMode); err != nil {
+			r.logger.Warn("failed to restore sql_mode after table creation", "error", err)
+		}
+	}()
+
+	for _, t := range r.sourceTables {
+		var name, createStmt string
+		row := r.source.db.QueryRowContext(ctx, "SHOW CREATE TABLE "+t.QuotedTableName)
+		if err := row.Scan(&name, &createStmt); err != nil {
+			return fmt.Errorf("failed to read CREATE TABLE for source %s: %w", t.TableName, err)
+		}
+		var exists int
+		err := conn.QueryRowContext(ctx,
+			"SELECT 1 FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?",
+			r.target.Config.DBName, t.TableName).Scan(&exists)
+		if err == nil {
+			r.logger.Info("target table already exists, skipping creation",
+				"table", t.TableName, "database", r.target.Config.DBName)
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("failed to check if table %s exists on target: %w", t.TableName, err)
+		}
+		if _, err := conn.ExecContext(ctx, createStmt); err != nil {
+			return fmt.Errorf("failed to create table %s on target: %w", t.TableName, err)
+		}
+		r.logger.Info("created table on target", "table", t.TableName, "database", r.target.Config.DBName)
+	}
+	return nil
+}
+
+// buildChunkers creates a chunker per source table and registers a
+// subscription on the change feed so changes during the copy are captured +
+// deduped. Returns the chunkers for assembly into the copy multi-chunker.
+func (r *Runner) buildChunkers() ([]table.Chunker, error) {
+	chunkers := make([]table.Chunker, 0, len(r.sourceTables))
+	for _, tbl := range r.sourceTables {
+		cc, err := table.NewChunker(tbl, table.ChunkerConfig{
+			TargetChunkTime: r.sync.TargetChunkTime,
+			Logger:          r.logger,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := r.replClient.AddSubscription(tbl, nil, cc); err != nil {
+			return nil, err
+		}
+		chunkers = append(chunkers, cc)
+	}
+	return chunkers, nil
+}
+
+// buildCopyPipeline builds the per-table chunkers (and, for continuous sync,
+// their change-feed subscriptions), assembles the multi-chunker, and
+// constructs the buffered copier. The caller opens the chunker afterwards —
+// Open() for a fresh sync, OpenAtWatermark() for a resume.
+func (r *Runner) buildCopyPipeline() error {
+	chunkers, err := r.buildChunkers()
+	if err != nil {
+		return err
+	}
+	r.setCopyChunker(table.NewMultiChunker(chunkers...))
+	cp, err := copier.NewCopier(r.source.db, r.copyChunker, &copier.CopierConfig{
+		Concurrency:     r.sync.Threads,
+		TargetChunkTime: r.sync.TargetChunkTime,
+		Logger:          r.logger,
+		Throttler:       &throttler.Noop{},
+		MetricsSink:     &metrics.NoopSink{},
+		DBConfig:        r.sourceDBConfig,
+		Applier:         r.applier,
+		Buffered:        true, // sync always uses the buffered copier
+	})
+	if err != nil {
+		return err
+	}
+	r.setCopier(cp)
+	return nil
+}
+
+// startFresh creates the target tables, builds the copy pipeline, opens the
+// chunker from the beginning, starts the change feed (continuous only), and
+// creates the checkpoint table so copy progress can be recorded from the
+// start of the copy.
+func (r *Runner) startFresh(ctx context.Context) error {
+	if err := r.createTargetTables(ctx); err != nil {
+		return err
+	}
+	if err := r.buildCopyPipeline(); err != nil {
+		return err
+	}
+	if err := r.copyChunker.Open(); err != nil {
+		return err
+	}
+	if err := r.replClient.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start change source: %w", err)
+	}
+	return r.createCheckpointTable(ctx)
+}
+
+// startResume rebuilds the copy pipeline and opens the chunker at the
+// checkpointed watermark, so the copier continues a partial copy (or finishes
+// immediately if the copy had completed). For continuous sync it also disables
+// the watermark optimization (every change applies) and opens the feed at the
+// saved position. The target tables already exist (createTargetTables is
+// idempotent, skipping them) and the target-empty check is skipped.
+func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
+	if err := r.createTargetTables(ctx); err != nil {
+		return err
+	}
+	if err := r.buildCopyPipeline(); err != nil {
+		return err
+	}
+	// Open at the saved watermark when we have one; otherwise (the prior
+	// attempt failed before writing its first checkpoint) open from the start
+	// and re-copy. The copy is idempotent (INSERT IGNORE), and we still skip
+	// the fresh-sync target-empty check because this import owns the
+	// (partially-populated) target.
+	if watermark != "" {
+		if err := r.copyChunker.OpenAtWatermark(watermark); err != nil {
+			return fmt.Errorf("failed to open copier at checkpoint watermark: %w", err)
+		}
+	} else {
+		if err := r.copyChunker.Open(); err != nil {
+			return err
+		}
+	}
+	if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+		return err
+	}
+	if pos != "" {
+		if err := r.replClient.StartFromPosition(ctx, pos); err != nil {
+			return fmt.Errorf("failed to resume change source from position %q: %w", pos, err)
+		}
+	} else if err := r.replClient.Start(ctx); err != nil {
+		// No saved position (prior attempt failed before checkpointing):
+		// start the feed fresh; changes apply with the optimization off.
+		return fmt.Errorf("failed to start change source: %w", err)
+	}
+	return r.createCheckpointTable(ctx)
+}
+
+// createCheckpointTable creates the checkpoint table on the target (always
+// the target, since the source may be read-only). It records the copier's low
+// watermark (resume point for a partial copy) and the change-feed position
+// (resume point for continuous sync).
+func (r *Runner) createCheckpointTable(ctx context.Context) error {
+	if err := dbconn.Exec(ctx, r.target.DB, `CREATE TABLE IF NOT EXISTS %n.%n (
+	id INT NOT NULL PRIMARY KEY,
+	copier_watermark TEXT,
+	source_position TEXT,
+	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+	)`, r.target.Config.DBName, syncCheckpointTableName); err != nil {
+		return fmt.Errorf("failed to create checkpoint table on target: %w", err)
+	}
+	return nil
+}
+
+// dumpCheckpoint records the copier's low watermark (so a partial copy can
+// resume) and the change-feed position (so continuous sync can resume) in the
+// target checkpoint table (single row, id=1). It is a no-op until the copy
+// pipeline is built, and skips writing whenever the watermark isn't ready yet,
+// so it never persists an unparseable watermark.
+func (r *Runner) dumpCheckpoint(ctx context.Context) error {
+	r.progMu.RLock()
+	chunker := r.copyChunker
+	repl := r.replClient
+	r.progMu.RUnlock()
+	if chunker == nil {
+		return nil // pipeline not built yet; nothing to checkpoint
+	}
+	watermark, err := chunker.GetLowWatermark()
+	if err != nil {
+		// The chunker's watermark isn't ready yet (e.g. a single-table copy
+		// whose only chunk hasn't produced a resumable boundary). Skip this
+		// write so we never persist an unparseable watermark; we'll try again
+		// on the next tick once it advances.
+		return nil
+	}
+	var pos string
+	if repl != nil {
+		pos = repl.Position()
+	}
+	return dbconn.Exec(ctx, r.target.DB,
+		"REPLACE INTO %n.%n (id, copier_watermark, source_position) VALUES (1, %?, %?)",
+		r.target.Config.DBName, syncCheckpointTableName, watermark, pos)
+}
+
+// readCheckpoint reports whether the target carries a sync checkpoint and, if
+// so, the saved copier watermark + change-feed position.
+//
+// The "resume" signal is the existence of the checkpoint TABLE, not merely a
+// saved watermark. The table is created (in startFresh) before any rows are
+// copied, so its presence means a prior attempt of this import already owns
+// the target — even if that attempt died before writing its first watermark
+// row, leaving partial data behind. Treating that as resumable lets the retry
+// re-copy idempotently instead of tripping the fresh-sync target-empty guard.
+// (watermark/pos may be empty in that case; startResume handles it.)
+func (r *Runner) readCheckpoint(ctx context.Context) (watermark, pos string, ok bool, err error) {
+	var exists int
+	e := r.target.DB.QueryRowContext(ctx,
+		"SELECT 1 FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?",
+		r.target.Config.DBName, syncCheckpointTableName).Scan(&exists)
+	if errors.Is(e, sql.ErrNoRows) {
+		return "", "", false, nil // no checkpoint table → not a prior import; fresh sync
+	}
+	if e != nil {
+		return "", "", false, fmt.Errorf("failed to check for checkpoint table: %w", e)
+	}
+	// The table exists: a prior attempt owns this target. Read its (optional)
+	// saved watermark/position.
+	e = r.target.DB.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT IFNULL(copier_watermark, ''), IFNULL(source_position, '') FROM `%s`.`%s` WHERE id = 1",
+			r.target.Config.DBName, syncCheckpointTableName)).Scan(&watermark, &pos)
+	if errors.Is(e, sql.ErrNoRows) {
+		return "", "", true, nil // table exists but no row written yet → resume, re-copy from scratch
+	}
+	if e != nil {
+		return "", "", false, fmt.Errorf("failed to read checkpoint: %w", e)
+	}
+	return watermark, pos, true, nil
+}
+
+// dumpCheckpointLoop periodically records the source position on the
+// target until ctx is cancelled.
+func (r *Runner) dumpCheckpointLoop(ctx context.Context, done chan struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(status.CheckpointDumpInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := r.dumpCheckpoint(ctx); err != nil {
+				r.logger.Warn("failed to write checkpoint", "error", err)
+			}
+		}
+	}
+}
+
+// startBackgroundRoutines starts the periodic flush (which advances the
+// applied position and keeps the target caught up), the status logger, and the
+// periodic checkpoint loop. The checkpoint loop runs for the whole run (copy
+// and continuous), so a restart at any point resumes from the last checkpoint.
+func (r *Runner) startBackgroundRoutines(ctx context.Context) {
+	r.replClient.StartPeriodicFlush(ctx, r.sync.FlushInterval)
+	r.watchDone = make(chan struct{})
+	go r.watchStatus(ctx)
+	r.checkpointDone = make(chan struct{})
+	go r.dumpCheckpointLoop(ctx, r.checkpointDone)
+}
+
+// watchStatus logs progress periodically until ctx is cancelled.
+func (r *Runner) watchStatus(ctx context.Context) {
+	defer close(r.watchDone)
+	ticker := time.NewTicker(status.StatusInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Guard the change feed in case status logging starts before the
+			// repl client is wired.
+			pending := 0
+			if r.replClient != nil {
+				pending = r.replClient.GetDeltaLen()
+			}
+			switch {
+			case r.status.Get() == status.CopyRows && r.copier != nil:
+				r.logger.Info("sync status",
+					"phase", "initial-copy",
+					"progress", r.copier.GetProgress(),
+					"eta", r.copier.GetETA(),
+					"pending-changes", pending,
+					"elapsed", time.Since(r.startTime).Round(time.Second),
+				)
+			case r.replClient != nil:
+				r.logger.Info("sync status",
+					"phase", "continuous",
+					"pending-changes", pending,
+					"position", r.replClient.Position(),
+					"elapsed", time.Since(r.startTime).Round(time.Second),
+				)
+			}
+		}
+	}
+}
+
+// fatalError is the change client's CancelFunc: it records the fatal
+// condition (e.g. DDL on a synced table) and cancels the run so
+// runContinuous can surface it.
+func (r *Runner) fatalError() bool {
+	r.fatalMu.Lock()
+	if r.fatalErr == nil {
+		r.fatalErr = errors.New("a DDL change was detected on a synced table; sync cannot continue safely")
+	}
+	r.fatalMu.Unlock()
+	if r.cancelFunc != nil {
+		r.cancelFunc()
+	}
+	return true
+}
+
+func (r *Runner) fatal() error {
+	r.fatalMu.Lock()
+	defer r.fatalMu.Unlock()
+	return r.fatalErr
+}
+
+// Close releases resources. Safe to call once after Run returns. The
+// applier's worker lifecycle is owned by the copier (which stops it after
+// the initial copy), so Close does not stop it. An injected change.Source
+// and injected applier/target are owned by the caller, but Close still
+// calls change.Source.Close (documented idempotent) to release the
+// runner's reference.
+func (r *Runner) Close() error {
+	if r.cancelFunc != nil {
+		r.cancelFunc()
+	}
+	if r.watchDone != nil {
+		<-r.watchDone
+	}
+	if r.checkpointDone != nil {
+		<-r.checkpointDone
+	}
+	if r.replClient != nil {
+		r.replClient.StopPeriodicFlush()
+		r.replClient.Close()
+	}
+	if r.copyChunker != nil {
+		if err := r.copyChunker.Close(); err != nil {
+			return err
+		}
+	}
+	if r.ownsTarget && r.target.DB != nil {
+		if err := r.target.DB.Close(); err != nil {
+			return err
+		}
+	}
+	if r.source.db != nil {
+		if err := r.source.db.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- progress-field setters (guard the fields the status.Task accessors read) ---
+
+func (r *Runner) setReplClient(c change.Source) {
+	r.progMu.Lock()
+	r.replClient = c
+	r.progMu.Unlock()
+}
+
+func (r *Runner) setCopier(c copier.Copier) {
+	r.progMu.Lock()
+	r.copier = c
+	r.progMu.Unlock()
+}
+
+func (r *Runner) setCopyChunker(c table.Chunker) {
+	r.progMu.Lock()
+	r.copyChunker = c
+	r.progMu.Unlock()
+}
+
+// --- status.Task ---
+//
+// Runner implements status.Task so a caller (e.g. tern's import engine) can
+// surface live progress and force a checkpoint, the same way it monitors a
+// spirit migration.Runner. These accessors are safe to call concurrently with
+// Run from another goroutine.
+
+// Progress returns a structured snapshot of the sync's current state: the
+// phase, a short human-readable summary, and per-table copy progress during
+// the initial copy.
+func (r *Runner) Progress() status.Progress {
+	state := r.status.Get()
+
+	r.progMu.RLock()
+	cp := r.copier
+	chunker := r.copyChunker
+	repl := r.replClient
+	r.progMu.RUnlock()
+
+	var summary string
+	switch state { //nolint:exhaustive // sync only uses Initial/CopyRows/ApplyChangeset
+	case status.CopyRows:
+		if cp != nil {
+			summary = fmt.Sprintf("%s copyRows ETA %s", cp.GetProgress(), cp.GetETA())
+		} else {
+			summary = "copyRows"
+		}
+	case status.ApplyChangeset:
+		if repl != nil {
+			summary = fmt.Sprintf("continuous sync position=%s pending-changes=%d", repl.Position(), repl.GetDeltaLen())
+		} else {
+			summary = "continuous sync"
+		}
+	default:
+		summary = state.String()
+	}
+
+	// Per-table progress: the multi-chunker reports each table; fall back to
+	// the single-table chunker view if it's not a multi-chunker.
+	var tables []status.TableProgress
+	if mc, ok := chunker.(interface {
+		PerTableProgress() []table.TableProgress
+	}); ok {
+		for _, tp := range mc.PerTableProgress() {
+			tables = append(tables, status.TableProgress{
+				TableName:  tp.TableName,
+				RowsCopied: tp.RowsCopied,
+				RowsTotal:  tp.RowsTotal,
+				IsComplete: tp.IsComplete,
+			})
+		}
+	} else if chunker != nil {
+		rowsCopied, _, rowsTotal := chunker.Progress()
+		name := ""
+		if ts := chunker.Tables(); len(ts) > 0 {
+			name = ts[0].TableName
+		}
+		tables = append(tables, status.TableProgress{
+			TableName:  name,
+			RowsCopied: rowsCopied,
+			RowsTotal:  rowsTotal,
+			IsComplete: chunker.IsRead(),
+		})
+	}
+
+	return status.Progress{CurrentState: state, Summary: summary, Tables: tables}
+}
+
+// Status returns a one-line, human-readable status for logging. It does not
+// log itself; status.WatchTask (when used) logs the returned value.
+func (r *Runner) Status() string {
+	state := r.status.Get()
+
+	r.progMu.RLock()
+	cp := r.copier
+	repl := r.replClient
+	start := r.startTime
+	r.progMu.RUnlock()
+
+	elapsed := time.Since(start).Round(time.Second)
+	switch state { //nolint:exhaustive // sync only uses Initial/CopyRows/ApplyChangeset
+	case status.CopyRows:
+		progress, eta := "", ""
+		if cp != nil {
+			progress, eta = cp.GetProgress(), cp.GetETA()
+		}
+		pending := 0
+		if repl != nil {
+			pending = repl.GetDeltaLen()
+		}
+		return fmt.Sprintf("sync status: state=%s copy-progress=%s copy-eta=%s pending-changes=%d total-time=%s",
+			state.String(), progress, eta, pending, elapsed)
+	case status.ApplyChangeset:
+		pos := ""
+		pending := 0
+		if repl != nil {
+			pos, pending = repl.Position(), repl.GetDeltaLen()
+		}
+		return fmt.Sprintf("sync status: state=%s position=%s pending-changes=%d total-time=%s",
+			state.String(), pos, pending, elapsed)
+	default:
+		return fmt.Sprintf("sync status: state=%s total-time=%s", state.String(), elapsed)
+	}
+}
+
+// DumpCheckpoint records the copier watermark (and, for continuous sync, the
+// change-feed position) on the target so a restart can resume a partial copy
+// and the stream. It is a no-op until the copy pipeline is built.
+func (r *Runner) DumpCheckpoint(ctx context.Context) error {
+	r.progMu.RLock()
+	chunker := r.copyChunker
+	r.progMu.RUnlock()
+	if chunker == nil {
+		return nil // copy pipeline not built yet; nothing to checkpoint
+	}
+	// Idempotent: createCheckpointTable uses CREATE TABLE IF NOT EXISTS, so
+	// this is safe even in the brief window before startFresh/startResume has
+	// created the table.
+	if err := r.createCheckpointTable(ctx); err != nil {
+		return err
+	}
+	return r.dumpCheckpoint(ctx)
+}
+
+// Cancel stops the sync by cancelling the Run context. Safe to call before
+// Run has started (no-op until cancelFunc is set).
+func (r *Runner) Cancel() {
+	r.progMu.RLock()
+	cancel := r.cancelFunc
+	r.progMu.RUnlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// redactDSN strips credentials from a DSN for safe logging.
+func redactDSN(dsn string) string {
+	if i := strings.LastIndex(dsn, "@"); i >= 0 {
+		return "<redacted>" + dsn[i:]
+	}
+	return dsn
+}

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -147,12 +147,13 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.logger.Info("Starting sync", "source_dsn", redactDSN(r.sync.SourceDSN))
 
 	r.sourceDBConfig = dbconn.NewDBConfig()
-	// Sync only ever reads from the source (copy SELECTs + the change feed).
-	// It never writes to the source, acquires no source locks, and performs
-	// no cutover, so it needs only SELECT on the source schema (plus
-	// REPLICATION SLAVE/CLIENT when the change feed is the built-in MySQL
-	// binlog client, which that client validates on Start). Disable the two
-	// dbConfig behaviours that would otherwise demand more:
+	// Sync only ever reads the source data (copy SELECTs + the change feed).
+	// It never writes the source's data, acquires no source locks, and
+	// performs no cutover. With an injected change.Source it needs only SELECT
+	// on the source schema; the built-in MySQL binlog client additionally
+	// needs REPLICATION SLAVE/CLIENT (validated on Start) and RELOAD, because
+	// it issues FLUSH BINARY LOGS to establish its start position. Disable the
+	// two dbConfig behaviours that would otherwise demand more:
 	//   - ForceKill needs CONNECTION_ADMIN/PROCESS + performance_schema, and
 	//     is only used to break metadata locks during cutover — which sync
 	//     never does.

--- a/pkg/datasync/sync.go
+++ b/pkg/datasync/sync.go
@@ -1,0 +1,119 @@
+// Package datasync implements the `sync` command: a continuous,
+// heterogeneous data sync.
+//
+// A sync performs an initial copy of the source tables into the target,
+// then streams ongoing changes from the source to the target
+// indefinitely until the context is cancelled. Unlike `move`, there is
+// no checksum and no cutover — the sync simply keeps the target caught
+// up with the source for as long as it runs. Cancelling the command
+// (SIGINT/SIGTERM, or a caller-cancelled context) drains the in-flight
+// backlog and exits cleanly.
+//
+// The source is either a built-in MySQL binlog client (constructed from
+// SourceDSN) or a caller-injected change.Source — e.g. a Vitess /
+// PlanetScale VStream. The target is written through an applier; today
+// that is a MySQL SingleTargetApplier, but the applier abstraction is
+// what makes the sync heterogeneous: a future Postgres applier would
+// let this sync MySQL → Postgres without changing the runner.
+//
+// The package is deliberately named datasync (not sync) so it does not
+// shadow the standard library's sync package. The CLI command is still
+// `sync` (the kong field name drives the command name, the same way
+// migration.Migration is exposed as `migrate`).
+package datasync
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/utils"
+)
+
+// Sync is the configuration for a continuous data sync. The exported,
+// kong-tagged fields are the CLI surface; the kong:"-" fields are for
+// programmatic callers (e.g. strata's Vitess/PlanetScale import) that
+// inject a non-MySQL change source and/or a custom applier.
+type Sync struct {
+	SourceDSN       string        `name:"source-dsn" help:"Where to sync the tables from." default:"spirit:spirit@tcp(127.0.0.1:3306)/src"`
+	TargetDSN       string        `name:"target-dsn" help:"Where to sync the tables to." default:"spirit:spirit@tcp(127.0.0.1:3306)/dest"`
+	TargetChunkTime time.Duration `name:"target-chunk-time" help:"How long each copy chunk should take." default:"5s"`
+	Threads         int           `name:"threads" help:"How many chunks to copy in parallel during the initial copy." default:"4"`
+	WriteThreads    int           `name:"write-threads" help:"How many concurrent write threads to use on the target." default:"4"`
+	// FlushInterval controls how often buffered changes are applied to the
+	// target during continuous sync — i.e. the replication latency vs.
+	// batching trade-off. Defaults to change.DefaultFlushInterval.
+	FlushInterval time.Duration `name:"flush-interval" help:"How often to flush buffered changes to the target during continuous sync." default:"30s"`
+
+	// Force, when set, makes the runner drop and recreate the target database
+	// at startup *unless* a resumable checkpoint exists — i.e. it only nukes
+	// the target when the copy could not have resumed anyway. A resumable
+	// run (checkpoint present) is left intact and resumes as normal. Intended
+	// for testing/iterating, where a previous partial run can leave the target
+	// non-empty with no usable checkpoint, otherwise tripping the fresh-sync
+	// target-empty guard.
+	Force bool `name:"force" help:"Drop and recreate the target database when the copy cannot resume from a checkpoint." default:"false"`
+
+	// Source optionally provides a pre-constructed change.Source to use
+	// for replication instead of constructing a built-in MySQL-binlog
+	// client from SourceDSN. When set, the runner uses this as the change
+	// feed. SourceDSN is still required for source-side SQL (SHOW TABLES,
+	// SHOW CREATE TABLE, the initial-copy SELECTs). Setting Source requires
+	// setting Applier (see below).
+	//
+	// Intended for callers (e.g. strata's Vitess/PlanetScale import) that
+	// need a non-MySQL-binlog change source.
+	Source change.Source `kong:"-"`
+
+	// Applier optionally provides a pre-constructed applier.Applier. When
+	// set, the runner uses this instead of constructing a MySQL
+	// SingleTargetApplier from the target. Required when Source is set: the
+	// injected change.Source needs the same applier instance the copier
+	// uses, so all writes flow through one logical apply path.
+	Applier applier.Applier `kong:"-"`
+
+	// Target optionally supplies a pre-opened target. When nil, a single
+	// MySQL target is opened from TargetDSN (auto-creating the database if
+	// it does not exist). Sync writes to exactly one logical target — there
+	// is no N:M fan-out.
+	Target *applier.Target `kong:"-"`
+}
+
+// Run is the kong CLI entry point. It runs the sync until the process
+// receives SIGINT/SIGTERM, then drains and exits cleanly. Programmatic
+// callers that want to supply their own context should construct a
+// Runner via NewRunner and call Runner.Run directly.
+//
+// Signal handling is two-stage: the first SIGINT/SIGTERM cancels the
+// context for a graceful drain, and a second forces an immediate exit.
+// The force-quit matters because the change feed can be slow to unwind
+// (e.g. a busy or repeatedly-reconnecting binlog stream), and without it
+// a second Ctrl+C would be swallowed — making the command feel hung.
+func (s *Sync) Run() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		<-sigCh
+		slog.Default().Info("sync: signal received, shutting down — press Ctrl+C again to force-quit")
+		cancel()
+		<-sigCh
+		slog.Default().Warn("sync: second signal received, forcing exit")
+		os.Exit(130)
+	}()
+
+	runner, err := NewRunner(s)
+	if err != nil {
+		return err
+	}
+	defer utils.CloseAndLog(runner)
+	return runner.Run(ctx)
+}

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -1,0 +1,535 @@
+package datasync
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	// Tick the status logger fast. Continuous-replication latency is set
+	// per-test via Sync.FlushInterval.
+	status.StatusInterval = 100 * time.Millisecond
+	goleak.VerifyTestMain(m)
+}
+
+// runUntilCopied drives a continuous sync until the initial copy has completed
+// (status advances to ApplyChangeset) and then cancels it, so Run performs its
+// final flush + checkpoint and returns. This is the test affordance for
+// exercising the copy + checkpoint/resume path without waiting on any streamed
+// change. If Run returns before the continuous phase is reached (e.g. a
+// setup-time error such as the fresh-target-empty guard), that error is
+// returned directly.
+func runUntilCopied(t *testing.T, runner *Runner) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case err := <-done:
+			// Run returned before the continuous phase (error or early exit).
+			return err
+		case <-tick.C:
+			if runner.Progress().CurrentState == status.ApplyChangeset {
+				cancel()
+				return <-done
+			}
+		}
+	}
+}
+
+func TestNewRunnerValidation(t *testing.T) {
+	// Defaults are applied for zero-valued knobs.
+	r, err := NewRunner(&Sync{})
+	require.NoError(t, err)
+	require.Equal(t, 4, r.sync.Threads)
+	require.Equal(t, 4, r.sync.WriteThreads)
+	require.Equal(t, 5*time.Second, r.sync.TargetChunkTime)
+	require.Positive(t, r.sync.FlushInterval)
+}
+
+// TestSyncE2E drives the full sync lifecycle against a local MySQL using
+// the built-in binlog change source: initial copy, then continuous
+// replication of an INSERT, an UPDATE and a DELETE, then a clean
+// cancellation.
+func TestSyncE2E(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_dest"
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_dest`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_dest`)
+
+	tgt, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt)
+
+	countRows := func() int {
+		var n int
+		if err := tgt.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM t1`).Scan(&n); err != nil {
+			return -1 // table may not exist yet
+		}
+		return n
+	}
+	valOf := func(id int) string {
+		var v string
+		if err := tgt.QueryRowContext(context.Background(), `SELECT val FROM t1 WHERE id = ?`, id).Scan(&v); err != nil {
+			return ""
+		}
+		return v
+	}
+
+	s := &Sync{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+		WriteThreads:    2,
+		FlushInterval:   100 * time.Millisecond,
+	}
+	runner, err := NewRunner(s)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+
+	// Initial copy lands all three rows.
+	require.Eventually(t, func() bool { return countRows() == 3 },
+		30*time.Second, 100*time.Millisecond, "initial copy should replicate 3 rows")
+
+	// Continuous: an INSERT replicates.
+	testutils.RunSQL(t, `INSERT INTO sync_src.t1 VALUES (4,'four')`)
+	require.Eventually(t, func() bool { return countRows() == 4 },
+		30*time.Second, 100*time.Millisecond, "continuous sync should replicate the INSERT")
+
+	// Continuous: an UPDATE and a DELETE replicate.
+	testutils.RunSQL(t, `UPDATE sync_src.t1 SET val='ONE' WHERE id=1`)
+	testutils.RunSQL(t, `DELETE FROM sync_src.t1 WHERE id=2`)
+	require.Eventually(t, func() bool { return countRows() == 3 && valOf(1) == "ONE" },
+		30*time.Second, 100*time.Millisecond, "continuous sync should replicate the UPDATE + DELETE")
+
+	// Cancellation drains and returns cleanly. The drain is bounded by the
+	// runner's short shutdown budgets, so this wait only needs enough margin to
+	// absorb CI scheduling jitter on a busy server.
+	cancel()
+	select {
+	case runErr := <-done:
+		require.NoError(t, runErr)
+	case <-time.After(60 * time.Second):
+		t.Fatal("sync did not stop within 60s of cancellation")
+	}
+	require.NoError(t, runner.Close())
+}
+
+// TestSyncInitialCopy verifies the initial copy: the snapshot is copied to the
+// target (auto-creating the target database) before the continuous phase
+// begins.
+func TestSyncInitialCopy(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_initialcopy_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_initialcopy_dest"
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_initialcopy_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_initialcopy_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_initialcopy_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_initialcopy_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	// Leave the target database absent — the sync must auto-create it.
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_initialcopy_dest`)
+
+	s := &Sync{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+		WriteThreads:    2,
+	}
+	runner, err := NewRunner(s)
+	require.NoError(t, err)
+
+	require.NoError(t, runUntilCopied(t, runner))
+	require.NoError(t, runner.Close())
+
+	tgt, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt)
+	var n int
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM t1").Scan(&n))
+	require.Equal(t, 3, n)
+	var v string
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT val FROM t1 WHERE id = 2").Scan(&v))
+	require.Equal(t, "two", v)
+}
+
+// TestRunnerStatusTask exercises the status.Task surface (Progress, Status,
+// DumpCheckpoint, Cancel) concurrently with Run, validating both the values
+// reported and the locking around the progress fields (run with -race).
+func TestRunnerStatusTask(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_statustask_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_statustask_dest"
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_statustask_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_statustask_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_statustask_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_statustask_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_statustask_dest`)
+
+	s := &Sync{
+		SourceDSN:       src.FormatDSN(),
+		TargetDSN:       dest.FormatDSN(),
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+		WriteThreads:    2,
+	}
+	runner, err := NewRunner(s)
+	require.NoError(t, err)
+
+	// Safe to poll before Run starts: reports the Initial state, no panic, and
+	// the pre-Run checkpoint is a no-op.
+	require.Equal(t, status.Initial, runner.Progress().CurrentState)
+	require.NotEmpty(t, runner.Status())
+	require.NoError(t, runner.DumpCheckpoint(context.Background()))
+
+	// Hammer the status.Task accessors from another goroutine while Run runs,
+	// so the race detector covers the locking around copier/copyChunker/etc.
+	done := make(chan struct{})
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = runner.Progress()
+				_ = runner.Status()
+				_ = runner.DumpCheckpoint(context.Background())
+			}
+		}
+	}()
+
+	runErr := runUntilCopied(t, runner)
+	close(done)
+	<-pollDone
+	require.NoError(t, runErr)
+	runner.Cancel() // post-run cancel must be harmless
+	require.NoError(t, runner.Close())
+
+	// After a completed copy, Progress reports the table as fully copied.
+	p := runner.Progress()
+	require.Len(t, p.Tables, 1)
+	require.Equal(t, "t1", p.Tables[0].TableName)
+	require.True(t, p.Tables[0].IsComplete)
+	require.Equal(t, uint64(3), p.Tables[0].RowsCopied)
+}
+
+// TestSyncResume verifies that the initial copy writes a copier-watermark
+// checkpoint and that a second run against the same (non-empty) target detects
+// it and resumes — opening the chunker at the saved watermark instead of
+// tripping the fresh-sync target-empty check — leaving the data intact. Uses
+// two tables so the copier is a multi-chunker (as a real per-shard keyspace
+// import is), which always records a checkpoint.
+func TestSyncResume(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_resume_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_resume_dest"
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_resume_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_resume_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_resume_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_resume_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	testutils.RunSQL(t, `CREATE TABLE sync_resume_src.t2 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_resume_src.t2 VALUES (10,'ten'),(20,'twenty')`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_resume_dest`)
+
+	newSync := func() *Sync {
+		return &Sync{
+			SourceDSN:       sourceDSN,
+			TargetDSN:       targetDSN,
+			TargetChunkTime: 100 * time.Millisecond,
+			Threads:         2,
+			WriteThreads:    2,
+		}
+	}
+
+	// First run: copies both tables and records a checkpoint.
+	r1, err := NewRunner(newSync())
+	require.NoError(t, err)
+	require.NoError(t, runUntilCopied(t, r1))
+	require.NoError(t, r1.Close())
+
+	tgt, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt)
+
+	countRows := func(tbl string) int {
+		var n int
+		require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM "+tbl).Scan(&n))
+		return n
+	}
+	require.Equal(t, 3, countRows("t1"))
+	require.Equal(t, 2, countRows("t2"))
+
+	// A copy must persist a checkpoint with a copier watermark.
+	var wm string
+	require.NoError(t, tgt.QueryRowContext(context.Background(),
+		"SELECT IFNULL(copier_watermark, '') FROM _spirit_sync_checkpoint WHERE id = 1").Scan(&wm))
+	require.NotEmpty(t, wm, "a copy should record a copier watermark")
+
+	// Second run with the target left intact: it must detect the checkpoint and
+	// resume (open the chunker at the watermark) rather than fail the fresh
+	// target-empty check, and the data must be unchanged.
+	r2, err := NewRunner(newSync())
+	require.NoError(t, err)
+	require.NoError(t, runUntilCopied(t, r2))
+	require.NoError(t, r2.Close())
+
+	require.Equal(t, 3, countRows("t1"), "resume must not duplicate or drop rows")
+	require.Equal(t, 2, countRows("t2"), "resume must not duplicate or drop rows")
+}
+
+// TestSyncResumeNoWatermarkRow simulates a prior attempt that created the
+// checkpoint table and copied data but died before writing its first watermark
+// row. The re-run must treat the checkpoint table's existence as "this import
+// owns the target" and resume (re-copy) rather than tripping the fresh-sync
+// target-empty check on the partial data.
+func TestSyncResumeNoWatermarkRow(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_norow_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_norow_dest"
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_norow_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_norow_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_norow_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_norow_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	testutils.RunSQL(t, `CREATE TABLE sync_norow_src.t2 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_norow_src.t2 VALUES (10,'ten'),(20,'twenty')`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_norow_dest`)
+
+	newSync := func() *Sync {
+		return &Sync{
+			SourceDSN:       sourceDSN,
+			TargetDSN:       targetDSN,
+			TargetChunkTime: 100 * time.Millisecond,
+			Threads:         2,
+			WriteThreads:    2,
+		}
+	}
+
+	// First run completes: target has data + a checkpoint table with a row.
+	r1, err := NewRunner(newSync())
+	require.NoError(t, err)
+	require.NoError(t, runUntilCopied(t, r1))
+	require.NoError(t, r1.Close())
+
+	// Simulate "died before first checkpoint row": keep the data + the
+	// checkpoint table, but remove its row.
+	testutils.RunSQL(t, "DELETE FROM sync_norow_dest._spirit_sync_checkpoint")
+
+	// Re-run: must resume (checkpoint table exists) and re-copy, not fail the
+	// target-empty check on the leftover data.
+	r2, err := NewRunner(newSync())
+	require.NoError(t, err)
+	require.NoError(t, runUntilCopied(t, r2))
+	require.NoError(t, r2.Close())
+
+	tgt, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt)
+	var n int
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM t1").Scan(&n))
+	require.Equal(t, 3, n)
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM t2").Scan(&n))
+	require.Equal(t, 2, n)
+}
+
+// TestSyncForce verifies the Force flag: when a resumable checkpoint exists the
+// target is kept and resumed (no drop); when it can't resume (no checkpoint but
+// a non-empty target) the target database is dropped and recreated so the copy
+// can proceed instead of tripping the fresh-sync target-empty guard.
+func TestSyncForce(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_force_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_force_dest"
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_force_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_force_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_force_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_force_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	testutils.RunSQL(t, `CREATE TABLE sync_force_src.t2 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_force_src.t2 VALUES (10,'ten'),(20,'twenty')`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_force_dest`)
+
+	newSync := func(force bool) *Sync {
+		return &Sync{
+			SourceDSN:       sourceDSN,
+			TargetDSN:       targetDSN,
+			TargetChunkTime: 100 * time.Millisecond,
+			Threads:         2,
+			WriteThreads:    2,
+			Force:           force,
+		}
+	}
+	run := func(force bool) error {
+		r, nerr := NewRunner(newSync(force))
+		require.NoError(t, nerr)
+		rerr := runUntilCopied(t, r)
+		require.NoError(t, r.Close())
+		return rerr
+	}
+
+	tgt, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt)
+	tableExists := func(name string) bool {
+		var n int
+		require.NoError(t, tgt.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM information_schema.TABLES WHERE table_schema='sync_force_dest' AND table_name=?", name).Scan(&n))
+		return n == 1
+	}
+
+	// First copy completes and writes a checkpoint.
+	require.NoError(t, run(false))
+
+	// Sentinel table not present in the source: survives a resume, vanishes
+	// on a force drop+recreate.
+	testutils.RunSQL(t, `CREATE TABLE sync_force_dest._keep_me (id INT PRIMARY KEY)`)
+
+	// Force with a resumable checkpoint present: must NOT drop — the sentinel
+	// (and the checkpoint) survive.
+	require.NoError(t, run(true))
+	require.True(t, tableExists("_keep_me"), "force must not drop when a resumable checkpoint exists")
+	require.True(t, tableExists("t1"))
+
+	// Simulate "can't resume": remove the checkpoint table but leave the data,
+	// so the target is non-empty with no resumable checkpoint.
+	testutils.RunSQL(t, "DROP TABLE sync_force_dest._spirit_sync_checkpoint")
+
+	// Without force this would fail the target-empty guard.
+	require.Error(t, run(false), "a non-empty target with no checkpoint must fail without force")
+
+	// With force it drops + recreates: the sentinel is gone and the data is
+	// freshly re-copied.
+	require.NoError(t, run(true))
+	require.False(t, tableExists("_keep_me"), "force must drop+recreate when it cannot resume")
+	var n int
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM sync_force_dest.t1").Scan(&n))
+	require.Equal(t, 3, n)
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM sync_force_dest.t2").Scan(&n))
+	require.Equal(t, 2, n)
+}
+
+// TestSyncCreateTableLegacyDefault verifies that target tables are created with
+// a relaxed sql_mode. The source DDL can carry a legacy zero-date default that
+// a strict target (sql_mode=TRADITIONAL, as the import's injected target uses)
+// would reject with "Invalid default value" (1067). The data itself has valid
+// timestamps, so only the CREATE needs the relaxed mode.
+func TestSyncCreateTableLegacyDefault(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_legacy_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_legacy_dest"
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_legacy_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_legacy_src`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_legacy_dest`)
+
+	// Create the source table with a legacy zero-date TIMESTAMP default — the
+	// server default (NO_ZERO_DATE) rejects it, so use a relaxed connection.
+	// The rows themselves carry valid timestamps.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	laxDB, err := sql.Open("mysql", src.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(laxDB)
+	laxConn, err := laxDB.Conn(ctx)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(laxConn)
+	_, err = laxConn.ExecContext(ctx, "SET SESSION sql_mode = ''")
+	require.NoError(t, err)
+	_, err = laxConn.ExecContext(ctx,
+		"CREATE TABLE t1 (id INT PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00')")
+	require.NoError(t, err)
+	_, err = laxConn.ExecContext(ctx,
+		"INSERT INTO t1 (id, updated_at) VALUES (1,'2025-01-01 00:00:00'),(2,'2025-01-02 00:00:00')")
+	require.NoError(t, err)
+
+	// Inject a STRICT (TRADITIONAL) target — this is what rejects the zero-date
+	// default during CREATE without the relaxed-DDL fix.
+	targetCfg := dest.Clone()
+	if targetCfg.Params == nil {
+		targetCfg.Params = map[string]string{}
+	}
+	targetCfg.Params["sql_mode"] = "TRADITIONAL"
+	targetDB, err := sql.Open("mysql", targetCfg.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB) // injected target: the runner doesn't own/close it
+	target := applier.Target{DB: targetDB, Config: targetCfg, KeyRange: "0"}
+
+	s := &Sync{
+		SourceDSN:       src.FormatDSN(),
+		Target:          &target,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+		WriteThreads:    2,
+	}
+	runner, err := NewRunner(s)
+	require.NoError(t, err)
+	require.NoError(t, runUntilCopied(t, runner)) // would fail with 1067 without the relaxed-DDL fix
+	require.NoError(t, runner.Close())
+
+	tgt, err := sql.Open("mysql", dest.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt)
+	var n int
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM t1").Scan(&n))
+	require.Equal(t, 2, n)
+}


### PR DESCRIPTION
## Summary

Adds an **experimental** `spirit sync` subcommand (#893). `sync` performs an
initial copy of a source schema into a target and then **continuously applies
the source's change stream** to the target until interrupted (Ctrl-C /
SIGTERM). Unlike [`move`](../blob/main/docs/move.md), it does **not** cut over —
it keeps a target continuously up to date.

Initial scope is **MySQL → MySQL**, using the existing binlog change client.
The runner also accepts an injected `change.Source` / `applier.Applier`, so an
out-of-tree producer (e.g. a Vitess VStream source) can drive the same pipeline
without `sync` needing to know about it.

### Behavior
- **Read-only source.** `sync` needs only `SELECT` on the source schema (plus
  `REPLICATION SLAVE`/`CLIENT` for the binlog feed): no `ANALYZE`, no source
  locks, no cutover — so it can run against a replica. Source connections
  disable `ForceKill` and `rejectReadOnly`; the writable **target** keeps the
  standard defaults (`rejectReadOnly` on, for Aurora-failover safety).
- **Auto-creates** the target database and tables from the source schema, with
  a relaxed `sql_mode` for the `CREATE`s so legacy zero-date defaults copy.
- **Resumable.** The copier watermark and change-feed position are checkpointed
  to the target; a restart resumes instead of re-copying. On clean shutdown the
  final flush and the final checkpoint write get **independent** timeout
  budgets, so a slow final flush can't starve the checkpoint that enables
  resume.
- `--force` drops+recreates the target only when it can't resume (non-empty, no
  usable checkpoint), so a resumable run is never nuked.

### Docs
Adds `docs/sync.md` (clearly marked experimental, MySQL→MySQL) and a `docs/README.md` index entry; the CLI help is prefixed `[EXPERIMENTAL]`.

## Notes for reviewers
- Builds on the public `NewBufferedSubscription` from #896 conceptually but is
  **independent** of it — this branch is cut from `main` and uses the binlog
  client directly.
- The continuous-replication tests run a real binlog feed and then cancel,
  draining on shutdown. On a clean MySQL these are fast; on a server with a
  large binlog backlog the final-flush catch-up can burn its timeout budget
  (the same shutdown-timing characteristic as the existing `TestSyncE2E`),
  making them slow but green.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/datasync/... ./cmd/spirit/...`
- [x] `go test ./pkg/datasync/...` (MySQL on :13306)
- [x] `golangci-lint run ./pkg/datasync/... ./cmd/spirit/...`