### PR TITLE
datasync: add --copy-only mode to sync

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -64,6 +64,7 @@ source privileges depend on the change feed:
 - [threads](#threads)
 - [write-threads](#write-threads)
 - [flush-interval](#flush-interval)
+- [copy-only](#copy-only)
 - [force](#force)
 - [gtid](#gtid)
 
@@ -113,6 +114,18 @@ How many concurrent write threads to use on the target.
 
 How often buffered changes are applied to the target during continuous sync —
 the replication-latency vs. batching trade-off.
+
+### copy-only
+
+- Type: Boolean
+- Default value: `false`
+
+Run only the initial copy and then exit — no change capture, no continuous
+replication. Use it for a one-shot snapshot, or when the source cannot provide
+a change feed (e.g. a managed Vitess without binlog/VStream access, or a
+replica lacking the `REPLICATION` privileges the binlog client needs). A
+checkpoint is still written, so a re-run resumes the copy (or no-ops if it had
+already completed) rather than starting over.
 
 ### force
 

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -234,7 +234,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// — and finishes immediately if the copy had already completed. The applier
 	// copies with INSERT IGNORE, so re-copying the chunks straddling the
 	// watermark is idempotent.
-	if !r.resuming {
+	if !r.sync.CopyOnly && !r.resuming {
 		// Watermark optimization ON during a fresh continuous copy: change
 		// events for keys the copier has not reached yet (above the watermark)
 		// are discarded, because the copier will copy those rows directly.
@@ -260,15 +260,29 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err := r.copier.Run(ctx); err != nil {
 		return fmt.Errorf("copy failed: %w", err)
 	}
-	if !r.resuming {
-		if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
-			return err
+	if !r.sync.CopyOnly {
+		if !r.resuming {
+			if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+				return err
+			}
+		}
+		// Drain the copy-phase backlog so every change observed so far is
+		// applied before steady-state streaming.
+		if err := r.replClient.Flush(ctx); err != nil {
+			return fmt.Errorf("failed to flush after copy: %w", err)
 		}
 	}
-	// Drain the copy-phase backlog so every change observed so far is
-	// applied before steady-state streaming.
-	if err := r.replClient.Flush(ctx); err != nil {
-		return fmt.Errorf("failed to flush after copy: %w", err)
+
+	// Copy-only ends here: the snapshot is on the target and there is no change
+	// capture to continue. A final checkpoint records the copier's completed
+	// watermark so a re-run resumes to a no-op instead of re-copying.
+	if r.sync.CopyOnly {
+		if err := r.dumpCheckpoint(ctx); err != nil {
+			r.logger.Warn("final checkpoint write failed", "error", err)
+		}
+		r.logger.Info("Copy-only sync complete: data copied to target; replication disabled, exiting",
+			"total_time", time.Since(r.startTime).Round(time.Second))
+		return nil
 	}
 
 	r.logger.Info("Copy complete; entering continuous sync")
@@ -349,22 +363,25 @@ func (r *Runner) setup(ctx context.Context) error {
 		return err
 	}
 
-	// Wire the change source: injected (e.g. VStream), or a built-in MySQL
-	// binlog client constructed from the source DSN. Sync replicates a whole
-	// schema, so the DDL filter is by schema only.
-	if r.sync.Source != nil {
-		r.setReplClient(r.sync.Source)
-	} else {
-		replConfig := change.NewClientDefaultConfig()
-		replConfig.Logger = r.logger
-		replConfig.CancelFunc = r.fatalError
-		replConfig.DDLFilterSchema = r.source.config.DBName
-		replConfig.DBConfig = r.sourceDBConfig
-		if r.sync.GTID {
-			r.logger.Info("EXPERIMENTAL: using GTID-based change source")
-			r.setReplClient(change.NewGTIDClient(r.source.db, r.source.config.Addr, r.source.config.User, r.source.config.Passwd, r.applier, replConfig))
+	// Wire the change source (continuous mode only): injected (e.g. VStream),
+	// or a built-in MySQL binlog client constructed from the source DSN. Sync
+	// replicates a whole schema, so the DDL filter is by schema only. Copy-only
+	// sync constructs no change source.
+	if !r.sync.CopyOnly {
+		if r.sync.Source != nil {
+			r.setReplClient(r.sync.Source)
 		} else {
-			r.setReplClient(change.NewBinlogClient(r.source.db, r.source.config.Addr, r.source.config.User, r.source.config.Passwd, r.applier, replConfig))
+			replConfig := change.NewClientDefaultConfig()
+			replConfig.Logger = r.logger
+			replConfig.CancelFunc = r.fatalError
+			replConfig.DDLFilterSchema = r.source.config.DBName
+			replConfig.DBConfig = r.sourceDBConfig
+			if r.sync.GTID {
+				r.logger.Info("EXPERIMENTAL: using GTID-based change source")
+				r.setReplClient(change.NewGTIDClient(r.source.db, r.source.config.Addr, r.source.config.User, r.source.config.Passwd, r.applier, replConfig))
+			} else {
+				r.setReplClient(change.NewBinlogClient(r.source.db, r.source.config.Addr, r.source.config.User, r.source.config.Passwd, r.applier, replConfig))
+			}
 		}
 	}
 
@@ -621,8 +638,10 @@ func (r *Runner) buildChunkers() ([]table.Chunker, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := r.replClient.AddSubscription(tbl, nil, cc); err != nil {
-			return nil, err
+		if !r.sync.CopyOnly {
+			if err := r.replClient.AddSubscription(tbl, nil, cc); err != nil {
+				return nil, err
+			}
 		}
 		chunkers = append(chunkers, cc)
 	}
@@ -670,8 +689,11 @@ func (r *Runner) startFresh(ctx context.Context) error {
 	if err := r.copyChunker.Open(); err != nil {
 		return err
 	}
-	if err := r.replClient.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start change source: %w", err)
+	// Copy-only sync has no change feed to start.
+	if !r.sync.CopyOnly {
+		if err := r.replClient.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start change source: %w", err)
+		}
 	}
 	return r.createCheckpointTable(ctx)
 }
@@ -703,17 +725,19 @@ func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
 			return err
 		}
 	}
-	if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
-		return err
-	}
-	if pos != "" {
-		if err := r.replClient.StartFromPosition(ctx, pos); err != nil {
-			return fmt.Errorf("failed to resume change source from position %q: %w", pos, err)
+	if !r.sync.CopyOnly {
+		if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+			return err
 		}
-	} else if err := r.replClient.Start(ctx); err != nil {
-		// No saved position (prior attempt failed before checkpointing):
-		// start the feed fresh; changes apply with the optimization off.
-		return fmt.Errorf("failed to start change source: %w", err)
+		if pos != "" {
+			if err := r.replClient.StartFromPosition(ctx, pos); err != nil {
+				return fmt.Errorf("failed to resume change source from position %q: %w", pos, err)
+			}
+		} else if err := r.replClient.Start(ctx); err != nil {
+			// No saved position (prior attempt failed before checkpointing):
+			// start the feed fresh; changes apply with the optimization off.
+			return fmt.Errorf("failed to start change source: %w", err)
+		}
 	}
 	return r.createCheckpointTable(ctx)
 }
@@ -822,7 +846,10 @@ func (r *Runner) dumpCheckpointLoop(ctx context.Context, done chan struct{}) {
 // periodic checkpoint loop. The checkpoint loop runs for the whole run (copy
 // and continuous), so a restart at any point resumes from the last checkpoint.
 func (r *Runner) startBackgroundRoutines(ctx context.Context) {
-	r.replClient.StartPeriodicFlush(ctx, r.sync.FlushInterval)
+	// Copy-only sync has no change feed, so no periodic flush.
+	if !r.sync.CopyOnly {
+		r.replClient.StartPeriodicFlush(ctx, r.sync.FlushInterval)
+	}
 	r.watchDone = make(chan struct{})
 	go r.watchStatus(ctx)
 	r.checkpointDone = make(chan struct{})

--- a/pkg/datasync/sync.go
+++ b/pkg/datasync/sync.go
@@ -50,6 +50,16 @@ type Sync struct {
 	// batching trade-off. Defaults to change.DefaultFlushInterval.
 	FlushInterval time.Duration `name:"flush-interval" help:"How often to flush buffered changes to the target during continuous sync." default:"30s"`
 
+	// CopyOnly performs only the initial copy and then returns — no change
+	// capture and no continuous replication, so no change.Source is
+	// constructed or required. Useful for a one-shot snapshot, or when the
+	// source cannot provide a change feed (e.g. a managed Vitess without
+	// binlog/VStream access, or a replica lacking the REPLICATION privileges
+	// the built-in binlog client needs). A final checkpoint is still written,
+	// so a later run resumes the copy from there (or no-ops if it had already
+	// completed) rather than starting over.
+	CopyOnly bool `name:"copy-only" help:"Only run the initial copy, then exit (no continuous change capture)." default:"false"`
+
 	// Force, when set, makes the runner drop and recreate the target database
 	// at startup *unless* a resumable checkpoint exists — i.e. it only nukes
 	// the target when the copy could not have resumed anyway. A resumable

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -188,6 +188,54 @@ func TestSyncInitialCopy(t *testing.T) {
 	require.Equal(t, "two", v)
 }
 
+// TestSyncCopyOnly verifies CopyOnly mode: the initial copy runs and Run
+// returns on its own — no change source is constructed (so no REPLICATION/
+// RELOAD privileges or change feed are required), no continuous phase, and no
+// cancellation is needed. A checkpoint is still written so a re-run resumes.
+func TestSyncCopyOnly(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_copyonly_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_copyonly_dest"
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_copyonly_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_copyonly_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_copyonly_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_copyonly_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_copyonly_dest`)
+
+	s := &Sync{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+		WriteThreads:    2,
+		CopyOnly:        true,
+	}
+	runner, err := NewRunner(s)
+	require.NoError(t, err)
+
+	// CopyOnly Run returns on its own once the copy completes (no cancel).
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	require.NoError(t, runner.Run(ctx))
+	require.NoError(t, runner.Close())
+
+	tgt, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt)
+	var n int
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM t1").Scan(&n))
+	require.Equal(t, 3, n)
+	var v string
+	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT val FROM t1 WHERE id = 2").Scan(&v))
+	require.Equal(t, "two", v)
+}
+
 // TestRunnerStatusTask exercises the status.Task surface (Progress, Status,
 // DumpCheckpoint, Cancel) concurrently with Run, validating both the values
 // reported and the locking around the progress fields (run with -race).


### PR DESCRIPTION
This adds a  `--copy-only` flag to the `sync` subcommand.

Practically, I don't think it has much use, but since we are building this and trying to sync from Vitess v22 which doesn't yet support binlog dump GTIDs, we need to have a temporary bridge so we can do some testing.

We can remove this at a later point before `sync` is declared stable.