### PR TITLE
ci: run version-agnostic tests once in a single-version suite (8.0.45)

### DIFF
--- a/.github/workflows/mysql8.0.45-recovery-docker.yml
+++ b/.github/workflows/mysql8.0.45-recovery-docker.yml
@@ -1,0 +1,36 @@
+name: MySQL 8.0.45 recovery suite /w docker-compose
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect non-docs changes
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+
+      # Runs the version-agnostic recovery / resume-from-checkpoint suite
+      # (pkg/migration/resume_test.go, behind `//go:build recovery`) once,
+      # against the base 8.0.45 image. The other version-matrix jobs omit the
+      # `recovery` build tag and therefore skip this suite. See the recovery-test
+      # service in compose/compose.yml and the header of resume_test.go.
+      - name: Recovery suite
+        if: steps.filter.outputs.code == 'true'
+        run: docker compose -f compose.yml up mysql recovery-test --abort-on-container-exit --exit-code-from recovery-test
+        working-directory: compose
+
+      - name: Skip — documentation-only change
+        if: steps.filter.outputs.code != 'true'
+        run: echo "Documentation-only change detected; skipping tests."

--- a/.github/workflows/mysql8.0.45-recovery-docker.yml
+++ b/.github/workflows/mysql8.0.45-recovery-docker.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mysql8.0.45-singleversion-docker.yml
+++ b/.github/workflows/mysql8.0.45-singleversion-docker.yml
@@ -1,4 +1,4 @@
-name: MySQL 8.0.45 recovery suite /w docker-compose
+name: MySQL 8.0.45 single-version suite /w docker-compose
 on:
   push:
     branches: [ main ]
@@ -23,14 +23,15 @@ jobs:
               - '!**/*.md'
               - '!docs/**'
 
-      # Runs the version-agnostic recovery / resume-from-checkpoint suite
-      # (pkg/migration/resume_test.go, behind `//go:build recovery`) once,
-      # against the base 8.0.45 image. The other version-matrix jobs omit the
-      # `recovery` build tag and therefore skip this suite. See the recovery-test
-      # service in compose/compose.yml and the header of resume_test.go.
-      - name: Recovery suite
+      # Runs the version-agnostic "single-version" suite
+      # (pkg/migration/{resume,singleversion,lint}_test.go, behind
+      # `//go:build singleversion`) once, against the base 8.0.45 image. The
+      # other version-matrix jobs omit the `singleversion` build tag and so skip
+      # these files. See the singleversion-test service in compose/compose.yml
+      # and the header of singleversion_test.go.
+      - name: Single-version suite
         if: steps.filter.outputs.code == 'true'
-        run: docker compose -f compose.yml up mysql recovery-test --abort-on-container-exit --exit-code-from recovery-test
+        run: docker compose -f compose.yml up mysql singleversion-test --abort-on-container-exit --exit-code-from singleversion-test
         working-directory: compose
 
       - name: Skip — documentation-only change

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -35,17 +35,18 @@ services:
     environment:
       MYSQL_DSN: tsandbox:msandbox@tcp(mysql)/test
 
-  # Dedicated runner for the version-agnostic recovery / resume-from-checkpoint
-  # suite (pkg/migration/resume_test.go, behind `//go:build recovery`). It is
-  # gated to this one service so it isn't re-run against every MySQL version in
-  # the matrix — the recovery logic is Spirit's own and doesn't vary by server
-  # version. Invoked by .github/workflows/mysql8.0.45-recovery-docker.yml against
-  # the base 8.0.45 image (GTID enabled above, for the GTID resume tests).
-  # The -run filter restricts the run to the recovery tests; see resume_test.go.
-  recovery-test:
+  # Dedicated runner for the version-agnostic "single-version" suite
+  # (pkg/migration/{resume,singleversion,lint}_test.go, behind
+  # `//go:build singleversion`). It is gated to this one service so it isn't
+  # re-run against every MySQL version in the matrix — these tests exercise
+  # Spirit's own logic and don't vary by server version. Invoked by
+  # .github/workflows/mysql8.0.45-singleversion-docker.yml against the base
+  # 8.0.45 image (GTID enabled above, for the GTID resume tests). The -run filter
+  # restricts the run to the suite's tests; see singleversion_test.go.
+  singleversion-test:
     build:
       context: ../
-    command: bash -c "go test -json -race -v -tags recovery -run 'Resume|Checkpoint' -timeout=10m -parallel=4 ./pkg/migration/... | tee /proc/1/fd/1 | tparse -all"
+    command: bash -c "go test -json -race -v -tags singleversion -run 'Resume|Checkpoint|UniqueOnNonUniqueData|ChunkerPrefetching|Unparsable|Lint' -timeout=10m -parallel=4 ./pkg/migration/... | tee /proc/1/fd/1 | tparse -all"
     depends_on:
       mysql:
         condition: service_healthy

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -35,6 +35,23 @@ services:
     environment:
       MYSQL_DSN: tsandbox:msandbox@tcp(mysql)/test
 
+  # Dedicated runner for the version-agnostic recovery / resume-from-checkpoint
+  # suite (pkg/migration/resume_test.go, behind `//go:build recovery`). It is
+  # gated to this one service so it isn't re-run against every MySQL version in
+  # the matrix — the recovery logic is Spirit's own and doesn't vary by server
+  # version. Invoked by .github/workflows/mysql8.0.45-recovery-docker.yml against
+  # the base 8.0.45 image (GTID enabled above, for the GTID resume tests).
+  # The -run filter restricts the run to the recovery tests; see resume_test.go.
+  recovery-test:
+    build:
+      context: ../
+    command: bash -c "go test -json -race -v -tags recovery -run 'Resume|Checkpoint' -timeout=10m -parallel=4 ./pkg/migration/... | tee /proc/1/fd/1 | tparse -all"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      MYSQL_DSN: tsandbox:msandbox@tcp(mysql)/test
+
   buildandrun:
     build:
       context: ../

--- a/pkg/migration/e2e_test.go
+++ b/pkg/migration/e2e_test.go
@@ -311,33 +311,6 @@ func TestVarcharE2E(t *testing.T) {
 	require.NoError(t, m.Close())
 }
 
-// TestChunkerPrefetching tests that the chunker handles large ID gaps correctly.
-func TestChunkerPrefetching(t *testing.T) {
-	t.Parallel()
-	testutils.NewTestTable(t, "prefetchtest", `CREATE TABLE prefetchtest (
-		id BIGINT NOT NULL AUTO_INCREMENT,
-		created_at DATETIME(3) NULL,
-		PRIMARY KEY (id)
-	)`)
-	// Insert about 11K rows, then add large ID gaps to test prefetching.
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) VALUES (NULL)`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b JOIN prefetchtest c`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b JOIN prefetchtest c`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b JOIN prefetchtest c`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b LIMIT 10000`)
-
-	// Insert far-off IDs to create large gaps that test the prefetcher.
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (id, created_at) VALUES (300000000000, NULL)`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b LIMIT 300000`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (id, created_at) VALUES (600000000000, NULL)`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b LIMIT 300000`)
-	testutils.RunSQL(t, `INSERT INTO prefetchtest (id, created_at) VALUES (900000000000, NULL)`)
-
-	m := NewTestRunner(t, "prefetchtest", "engine=innodb")
-	require.NoError(t, m.Run(t.Context()))
-	require.NoError(t, m.Close())
-}
-
 // TestPreRunChecksE2E tests that pre-run checks execute correctly during migration setup.
 func TestPreRunChecksE2E(t *testing.T) {
 	t.Parallel()

--- a/pkg/migration/lint_test.go
+++ b/pkg/migration/lint_test.go
@@ -1,3 +1,9 @@
+//go:build singleversion
+
+// The linters test Spirit's own statement analysis, which is independent of the
+// MySQL server version — so they're part of the version-agnostic "single-version"
+// suite (build tag `singleversion`); see singleversion_test.go. A plain
+// `go test ./...` (no tag) skips this file.
 package migration
 
 import (

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -130,22 +130,6 @@ func TestRenameInMySQL80(t *testing.T) {
 	require.NoError(t, m.Run())
 }
 
-// TestUniqueOnNonUniqueData tests that we:
-// 1. Fail trying to add a unique index on non-unique data.
-// 2. The error does not blame spirit, but is instead suggestive of user-data error.
-func TestUniqueOnNonUniqueData(t *testing.T) {
-	t.Parallel()
-	tt := testutils.NewTestTable(t, "uniquet1", `CREATE TABLE uniquet1 (id int not null primary key auto_increment, b int not null, pad1 varbinary(1024))`)
-	tt.SeedRows(t, "INSERT INTO uniquet1 (b, pad1) SELECT 1, RANDOM_BYTES(1024)", 100000)
-	testutils.RunSQL(t, `UPDATE uniquet1 SET b = id`)
-	testutils.RunSQL(t, `UPDATE uniquet1 SET b = 12345 ORDER BY RAND() LIMIT 2`)
-
-	m := NewTestMigration(t, WithTable("uniquet1"), WithAlter("ADD UNIQUE (b)"))
-	err := m.Run()
-	require.Error(t, err)
-	require.ErrorContains(t, err, "checksum failed after several attempts. This is likely related to your statement adding a UNIQUE index on non-unique data")
-}
-
 func TestGeneratedColumns(t *testing.T) {
 	t.Parallel()
 	t.Run("unbuffered", func(t *testing.T) {
@@ -293,43 +277,6 @@ func TestStmtWorkflow(t *testing.T) {
 	require.NoError(t, m.Run())
 	// cleanup
 	testutils.RunSQL(t, `DROP TABLE IF EXISTS t1s`)
-}
-
-// TestUnparsableStatements tests that the behavior is expected in cases
-// where we know the TiDB parser does not support the statement. We document
-// that we require the TiDB parser to parse the statement for it to execute,
-// which feels like a reasonable limitation based on its capabilities.
-// Example TiDB bug: https://github.com/pingcap/tidb/issues/54700
-func TestUnparsableStatements(t *testing.T) {
-	t.Parallel()
-	// CREATE TABLE with BLOB DEFAULT — TiDB parser doesn't support this but MySQL does.
-	m := NewTestMigration(t, WithStatement(`CREATE TABLE t1parse (id int not null primary key auto_increment, b BLOB DEFAULT ('abc'))`))
-	require.NoError(t, m.Run())
-
-	// ALTER TABLE with BLOB DEFAULT via --statement — fails because TiDB parser rejects it.
-	m = NewTestMigration(t, WithStatement("ALTER TABLE t1parse ADD COLUMN c BLOB DEFAULT ('abc')"))
-	err := m.Run()
-	require.Error(t, err)
-	require.ErrorContains(t, err, "can't have a default value")
-
-	// ALTER TABLE with BLOB DEFAULT via --table/--alter — works (bypasses parser limitation).
-	m = NewTestMigration(t, WithTable("t1parse"),
-		WithAlter("ADD COLUMN c BLOB DEFAULT ('abc')"))
-	require.NoError(t, m.Run())
-
-	// CREATE TRIGGER — not supported.
-	m = NewTestMigration(t, WithStatement("CREATE TRIGGER ins_sum BEFORE INSERT ON t1parse FOR EACH ROW SET @sum = @sum + NEW.b;"))
-	err = m.Run()
-	require.Error(t, err)
-	require.ErrorContains(t, err, "line 1 column 14 near \"TRIGGER")
-
-	// https://github.com/pingcap/tidb/pull/61498
-	m = NewTestMigration(t, WithTable("t1parse"),
-		WithAlter(`ADD COLUMN src_col timestamp NULL DEFAULT NULL, add column new_col timestamp NULL DEFAULT(src_col)`))
-	require.NoError(t, m.Run())
-
-	// Cleanup
-	testutils.RunSQL(t, `DROP TABLE IF EXISTS t1parse`)
 }
 
 func TestCreateIndexIsRewritten(t *testing.T) {

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -1,3 +1,23 @@
+//go:build recovery
+
+// This file holds the recovery / resume-from-checkpoint suite. It exercises
+// Spirit's own checkpoint-and-resume logic, which is independent of the MySQL
+// server version — so there is no value in re-running it against every MySQL
+// version in CI. It is gated behind the `recovery` build tag and run in one
+// dedicated CI job against MySQL 8.0.45 (GTID enabled, for the GTID resume
+// tests) — see .github/workflows/mysql8.0.45-recovery-docker.yml and the
+// `recovery-test` service in compose/compose.yml. Every other version job runs
+// without the tag and so excludes this file.
+//
+// The dedicated job selects these tests with `-run 'Resume|Checkpoint'`, so new
+// recovery tests added here should keep "Resume" or "Checkpoint" in their name
+// to be picked up.
+//
+// To run it locally:
+//
+//	go test -tags recovery -run 'Resume|Checkpoint' ./pkg/migration/...
+//
+// A plain `go test ./...` (no tag) skips this file.
 package migration
 
 import (

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -1,23 +1,9 @@
-//go:build recovery
+//go:build singleversion
 
-// This file holds the recovery / resume-from-checkpoint suite. It exercises
-// Spirit's own checkpoint-and-resume logic, which is independent of the MySQL
-// server version — so there is no value in re-running it against every MySQL
-// version in CI. It is gated behind the `recovery` build tag and run in one
-// dedicated CI job against MySQL 8.0.45 (GTID enabled, for the GTID resume
-// tests) — see .github/workflows/mysql8.0.45-recovery-docker.yml and the
-// `recovery-test` service in compose/compose.yml. Every other version job runs
-// without the tag and so excludes this file.
-//
-// The dedicated job selects these tests with `-run 'Resume|Checkpoint'`, so new
-// recovery tests added here should keep "Resume" or "Checkpoint" in their name
-// to be picked up.
-//
-// To run it locally:
-//
-//	go test -tags recovery -run 'Resume|Checkpoint' ./pkg/migration/...
-//
-// A plain `go test ./...` (no tag) skips this file.
+// This file holds the recovery / resume-from-checkpoint tests. They are part of
+// the version-agnostic "single-version" suite (build tag `singleversion`); see
+// singleversion_test.go for the suite's rationale, the dedicated CI job, and the
+// `-run` selection. A plain `go test ./...` (no tag) skips this file.
 package migration
 
 import (

--- a/pkg/migration/singleversion_test.go
+++ b/pkg/migration/singleversion_test.go
@@ -1,0 +1,110 @@
+//go:build singleversion
+
+// This file (together with resume_test.go and lint_test.go) makes up the
+// "single-version" test suite: tests that exercise Spirit's own logic and do
+// not depend on the MySQL server version, so there is no value in re-running
+// them against every MySQL version in the CI matrix. They are gated behind the
+// `singleversion` build tag and run in one dedicated CI job against MySQL 8.0.45
+// (GTID enabled, for the GTID resume tests in resume_test.go) — see
+// .github/workflows/mysql8.0.45-singleversion-docker.yml and the
+// `singleversion-test` service in compose/compose.yml. Every other version job
+// runs without the tag and therefore excludes these files.
+//
+// The dedicated job selects the suite with
+// `-run 'Resume|Checkpoint|UniqueOnNonUniqueData|ChunkerPrefetching|Unparsable|Lint'`,
+// so a new single-version test must either match that pattern by name or be
+// added to it.
+//
+// To run the suite locally:
+//
+//	go test -tags singleversion -run 'Resume|Checkpoint|UniqueOnNonUniqueData|ChunkerPrefetching|Unparsable|Lint' ./pkg/migration/...
+//
+// A plain `go test ./...` (no tag) skips these files.
+package migration
+
+import (
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUniqueOnNonUniqueData tests that we:
+// 1. Fail trying to add a unique index on non-unique data.
+// 2. The error does not blame spirit, but is instead suggestive of user-data error.
+func TestUniqueOnNonUniqueData(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "uniquet1", `CREATE TABLE uniquet1 (id int not null primary key auto_increment, b int not null, pad1 varbinary(1024))`)
+	tt.SeedRows(t, "INSERT INTO uniquet1 (b, pad1) SELECT 1, RANDOM_BYTES(1024)", 100000)
+	testutils.RunSQL(t, `UPDATE uniquet1 SET b = id`)
+	testutils.RunSQL(t, `UPDATE uniquet1 SET b = 12345 ORDER BY RAND() LIMIT 2`)
+
+	m := NewTestMigration(t, WithTable("uniquet1"), WithAlter("ADD UNIQUE (b)"))
+	err := m.Run()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "checksum failed after several attempts. This is likely related to your statement adding a UNIQUE index on non-unique data")
+}
+
+// TestUnparsableStatements tests that the behavior is expected in cases
+// where we know the TiDB parser does not support the statement. We document
+// that we require the TiDB parser to parse the statement for it to execute,
+// which feels like a reasonable limitation based on its capabilities.
+// Example TiDB bug: https://github.com/pingcap/tidb/issues/54700
+func TestUnparsableStatements(t *testing.T) {
+	t.Parallel()
+	// CREATE TABLE with BLOB DEFAULT — TiDB parser doesn't support this but MySQL does.
+	m := NewTestMigration(t, WithStatement(`CREATE TABLE t1parse (id int not null primary key auto_increment, b BLOB DEFAULT ('abc'))`))
+	require.NoError(t, m.Run())
+
+	// ALTER TABLE with BLOB DEFAULT via --statement — fails because TiDB parser rejects it.
+	m = NewTestMigration(t, WithStatement("ALTER TABLE t1parse ADD COLUMN c BLOB DEFAULT ('abc')"))
+	err := m.Run()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "can't have a default value")
+
+	// ALTER TABLE with BLOB DEFAULT via --table/--alter — works (bypasses parser limitation).
+	m = NewTestMigration(t, WithTable("t1parse"),
+		WithAlter("ADD COLUMN c BLOB DEFAULT ('abc')"))
+	require.NoError(t, m.Run())
+
+	// CREATE TRIGGER — not supported.
+	m = NewTestMigration(t, WithStatement("CREATE TRIGGER ins_sum BEFORE INSERT ON t1parse FOR EACH ROW SET @sum = @sum + NEW.b;"))
+	err = m.Run()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "line 1 column 14 near \"TRIGGER")
+
+	// https://github.com/pingcap/tidb/pull/61498
+	m = NewTestMigration(t, WithTable("t1parse"),
+		WithAlter(`ADD COLUMN src_col timestamp NULL DEFAULT NULL, add column new_col timestamp NULL DEFAULT(src_col)`))
+	require.NoError(t, m.Run())
+
+	// Cleanup
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS t1parse`)
+}
+
+// TestChunkerPrefetching tests that the chunker handles large ID gaps correctly.
+func TestChunkerPrefetching(t *testing.T) {
+	t.Parallel()
+	testutils.NewTestTable(t, "prefetchtest", `CREATE TABLE prefetchtest (
+		id BIGINT NOT NULL AUTO_INCREMENT,
+		created_at DATETIME(3) NULL,
+		PRIMARY KEY (id)
+	)`)
+	// Insert about 11K rows, then add large ID gaps to test prefetching.
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) VALUES (NULL)`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b JOIN prefetchtest c`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b JOIN prefetchtest c`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b JOIN prefetchtest c`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b LIMIT 10000`)
+
+	// Insert far-off IDs to create large gaps that test the prefetcher.
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (id, created_at) VALUES (300000000000, NULL)`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b LIMIT 300000`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (id, created_at) VALUES (600000000000, NULL)`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (created_at) SELECT NULL FROM prefetchtest a JOIN prefetchtest b LIMIT 300000`)
+	testutils.RunSQL(t, `INSERT INTO prefetchtest (id, created_at) VALUES (900000000000, NULL)`)
+
+	m := NewTestRunner(t, "prefetchtest", "engine=innodb")
+	require.NoError(t, m.Run(t.Context()))
+	require.NoError(t, m.Close())
+}


### PR DESCRIPTION
## What

Introduces a **`singleversion` build tag** for tests that exercise Spirit's own logic and don't depend on the MySQL server version. They run in **one** dedicated CI job (MySQL 8.0.45) instead of being re-run against every version in the matrix.

Gated files (behind `//go:build singleversion`):
- `resume_test.go` — recovery / resume-from-checkpoint
- `lint_test.go` — linter logic
- `singleversion_test.go` (new) — `TestUniqueOnNonUniqueData`, `TestChunkerPrefetching`, `TestUnparsableStatements` (moved here from `migration_test.go` / `e2e_test.go`, since build tags gate per file)

Wiring:
- `compose/compose.yml`: `singleversion-test` service runs `go test -tags singleversion -run 'Resume|Checkpoint|UniqueOnNonUniqueData|ChunkerPrefetching|Unparsable|Lint' ./pkg/migration/...` against the base 8.0.45 image (GTID enabled, for the GTID resume tests).
- `.github/workflows/mysql8.0.45-singleversion-docker.yml`: new workflow invoking it (with an explicit `permissions: contents: read`, per CodeQL).

## Why

These tests are version-agnostic — recovery/checkpoint, the chunker's gap handling, the TiDB statement parser, the linters. Re-running them across all ~6 version jobs is pure duplication. Every other version job omits the tag and skips these files, so **no coverage is lost** — the genuinely version-sensitive tests (enum/set/binary/charset conversions, PK widening, INSTANT/INPLACE detection, etc.) still run everywhere.

## Verification (local)

- Compiles both with and without `-tags singleversion` (`go vet`); no duplicate definitions, no orphaned imports after the moves.
- Without the tag, the gated files are excluded (the `-run` pattern matches only 2 harmless pre-existing checkpoint-named tests); with the tag it selects the full suite.
- The moved tests and a no-tag version-sensitive test (`TestOnline`) pass.
- `docker compose config` and the workflow YAML validate; gofmt clean.

Draft so it can be exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)