### PR TITLE
use default threads when target is not aurora

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -34,7 +34,7 @@ type Migration struct {
 	Table                string        `name:"table" help:"Table" optional:""`
 	Alter                string        `name:"alter" help:"The alter statement to run on the table" optional:""`
 	Threads              int           `name:"threads" help:"Number of concurrent threads for copy and checksum tasks" optional:"" default:"4"`
-	WriteThreads         int           `name:"write-threads" help:"Number of concurrent apply (write) threads. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets 0 is an error" optional:"" default:"4"`
+	WriteThreads         int           `name:"write-threads" help:"Number of concurrent apply (write) threads. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" optional:"" default:"4"`
 	TargetChunkTime      time.Duration `name:"target-chunk-time" help:"The target copy time for each chunk" optional:"" default:"500ms"`
 	ReplicaDSN           string        `name:"replica-dsn" help:"DSN(s) for replica(s) used for lag checking. Multiple replicas can be comma-separated; Spirit throttles on the slowest." optional:""`
 	ReplicaMaxLag        time.Duration `name:"replica-max-lag" help:"The maximum lag allowed on the replica before the migration throttles." optional:"" default:"120s"`

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -493,11 +493,10 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 
 	// Resolve the number of apply (write) threads now that we have a
 	// connection. WriteThreads==0 means "auto-size": on Aurora it becomes the
-	// instance vCPU count; on non-Aurora it is an error (there is no reliable
-	// vCPU signal to size from — the CLI default of 4 keeps interactive users
-	// out of this path). Idempotent: a resolved (non-zero) value passes
-	// through unchanged if this runs again.
-	r.migration.WriteThreads, err = throttler.ResolveWriteThreads(ctx, r.db, r.migration.WriteThreads)
+	// instance vCPU count; on non-Aurora there is no reliable vCPU signal to
+	// size from, so it falls back to the default. Idempotent: a resolved
+	// (non-zero) value passes through unchanged if this runs again.
+	r.migration.WriteThreads, err = throttler.ResolveWriteThreads(ctx, r.db, r.migration.WriteThreads, r.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -14,7 +14,7 @@ type Move struct {
 	TargetDSN             string        `name:"target-dsn" help:"Where to copy the tables to." default:"spirit:spirit@tcp(127.0.0.1:3306)/dest"`
 	TargetChunkTime       time.Duration `name:"target-chunk-time" help:"How long each chunk should take to copy" default:"5s"`
 	Threads               int           `name:"threads" help:"How many chunks to copy in parallel" default:"2"`
-	WriteThreads          int           `name:"write-threads" help:"How many concurrent write threads to use per target. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets 0 is an error" default:"4"`
+	WriteThreads          int           `name:"write-threads" help:"How many concurrent write threads to use per target. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" default:"4"`
 	CreateSentinel        bool          `name:"create-sentinel" help:"Create a sentinel table on the source database to block after table copy" default:"false"`
 	DeferSecondaryIndexes bool          `name:"defer-secondary-indexes" help:"Create target tables without secondary indexes, add them before cutover" default:"false"`
 

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -404,10 +404,9 @@ func (r *Runner) setup(ctx context.Context) error {
 
 	// Resolve the number of apply (write) threads against the target now that
 	// it is connected. WriteThreads==0 means "auto-size": on Aurora it becomes
-	// the instance vCPU count; on non-Aurora it is an error (there is no
-	// reliable vCPU signal to size from — the CLI default of 4 keeps
-	// interactive users out of this path).
-	r.move.WriteThreads, err = throttler.ResolveWriteThreads(ctx, r.targets[0].DB, r.move.WriteThreads)
+	// the instance vCPU count; on non-Aurora there is no reliable vCPU signal
+	// to size from, so it falls back to the default.
+	r.move.WriteThreads, err = throttler.ResolveWriteThreads(ctx, r.targets[0].DB, r.move.WriteThreads, r.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/throttler/aurora_activethreads.go
+++ b/pkg/throttler/aurora_activethreads.go
@@ -54,6 +54,14 @@ const (
 	auroraVCPUsQuery = `SELECT @@innodb_purge_threads`
 )
 
+// DefaultWriteThreads is the fallback apply (write) thread count used when
+// auto-sizing is requested (write-threads=0) but the target offers no reliable
+// vCPU signal to size from — i.e. a non-Aurora server. It must match the
+// `default:"4"` kong tags on the WriteThreads CLI flags (see Migration and
+// Move), so that requesting auto-sizing on non-Aurora lands on the same value
+// as not requesting it at all.
+const DefaultWriteThreads = 4
+
 // auroraVCPUs reads the instance vCPU count from @@innodb_purge_threads, which
 // Aurora pins to the vCPU count (issue #831). It returns an error if the value
 // is non-positive. This is only meaningful on Aurora — callers should gate on
@@ -73,9 +81,9 @@ func auroraVCPUs(ctx context.Context, db *sql.DB) (int, error) {
 // against a target. A positive requested value is returned unchanged. Zero
 // means "auto-size": on Aurora it resolves to the instance vCPU count
 // (@@innodb_purge_threads); on non-Aurora there is no reliable vCPU signal to
-// size from, so it is an error — callers must pass an explicit positive value.
+// size from, so it falls back to DefaultWriteThreads (logging that it did so).
 // A negative value is rejected.
-func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int) (int, error) {
+func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int, logger *slog.Logger) (int, error) {
 	if requested < 0 {
 		return 0, fmt.Errorf("write threads must be non-negative, got %d", requested)
 	}
@@ -92,7 +100,12 @@ func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int) (int, e
 		return 0, err
 	}
 	if !isAurora {
-		return 0, errors.New("write threads cannot be auto-sized on a non-Aurora target: set write-threads to a positive value")
+		// No reliable vCPU signal off Aurora, so we can't honor auto-sizing.
+		// Rather than fail, fall back to the default the user would have got
+		// had they not asked to auto-size at all.
+		logger.Info("write-threads=0 requested auto-sizing, but the target is not Aurora (no reliable vCPU signal); using the default instead",
+			"write_threads", DefaultWriteThreads)
+		return DefaultWriteThreads, nil
 	}
 	return auroraVCPUs(ctx, db)
 }

--- a/pkg/throttler/aurora_activethreads_test.go
+++ b/pkg/throttler/aurora_activethreads_test.go
@@ -112,31 +112,33 @@ func TestCanReadActiveThreads_LocalMySQL(t *testing.T) {
 func TestResolveWriteThreads_PassThroughPositive(t *testing.T) {
 	// A positive value is returned unchanged without touching the DB, so a
 	// nil DB is safe here.
-	n, err := ResolveWriteThreads(t.Context(), nil, 8)
+	n, err := ResolveWriteThreads(t.Context(), nil, 8, discardLogger())
 	require.NoError(t, err)
 	require.Equal(t, 8, n)
 }
 
 func TestResolveWriteThreads_RejectsNegative(t *testing.T) {
-	_, err := ResolveWriteThreads(t.Context(), nil, -1)
+	_, err := ResolveWriteThreads(t.Context(), nil, -1, discardLogger())
 	require.ErrorContains(t, err, "non-negative")
 }
 
 func TestResolveWriteThreads_NilDBWhenAutoSizing(t *testing.T) {
 	// Auto-sizing (requested==0) must reject a nil DB rather than panic.
-	_, err := ResolveWriteThreads(t.Context(), nil, 0)
+	_, err := ResolveWriteThreads(t.Context(), nil, 0, discardLogger())
 	require.ErrorContains(t, err, "no database connection")
 }
 
-func TestResolveWriteThreads_NonAuroraErrors_LocalMySQL(t *testing.T) {
+func TestResolveWriteThreads_NonAuroraUsesDefault_LocalMySQL(t *testing.T) {
 	db, err := sql.Open("mysql", testutils.DSN())
 	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
 	// 0 means "auto-size". On a stock (non-Aurora) MySQL there is no reliable
-	// vCPU signal, so auto-sizing must fail rather than guess.
-	_, err = ResolveWriteThreads(t.Context(), db, 0)
-	require.ErrorContains(t, err, "non-Aurora")
+	// vCPU signal, so auto-sizing falls back to the default rather than guess
+	// or fail.
+	n, err := ResolveWriteThreads(t.Context(), db, 0, discardLogger())
+	require.NoError(t, err)
+	require.Equal(t, DefaultWriteThreads, n)
 }
 
 func TestAuroraVCPUs_LocalMySQL(t *testing.T) {


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Followup from https://github.com/block/spirit/pull/906

Changes the behavior when it is not an aurora target.