### PR TITLE
test: shrink TestEnumDrop seed (relies on the throttler, not row count)

### DIFF
--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -346,9 +346,13 @@ func testEnumDrop(t *testing.T, enableBuffered, useGTID bool) {
 		status ENUM('active', 'inactive', 'pending', 'archived') NOT NULL
 	)`, tableName))
 	// Seed only with retained values; 'inactive' will be dropped and must
-	// not appear in any row when the checksum runs.
-	tt.SeedRows(t, fmt.Sprintf("INSERT INTO %s (status) SELECT 'active'", tableName), 3000)
-	tt.SeedRows(t, fmt.Sprintf("INSERT INTO %s (status) SELECT 'pending'", tableName), 3000)
+	// not appear in any row when the checksum runs. A few hundred rows is
+	// plenty: WithTestThrottler() paces the copy (1s per chunk), so the runtime
+	// is driven by the chunk count, not the row count — a larger seed just adds
+	// I/O without changing what's exercised. The concurrent DML below targets
+	// ids well within this range.
+	tt.SeedRows(t, fmt.Sprintf("INSERT INTO %s (status) SELECT 'active'", tableName), 200)
+	tt.SeedRows(t, fmt.Sprintf("INSERT INTO %s (status) SELECT 'pending'", tableName), 200)
 	_, err := tt.DB.ExecContext(t.Context(), fmt.Sprintf("INSERT INTO %s (status) VALUES ('archived')", tableName))
 	require.NoError(t, err)
 
@@ -382,7 +386,7 @@ func testEnumDrop(t *testing.T, enableBuffered, useGTID bool) {
 			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s (status) VALUES ('pending')`, tableName))
 			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s (status) VALUES ('archived')`, tableName))
 			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET status = 'pending' WHERE id = %d`, tableName, i))
-			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET status = 'archived' WHERE id = %d`, tableName, 3000+i))
+			_, _ = tt.DB.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET status = 'archived' WHERE id = %d`, tableName, 100+i))
 		}
 	}()
 


### PR DESCRIPTION
## What

`TestEnumDrop` seeded ~4k rows, but it runs with `WithTestThrottler()` — and `Mock.BlockWait` sleeps a fixed **1 second per chunk**. So the copy is paced by the throttler, not the row count; the large seed only added I/O without changing what's exercised. This reduces the seed to a few hundred rows and retargets the second concurrent `UPDATE` (`3000+i` → `100+i`) so it still lands within the seeded range.

## Effect

`TestEnumDrop` runs 4 matrix cells (`binlog/gtid × buffered/unbuffered`):

| | per cell | total |
|---|---|---|
| before | ~11.3s | **45.1s** |
| after | ~3.3s | **12.9s** |

No change to coverage — same enum-ordinal-decode-under-concurrent-DML path; the DML still updates real rows (ids 1–100 and 101–200, both within the ~256 seeded rows) and exercises all three retained values. Verified stable across repeated runs (`-count=3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)