### PR TITLE
treat column names case-insensitively in rename mapping

### DIFF
--- a/pkg/migration/check/rename.go
+++ b/pkg/migration/check/rename.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
@@ -26,15 +27,20 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 		return errors.New("not a valid alter table statement")
 	}
 
-	// Build set of primary key columns for quick lookup (if table info is available)
+	// Build set of primary key columns for quick lookup (if table info is available).
+	// MySQL column identifiers are case-insensitive, so all comparisons in this
+	// check are performed on lower-cased names (the ALTER may type a column with
+	// different case than it was declared with). The TiDB parser's Name.L is the
+	// pre-lowercased form of Name.O.
 	pkColumns := make(map[string]struct{})
 	if r.Table != nil {
 		for _, col := range r.Table.KeyColumns {
-			pkColumns[col] = struct{}{}
+			pkColumns[strings.ToLower(col)] = struct{}{}
 		}
 	}
 
 	// Collect all renames and added columns to check for dangerous overlaps.
+	// All names are lower-cased.
 	// renamedFrom maps old_name → new_name for all renames in this ALTER.
 	renamedFrom := make(map[string]string)
 	// renamedTo maps new_name → old_name (the reverse) for overlap detection.
@@ -50,12 +56,14 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 
 		if spec.Tp == ast.AlterTableRenameColumn {
 			if spec.OldColumnName != nil {
-				if _, isPK := pkColumns[spec.OldColumnName.Name.O]; isPK {
+				if _, isPK := pkColumns[spec.OldColumnName.Name.L]; isPK {
 					return fmt.Errorf("renaming primary key column %q is not supported", spec.OldColumnName.Name.O)
 				}
-				if spec.NewColumnName != nil && spec.OldColumnName.Name.O != spec.NewColumnName.Name.O {
-					renamedFrom[spec.OldColumnName.Name.O] = spec.NewColumnName.Name.O
-					renamedTo[spec.NewColumnName.Name.O] = spec.OldColumnName.Name.O
+				// A case-only rename (foo → FOO) is not a rename for data-mapping
+				// purposes, since identifiers are case-insensitive.
+				if spec.NewColumnName != nil && spec.OldColumnName.Name.L != spec.NewColumnName.Name.L {
+					renamedFrom[spec.OldColumnName.Name.L] = spec.NewColumnName.Name.L
+					renamedTo[spec.NewColumnName.Name.L] = spec.OldColumnName.Name.L
 				}
 			}
 			continue
@@ -63,11 +71,11 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 
 		if spec.Tp == ast.AlterTableChangeColumn {
 			if spec.OldColumnName != nil && len(spec.NewColumns) > 0 {
-				oldName := spec.OldColumnName.Name.O
-				newName := spec.NewColumns[0].Name.Name.O
+				oldName := spec.OldColumnName.Name.L
+				newName := spec.NewColumns[0].Name.Name.L
 				if oldName != newName {
 					if _, isPK := pkColumns[oldName]; isPK {
-						return fmt.Errorf("renaming primary key column %q is not supported", oldName)
+						return fmt.Errorf("renaming primary key column %q is not supported", spec.OldColumnName.Name.O)
 					}
 					renamedFrom[oldName] = newName
 					renamedTo[newName] = oldName
@@ -78,7 +86,7 @@ func renameCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 
 		if spec.Tp == ast.AlterTableAddColumns {
 			for _, col := range spec.NewColumns {
-				addedColumns[col.Name.Name.O] = struct{}{}
+				addedColumns[col.Name.Name.L] = struct{}{}
 			}
 		}
 	}

--- a/pkg/migration/check/rename_test.go
+++ b/pkg/migration/check/rename_test.go
@@ -65,6 +65,64 @@ func TestRenamePKColumnBlocked(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRenamePKColumnBlockedCaseInsensitive covers that PK renames are blocked
+// regardless of the case the column is typed with in the ALTER. MySQL column
+// identifiers are case-insensitive, so a case-mismatched PK rename is just as
+// dangerous as an exact-case one.
+func TestRenamePKColumnBlockedCaseInsensitive(t *testing.T) {
+	ti := table.NewTableInfo(nil, "test", "t1")
+	ti.KeyColumns = []string{"id"}
+
+	// PK column declared "id", rename typed as "ID" — must be blocked.
+	r := Resources{
+		Statement: statement.MustNew("ALTER TABLE t1 RENAME COLUMN ID TO id2")[0],
+		Table:     ti,
+	}
+	err := renameCheck(t.Context(), r, slog.Default())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "renaming primary key column")
+
+	// Same via CHANGE COLUMN.
+	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE Id new_id BIGINT")[0]
+	err = renameCheck(t.Context(), r, slog.Default())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "renaming primary key column")
+
+	// PK column declared with mixed case, rename typed lowercase — must be blocked.
+	ti.KeyColumns = []string{"ID"}
+	r.Statement = statement.MustNew("ALTER TABLE t1 RENAME COLUMN id TO id2")[0]
+	err = renameCheck(t.Context(), r, slog.Default())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "renaming primary key column")
+}
+
+// TestRenameColumnNameOverlapCaseInsensitive covers that the dangerous
+// rename/add-column overlap patterns are detected case-insensitively.
+func TestRenameColumnNameOverlapCaseInsensitive(t *testing.T) {
+	// Pattern 1 with mismatched case: the old name is reused by a new column.
+	r := Resources{
+		Statement: statement.MustNew("ALTER TABLE t1 RENAME COLUMN C1 TO n1, ADD COLUMN c1 VARCHAR(100)")[0],
+	}
+	err := renameCheck(t.Context(), r, slog.Default())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "conflicts with added column")
+	require.ErrorContains(t, err, "old column name is reused")
+
+	// Pattern 2 with mismatched case: the new name collides with an added column.
+	r.Statement = statement.MustNew("ALTER TABLE t1 RENAME COLUMN a TO C, ADD COLUMN c INT")[0]
+	err = renameCheck(t.Context(), r, slog.Default())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "conflicts with added column")
+	require.ErrorContains(t, err, "new column name collides")
+
+	// A case-only rename (foo → FOO) is not a rename for data-mapping
+	// purposes — identifiers are case-insensitive — and is allowed.
+	r.Statement = statement.MustNew("ALTER TABLE t1 RENAME COLUMN c1 TO C1")[0]
+	require.NoError(t, renameCheck(t.Context(), r, slog.Default()))
+	r.Statement = statement.MustNew("ALTER TABLE t1 CHANGE c1 C1 VARCHAR(100)")[0]
+	require.NoError(t, renameCheck(t.Context(), r, slog.Default()))
+}
+
 func TestRenameColumnNameOverlap(t *testing.T) {
 	// Pattern 1: RENAME COLUMN c1 TO n1, ADD COLUMN c1 ...
 	// The old name is reused by a new column — data corruption risk.

--- a/pkg/migration/rename_column_test.go
+++ b/pkg/migration/rename_column_test.go
@@ -563,6 +563,59 @@ func testRenameColumnForceCopyPath(t *testing.T, enableBuffered bool) {
 	require.Equal(t, "varchar(200)", colType)
 }
 
+// TestRenameColumnCaseInsensitive tests renames where the ALTER references
+// columns with different case than they were declared with. MySQL identifiers
+// are case-insensitive, so this must behave identically to a same-case rename.
+// Regression test: spirit previously matched rename names case-sensitively,
+// which silently dropped the renamed column from the copy intersection and
+// lost all of its data (the checksum uses the same intersection, so it could
+// not detect the loss).
+func TestRenameColumnCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	t.Run("unbuffered", func(t *testing.T) {
+		testRenameColumnCaseInsensitive(t, false)
+	})
+	t.Run("buffered", func(t *testing.T) {
+		testRenameColumnCaseInsensitive(t, true)
+	})
+}
+
+func testRenameColumnCaseInsensitive(t *testing.T, enableBuffered bool) {
+	// The INT→BIGINT change forces Spirit's copy algorithm (it is neither
+	// INSTANT nor safe-INPLACE). A simple RENAME COLUMN on its own would
+	// succeed via MySQL's instant DDL and never exercise the copy path.
+	// Both the RENAME COLUMN and CHANGE COLUMN branches are covered, with
+	// the old names typed in a different case than declared.
+	// The renamed columns are deliberately nullable: with the bug, the
+	// columns silently dropped out of the copy intersection and every row
+	// got NULL (a NOT NULL column would at least abort on the missing
+	// default warning).
+	runRenameTest(t, enableBuffered,
+		"rcol_case",
+		`CREATE TABLE rcol_case (
+			id int NOT NULL AUTO_INCREMENT,
+			first_name varchar(100) DEFAULT NULL,
+			age_years int DEFAULT NULL,
+			PRIMARY KEY (id)
+		)`,
+		`INSERT INTO rcol_case (first_name, age_years) VALUES ('alice', 30), ('bob', 40), ('charlie', 50)`,
+		"RENAME COLUMN FIRST_NAME TO given_name, CHANGE COLUMN AGE_YEARS age_total BIGINT",
+		func(t *testing.T, db *sql.DB) {
+			t.Helper()
+			var count int
+			err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM rcol_case WHERE given_name IN ('alice','bob','charlie')").Scan(&count)
+			require.NoError(t, err)
+			require.Equal(t, 3, count)
+
+			var sum sql.NullInt64
+			err = db.QueryRowContext(t.Context(), "SELECT SUM(age_total) FROM rcol_case").Scan(&sum)
+			require.NoError(t, err)
+			require.True(t, sum.Valid)
+			require.Equal(t, int64(120), sum.Int64)
+		},
+	)
+}
+
 // TestRenameColumnEmpty tests rename on an empty table.
 func TestRenameColumnEmpty(t *testing.T) {
 	t.Parallel()

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -295,6 +295,11 @@ func (a *AbstractStatement) AlterContainsAddUnique() error {
 // for any RENAME COLUMN or CHANGE COLUMN (with a different name) specs
 // in this ALTER TABLE statement. Returns nil if there are no renames
 // or if this is not an ALTER TABLE statement.
+// MySQL column identifiers are case-insensitive, so a case-only change
+// (e.g. foo → FOO) is not considered a rename: the data mapping is
+// unaffected and case-insensitive identity matching handles it. The map
+// keys and values keep the case as typed in the ALTER; consumers must
+// match them against declared column names case-insensitively.
 func (a *AbstractStatement) ColumnRenameMap() map[string]string {
 	alterStmt, ok := (*a.StmtNode).(*ast.AlterTableStmt)
 	if !ok {
@@ -306,25 +311,22 @@ func (a *AbstractStatement) ColumnRenameMap() map[string]string {
 		case ast.AlterTableRenameColumn:
 			// ALTER TABLE t RENAME COLUMN old TO new
 			if spec.OldColumnName != nil && spec.NewColumnName != nil {
-				oldName := spec.OldColumnName.Name.O
-				newName := spec.NewColumnName.Name.O
-				if oldName != newName {
+				// Name.L is the lower-cased form of Name.O.
+				if spec.OldColumnName.Name.L != spec.NewColumnName.Name.L {
 					if renames == nil {
 						renames = make(map[string]string)
 					}
-					renames[oldName] = newName
+					renames[spec.OldColumnName.Name.O] = spec.NewColumnName.Name.O
 				}
 			}
 		case ast.AlterTableChangeColumn:
 			// ALTER TABLE t CHANGE COLUMN old new <type>
 			if spec.OldColumnName != nil && len(spec.NewColumns) > 0 {
-				oldName := spec.OldColumnName.Name.O
-				newName := spec.NewColumns[0].Name.Name.O
-				if oldName != newName {
+				if spec.OldColumnName.Name.L != spec.NewColumns[0].Name.Name.L {
 					if renames == nil {
 						renames = make(map[string]string)
 					}
-					renames[oldName] = newName
+					renames[spec.OldColumnName.Name.O] = spec.NewColumns[0].Name.Name.O
 				}
 			}
 		}

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -403,4 +403,19 @@ func TestColumnRenameMap(t *testing.T) {
 	stmts = MustNew("ALTER TABLE t1 RENAME COLUMN a TO b, ADD COLUMN c INT")
 	renames = stmts[0].ColumnRenameMap()
 	require.Equal(t, map[string]string{"a": "b"}, renames)
+
+	// Case-only renames are not renames: MySQL column identifiers are
+	// case-insensitive, so the data mapping is unaffected.
+	stmts = MustNew("ALTER TABLE t1 RENAME COLUMN foo TO FOO")
+	renames = stmts[0].ColumnRenameMap()
+	require.Nil(t, renames)
+
+	stmts = MustNew("ALTER TABLE t1 CHANGE COLUMN foo FOO BIGINT")
+	renames = stmts[0].ColumnRenameMap()
+	require.Nil(t, renames)
+
+	// A real rename keeps the case as typed (consumers match case-insensitively)
+	stmts = MustNew("ALTER TABLE t1 RENAME COLUMN Foo TO Bar")
+	renames = stmts[0].ColumnRenameMap()
+	require.Equal(t, map[string]string{"Foo": "Bar"}, renames)
 }

--- a/pkg/table/column_mapping.go
+++ b/pkg/table/column_mapping.go
@@ -37,36 +37,48 @@ func NewColumnMapping(source, target *TableInfo, renames map[string]string) *Col
 }
 
 // computeIntersection calculates the column intersection between source and target.
+// MySQL column identifiers are case-insensitive, so all matching is performed
+// on lower-cased names: the rename map comes from the user's ALTER statement
+// and may use different case than the columns were declared with. The returned
+// slices always use the declared (information_schema) case so that downstream
+// exact-name lookups (e.g. column type maps) succeed.
 func (m *ColumnMapping) computeIntersection() ([]string, []string) {
-	// Build a set of target column names for fast lookup
-	t2Set := make(map[string]struct{}, len(m.targetTable.NonGeneratedColumns))
+	// Map of lower-cased target column name → declared target column name.
+	t2Set := make(map[string]string, len(m.targetTable.NonGeneratedColumns))
 	for _, col := range m.targetTable.NonGeneratedColumns {
-		t2Set[col] = struct{}{}
+		t2Set[strings.ToLower(col)] = col
+	}
+
+	// Lower-cased copy of the rename map (old→new).
+	renames := make(map[string]string, len(m.renames))
+	for oldName, newName := range m.renames {
+		renames[strings.ToLower(oldName)] = strings.ToLower(newName)
 	}
 
 	// Build a set of target columns that are "claimed" by renames.
 	// These cannot be used for identity matching by other source columns.
-	claimedTargets := make(map[string]struct{}, len(m.renames))
-	for _, newName := range m.renames {
+	claimedTargets := make(map[string]struct{}, len(renames))
+	for _, newName := range renames {
 		claimedTargets[newName] = struct{}{}
 	}
 
 	var srcCols, tgtCols []string
 	for _, srcCol := range m.sourceTable.NonGeneratedColumns {
+		srcLower := strings.ToLower(srcCol)
 		// Check if this column was renamed
-		if newName, ok := m.renames[srcCol]; ok {
-			if _, exists := t2Set[newName]; exists {
+		if newName, ok := renames[srcLower]; ok {
+			if declared, exists := t2Set[newName]; exists {
 				srcCols = append(srcCols, srcCol)
-				tgtCols = append(tgtCols, newName)
+				tgtCols = append(tgtCols, declared)
 				continue
 			}
 		}
 		// Identity match (same name in both tables), but only if the target
 		// column is not already claimed by a rename from another source column.
-		if _, exists := t2Set[srcCol]; exists {
-			if _, claimed := claimedTargets[srcCol]; !claimed {
+		if declared, exists := t2Set[srcLower]; exists {
+			if _, claimed := claimedTargets[srcLower]; !claimed {
 				srcCols = append(srcCols, srcCol)
-				tgtCols = append(tgtCols, srcCol)
+				tgtCols = append(tgtCols, declared)
 			}
 		}
 	}

--- a/pkg/table/column_mapping_test.go
+++ b/pkg/table/column_mapping_test.go
@@ -139,6 +139,48 @@ func TestColumnMappingWithRenames(t *testing.T) {
 	require.Equal(t, []string{"id", "c"}, tgtSlice)
 }
 
+func TestColumnMappingCaseInsensitive(t *testing.T) {
+	t1 := NewTableInfo(nil, "test", "t1")
+	t1new := NewTableInfo(nil, "test", "t1_new")
+
+	// Rename key typed with different case than the declared column:
+	// table declares "foo", user typed "RENAME COLUMN Foo TO bar".
+	// MySQL identifiers are case-insensitive, so the rename must still apply.
+	t1.NonGeneratedColumns = []string{"id", "foo"}
+	t1new.NonGeneratedColumns = []string{"id", "bar"}
+	m := NewColumnMapping(t1, t1new, map[string]string{"Foo": "bar"})
+	srcCols, tgtCols := m.ColumnsSlice()
+	require.Equal(t, []string{"id", "foo"}, srcCols)
+	require.Equal(t, []string{"id", "bar"}, tgtCols)
+
+	// Rename value typed with different case than the target declares:
+	// the mapping must emit the declared target name so downstream exact-name
+	// lookups (e.g. column type maps) succeed.
+	m = NewColumnMapping(t1, t1new, map[string]string{"foo": "BAR"})
+	srcCols, tgtCols = m.ColumnsSlice()
+	require.Equal(t, []string{"id", "foo"}, srcCols)
+	require.Equal(t, []string{"id", "bar"}, tgtCols)
+
+	// Identity match with a case difference between source and target
+	// declarations (e.g. a case-only CHANGE COLUMN foo FOO ...).
+	t1.NonGeneratedColumns = []string{"id", "foo"}
+	t1new.NonGeneratedColumns = []string{"id", "FOO"}
+	m = NewColumnMapping(t1, t1new, nil)
+	srcCols, tgtCols = m.ColumnsSlice()
+	require.Equal(t, []string{"id", "foo"}, srcCols)
+	require.Equal(t, []string{"id", "FOO"}, tgtCols)
+
+	// Claimed-target exclusion is case-insensitive: source [id, a, c],
+	// target [id, C] where A→c is the rename. source.c must NOT identity
+	// match target.C because it is claimed by the rename from source.a.
+	t1.NonGeneratedColumns = []string{"id", "a", "c"}
+	t1new.NonGeneratedColumns = []string{"id", "C"}
+	m = NewColumnMapping(t1, t1new, map[string]string{"A": "c"})
+	srcCols, tgtCols = m.ColumnsSlice()
+	require.Equal(t, []string{"id", "a"}, srcCols)
+	require.Equal(t, []string{"id", "C"}, tgtCols)
+}
+
 func TestColumnMappingTargetNil(t *testing.T) {
 	// When target is nil, source is used as target
 	t1 := NewTableInfo(nil, "test", "t1")


### PR DESCRIPTION
## Problem

MySQL column identifiers are case-insensitive, but the column-rename path compared them case-sensitively. If an ALTER typed a column with different case than declared — e.g. table declares `foo`, ALTER says `RENAME COLUMN Foo TO bar` (valid MySQL) — the rename map keyed by the typed case never matched the declared column name from information_schema in `ColumnMapping.computeIntersection`. The column silently dropped out of the copy intersection: every copied row got NULL/default in the renamed column, and because the checksum is built from the same intersection, it could not detect the loss. The migration completed "successfully" with the column's data gone.

The pre-flight `renameCheck` had the same flaw, so even a case-mismatched primary-key rename passed the check.

## Fix

Fold case at the comparison points, matching MySQL identifier semantics:

- `ColumnMapping.computeIntersection` matches rename-map entries, identity columns, and claimed targets on lower-cased names, while still emitting the declared (information_schema) case so downstream exact-name lookups keep working.
- `renameCheck` folds PK column names and uses the TiDB parser's pre-lowercased `Name.L` for rename/added-column names, so case-mismatched PK renames and rename/ADD-overlap patterns are rejected.
- `ColumnRenameMap` compares `Name.L`, so a case-only change (`foo -> FOO`) is no longer treated as a rename (identity matching handles it).

Other known case-sensitivity issues (e.g. dropAddCheck) are intentionally out of scope for this PR.

## Testing

- New integration test `TestRenameColumnCaseInsensitive`: verified on the unfixed code to reproduce silent total data loss (migration succeeded, checksum passed, 0 of 3 values survived) in both buffered and unbuffered modes; passes with the fix. Uses INT->BIGINT to force the copy path and nullable columns to expose the truly silent path (NOT NULL aborts on a missing-default warning).
- Check-level tests: case-mismatched PK renames and overlap patterns are rejected.
- Unit tests for the mapping and `ColumnRenameMap` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)