### PR TITLE
lint: downgrade type_pedantic inferred-FK default to warning

### DIFF
--- a/pkg/lint/lint_type_pedantic.go
+++ b/pkg/lint/lint_type_pedantic.go
@@ -43,7 +43,7 @@ func (l *TypePedanticLinter) DefaultConfig() map[string]string {
 		"checkInferredFK":  "true",
 		"requireIndexed":   "true",
 		"ignoreColumns":    "id",
-		"fkSeverity":       "error",
+		"fkSeverity":       "warning",
 		"sameNameSeverity": "warning",
 	}
 }
@@ -57,7 +57,7 @@ func (l *TypePedanticLinter) setDefaults() {
 	l.checkInferredFK = true
 	l.requireIndexed = true
 	l.ignoreColumns = map[string]struct{}{"id": {}}
-	l.fkSeverity = SeverityError
+	l.fkSeverity = SeverityWarning
 	l.sameNameSeverity = SeverityWarning
 }
 

--- a/pkg/lint/lint_type_pedantic_test.go
+++ b/pkg/lint/lint_type_pedantic_test.go
@@ -122,7 +122,7 @@ func TestTypePedantic_InferredFK_Mismatch(t *testing.T) {
 	violations := filterRule(newTypePedantic(t).Lint(tables, nil), "inferred_fk")
 	require.Len(t, violations, 1)
 	v := violations[0]
-	require.Equal(t, SeverityError, v.Severity)
+	require.Equal(t, SeverityWarning, v.Severity)
 	require.Equal(t, "orders", v.Location.Table)
 	require.Equal(t, "customer_id", *v.Location.Column)
 	require.Contains(t, v.Message, "customers")
@@ -193,6 +193,8 @@ func TestTypePedantic_InferredFK_DisabledViaConfig(t *testing.T) {
 }
 
 func TestTypePedantic_InferredFK_ConfigurableSeverity(t *testing.T) {
+	// Default is warning (heuristic can false-positive on generic names like
+	// client_id); users who want strict gating can opt back into error.
 	tables := parseTables(t,
 		`CREATE TABLE customers (id BIGINT UNSIGNED PRIMARY KEY)`,
 		`CREATE TABLE orders (id BIGINT UNSIGNED PRIMARY KEY, customer_id INT NOT NULL)`,
@@ -202,12 +204,12 @@ func TestTypePedantic_InferredFK_ConfigurableSeverity(t *testing.T) {
 		"checkSameName":    "true",
 		"checkInferredFK":  "true",
 		"ignoreColumns":    "id",
-		"fkSeverity":       "warning",
+		"fkSeverity":       "error",
 		"sameNameSeverity": "warning",
 	}))
 	violations := filterRule(l.Lint(tables, nil), "inferred_fk")
 	require.Len(t, violations, 1)
-	require.Equal(t, SeverityWarning, violations[0].Severity)
+	require.Equal(t, SeverityError, violations[0].Severity)
 }
 
 func TestTypePedantic_InferredFK_FromChanges(t *testing.T) {


### PR DESCRIPTION
## Summary

- Change `type_pedantic`'s `fkSeverity` default from `error` to `warning`.
- The inferred-FK rule still fires; only its default severity changes.
- Existing config-driven escape hatch (`fkSeverity: error`) is preserved for projects that want the strict behavior.

Closes #903.

## Motivation

The inferred-FK rule uses a naming heuristic: a column like `customer_id` is assumed to reference `customers.id`. The heuristic has no way to verify the relationship is real, and internal usage has surfaced false positives on generic names like `client_id`, where a same-named table happens to exist for unrelated reasons. Failing CI on a heuristic match is too strong by default. Warning still surfaces the signal without blocking.

The `same_name` rule is already a warning. This change makes the two rules' defaults consistent.

## Test plan

- [x] `go test ./pkg/lint/...` passes
- [x] `TestTypePedantic_InferredFK_Mismatch` updated to assert the new default (`SeverityWarning`)
- [x] `TestTypePedantic_InferredFK_ConfigurableSeverity` updated to exercise opt-in `fkSeverity: error` and assert `SeverityError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)