### PR TITLE
fix checksum blindness to binary(n) columns

### DIFF
--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -230,6 +230,48 @@ func TestCorruptChecksum(t *testing.T) {
 	require.ErrorContains(t, err, "checksum mismatch")
 }
 
+// TestCorruptBinaryChecksum tests that the checksum detects corruption in a
+// fixed-length BINARY(N) column. Previously the checksum cast binary columns
+// to binary(0), which truncates every value to zero bytes — so any two values
+// produced identical CRCs and the contents of BINARY(N) columns were
+// completely invisible to the checksum.
+func TestCorruptBinaryChecksum(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS chkpcorruptbin1, _chkpcorruptbin1_new, _chkpcorruptbin1_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE chkpcorruptbin1 (a INT NOT NULL, b BINARY(16) NOT NULL, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _chkpcorruptbin1_new (a INT NOT NULL, b BINARY(16) NOT NULL, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _chkpcorruptbin1_chkpnt (a INT)") // for binlog advancement
+	testutils.RunSQL(t, "INSERT INTO chkpcorruptbin1 VALUES (1, UNHEX('00112233445566778899AABBCCDDEEFF'))")
+	testutils.RunSQL(t, "INSERT INTO _chkpcorruptbin1_new SELECT * FROM chkpcorruptbin1")
+	// Corrupt the binary value on the target: same length, different contents.
+	testutils.RunSQL(t, "UPDATE _chkpcorruptbin1_new SET b = UNHEX('FFEEDDCCBBAA99887766554433221100') WHERE a = 1")
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "chkpcorruptbin1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_chkpcorruptbin1_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	checker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, NewCheckerDefaultConfig())
+	require.NoError(t, err)
+	singleChecker, ok := checker.(*SingleChecker)
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	err = singleChecker.runChecksum(t.Context())
+	require.ErrorContains(t, err, "checksum mismatch")
+}
+
 func TestBoundaryCases(t *testing.T) {
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS checkert1, _checkert1_new, _checkert1_chkpnt")
 	testutils.RunSQL(t, "CREATE TABLE checkert1 (a INT NOT NULL, b FLOAT, c VARCHAR(255), PRIMARY KEY (a))")

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -37,7 +37,17 @@ func castableTp(tp string) string {
 	case "tinyblob", "blob", "mediumblob", "longblob", "varbinary":
 		return "binary"
 	case "binary":
-		return "binary(0)" // weirdly only binary needs special handling; blob etc is fine.
+		// Fixed-length binary needs special handling; blob etc is fine.
+		// We must preserve the width (e.g. binary(16)) in the cast:
+		//  - A plain CAST(col AS binary) does not pad, so a binary(50)->binary(100)
+		//    widening migration would checksum-mismatch (the two sides zero-pad
+		//    to different lengths). Casting both sides to the target's full type
+		//    pads them to the same length, since the cast type always comes from
+		//    the target table (see ColumnMapping.ChecksumExprs).
+		//  - CAST(col AS binary(0)) must never be used: it truncates every value
+		//    to zero bytes, which would make the checksum blind to the column's
+		//    contents entirely.
+		return tp
 	case "float", "double": // required for MySQL 5.7
 		return "char"
 	case "json":

--- a/pkg/table/utils_test.go
+++ b/pkg/table/utils_test.go
@@ -51,8 +51,14 @@ func TestCastableTp(t *testing.T) {
 		{"mediumblob", "binary"},
 		{"longblob", "binary"},
 		{"varbinary", "binary"},
+		{"varbinary(255)", "binary"}, // variable-length: no padding, width not needed
 		{"char(100)", "char CHARACTER SET utf8mb4"},
-		{"binary(100)", "binary(0)"},
+		// binary(N) must preserve its width in the cast: binary(0) would
+		// truncate every value to zero bytes (checksum blindness), and a
+		// plain binary cast would not zero-pad, breaking widening migrations.
+		{"binary(100)", "binary(100)"},
+		{"binary(16)", "binary(16)"},
+		{"binary(1)", "binary(1)"},
 		{"datetime", "datetime"},
 		{"datetime(6)", "datetime"},
 		{"year", "char CHARACTER SET utf8mb4"},


### PR DESCRIPTION
## Problem

The checksum cast every fixed-length `BINARY(N)` column to `BINARY(0)`. In MySQL, `CAST(expr AS BINARY(0))` truncates to zero bytes, so any two values produce identical CRC32s:

```sql
SELECT CRC32(CONCAT(IFNULL(CAST('abc' AS binary(0)), ''), ISNULL('abc')));  -- 4108050209
SELECT CRC32(CONCAT(IFNULL(CAST('xyz' AS binary(0)), ''), ISNULL('xyz')));  -- 4108050209
```

The contents of `BINARY(N)` columns (e.g. `BINARY(16)` UUIDs) were therefore completely invisible to all three checksums (single, distributed, continuous) and to row-level difference inspection. Corruption in such a column would pass the checksum and ship at cutover.

The `binary(0)` mapping was introduced in 89c4f160 to make `binary(50) -> binary(100)` widening migrations checksum-clean (a plain `CAST AS BINARY` mismatches because the two sides zero-pad to different widths) — but it made that test pass by checksumming the empty string on both sides.

## Fix

Preserve the column width in the cast. Since the cast type always comes from the target table, both sides are cast to the target's full type (e.g. `binary(100)`), zero-padding them to the same length: genuinely-equal data still compares equal across widening, while differing data is detected. `varbinary`/blob (no padding) are unchanged.

## Testing

- New `TestCorruptBinaryChecksum`: corrupts a `BINARY(16)` value on the target and asserts the checksum reports a mismatch. Verified to FAIL against the unfixed code (checksum passed despite corruption).
- `TestCastableTp` cases for `binary(100)`, `binary(16)`, `binary(1)`, `varbinary`.
- The original 89c4f160 widening scenario (`TestBinaryChecksum`, all 10 type pairs, buffered + unbuffered) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)