### PR TITLE
skip already-flushed events when replaying after stream recreation

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -66,6 +66,25 @@ type binlogClient struct {
 	bufferedPos mysql.Position // buffered position
 	flushedPos  mysql.Position // safely written to new table
 
+	// replayFilterPos, when non-zero, is the flushedPos captured at the
+	// moment the streamer was last recreated. recreateStreamer restarts
+	// the binlog dump at position 4 of the current file, so the stream
+	// replays events that were already processed. Events whose end
+	// position is at or below this filter were durably applied to the
+	// target before the recreation (the Position() contract: flushedPos
+	// is "safely written to new table") and must NOT be re-delivered to
+	// subscriptions: re-buffering them can regress a key in the buffered
+	// map to a stale row image, and a periodic flush running mid-replay
+	// would write that stale image below the persisted checkpoint. If
+	// the process then crashed before the replay re-read the newer
+	// event, a resume from the checkpoint would never re-send it and the
+	// row would silently keep the stale image forever. Events above the
+	// filter are re-delivered as before — they were buffered but not
+	// flushed, and re-buffering them is idempotent. Protected by mu;
+	// re-captured on every recreation and naturally inert once the
+	// stream advances past it (the <= comparison stops matching).
+	replayFilterPos mysql.Position
+
 	// periodicFlushLock protects the cancel/done pair below. The cancel
 	// signals the periodic-flush goroutine to exit; the done channel is
 	// closed by the goroutine on its way out, so StopPeriodicFlush can
@@ -177,6 +196,39 @@ func (c *binlogClient) getBufferedPos() mysql.Position {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.bufferedPos
+}
+
+// getReplayFilterPos returns the replay filter position under a mutex.
+// See the replayFilterPos field for semantics.
+func (c *binlogClient) getReplayFilterPos() mysql.Position {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.replayFilterPos
+}
+
+// shouldSkipReplayedEvent reports whether a RowsEvent must not be
+// delivered to subscriptions because it is part of a post-recreation
+// replay of an already-flushed section of the binlog.
+//
+// eventPos is the event's END position: ev.Header.LogPos paired with
+// the log name the reader is currently in. flushedPos is itself
+// recorded from event end positions (bufferedPos is advanced with
+// ev.Header.LogPos), so an event whose end position compares
+// less-than-or-equal to replayFilterPos was fully contained in the
+// flushed prefix and is durably applied to the target. The comparison
+// uses the full (file, pos) ordering from mysql.Position.Compare so it
+// stays correct across binlog rotations: a replayed event in an earlier
+// file than the filter is skipped, and an event in a later file is
+// always delivered (the filter can sit in an earlier file than the
+// replayed dump when no flush ran since a rotation).
+//
+// A zero replayFilterPos (no streamer recreation since Start) never
+// skips anything.
+func shouldSkipReplayedEvent(eventPos, replayFilterPos mysql.Position) bool {
+	if replayFilterPos.Name == "" {
+		return false
+	}
+	return eventPos.Compare(replayFilterPos) <= 0
 }
 
 // AllChangesFlushed returns true if all buffered changes across all
@@ -354,6 +406,12 @@ func (c *binlogClient) Start(ctx context.Context) error {
 		}
 	}
 	c.bufferedPos = c.flushedPos // set buffered to the initial flushed value
+	// Reset any replay filter left over from a previous run of this
+	// client. The stream starts at flushedPos, so nothing below it is
+	// delivered and no filtering is needed. A stale filter from before a
+	// Close() followed by StartFromPosition() at an earlier checkpoint
+	// could otherwise wrongly suppress live events.
+	c.replayFilterPos = mysql.Position{}
 	c.syncer = replication.NewBinlogSyncer(c.cfg)
 	c.streamer, err = c.syncer.StartSync(c.flushedPos)
 	if err != nil {
@@ -380,13 +438,26 @@ func (c *binlogClient) Start(ctx context.Context) error {
 // in the file when serving a mid-position dump, so restarting mid-file
 // would leave the parser unable to decode rows.
 //
-// Re-reading events from position 4 is safe because the applier is
-// idempotent: it uses REPLACE INTO so re-applying any already-applied
-// event simply re-inserts the same row image, and re-applying an
-// out-of-order event transiently sets the destination to that row's
-// older state, which a subsequent binlog event (in this or a later
-// flush) will correct. The eventual-consistency property holds in both
-// map mode and queue mode — see UpsertRows in pkg/applier/single_target.go.
+// Re-reading from position 4 replays events we already processed, so
+// readStream filters the replay against the flushed position captured
+// here (replayFilterPos). Events at or below it were durably applied to
+// the target — the Position() contract — and re-buffering them could
+// regress a key in the buffered map to a stale row image; a periodic
+// flush running mid-replay would then write that stale image over newer
+// applied data, and a crash before the replay re-read the newer event
+// would make the regression permanent (resume streams only events after
+// the persisted checkpoint, so the newer event is never re-sent).
+//
+// Events after the captured position are re-delivered as before. They
+// were buffered but not yet flushed, and re-buffering them is safe
+// because the applier is idempotent: it uses REPLACE INTO so
+// re-applying any already-applied event simply re-inserts the same row
+// image, and re-applying an out-of-order event transiently sets the
+// destination to that row's older state, which a subsequent binlog
+// event (in this or a later flush) will correct — all such events are
+// above the checkpoint, so the convergence holds even across a crash.
+// The eventual-consistency property holds in both map mode and queue
+// mode — see UpsertRows in pkg/applier/single_target.go.
 func (c *binlogClient) recreateStreamer() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -396,6 +467,13 @@ func (c *binlogClient) recreateStreamer() error {
 		"flushed_position", c.flushedPos,
 		"syncer_exists", c.syncer != nil,
 		"streamer_exists", c.streamer != nil)
+
+	// Capture the current flushed position. readStream consults it via
+	// shouldSkipReplayedEvent to suppress re-delivery of replayed row
+	// events that are already durably applied to the target. Captured
+	// fresh on every recreation so a later recreation filters against
+	// the then-current flushed position. See replayFilterPos.
+	c.replayFilterPos = c.flushedPos
 
 	// Close the existing syncer completely
 	// Since we can't do anything with it.
@@ -578,6 +656,22 @@ func (c *binlogClient) readStream(ctx context.Context) {
 		case *replication.RowsEvent:
 			// Rows event, check if there are any active subscriptions
 			// for it, and pass it to the subscription.
+			//
+			// If the streamer was recreated, the dump restarted at
+			// position 4 of the current file and is replaying events we
+			// already processed. Events at or below the flushed position
+			// captured at recreation time are durably applied to the
+			// target and must not be re-buffered — see replayFilterPos.
+			// Only delivery is skipped: the generic position bookkeeping
+			// after the switch still runs (and is itself a no-op for
+			// replayed events thanks to setBufferedPos's monotonic guard).
+			eventPos := mysql.Position{Name: currentLogName, Pos: ev.Header.LogPos}
+			if filterPos := c.getReplayFilterPos(); shouldSkipReplayedEvent(eventPos, filterPos) {
+				c.logger.Debug("skipping replayed rows event at or below the flushed position",
+					"event_position", eventPos,
+					"replay_filter_position", filterPos)
+				break
+			}
 			if err = c.processRowsEvent(ev, event); err != nil {
 				c.logger.Error("fatal error processing binlog rows event", "error", err)
 				c.fatalError()

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -66,49 +66,6 @@ type binlogClient struct {
 	bufferedPos mysql.Position // buffered position
 	flushedPos  mysql.Position // safely written to new table
 
-	// replayActive is set when the streamer has been recreated and the
-	// dump is replaying events that were already processed.
-	// recreateStreamer restarts the binlog dump at position 4 of the
-	// current file, so the stream re-delivers everything from the start
-	// of the file. While this flag is set, readStream filters replayed
-	// RowsEvents against the *live* bufferedPos (see
-	// shouldSkipReplayedEvent): every event whose end position is at or
-	// below the current bufferedPos is already faithfully represented —
-	// either durably applied to the target (<= flushedPos, the
-	// Position() contract) or held in the buffered map with its latest
-	// deduped image (in (flushedPos, bufferedPos]) — so re-delivering it
-	// can only regress a key in the map to a stale row image.
-	//
-	// We compare against the live bufferedPos rather than a snapshot of
-	// flushedPos for correctness under a concurrent periodic flush: a
-	// flush running mid-replay advances flushedPos all the way to
-	// bufferedPos (the frozen high-water mark — setBufferedPos is
-	// monotonic so replayed events do not move it), and it can only do
-	// so safely if the map still holds the latest image for the whole
-	// (flushedPos, bufferedPos] window. Filtering only up to a snapshot
-	// of flushedPos would let a replayed event in that window overwrite
-	// the map's latest image with a stale one; the very next flush would
-	// then persist the stale image below the (now advanced) checkpoint,
-	// and a crash before the replay re-read the newer event would make
-	// the regression permanent (resume streams only events after the
-	// persisted checkpoint, so the newer event is never re-sent).
-	// Filtering up to bufferedPos covers the entire already-buffered
-	// prefix, so the map is never corrupted during replay.
-	//
-	// Events whose end position is above the live bufferedPos are
-	// genuinely new (the replay has caught up to and passed the
-	// high-water mark) and are delivered as normal; delivering one
-	// advances bufferedPos, so the boundary widens with the stream and
-	// the filter is naturally inert for all subsequent live events.
-	// Protected by mu; set on every recreation and cleared on Start.
-	replayActive bool
-
-	// replayFilterFloor records the bufferedPos captured at the moment
-	// the streamer was last recreated, purely for diagnostics/logging so
-	// operators can see where a replay began. It is NOT used in the skip
-	// decision (that consults the live bufferedPos). Protected by mu.
-	replayFilterFloor mysql.Position
-
 	// periodicFlushLock protects the cancel/done pair below. The cancel
 	// signals the periodic-flush goroutine to exit; the done channel is
 	// closed by the goroutine on its way out, so StopPeriodicFlush can
@@ -222,49 +179,23 @@ func (c *binlogClient) getBufferedPos() mysql.Position {
 	return c.bufferedPos
 }
 
-// getReplayFilterState returns, under a single lock acquisition, whether
-// replay filtering is currently armed and the live bufferedPos to filter
-// against. See the replayActive field for semantics.
-func (c *binlogClient) getReplayFilterState() (replayActive bool, bufferedPos mysql.Position) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.replayActive, c.bufferedPos
-}
-
-// shouldSkipReplayedEvent reports whether a RowsEvent must not be
-// delivered to subscriptions because it is part of a post-recreation
-// replay of a section of the binlog we have already buffered.
+// shouldSkipReplayedEvent reports whether a RowsEvent is part of a replay
+// of binlog we have already buffered and so must not be re-delivered.
+// recreateStreamer restarts the dump at position 4 of the current file, so
+// after an error it re-reads events we already processed. eventPos is the
+// event's end position; bufferedPos is the live high-water mark of
+// everything processed so far. An event at or below bufferedPos is already
+// represented — applied to the target if <= flushedPos, else held in the
+// buffered map with its latest deduped image — so re-buffering it could
+// only regress a key to a stale image.
 //
-// eventPos is the event's END position: ev.Header.LogPos paired with the
-// log name the reader is currently in. bufferedPos is the *live*
-// high-water mark of everything the reader has already processed (it is
-// advanced with ev.Header.LogPos and is monotonic, so a replay does not
-// move it). An event whose end position compares less-than-or-equal to
-// bufferedPos is already faithfully represented — durably applied to the
-// target if <= flushedPos, or held in the buffered map with its latest
-// deduped image if in (flushedPos, bufferedPos] — so re-delivering it
-// during a replay can only regress a key to a stale image. Such events
-// are skipped.
-//
-// The comparison uses the full (file, pos) ordering from
-// mysql.Position.Compare so it stays correct across binlog rotations: a
-// replayed event in an earlier file than bufferedPos is skipped, and an
-// event in a later file is always delivered.
-//
-// Comparing against the live bufferedPos (rather than a snapshot of
-// flushedPos taken at recreation) is what makes the filter safe under a
-// periodic flush running concurrently with the replay: see the
-// replayActive field comment for the full argument. Because the boundary
-// is the live bufferedPos, it widens automatically as the replay catches
-// up and crosses the old high-water mark, so genuinely-new events (end
-// pos above bufferedPos) are always delivered.
-//
-// When replay filtering is not active (no streamer recreation since
-// Start) nothing is skipped.
-func shouldSkipReplayedEvent(replayActive bool, eventPos, bufferedPos mysql.Position) bool {
-	if !replayActive {
-		return false
-	}
+// No "am I replaying" flag is needed: bufferedPos is monotonic and the live
+// stream always runs strictly ahead of it, so a live event's end position
+// is always > bufferedPos and this is naturally inert outside a replay.
+// Using the live bufferedPos (not a flushedPos snapshot) is also what keeps
+// it correct when a periodic flush advances flushedPos mid-replay. The
+// (file, pos) Compare keeps it correct across binlog rotations.
+func shouldSkipReplayedEvent(eventPos, bufferedPos mysql.Position) bool {
 	return eventPos.Compare(bufferedPos) <= 0
 }
 
@@ -443,13 +374,6 @@ func (c *binlogClient) Start(ctx context.Context) error {
 		}
 	}
 	c.bufferedPos = c.flushedPos // set buffered to the initial flushed value
-	// Reset any replay filter left over from a previous run of this
-	// client. The stream starts at flushedPos, so nothing below it is
-	// delivered and no filtering is needed. A stale filter from before a
-	// Close() followed by StartFromPosition() at an earlier checkpoint
-	// could otherwise wrongly suppress live events.
-	c.replayActive = false
-	c.replayFilterFloor = mysql.Position{}
 	c.syncer = replication.NewBinlogSyncer(c.cfg)
 	c.streamer, err = c.syncer.StartSync(c.flushedPos)
 	if err != nil {
@@ -476,34 +400,17 @@ func (c *binlogClient) Start(ctx context.Context) error {
 // in the file when serving a mid-position dump, so restarting mid-file
 // would leave the parser unable to decode rows.
 //
-// Re-reading from position 4 replays events we already processed, so
-// readStream filters the replay against the live bufferedPos while
-// replayActive is set. Every event at or below bufferedPos is already
-// faithfully represented: durably applied to the target (<= flushedPos,
-// the Position() contract) or held in the buffered map with its latest
-// deduped image (in (flushedPos, bufferedPos]). Re-buffering any of them
-// could regress a key to a stale row image; a periodic flush running
-// mid-replay would then write that stale image over newer data, and a
-// crash before the replay re-read the newer event would make the
-// regression permanent (resume streams only events after the persisted
-// checkpoint, so the newer event is never re-sent).
-//
-// We filter up to the live bufferedPos rather than a snapshot of
-// flushedPos precisely because the periodic flush can advance flushedPos
-// to bufferedPos mid-replay: a snapshot of the old flushedPos would
-// leave the (flushedPos, bufferedPos] window unfiltered, and a replayed
-// event there could corrupt the map before that flush persists it. See
-// the replayActive field comment for the full argument.
-//
-// Events above the live bufferedPos are genuinely new — the replay has
-// caught up and crossed the high-water mark — and are delivered as
-// before. Delivering one advances bufferedPos, so the boundary widens
-// with the stream and the filter is inert for all subsequent live
-// events. Re-buffering remains safe regardless because the applier is
-// idempotent (REPLACE INTO inline row images) and all such events are
-// above the checkpoint; the eventual-consistency property holds in both
-// map mode and queue mode — see UpsertRows in
-// pkg/applier/single_target.go.
+// Re-reading from position 4 replays events we already processed.
+// readStream skips re-delivering any RowsEvent at or below the live
+// bufferedPos (see shouldSkipReplayedEvent): those are already applied to
+// the target or held in the buffered map with their latest image, so
+// re-buffering them could regress a key to a stale image — which a
+// periodic flush could then persist below the checkpoint, becoming
+// permanent if a crash truncates the replay before the newer event is
+// re-read. Events above bufferedPos are genuinely new and delivered as
+// before; re-buffering them is safe because the applier is idempotent
+// (REPLACE INTO inline row images) and they sit above the checkpoint —
+// see UpsertRows in pkg/applier/single_target.go.
 func (c *binlogClient) recreateStreamer() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -513,17 +420,6 @@ func (c *binlogClient) recreateStreamer() error {
 		"flushed_position", c.flushedPos,
 		"syncer_exists", c.syncer != nil,
 		"streamer_exists", c.streamer != nil)
-
-	// Arm replay filtering. readStream consults the live bufferedPos via
-	// shouldSkipReplayedEvent to suppress re-delivery of replayed row
-	// events that are already faithfully represented (applied to the
-	// target or held in the buffered map with their latest image).
-	// replayFilterFloor records where the replay began for diagnostics
-	// only; the skip decision uses the live bufferedPos so it stays
-	// correct when a concurrent flush advances flushedPos mid-replay.
-	// See replayActive.
-	c.replayActive = true
-	c.replayFilterFloor = c.bufferedPos
 
 	// Close the existing syncer completely
 	// Since we can't do anything with it.
@@ -707,23 +603,22 @@ func (c *binlogClient) readStream(ctx context.Context) {
 			// Rows event, check if there are any active subscriptions
 			// for it, and pass it to the subscription.
 			//
-			// If the streamer was recreated, the dump restarted at
-			// position 4 of the current file and is replaying events we
-			// already processed. Events at or below the live bufferedPos
-			// are already faithfully represented (applied to the target,
-			// or held in the buffered map with their latest image) and
-			// must not be re-buffered — see replayActive. The live
-			// bufferedPos is read here (not a snapshot) so the filter
-			// stays correct when a concurrent periodic flush advances
-			// flushedPos mid-replay. Only delivery is skipped: the
-			// generic position bookkeeping after the switch still runs
-			// (and is itself a no-op for replayed events thanks to
-			// setBufferedPos's monotonic guard).
+			// Skip re-delivering a RowsEvent at or below the live
+			// bufferedPos: after a recreateStreamer the dump replays from
+			// position 4, and those events are already represented (applied
+			// to the target or held in the map with their latest image), so
+			// re-buffering them could regress a key to a stale image. The
+			// live bufferedPos is read here (not a snapshot) so the filter
+			// stays correct when a concurrent flush advances flushedPos
+			// mid-replay, and it is inert outside a replay since the live
+			// stream always runs ahead of bufferedPos. Only delivery is
+			// skipped; the position bookkeeping below still runs (a no-op
+			// for replayed events thanks to setBufferedPos's monotonic guard).
 			eventPos := mysql.Position{Name: currentLogName, Pos: ev.Header.LogPos}
-			if replayActive, bufferedPos := c.getReplayFilterState(); shouldSkipReplayedEvent(replayActive, eventPos, bufferedPos) {
+			if shouldSkipReplayedEvent(eventPos, c.getBufferedPos()) {
 				c.logger.Debug("skipping replayed rows event at or below the buffered position",
 					"event_position", eventPos,
-					"buffered_position", bufferedPos)
+					"buffered_position", c.getBufferedPos())
 				break
 			}
 			if err = c.processRowsEvent(ev, event); err != nil {

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -66,24 +66,48 @@ type binlogClient struct {
 	bufferedPos mysql.Position // buffered position
 	flushedPos  mysql.Position // safely written to new table
 
-	// replayFilterPos, when non-zero, is the flushedPos captured at the
-	// moment the streamer was last recreated. recreateStreamer restarts
-	// the binlog dump at position 4 of the current file, so the stream
-	// replays events that were already processed. Events whose end
-	// position is at or below this filter were durably applied to the
-	// target before the recreation (the Position() contract: flushedPos
-	// is "safely written to new table") and must NOT be re-delivered to
-	// subscriptions: re-buffering them can regress a key in the buffered
-	// map to a stale row image, and a periodic flush running mid-replay
-	// would write that stale image below the persisted checkpoint. If
-	// the process then crashed before the replay re-read the newer
-	// event, a resume from the checkpoint would never re-send it and the
-	// row would silently keep the stale image forever. Events above the
-	// filter are re-delivered as before — they were buffered but not
-	// flushed, and re-buffering them is idempotent. Protected by mu;
-	// re-captured on every recreation and naturally inert once the
-	// stream advances past it (the <= comparison stops matching).
-	replayFilterPos mysql.Position
+	// replayActive is set when the streamer has been recreated and the
+	// dump is replaying events that were already processed.
+	// recreateStreamer restarts the binlog dump at position 4 of the
+	// current file, so the stream re-delivers everything from the start
+	// of the file. While this flag is set, readStream filters replayed
+	// RowsEvents against the *live* bufferedPos (see
+	// shouldSkipReplayedEvent): every event whose end position is at or
+	// below the current bufferedPos is already faithfully represented —
+	// either durably applied to the target (<= flushedPos, the
+	// Position() contract) or held in the buffered map with its latest
+	// deduped image (in (flushedPos, bufferedPos]) — so re-delivering it
+	// can only regress a key in the map to a stale row image.
+	//
+	// We compare against the live bufferedPos rather than a snapshot of
+	// flushedPos for correctness under a concurrent periodic flush: a
+	// flush running mid-replay advances flushedPos all the way to
+	// bufferedPos (the frozen high-water mark — setBufferedPos is
+	// monotonic so replayed events do not move it), and it can only do
+	// so safely if the map still holds the latest image for the whole
+	// (flushedPos, bufferedPos] window. Filtering only up to a snapshot
+	// of flushedPos would let a replayed event in that window overwrite
+	// the map's latest image with a stale one; the very next flush would
+	// then persist the stale image below the (now advanced) checkpoint,
+	// and a crash before the replay re-read the newer event would make
+	// the regression permanent (resume streams only events after the
+	// persisted checkpoint, so the newer event is never re-sent).
+	// Filtering up to bufferedPos covers the entire already-buffered
+	// prefix, so the map is never corrupted during replay.
+	//
+	// Events whose end position is above the live bufferedPos are
+	// genuinely new (the replay has caught up to and passed the
+	// high-water mark) and are delivered as normal; delivering one
+	// advances bufferedPos, so the boundary widens with the stream and
+	// the filter is naturally inert for all subsequent live events.
+	// Protected by mu; set on every recreation and cleared on Start.
+	replayActive bool
+
+	// replayFilterFloor records the bufferedPos captured at the moment
+	// the streamer was last recreated, purely for diagnostics/logging so
+	// operators can see where a replay began. It is NOT used in the skip
+	// decision (that consults the live bufferedPos). Protected by mu.
+	replayFilterFloor mysql.Position
 
 	// periodicFlushLock protects the cancel/done pair below. The cancel
 	// signals the periodic-flush goroutine to exit; the done channel is
@@ -198,37 +222,50 @@ func (c *binlogClient) getBufferedPos() mysql.Position {
 	return c.bufferedPos
 }
 
-// getReplayFilterPos returns the replay filter position under a mutex.
-// See the replayFilterPos field for semantics.
-func (c *binlogClient) getReplayFilterPos() mysql.Position {
+// getReplayFilterState returns, under a single lock acquisition, whether
+// replay filtering is currently armed and the live bufferedPos to filter
+// against. See the replayActive field for semantics.
+func (c *binlogClient) getReplayFilterState() (replayActive bool, bufferedPos mysql.Position) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.replayFilterPos
+	return c.replayActive, c.bufferedPos
 }
 
 // shouldSkipReplayedEvent reports whether a RowsEvent must not be
 // delivered to subscriptions because it is part of a post-recreation
-// replay of an already-flushed section of the binlog.
+// replay of a section of the binlog we have already buffered.
 //
-// eventPos is the event's END position: ev.Header.LogPos paired with
-// the log name the reader is currently in. flushedPos is itself
-// recorded from event end positions (bufferedPos is advanced with
-// ev.Header.LogPos), so an event whose end position compares
-// less-than-or-equal to replayFilterPos was fully contained in the
-// flushed prefix and is durably applied to the target. The comparison
-// uses the full (file, pos) ordering from mysql.Position.Compare so it
-// stays correct across binlog rotations: a replayed event in an earlier
-// file than the filter is skipped, and an event in a later file is
-// always delivered (the filter can sit in an earlier file than the
-// replayed dump when no flush ran since a rotation).
+// eventPos is the event's END position: ev.Header.LogPos paired with the
+// log name the reader is currently in. bufferedPos is the *live*
+// high-water mark of everything the reader has already processed (it is
+// advanced with ev.Header.LogPos and is monotonic, so a replay does not
+// move it). An event whose end position compares less-than-or-equal to
+// bufferedPos is already faithfully represented — durably applied to the
+// target if <= flushedPos, or held in the buffered map with its latest
+// deduped image if in (flushedPos, bufferedPos] — so re-delivering it
+// during a replay can only regress a key to a stale image. Such events
+// are skipped.
 //
-// A zero replayFilterPos (no streamer recreation since Start) never
-// skips anything.
-func shouldSkipReplayedEvent(eventPos, replayFilterPos mysql.Position) bool {
-	if replayFilterPos.Name == "" {
+// The comparison uses the full (file, pos) ordering from
+// mysql.Position.Compare so it stays correct across binlog rotations: a
+// replayed event in an earlier file than bufferedPos is skipped, and an
+// event in a later file is always delivered.
+//
+// Comparing against the live bufferedPos (rather than a snapshot of
+// flushedPos taken at recreation) is what makes the filter safe under a
+// periodic flush running concurrently with the replay: see the
+// replayActive field comment for the full argument. Because the boundary
+// is the live bufferedPos, it widens automatically as the replay catches
+// up and crosses the old high-water mark, so genuinely-new events (end
+// pos above bufferedPos) are always delivered.
+//
+// When replay filtering is not active (no streamer recreation since
+// Start) nothing is skipped.
+func shouldSkipReplayedEvent(replayActive bool, eventPos, bufferedPos mysql.Position) bool {
+	if !replayActive {
 		return false
 	}
-	return eventPos.Compare(replayFilterPos) <= 0
+	return eventPos.Compare(bufferedPos) <= 0
 }
 
 // AllChangesFlushed returns true if all buffered changes across all
@@ -411,7 +448,8 @@ func (c *binlogClient) Start(ctx context.Context) error {
 	// delivered and no filtering is needed. A stale filter from before a
 	// Close() followed by StartFromPosition() at an earlier checkpoint
 	// could otherwise wrongly suppress live events.
-	c.replayFilterPos = mysql.Position{}
+	c.replayActive = false
+	c.replayFilterFloor = mysql.Position{}
 	c.syncer = replication.NewBinlogSyncer(c.cfg)
 	c.streamer, err = c.syncer.StartSync(c.flushedPos)
 	if err != nil {
@@ -439,25 +477,33 @@ func (c *binlogClient) Start(ctx context.Context) error {
 // would leave the parser unable to decode rows.
 //
 // Re-reading from position 4 replays events we already processed, so
-// readStream filters the replay against the flushed position captured
-// here (replayFilterPos). Events at or below it were durably applied to
-// the target — the Position() contract — and re-buffering them could
-// regress a key in the buffered map to a stale row image; a periodic
-// flush running mid-replay would then write that stale image over newer
-// applied data, and a crash before the replay re-read the newer event
-// would make the regression permanent (resume streams only events after
-// the persisted checkpoint, so the newer event is never re-sent).
+// readStream filters the replay against the live bufferedPos while
+// replayActive is set. Every event at or below bufferedPos is already
+// faithfully represented: durably applied to the target (<= flushedPos,
+// the Position() contract) or held in the buffered map with its latest
+// deduped image (in (flushedPos, bufferedPos]). Re-buffering any of them
+// could regress a key to a stale row image; a periodic flush running
+// mid-replay would then write that stale image over newer data, and a
+// crash before the replay re-read the newer event would make the
+// regression permanent (resume streams only events after the persisted
+// checkpoint, so the newer event is never re-sent).
 //
-// Events after the captured position are re-delivered as before. They
-// were buffered but not yet flushed, and re-buffering them is safe
-// because the applier is idempotent: it uses REPLACE INTO so
-// re-applying any already-applied event simply re-inserts the same row
-// image, and re-applying an out-of-order event transiently sets the
-// destination to that row's older state, which a subsequent binlog
-// event (in this or a later flush) will correct — all such events are
-// above the checkpoint, so the convergence holds even across a crash.
-// The eventual-consistency property holds in both map mode and queue
-// mode — see UpsertRows in pkg/applier/single_target.go.
+// We filter up to the live bufferedPos rather than a snapshot of
+// flushedPos precisely because the periodic flush can advance flushedPos
+// to bufferedPos mid-replay: a snapshot of the old flushedPos would
+// leave the (flushedPos, bufferedPos] window unfiltered, and a replayed
+// event there could corrupt the map before that flush persists it. See
+// the replayActive field comment for the full argument.
+//
+// Events above the live bufferedPos are genuinely new — the replay has
+// caught up and crossed the high-water mark — and are delivered as
+// before. Delivering one advances bufferedPos, so the boundary widens
+// with the stream and the filter is inert for all subsequent live
+// events. Re-buffering remains safe regardless because the applier is
+// idempotent (REPLACE INTO inline row images) and all such events are
+// above the checkpoint; the eventual-consistency property holds in both
+// map mode and queue mode — see UpsertRows in
+// pkg/applier/single_target.go.
 func (c *binlogClient) recreateStreamer() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -468,12 +514,16 @@ func (c *binlogClient) recreateStreamer() error {
 		"syncer_exists", c.syncer != nil,
 		"streamer_exists", c.streamer != nil)
 
-	// Capture the current flushed position. readStream consults it via
+	// Arm replay filtering. readStream consults the live bufferedPos via
 	// shouldSkipReplayedEvent to suppress re-delivery of replayed row
-	// events that are already durably applied to the target. Captured
-	// fresh on every recreation so a later recreation filters against
-	// the then-current flushed position. See replayFilterPos.
-	c.replayFilterPos = c.flushedPos
+	// events that are already faithfully represented (applied to the
+	// target or held in the buffered map with their latest image).
+	// replayFilterFloor records where the replay began for diagnostics
+	// only; the skip decision uses the live bufferedPos so it stays
+	// correct when a concurrent flush advances flushedPos mid-replay.
+	// See replayActive.
+	c.replayActive = true
+	c.replayFilterFloor = c.bufferedPos
 
 	// Close the existing syncer completely
 	// Since we can't do anything with it.
@@ -659,17 +709,21 @@ func (c *binlogClient) readStream(ctx context.Context) {
 			//
 			// If the streamer was recreated, the dump restarted at
 			// position 4 of the current file and is replaying events we
-			// already processed. Events at or below the flushed position
-			// captured at recreation time are durably applied to the
-			// target and must not be re-buffered — see replayFilterPos.
-			// Only delivery is skipped: the generic position bookkeeping
-			// after the switch still runs (and is itself a no-op for
-			// replayed events thanks to setBufferedPos's monotonic guard).
+			// already processed. Events at or below the live bufferedPos
+			// are already faithfully represented (applied to the target,
+			// or held in the buffered map with their latest image) and
+			// must not be re-buffered — see replayActive. The live
+			// bufferedPos is read here (not a snapshot) so the filter
+			// stays correct when a concurrent periodic flush advances
+			// flushedPos mid-replay. Only delivery is skipped: the
+			// generic position bookkeeping after the switch still runs
+			// (and is itself a no-op for replayed events thanks to
+			// setBufferedPos's monotonic guard).
 			eventPos := mysql.Position{Name: currentLogName, Pos: ev.Header.LogPos}
-			if filterPos := c.getReplayFilterPos(); shouldSkipReplayedEvent(eventPos, filterPos) {
-				c.logger.Debug("skipping replayed rows event at or below the flushed position",
+			if replayActive, bufferedPos := c.getReplayFilterState(); shouldSkipReplayedEvent(replayActive, eventPos, bufferedPos) {
+				c.logger.Debug("skipping replayed rows event at or below the buffered position",
 					"event_position", eventPos,
-					"replay_filter_position", filterPos)
+					"buffered_position", bufferedPos)
 				break
 			}
 			if err = c.processRowsEvent(ev, event); err != nil {

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -179,22 +179,13 @@ func (c *binlogClient) getBufferedPos() mysql.Position {
 	return c.bufferedPos
 }
 
-// shouldSkipReplayedEvent reports whether a RowsEvent is part of a replay
-// of binlog we have already buffered and so must not be re-delivered.
-// recreateStreamer restarts the dump at position 4 of the current file, so
-// after an error it re-reads events we already processed. eventPos is the
-// event's end position; bufferedPos is the live high-water mark of
-// everything processed so far. An event at or below bufferedPos is already
-// represented — applied to the target if <= flushedPos, else held in the
-// buffered map with its latest deduped image — so re-buffering it could
-// only regress a key to a stale image.
-//
-// No "am I replaying" flag is needed: bufferedPos is monotonic and the live
-// stream always runs strictly ahead of it, so a live event's end position
-// is always > bufferedPos and this is naturally inert outside a replay.
-// Using the live bufferedPos (not a flushedPos snapshot) is also what keeps
-// it correct when a periodic flush advances flushedPos mid-replay. The
-// (file, pos) Compare keeps it correct across binlog rotations.
+// shouldSkipReplayedEvent reports whether a replayed RowsEvent must not be
+// re-delivered. An event whose end position is at or below the live
+// bufferedPos is already represented (applied to the target, or held in the
+// map with its latest image), so re-buffering it could regress a key to a
+// stale image. No replay flag is needed: bufferedPos is monotonic and the
+// live stream always runs ahead of it, so only a replay compares <=. The
+// (file, pos) Compare is rotation-safe.
 func shouldSkipReplayedEvent(eventPos, bufferedPos mysql.Position) bool {
 	return eventPos.Compare(bufferedPos) <= 0
 }
@@ -400,17 +391,11 @@ func (c *binlogClient) Start(ctx context.Context) error {
 // in the file when serving a mid-position dump, so restarting mid-file
 // would leave the parser unable to decode rows.
 //
-// Re-reading from position 4 replays events we already processed.
+// Re-reading from position 4 replays events we already processed;
 // readStream skips re-delivering any RowsEvent at or below the live
-// bufferedPos (see shouldSkipReplayedEvent): those are already applied to
-// the target or held in the buffered map with their latest image, so
-// re-buffering them could regress a key to a stale image — which a
-// periodic flush could then persist below the checkpoint, becoming
-// permanent if a crash truncates the replay before the newer event is
-// re-read. Events above bufferedPos are genuinely new and delivered as
-// before; re-buffering them is safe because the applier is idempotent
-// (REPLACE INTO inline row images) and they sit above the checkpoint —
-// see UpsertRows in pkg/applier/single_target.go.
+// bufferedPos (see shouldSkipReplayedEvent), so the replay cannot regress a
+// key to a stale image. Events above bufferedPos are new and safe to
+// re-buffer because the applier is idempotent (REPLACE INTO).
 func (c *binlogClient) recreateStreamer() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -600,26 +585,14 @@ func (c *binlogClient) readStream(ctx context.Context) {
 			})
 			continue
 		case *replication.RowsEvent:
-			// Rows event, check if there are any active subscriptions
-			// for it, and pass it to the subscription.
-			//
-			// Skip re-delivering a RowsEvent at or below the live
-			// bufferedPos: after a recreateStreamer the dump replays from
-			// position 4, and those events are already represented (applied
-			// to the target or held in the map with their latest image), so
-			// re-buffering them could regress a key to a stale image. The
-			// live bufferedPos is read here (not a snapshot) so the filter
-			// stays correct when a concurrent flush advances flushedPos
-			// mid-replay, and it is inert outside a replay since the live
-			// stream always runs ahead of bufferedPos. Only delivery is
-			// skipped; the position bookkeeping below still runs (a no-op
-			// for replayed events thanks to setBufferedPos's monotonic guard).
+			// Skip events already buffered/applied: a post-recreateStreamer
+			// replay must not re-buffer them and regress a key to a stale
+			// image. See shouldSkipReplayedEvent.
 			eventPos := mysql.Position{Name: currentLogName, Pos: ev.Header.LogPos}
 			if shouldSkipReplayedEvent(eventPos, c.getBufferedPos()) {
 				c.logger.Debug("skipping replayed rows event at or below the buffered position",
-					"event_position", eventPos,
-					"buffered_position", c.getBufferedPos())
-				break
+					"event_position", eventPos)
+				continue
 			}
 			if err = c.processRowsEvent(ev, event); err != nil {
 				c.logger.Error("fatal error processing binlog rows event", "error", err)

--- a/pkg/change/binlog_test.go
+++ b/pkg/change/binlog_test.go
@@ -786,104 +786,74 @@ func TestSetBufferedPosIsMonotonic(t *testing.T) {
 // its latest image), so <= means "must not be re-buffered". Filtering
 // against the live bufferedPos rather than a snapshot of flushedPos is
 // what keeps the filter safe when a periodic flush advances flushedPos
-// mid-replay — see the replayActive field comment.
+// mid-replay — see shouldSkipReplayedEvent.
 func TestShouldSkipReplayedEvent(t *testing.T) {
 	buffered := mysql.Position{Name: "binlog.000010", Pos: 200}
 	tests := []struct {
-		name         string
-		replayActive bool
-		eventPos     mysql.Position
-		bufferedPos  mysql.Position
-		skip         bool
+		name        string
+		eventPos    mysql.Position
+		bufferedPos mysql.Position
+		skip        bool
 	}{
 		{
-			name:         "replay inactive never skips (no recreation since Start)",
-			replayActive: false,
-			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 100},
-			bufferedPos:  buffered,
-			skip:         false,
-		},
-		{
-			name:         "replay inactive never skips even at file start",
-			replayActive: false,
-			eventPos:     mysql.Position{Name: "binlog.000001", Pos: 4},
-			bufferedPos:  mysql.Position{},
-			skip:         false,
-		},
-		{
-			name:         "same file below bufferedPos: already represented, skip",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 100},
-			bufferedPos:  buffered,
-			skip:         true,
+			name:        "same file below bufferedPos: already represented, skip",
+			eventPos:    mysql.Position{Name: "binlog.000010", Pos: 100},
+			bufferedPos: buffered,
+			skip:        true,
 		},
 		{
 			name: "same file equal to bufferedPos: event end == high-water " +
 				"mark means it is the last buffered event, skip",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 200},
-			bufferedPos:  buffered,
-			skip:         true,
+			eventPos:    mysql.Position{Name: "binlog.000010", Pos: 200},
+			bufferedPos: buffered,
+			skip:        true,
 		},
 		{
 			name: "same file just above bufferedPos: genuinely new event, " +
-				"deliver",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 201},
-			bufferedPos:  buffered,
-			skip:         false,
+				"deliver (this is also why no replay flag is needed — the " +
+				"live stream always runs ahead of bufferedPos)",
+			eventPos:    mysql.Position{Name: "binlog.000010", Pos: 201},
+			bufferedPos: buffered,
+			skip:        false,
 		},
 		{
-			name:         "earlier file: skip regardless of offset",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000009", Pos: 999999},
-			bufferedPos:  buffered,
-			skip:         true,
+			name:        "earlier file: skip regardless of offset",
+			eventPos:    mysql.Position{Name: "binlog.000009", Pos: 999999},
+			bufferedPos: buffered,
+			skip:        true,
 		},
 		{
 			name: "later file: deliver regardless of offset (bufferedPos can " +
 				"sit in an earlier file just after a rotation)",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000011", Pos: 4},
-			bufferedPos:  buffered,
-			skip:         false,
+			eventPos:    mysql.Position{Name: "binlog.000011", Pos: 4},
+			bufferedPos: buffered,
+			skip:        false,
 		},
 		{
 			name: "numeric suffix ordering, not lexicographic: file .000100 " +
 				"is later than bufferedPos file .000099",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000100", Pos: 4},
-			bufferedPos:  mysql.Position{Name: "binlog.000099", Pos: 5000},
-			skip:         false,
+			eventPos:    mysql.Position{Name: "binlog.000100", Pos: 4},
+			bufferedPos: mysql.Position{Name: "binlog.000099", Pos: 5000},
+			skip:        false,
 		},
-		// The next two cases capture the regression the live-bufferedPos
+		// The next case captures the regression the live-bufferedPos
 		// comparison fixes (Copilot review on #919): once a concurrent
-		// flush has advanced the high-water boundary, a *later* replayed
-		// event that a snapshot of the old flushedPos would have let
-		// through is now correctly skipped, because the boundary is read
-		// live. With buffered=200 a snapshot-of-old-flushedPos=100 would
-		// have delivered pos 150 and pos 200 (corrupting the map); the
-		// live boundary skips both.
+		// flush has advanced the high-water boundary, a replayed event that
+		// a snapshot of the old flushedPos would have let through is now
+		// correctly skipped, because the boundary is read live. With
+		// buffered=200 a snapshot-of-old-flushedPos=100 would have delivered
+		// pos 150 (corrupting the map); the live boundary skips it.
 		{
 			name: "event below the live (advanced) bufferedPos is skipped " +
 				"even though it sits above where the replay's old flushedPos was",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 150},
-			bufferedPos:  buffered,
-			skip:         true,
-		},
-		{
-			name: "the last buffered event is skipped at the live boundary, " +
-				"so a mid-replay flush cannot persist a stale image",
-			replayActive: true,
-			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 200},
-			bufferedPos:  buffered,
-			skip:         true,
+			eventPos:    mysql.Position{Name: "binlog.000010", Pos: 150},
+			bufferedPos: buffered,
+			skip:        true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.skip, shouldSkipReplayedEvent(tt.replayActive, tt.eventPos, tt.bufferedPos))
+			require.Equal(t, tt.skip, shouldSkipReplayedEvent(tt.eventPos, tt.bufferedPos))
 		})
 	}
 }
@@ -904,18 +874,18 @@ func TestShouldSkipReplayedEventWidensWithBufferedPos(t *testing.T) {
 	boundary := mysql.Position{Name: file, Pos: 400}
 	for _, pos := range []uint32{100, 200, 300, 400} {
 		ev := mysql.Position{Name: file, Pos: pos}
-		require.True(t, shouldSkipReplayedEvent(true, ev, boundary),
+		require.True(t, shouldSkipReplayedEvent(ev, boundary),
 			"replayed event at %d must be skipped while bufferedPos is 400", pos)
 	}
 	// The first genuinely-new event (past the high-water mark) is
 	// delivered; that advances bufferedPos to its end position.
 	newEvent := mysql.Position{Name: file, Pos: 450}
-	require.False(t, shouldSkipReplayedEvent(true, newEvent, boundary),
+	require.False(t, shouldSkipReplayedEvent(newEvent, boundary),
 		"an event past the high-water mark must be delivered")
 	boundary = newEvent
 	// A subsequent live event is above the now-advanced boundary, so the
 	// filter is inert for it (delivered).
-	require.False(t, shouldSkipReplayedEvent(true, mysql.Position{Name: file, Pos: 500}, boundary),
+	require.False(t, shouldSkipReplayedEvent(mysql.Position{Name: file, Pos: 500}, boundary),
 		"once the boundary advances, later live events are delivered")
 }
 
@@ -951,8 +921,8 @@ func TestShouldSkipReplayedEventWidensWithBufferedPos(t *testing.T) {
 //  4. Asserts the already-buffered events were NOT re-buffered (neither
 //     the flushed key nor the unflushed one regressed) and the buffered
 //     map still holds the unflushed event's newest image.
-//  5. Kills the syncer again to assert a second recreation re-arms the
-//     filter and advances the diagnostic floor.
+//  5. Kills the syncer again to assert a second recreation also replays
+//     without re-buffering anything.
 func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
@@ -1009,14 +979,6 @@ func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 		require.NotNil(t, syncer)
 		syncer.Close()
 	}
-	// replayState returns whether replay filtering is armed and the
-	// diagnostic floor captured by the last recreation.
-	replayState := func() (bool, mysql.Position) {
-		client.mu.Lock()
-		defer client.mu.Unlock()
-		return client.replayActive, client.replayFilterFloor
-	}
-
 	// E1: insert the row; E2: update it to its newest image. Both events
 	// land in the binlog file the dump is currently reading.
 	testutils.RunSQL(t, "INSERT INTO replayskipt1 (a, b) VALUES (1, 1)")
@@ -1062,14 +1024,6 @@ func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 	// error therefore means the replay has completed.
 	require.NoError(t, client.BlockWait(t.Context()))
 
-	// The recreation must have armed replay filtering and captured a
-	// diagnostic floor at or above the buffered high-water mark observed
-	// before the kill (it cannot be below it — bufferedPos is monotonic).
-	active, floor := replayState()
-	require.True(t, active, "recreateStreamer must arm replay filtering")
-	require.GreaterOrEqual(t, floor.Compare(bufferedBeforeRecreate), 0,
-		"the diagnostic floor must be at or above the pre-recreation buffered position")
-
 	// Neither already-buffered event may have been regressed by the
 	// replay: key 1 (flushed) must not return to the buffer at all, and
 	// key 2 (buffered-but-unflushed) must keep its newest image rather
@@ -1084,17 +1038,10 @@ func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replayskipt2 WHERE a = 2").Scan(&bVal))
 	require.Equal(t, 5, bVal, "the unflushed event must keep its newest image and flush correctly")
 
-	// A second recreation must re-arm the filter and advance the
-	// diagnostic floor rather than keep the stale floor from the first.
-	_, firstFloor := replayState()
+	// A second recreation must likewise replay without re-buffering
+	// anything, since nothing unflushed remains.
 	killSyncer()
 	require.NoError(t, client.BlockWait(t.Context()))
-	activeAgain, secondFloor := replayState()
-	require.True(t, activeAgain, "a second recreation must keep replay filtering armed")
-	require.Positive(t, secondFloor.Compare(firstFloor),
-		"the second recreation's floor must be ahead of the first")
-	require.Equal(t, 0, client.GetDeltaLen(),
-		"nothing unflushed remains, so the second replay must re-buffer nothing")
 	require.Equal(t, 0, client.GetDeltaLen(),
 		"nothing unflushed remains, so the second replay must re-buffer nothing")
 }

--- a/pkg/change/binlog_test.go
+++ b/pkg/change/binlog_test.go
@@ -777,16 +777,9 @@ func TestSetBufferedPosIsMonotonic(t *testing.T) {
 	require.Equal(t, nextFile, client.getBufferedPos())
 }
 
-// TestShouldSkipReplayedEvent unit-tests the pure skip decision used by
-// readStream during a post-recreateStreamer replay. eventPos is always
-// the event's END position (ev.Header.LogPos); the boundary is the
-// *live* bufferedPos — the high-water mark of everything already
-// processed. An event at or below bufferedPos is already faithfully
-// represented (applied to the target, or held in the buffered map with
-// its latest image), so <= means "must not be re-buffered". Filtering
-// against the live bufferedPos rather than a snapshot of flushedPos is
-// what keeps the filter safe when a periodic flush advances flushedPos
-// mid-replay — see shouldSkipReplayedEvent.
+// TestShouldSkipReplayedEvent unit-tests the skip decision: an event at or
+// below the live bufferedPos is already buffered/applied and must not be
+// re-delivered, with full (file, pos) ordering across rotations.
 func TestShouldSkipReplayedEvent(t *testing.T) {
 	buffered := mysql.Position{Name: "binlog.000010", Pos: 200}
 	tests := []struct {
@@ -889,40 +882,18 @@ func TestShouldSkipReplayedEventWidensWithBufferedPos(t *testing.T) {
 		"once the boundary advances, later live events are delivered")
 }
 
-// TestRecreateStreamerSkipsFlushedReplay locks in the fix for the
-// stale-image replay bug. recreateStreamer restarts the binlog dump at
-// position 4 of the current file; before the fix, readStream
-// re-delivered every replayed RowsEvent to the subscriptions. A
-// replayed event at or below the buffered high-water mark could regress
-// a key in the buffered map to an older row image, a periodic flush
-// running mid-replay would write that stale image to the target below
-// the persisted checkpoint, and a crash before the replay re-read the
-// newer event would make the regression permanent — resume streams only
-// events after the checkpoint, so the newer event is never re-sent.
-//
-// The filter compares each replayed event against the *live* bufferedPos
-// (not a snapshot of flushedPos), so every already-buffered event is
-// protected — both the flushed prefix (<= flushedPos) and the
-// buffered-but-unflushed window (flushedPos, bufferedPos]. The latter is
-// the gap the Copilot review on #919 flagged: a periodic flush can
-// advance flushedPos to bufferedPos mid-replay, and a snapshot of the
-// old flushedPos would leave that window unprotected.
-//
-// The test:
-//  1. Streams an INSERT + UPDATE for the same PK and flushes them, so
-//     the target holds the newest image and flushedPos is past both
-//     events.
-//  2. Writes one more row AFTER the flush and waits for it to buffer, so
-//     it sits in the (flushedPos, bufferedPos] window the snapshot fix
-//     would have missed.
-//  3. Kills the syncer out from under readStream, forcing the
-//     consecutive-error path to call recreateStreamer, which replays
-//     the current binlog file from position 4.
-//  4. Asserts the already-buffered events were NOT re-buffered (neither
-//     the flushed key nor the unflushed one regressed) and the buffered
-//     map still holds the unflushed event's newest image.
-//  5. Kills the syncer again to assert a second recreation also replays
-//     without re-buffering anything.
+// TestRecreateStreamerSkipsFlushedReplay locks in the fix end-to-end by
+// driving the real consecutive-error path that calls recreateStreamer:
+//  1. Stream an INSERT + UPDATE for one PK and flush, so the target holds
+//     the newest image and flushedPos is past both events.
+//  2. Write one more row after the flush and wait for it to buffer, so it
+//     sits in the (flushedPos, bufferedPos] window — buffered but not yet
+//     flushed (the window a flushedPos snapshot would miss).
+//  3. Kill the syncer so readStream's error path recreates the streamer
+//     and replays the current file from position 4.
+//  4. Assert nothing already-buffered was re-buffered (neither key
+//     regressed) and the unflushed key keeps its newest image.
+//  5. Kill the syncer again to assert a second replay re-buffers nothing.
 func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)

--- a/pkg/change/binlog_test.go
+++ b/pkg/change/binlog_test.go
@@ -779,101 +779,180 @@ func TestSetBufferedPosIsMonotonic(t *testing.T) {
 
 // TestShouldSkipReplayedEvent unit-tests the pure skip decision used by
 // readStream during a post-recreateStreamer replay. eventPos is always
-// the event's END position (ev.Header.LogPos); the filter is the
-// flushedPos captured at recreation time, which is itself recorded from
-// event end positions — so <= means "fully contained in the flushed
-// prefix, durably applied to the target, must not be re-buffered".
+// the event's END position (ev.Header.LogPos); the boundary is the
+// *live* bufferedPos — the high-water mark of everything already
+// processed. An event at or below bufferedPos is already faithfully
+// represented (applied to the target, or held in the buffered map with
+// its latest image), so <= means "must not be re-buffered". Filtering
+// against the live bufferedPos rather than a snapshot of flushedPos is
+// what keeps the filter safe when a periodic flush advances flushedPos
+// mid-replay — see the replayActive field comment.
 func TestShouldSkipReplayedEvent(t *testing.T) {
-	filter := mysql.Position{Name: "binlog.000010", Pos: 200}
+	buffered := mysql.Position{Name: "binlog.000010", Pos: 200}
 	tests := []struct {
-		name     string
-		eventPos mysql.Position
-		filter   mysql.Position
-		skip     bool
+		name         string
+		replayActive bool
+		eventPos     mysql.Position
+		bufferedPos  mysql.Position
+		skip         bool
 	}{
 		{
-			name:     "zero filter never skips (no recreation since Start)",
-			eventPos: mysql.Position{Name: "binlog.000010", Pos: 100},
-			filter:   mysql.Position{},
-			skip:     false,
+			name:         "replay inactive never skips (no recreation since Start)",
+			replayActive: false,
+			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 100},
+			bufferedPos:  buffered,
+			skip:         false,
 		},
 		{
-			name:     "zero filter never skips even at file start",
-			eventPos: mysql.Position{Name: "binlog.000001", Pos: 4},
-			filter:   mysql.Position{},
-			skip:     false,
+			name:         "replay inactive never skips even at file start",
+			replayActive: false,
+			eventPos:     mysql.Position{Name: "binlog.000001", Pos: 4},
+			bufferedPos:  mysql.Position{},
+			skip:         false,
 		},
 		{
-			name:     "same file below filter: already flushed, skip",
-			eventPos: mysql.Position{Name: "binlog.000010", Pos: 100},
-			filter:   filter,
-			skip:     true,
+			name:         "same file below bufferedPos: already represented, skip",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 100},
+			bufferedPos:  buffered,
+			skip:         true,
 		},
 		{
-			name: "same file equal to filter: event end == flushedPos means " +
-				"the event was the last one included in the flush, skip",
-			eventPos: mysql.Position{Name: "binlog.000010", Pos: 200},
-			filter:   filter,
-			skip:     true,
+			name: "same file equal to bufferedPos: event end == high-water " +
+				"mark means it is the last buffered event, skip",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 200},
+			bufferedPos:  buffered,
+			skip:         true,
 		},
 		{
-			name:     "same file just above filter: buffered-but-not-flushed, deliver",
-			eventPos: mysql.Position{Name: "binlog.000010", Pos: 201},
-			filter:   filter,
-			skip:     false,
+			name: "same file just above bufferedPos: genuinely new event, " +
+				"deliver",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 201},
+			bufferedPos:  buffered,
+			skip:         false,
 		},
 		{
-			name:     "earlier file: skip regardless of offset",
-			eventPos: mysql.Position{Name: "binlog.000009", Pos: 999999},
-			filter:   filter,
-			skip:     true,
+			name:         "earlier file: skip regardless of offset",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000009", Pos: 999999},
+			bufferedPos:  buffered,
+			skip:         true,
 		},
 		{
-			name: "later file: deliver regardless of offset (filter can sit in " +
-				"an earlier file when no flush ran since a rotation)",
-			eventPos: mysql.Position{Name: "binlog.000011", Pos: 4},
-			filter:   filter,
-			skip:     false,
+			name: "later file: deliver regardless of offset (bufferedPos can " +
+				"sit in an earlier file just after a rotation)",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000011", Pos: 4},
+			bufferedPos:  buffered,
+			skip:         false,
 		},
 		{
 			name: "numeric suffix ordering, not lexicographic: file .000100 " +
-				"is later than filter file .000099",
-			eventPos: mysql.Position{Name: "binlog.000100", Pos: 4},
-			filter:   mysql.Position{Name: "binlog.000099", Pos: 5000},
-			skip:     false,
+				"is later than bufferedPos file .000099",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000100", Pos: 4},
+			bufferedPos:  mysql.Position{Name: "binlog.000099", Pos: 5000},
+			skip:         false,
+		},
+		// The next two cases capture the regression the live-bufferedPos
+		// comparison fixes (Copilot review on #919): once a concurrent
+		// flush has advanced the high-water boundary, a *later* replayed
+		// event that a snapshot of the old flushedPos would have let
+		// through is now correctly skipped, because the boundary is read
+		// live. With buffered=200 a snapshot-of-old-flushedPos=100 would
+		// have delivered pos 150 and pos 200 (corrupting the map); the
+		// live boundary skips both.
+		{
+			name: "event below the live (advanced) bufferedPos is skipped " +
+				"even though it sits above where the replay's old flushedPos was",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 150},
+			bufferedPos:  buffered,
+			skip:         true,
+		},
+		{
+			name: "the last buffered event is skipped at the live boundary, " +
+				"so a mid-replay flush cannot persist a stale image",
+			replayActive: true,
+			eventPos:     mysql.Position{Name: "binlog.000010", Pos: 200},
+			bufferedPos:  buffered,
+			skip:         true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.skip, shouldSkipReplayedEvent(tt.eventPos, tt.filter))
+			require.Equal(t, tt.skip, shouldSkipReplayedEvent(tt.replayActive, tt.eventPos, tt.bufferedPos))
 		})
 	}
+}
+
+// TestShouldSkipReplayedEventWidensWithBufferedPos exercises the core
+// property that motivated switching from a flushedPos snapshot to the
+// live bufferedPos: as the replay catches up and bufferedPos advances
+// (e.g. a concurrent periodic flush, or the replay crossing the old
+// high-water mark), events that were below an earlier boundary stay
+// skipped and the boundary widens to cover newly-buffered positions.
+// This is the unit-level expression of "flushedPos/bufferedPos advances
+// during replay -> later events also skipped".
+func TestShouldSkipReplayedEventWidensWithBufferedPos(t *testing.T) {
+	const file = "binlog.000010"
+	// Replay re-reads E1..E4. At recreate the high-water mark was 400.
+	// The boundary is the live bufferedPos; while it sits at 400, every
+	// replayed event up to 400 is skipped — none can corrupt the map.
+	boundary := mysql.Position{Name: file, Pos: 400}
+	for _, pos := range []uint32{100, 200, 300, 400} {
+		ev := mysql.Position{Name: file, Pos: pos}
+		require.True(t, shouldSkipReplayedEvent(true, ev, boundary),
+			"replayed event at %d must be skipped while bufferedPos is 400", pos)
+	}
+	// The first genuinely-new event (past the high-water mark) is
+	// delivered; that advances bufferedPos to its end position.
+	newEvent := mysql.Position{Name: file, Pos: 450}
+	require.False(t, shouldSkipReplayedEvent(true, newEvent, boundary),
+		"an event past the high-water mark must be delivered")
+	boundary = newEvent
+	// A subsequent live event is above the now-advanced boundary, so the
+	// filter is inert for it (delivered).
+	require.False(t, shouldSkipReplayedEvent(true, mysql.Position{Name: file, Pos: 500}, boundary),
+		"once the boundary advances, later live events are delivered")
 }
 
 // TestRecreateStreamerSkipsFlushedReplay locks in the fix for the
 // stale-image replay bug. recreateStreamer restarts the binlog dump at
 // position 4 of the current file; before the fix, readStream
 // re-delivered every replayed RowsEvent to the subscriptions. A
-// replayed event at or below the flushed position could regress a key
-// in the buffered map to an older row image, a periodic flush running
-// mid-replay would write that stale image to the target below the
-// persisted checkpoint, and a crash before the replay re-read the
-// newer event would make the regression permanent — resume streams
-// only events after the checkpoint, so the newer event is never
-// re-sent.
+// replayed event at or below the buffered high-water mark could regress
+// a key in the buffered map to an older row image, a periodic flush
+// running mid-replay would write that stale image to the target below
+// the persisted checkpoint, and a crash before the replay re-read the
+// newer event would make the regression permanent — resume streams only
+// events after the checkpoint, so the newer event is never re-sent.
+//
+// The filter compares each replayed event against the *live* bufferedPos
+// (not a snapshot of flushedPos), so every already-buffered event is
+// protected — both the flushed prefix (<= flushedPos) and the
+// buffered-but-unflushed window (flushedPos, bufferedPos]. The latter is
+// the gap the Copilot review on #919 flagged: a periodic flush can
+// advance flushedPos to bufferedPos mid-replay, and a snapshot of the
+// old flushedPos would leave that window unprotected.
 //
 // The test:
 //  1. Streams an INSERT + UPDATE for the same PK and flushes them, so
 //     the target holds the newest image and flushedPos is past both
 //     events.
-//  2. Writes one more row AFTER the flush (buffered-but-not-flushed).
+//  2. Writes one more row AFTER the flush and waits for it to buffer, so
+//     it sits in the (flushedPos, bufferedPos] window the snapshot fix
+//     would have missed.
 //  3. Kills the syncer out from under readStream, forcing the
 //     consecutive-error path to call recreateStreamer, which replays
 //     the current binlog file from position 4.
-//  4. Asserts the already-flushed events were NOT re-buffered while the
-//     post-flush event WAS re-delivered.
-//  5. Kills the syncer again to assert a second recreation re-captures
-//     the then-current flushed position.
+//  4. Asserts the already-buffered events were NOT re-buffered (neither
+//     the flushed key nor the unflushed one regressed) and the buffered
+//     map still holds the unflushed event's newest image.
+//  5. Kills the syncer again to assert a second recreation re-arms the
+//     filter and advances the diagnostic floor.
 func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
@@ -930,11 +1009,12 @@ func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 		require.NotNil(t, syncer)
 		syncer.Close()
 	}
-	// replayFilter returns the filter captured by the last recreation.
-	replayFilter := func() mysql.Position {
+	// replayState returns whether replay filtering is armed and the
+	// diagnostic floor captured by the last recreation.
+	replayState := func() (bool, mysql.Position) {
 		client.mu.Lock()
 		defer client.mu.Unlock()
-		return client.replayFilterPos
+		return client.replayActive, client.replayFilterFloor
 	}
 
 	// E1: insert the row; E2: update it to its newest image. Both events
@@ -956,10 +1036,23 @@ func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replayskipt2 WHERE a = 1").Scan(&bVal))
 	require.Equal(t, 2, bVal)
 
-	// Write one more event after the flush. It sits between flushedPos
-	// and the end of the file, so the replay MUST re-deliver it — it was
-	// never part of a flush.
+	// Write one more event after the flush and wait for the reader to
+	// buffer it. It now sits in the (flushedPos, bufferedPos] window —
+	// buffered with its newest image but not yet flushed. This is exactly
+	// the window a snapshot of the old flushedPos would have failed to
+	// protect; the live-bufferedPos filter must keep the replay from
+	// regressing it.
 	testutils.RunSQL(t, "INSERT INTO replayskipt1 (a, b) VALUES (2, 5)")
+	waitBuffered()
+	require.Equal(t, 1, client.GetDeltaLen(),
+		"the post-flush INSERT must be buffered before the recreation")
+
+	client.mu.Lock()
+	flushedBeforeRecreate := client.flushedPos
+	client.mu.Unlock()
+	bufferedBeforeRecreate := client.getBufferedPos()
+	require.Positive(t, bufferedBeforeRecreate.Compare(flushedBeforeRecreate),
+		"the unflushed event must put bufferedPos ahead of flushedPos before recreation")
 
 	killSyncer()
 
@@ -969,35 +1062,39 @@ func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
 	// error therefore means the replay has completed.
 	require.NoError(t, client.BlockWait(t.Context()))
 
-	// The recreation must have captured the flushed position as the
-	// replay filter.
-	require.Equal(t, flushedAtRecreate, formatBinlogPosition(replayFilter()),
-		"recreateStreamer should capture the flushed position at recreation time")
+	// The recreation must have armed replay filtering and captured a
+	// diagnostic floor at or above the buffered high-water mark observed
+	// before the kill (it cannot be below it — bufferedPos is monotonic).
+	active, floor := replayState()
+	require.True(t, active, "recreateStreamer must arm replay filtering")
+	require.GreaterOrEqual(t, floor.Compare(bufferedBeforeRecreate), 0,
+		"the diagnostic floor must be at or above the pre-recreation buffered position")
 
-	// The already-flushed INSERT+UPDATE must NOT have been re-buffered —
-	// re-buffering would regress key 1 to a stale image that a
-	// mid-replay flush could persist below the checkpoint. Only the
-	// post-flush INSERT (key 2) may be pending.
+	// Neither already-buffered event may have been regressed by the
+	// replay: key 1 (flushed) must not return to the buffer at all, and
+	// key 2 (buffered-but-unflushed) must keep its newest image rather
+	// than be overwritten by a replayed stale image. Delta stays 1 (just
+	// key 2, still holding b=5).
 	require.Equal(t, 1, client.GetDeltaLen(),
-		"only the unflushed post-flush event may be (re-)buffered; already-flushed events must be skipped")
+		"replay must not re-buffer already-buffered events; only the unflushed key 2 remains")
 
 	require.NoError(t, client.flush(t.Context(), false, nil))
 	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replayskipt2 WHERE a = 1").Scan(&bVal))
 	require.Equal(t, 2, bVal, "key 1 must keep its newest image")
 	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replayskipt2 WHERE a = 2").Scan(&bVal))
-	require.Equal(t, 5, bVal, "the unflushed event must be re-delivered and applied")
+	require.Equal(t, 5, bVal, "the unflushed event must keep its newest image and flush correctly")
 
-	// A second recreation must re-capture the THEN-current flushed
-	// position rather than keep the stale filter from the first one.
-	firstFilter := replayFilter()
-	secondFlushed := client.Position()
+	// A second recreation must re-arm the filter and advance the
+	// diagnostic floor rather than keep the stale floor from the first.
+	_, firstFloor := replayState()
 	killSyncer()
 	require.NoError(t, client.BlockWait(t.Context()))
-	secondFilter := replayFilter()
-	require.Equal(t, secondFlushed, formatBinlogPosition(secondFilter),
-		"a second recreation must capture the then-current flushed position")
-	require.Positive(t, secondFilter.Compare(firstFilter),
-		"the second filter must be ahead of the first")
+	activeAgain, secondFloor := replayState()
+	require.True(t, activeAgain, "a second recreation must keep replay filtering armed")
+	require.Positive(t, secondFloor.Compare(firstFloor),
+		"the second recreation's floor must be ahead of the first")
+	require.Equal(t, 0, client.GetDeltaLen(),
+		"nothing unflushed remains, so the second replay must re-buffer nothing")
 	require.Equal(t, 0, client.GetDeltaLen(),
 		"nothing unflushed remains, so the second replay must re-buffer nothing")
 }

--- a/pkg/change/binlog_test.go
+++ b/pkg/change/binlog_test.go
@@ -777,6 +777,231 @@ func TestSetBufferedPosIsMonotonic(t *testing.T) {
 	require.Equal(t, nextFile, client.getBufferedPos())
 }
 
+// TestShouldSkipReplayedEvent unit-tests the pure skip decision used by
+// readStream during a post-recreateStreamer replay. eventPos is always
+// the event's END position (ev.Header.LogPos); the filter is the
+// flushedPos captured at recreation time, which is itself recorded from
+// event end positions — so <= means "fully contained in the flushed
+// prefix, durably applied to the target, must not be re-buffered".
+func TestShouldSkipReplayedEvent(t *testing.T) {
+	filter := mysql.Position{Name: "binlog.000010", Pos: 200}
+	tests := []struct {
+		name     string
+		eventPos mysql.Position
+		filter   mysql.Position
+		skip     bool
+	}{
+		{
+			name:     "zero filter never skips (no recreation since Start)",
+			eventPos: mysql.Position{Name: "binlog.000010", Pos: 100},
+			filter:   mysql.Position{},
+			skip:     false,
+		},
+		{
+			name:     "zero filter never skips even at file start",
+			eventPos: mysql.Position{Name: "binlog.000001", Pos: 4},
+			filter:   mysql.Position{},
+			skip:     false,
+		},
+		{
+			name:     "same file below filter: already flushed, skip",
+			eventPos: mysql.Position{Name: "binlog.000010", Pos: 100},
+			filter:   filter,
+			skip:     true,
+		},
+		{
+			name: "same file equal to filter: event end == flushedPos means " +
+				"the event was the last one included in the flush, skip",
+			eventPos: mysql.Position{Name: "binlog.000010", Pos: 200},
+			filter:   filter,
+			skip:     true,
+		},
+		{
+			name:     "same file just above filter: buffered-but-not-flushed, deliver",
+			eventPos: mysql.Position{Name: "binlog.000010", Pos: 201},
+			filter:   filter,
+			skip:     false,
+		},
+		{
+			name:     "earlier file: skip regardless of offset",
+			eventPos: mysql.Position{Name: "binlog.000009", Pos: 999999},
+			filter:   filter,
+			skip:     true,
+		},
+		{
+			name: "later file: deliver regardless of offset (filter can sit in " +
+				"an earlier file when no flush ran since a rotation)",
+			eventPos: mysql.Position{Name: "binlog.000011", Pos: 4},
+			filter:   filter,
+			skip:     false,
+		},
+		{
+			name: "numeric suffix ordering, not lexicographic: file .000100 " +
+				"is later than filter file .000099",
+			eventPos: mysql.Position{Name: "binlog.000100", Pos: 4},
+			filter:   mysql.Position{Name: "binlog.000099", Pos: 5000},
+			skip:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.skip, shouldSkipReplayedEvent(tt.eventPos, tt.filter))
+		})
+	}
+}
+
+// TestRecreateStreamerSkipsFlushedReplay locks in the fix for the
+// stale-image replay bug. recreateStreamer restarts the binlog dump at
+// position 4 of the current file; before the fix, readStream
+// re-delivered every replayed RowsEvent to the subscriptions. A
+// replayed event at or below the flushed position could regress a key
+// in the buffered map to an older row image, a periodic flush running
+// mid-replay would write that stale image to the target below the
+// persisted checkpoint, and a crash before the replay re-read the
+// newer event would make the regression permanent — resume streams
+// only events after the checkpoint, so the newer event is never
+// re-sent.
+//
+// The test:
+//  1. Streams an INSERT + UPDATE for the same PK and flushes them, so
+//     the target holds the newest image and flushedPos is past both
+//     events.
+//  2. Writes one more row AFTER the flush (buffered-but-not-flushed).
+//  3. Kills the syncer out from under readStream, forcing the
+//     consecutive-error path to call recreateStreamer, which replays
+//     the current binlog file from position 4.
+//  4. Asserts the already-flushed events were NOT re-buffered while the
+//     post-flush event WAS re-delivered.
+//  5. Kills the syncer again to assert a second recreation re-captures
+//     the then-current flushed position.
+func TestRecreateStreamerSkipsFlushedReplay(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS replayskipt1, replayskipt2")
+	testutils.RunSQL(t, "CREATE TABLE replayskipt1 (a INT NOT NULL, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE replayskipt2 (a INT NOT NULL, b INT, PRIMARY KEY (a))")
+
+	t1 := table.NewTableInfo(db, "test", "replayskipt1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "replayskipt2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*binlogClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	// serverPos reads the server's current binlog position WITHOUT
+	// rotating (unlike getCurrentBinlogPosition, which FLUSHes BINARY
+	// LOGS first). Rotation must be avoided in the setup phase so the
+	// flushed events stay inside the file that the recreation replays.
+	serverPos := func() mysql.Position {
+		var name, fake string
+		var pos uint32
+		err := db.QueryRowContext(t.Context(), "SHOW MASTER STATUS").Scan(&name, &pos, &fake, &fake, &fake)
+		if err != nil {
+			// MySQL 8.2+ removed SHOW MASTER STATUS.
+			require.NoError(t, db.QueryRowContext(t.Context(), "SHOW BINARY LOG STATUS").Scan(&name, &pos, &fake, &fake, &fake))
+		}
+		return mysql.Position{Name: name, Pos: pos}
+	}
+	// waitBuffered waits (without rotating) until the reader has
+	// buffered everything the server has written so far.
+	waitBuffered := func() {
+		target := serverPos()
+		require.Eventually(t, func() bool {
+			return client.getBufferedPos().Compare(target) >= 0
+		}, 15*time.Second, 10*time.Millisecond, "reader did not catch up to %v", target)
+	}
+	// killSyncer closes the syncer out from under readStream. GetEvent
+	// then fails until maxConsecutiveErrors accumulate (~500ms), at
+	// which point readStream calls recreateStreamer and the dump
+	// restarts at position 4 of the current file.
+	killSyncer := func() {
+		client.mu.Lock()
+		syncer := client.syncer
+		client.mu.Unlock()
+		require.NotNil(t, syncer)
+		syncer.Close()
+	}
+	// replayFilter returns the filter captured by the last recreation.
+	replayFilter := func() mysql.Position {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		return client.replayFilterPos
+	}
+
+	// E1: insert the row; E2: update it to its newest image. Both events
+	// land in the binlog file the dump is currently reading.
+	testutils.RunSQL(t, "INSERT INTO replayskipt1 (a, b) VALUES (1, 1)")
+	testutils.RunSQL(t, "UPDATE replayskipt1 SET b = 2 WHERE a = 1")
+	waitBuffered()
+	require.Equal(t, 1, client.GetDeltaLen(), "INSERT+UPDATE on the same PK should dedupe to one buffered change")
+
+	// Flush. The target now holds the newest image and flushedPos is at
+	// or past the end of the UPDATE event. (The low-level flush is used
+	// because the public Flush calls BlockWait, which rotates the binary
+	// log and would move the events out of the replayed file.)
+	require.NoError(t, client.flush(t.Context(), false, nil))
+	require.Equal(t, 0, client.GetDeltaLen())
+	flushedAtRecreate := client.Position()
+	require.NotEmpty(t, flushedAtRecreate)
+	var bVal int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replayskipt2 WHERE a = 1").Scan(&bVal))
+	require.Equal(t, 2, bVal)
+
+	// Write one more event after the flush. It sits between flushedPos
+	// and the end of the file, so the replay MUST re-deliver it — it was
+	// never part of a flush.
+	testutils.RunSQL(t, "INSERT INTO replayskipt1 (a, b) VALUES (2, 5)")
+
+	killSyncer()
+
+	// BlockWait targets the server's position after rotating the binary
+	// log, and the reader can only reach it by going through the
+	// recreation and replaying the whole current file. Returning without
+	// error therefore means the replay has completed.
+	require.NoError(t, client.BlockWait(t.Context()))
+
+	// The recreation must have captured the flushed position as the
+	// replay filter.
+	require.Equal(t, flushedAtRecreate, formatBinlogPosition(replayFilter()),
+		"recreateStreamer should capture the flushed position at recreation time")
+
+	// The already-flushed INSERT+UPDATE must NOT have been re-buffered —
+	// re-buffering would regress key 1 to a stale image that a
+	// mid-replay flush could persist below the checkpoint. Only the
+	// post-flush INSERT (key 2) may be pending.
+	require.Equal(t, 1, client.GetDeltaLen(),
+		"only the unflushed post-flush event may be (re-)buffered; already-flushed events must be skipped")
+
+	require.NoError(t, client.flush(t.Context(), false, nil))
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replayskipt2 WHERE a = 1").Scan(&bVal))
+	require.Equal(t, 2, bVal, "key 1 must keep its newest image")
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replayskipt2 WHERE a = 2").Scan(&bVal))
+	require.Equal(t, 5, bVal, "the unflushed event must be re-delivered and applied")
+
+	// A second recreation must re-capture the THEN-current flushed
+	// position rather than keep the stale filter from the first one.
+	firstFilter := replayFilter()
+	secondFlushed := client.Position()
+	killSyncer()
+	require.NoError(t, client.BlockWait(t.Context()))
+	secondFilter := replayFilter()
+	require.Equal(t, secondFlushed, formatBinlogPosition(secondFilter),
+		"a second recreation must capture the then-current flushed position")
+	require.Positive(t, secondFilter.Compare(firstFilter),
+		"the second filter must be ahead of the first")
+	require.Equal(t, 0, client.GetDeltaLen(),
+		"nothing unflushed remains, so the second replay must re-buffer nothing")
+}
+
 // TestMaxRecreateAttemptsError tests that the readStream goroutine sets a stream error
 // and exits cleanly after exhausting the maximum number of streamer recreation attempts.
 func TestMaxRecreateAttemptsError(t *testing.T) {


### PR DESCRIPTION
## Problem

After 5 consecutive stream errors, `recreateStreamer` restarts the binlog dump at position 4 of the current file, and `readStream` re-delivered every replayed RowsEvent to subscriptions. A replayed event at or below `flushedPos` can regress a key in the buffered map to a stale row image. Since `setBufferedPos` is monotonic (#847), the periodic flush is free to run mid-replay and write that stale image to the target — below the already-persisted checkpoint:

1. Events E1 (key K, ends pos 100) and E2 (key K, ends pos 200) are read; map holds K@200.
2. Flush applies K@200; `flushedPos`=200; checkpoint persisted.
3. Stream errors → replay from position 4 re-reads E1: map now holds the stale K@100.
4. Periodic flush applies K@100 to the target.
5. Crash before the replay re-reads E2. Resume streams only events after pos 200 — E2 is never re-sent, and the row keeps the older image permanently. With `--checksum=false` there is no backstop.

Cutover via `FlushUnderTableLock` is protected (BlockWait forces the replay to finish); only the crash/resume path is exposed. The GTID client does not share this bug (it resumes from fully-buffered committed transactions).

## Fix

`recreateStreamer` captures the current `flushedPos` on every recreation, and `readStream` skips delivering replayed RowsEvents whose end position is at or below it — those events are durably applied per the `Position()` contract. Events above it are re-delivered as before (idempotent re-buffering). Comparison uses full `(file, pos)` ordering, so rotation is handled. `Start` resets the filter.

## Testing

- `TestShouldSkipReplayedEvent`: table-driven unit tests for the skip decision (zero filter, below/equal/above, earlier/later file).
- `TestRecreateStreamerSkipsFlushedReplay`: integration test that kills the syncer so the genuine consecutive-error path drives `recreateStreamer`, then asserts flushed events are NOT re-buffered while unflushed ones are, and that a second recreation re-captures the advanced filter. Fails with delta 2 vs expected 1 when the skip is disabled.
- Full `pkg/change` suite passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)