### PR TITLE
escape separator in hash keys to prevent collisions

### DIFF
--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -464,6 +464,84 @@ func TestSingleTargetApplierDeleteKeys(t *testing.T) {
 	require.NoError(t, rows.Err())
 }
 
+// TestSingleTargetApplierDeleteKeysSeparatorInValues tests DeleteKeys with
+// string PK values containing the hash-key separator "-#-". Before hash-key
+// components were escaped, a single-column PK value containing "-#-" was
+// split into multiple values, producing DELETE ... WHERE (pk) IN (('a','b'))
+// — MySQL error 1241 "Operand should contain 1 column(s)" — which blocked
+// the flush forever.
+func TestSingleTargetApplierDeleteKeysSeparatorInValues(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS single_delete_sep_test")
+	testutils.RunSQL(t, "CREATE DATABASE single_delete_sep_test")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	target := base.Clone()
+	target.DBName = "single_delete_sep_test"
+	targetDB, err := sql.Open("mysql", target.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+
+	// Single-column VARCHAR PK whose values contain the separator.
+	_, err = targetDB.ExecContext(t.Context(),
+		`CREATE TABLE test_table (id VARCHAR(64) PRIMARY KEY, name VARCHAR(100))`)
+	require.NoError(t, err)
+	_, err = targetDB.ExecContext(t.Context(),
+		`INSERT INTO test_table VALUES ('a-#-b', 'Alice'), ('plain', 'Bob'), ('-#-', 'Charlie')`)
+	require.NoError(t, err)
+
+	targetTable := table.NewTableInfo(targetDB, target.DBName, "test_table")
+	require.NoError(t, targetTable.SetInfo(t.Context()))
+
+	tar := Target{
+		DB:       targetDB,
+		Config:   target,
+		KeyRange: "0",
+	}
+	applier, err := NewSingleTargetApplier(tar, NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	keysToDelete := []string{
+		utils.HashKey([]any{"a-#-b"}),
+		utils.HashKey([]any{"-#-"}),
+	}
+	affectedRows, err := applier.DeleteKeys(t.Context(), targetTable, targetTable, keysToDelete, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), affectedRows)
+
+	var id, name string
+	require.NoError(t, targetDB.QueryRowContext(t.Context(),
+		"SELECT id, name FROM test_table").Scan(&id, &name))
+	require.Equal(t, "plain", id)
+	require.Equal(t, "Bob", name)
+
+	// Composite PK: values containing the separator must round-trip into a
+	// tuple of the correct arity and delete exactly the intended row.
+	_, err = targetDB.ExecContext(t.Context(),
+		`CREATE TABLE test_composite (id1 VARCHAR(64), id2 VARCHAR(64), name VARCHAR(100), PRIMARY KEY (id1, id2))`)
+	require.NoError(t, err)
+	_, err = targetDB.ExecContext(t.Context(),
+		`INSERT INTO test_composite VALUES ('a-#-b', 'c', 'collide1'), ('a', 'b-#-c', 'collide2'), ('keep', 'me', 'safe')`)
+	require.NoError(t, err)
+
+	compositeTable := table.NewTableInfo(targetDB, target.DBName, "test_composite")
+	require.NoError(t, compositeTable.SetInfo(t.Context()))
+
+	affectedRows, err = applier.DeleteKeys(t.Context(), compositeTable, compositeTable,
+		[]string{utils.HashKey([]any{"a-#-b", "c"})}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affectedRows, "only ('a-#-b','c') must be deleted, not ('a','b-#-c')")
+
+	var count int
+	require.NoError(t, targetDB.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM test_composite").Scan(&count))
+	require.Equal(t, 2, count)
+	require.NoError(t, targetDB.QueryRowContext(t.Context(),
+		"SELECT name FROM test_composite WHERE id1 = 'a' AND id2 = 'b-#-c'").Scan(&name))
+	require.Equal(t, "collide2", name, "the colliding sibling row must survive the delete")
+}
+
 // TestSingleTargetApplierDeleteKeysEmpty tests DeleteKeys with empty key list
 func TestSingleTargetApplierDeleteKeysEmpty(t *testing.T) {
 	testutils.RunSQL(t, "DROP DATABASE IF EXISTS single_delete_empty_test")

--- a/pkg/change/subscription_buffered_test.go
+++ b/pkg/change/subscription_buffered_test.go
@@ -1978,3 +1978,98 @@ func fetchJSONColumnCRC(t *testing.T, col string, tbl *table.TableInfo) int64 {
 		col, col, tbl.QuotedTableName)).Scan(&ck))
 	return ck
 }
+
+// TestBufferedMapSeparatorInPKValues exercises PK values containing the
+// hash-key separator "-#-" end-to-end through the buffered map and the
+// applier flush path. Before hash-key components were escaped, two bugs
+// existed here:
+//
+//  1. Map collision: for a composite PK, ("a-#-b", "c") and ("a", "b-#-c")
+//     hashed to the same string, so the second event silently overwrote
+//     the first row's buffered change and one row was never applied.
+//  2. Wrong-arity SQL: a DELETE on a single-column PK whose value contains
+//     "-#-" was split into multiple values, producing
+//     DELETE ... WHERE (pk) IN (('a','b')) — MySQL error 1241.
+func TestBufferedMapSeparatorInPKValues(t *testing.T) {
+	t1 := `CREATE TABLE subscription_test (
+		id1 VARCHAR(64) NOT NULL,
+		id2 VARCHAR(64) NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		PRIMARY KEY (id1, id2)
+	)`
+	t2 := `CREATE TABLE _subscription_test_new (
+		id1 VARCHAR(64) NOT NULL,
+		id2 VARCHAR(64) NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		PRIMARY KEY (id1, id2)
+	)`
+	srcTable, dstTable := setupTestTables(t, t1, t2)
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	target := applier.Target{DB: db, KeyRange: "0", Config: cfg}
+	applierInstance, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	mockChunker := table.NewMockChunker(srcTable.TableName, 1000)
+	mockChunker.SetColumnMapping(table.NewColumnMapping(srcTable, dstTable, nil))
+
+	client := &binlogClient{
+		db:       db,
+		logger:   slog.Default(),
+		dbConfig: dbconn.NewDBConfig(),
+	}
+
+	sub := &bufferedMap{
+		logger:               client.logger,
+		applier:              applierInstance,
+		table:                srcTable,
+		newTable:             dstTable,
+		changes:              make(map[string]bufferedChange),
+		chunker:              mockChunker,
+		pkIsMemoryComparable: false,
+		// watermarkOptimization on => map mode (copy phase). MockChunker
+		// returns false from KeyAboveHighWatermark for string keys, so
+		// nothing is dropped.
+		watermarkOptimization: true,
+	}
+	sub.cond = sync.NewCond(&sub.Mutex)
+
+	// Seed target with a row whose first PK component contains the
+	// separator, so the DELETE below has something to remove.
+	testutils.RunSQL(t, fmt.Sprintf(
+		`INSERT INTO %s (id1, id2, name) VALUES ('x-#-y', 'z', 'stale')`,
+		dstTable.QuotedTableName))
+
+	// These two upserts collide to the same map key without escaping.
+	sub.HasChanged([]any{"a-#-b", "c"}, []any{"a-#-b", "c", "first"}, false)
+	sub.HasChanged([]any{"a", "b-#-c"}, []any{"a", "b-#-c", "second"}, false)
+	// DELETE with separator inside a PK value: without unescape-aware
+	// splitting this produced a 4-value tuple for a 2-column key.
+	sub.HasChanged([]any{"x-#-y", "z"}, nil, true)
+	require.Len(t, sub.changes, 3,
+		"distinct PKs must occupy distinct map slots even when values contain the separator")
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Equal(t, 0, sub.Length())
+
+	rows, err := db.QueryContext(t.Context(),
+		fmt.Sprintf("SELECT id1, id2, name FROM %s ORDER BY id1, id2", dstTable.QuotedTableName))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+	var got []string
+	for rows.Next() {
+		var id1, id2, name string
+		require.NoError(t, rows.Scan(&id1, &id2, &name))
+		got = append(got, id1+"|"+id2+"="+name)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, []string{"a|b-#-c=second", "a-#-b|c=first"}, got,
+		"both upserted rows must be applied and the seeded row deleted")
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,22 +17,55 @@ const (
 
 // HashKey is used to convert a composite key into a string
 // so that it can be placed in a map.
+// Each component is escaped before joining so that values containing
+// the separator cannot collide with key boundaries: without escaping,
+// ("a-#-b", "c") and ("a", "b-#-c") would hash to the same string,
+// causing one row's buffered change to silently overwrite another's.
 func HashKey(key []any) string {
-	var pk []string
+	pk := make([]string, 0, len(key))
 	for _, v := range key {
-		pk = append(pk, fmt.Sprintf("%v", v))
+		pk = append(pk, escapeHashComponent(fmt.Sprintf("%v", v)))
 	}
 	return strings.Join(pk, PrimaryKeySeparator)
 }
 
+// escapeHashComponent escapes a single key component so the separator can
+// never appear inside it: backslashes are doubled first, then every "#" is
+// prefixed with a backslash. After escaping, every "#" originating from
+// user data is preceded by a backslash, while the bare "#" in the
+// separator never is — so splitting on the separator is unambiguous.
+func escapeHashComponent(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	return strings.ReplaceAll(s, `#`, `\#`)
+}
+
+// unescapeHashComponent reverses escapeHashComponent: each backslash
+// escapes the byte that follows it.
+func unescapeHashComponent(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
 // UnhashKeyToString converts a hashed key to a string that can be used in a query.
+// Components are unescaped (reversing HashKey's escaping) before being
+// SQL-escaped, so the resulting SQL contains the original values.
 func UnhashKeyToString(key string) string {
 	str := strings.Split(key, PrimaryKeySeparator)
 	if len(str) == 1 {
-		return "'" + sqlescape.EscapeString(str[0]) + "'"
+		return "'" + sqlescape.EscapeString(unescapeHashComponent(str[0])) + "'"
 	}
 	for i, v := range str {
-		str[i] = "'" + sqlescape.EscapeString(v) + "'"
+		str[i] = "'" + sqlescape.EscapeString(unescapeHashComponent(v)) + "'"
 	}
 	return "(" + strings.Join(str, ",") + ")"
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -48,6 +48,8 @@ func unescapeHashComponent(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	for i := 0; i < len(s); i++ {
+		// defensive: HashKey output never ends in a lone backslash, so the
+		// bound only guards against indexing past a malformed input.
 		if s[i] == '\\' && i+1 < len(s) {
 			i++
 		}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -29,6 +29,56 @@ func TestHashAndUnhashKey(t *testing.T) {
 	require.Equal(t, "'1234'", unhashed)
 }
 
+// TestHashKeySeparatorCollision pins the fix for hash-key collisions:
+// without escaping, ("a-#-b", "c") and ("a", "b-#-c") hash to the same
+// string, so one row's buffered change silently overwrites another's.
+func TestHashKeySeparatorCollision(t *testing.T) {
+	require.NotEqual(t,
+		HashKey([]any{"a-#-b", "c"}),
+		HashKey([]any{"a", "b-#-c"}))
+	require.NotEqual(t,
+		HashKey([]any{"a-#-b-#-c"}),
+		HashKey([]any{"a", "b", "c"}))
+	require.NotEqual(t,
+		HashKey([]any{"a#", "#b"}),
+		HashKey([]any{"a", "#", "b"}))
+	// Components containing escape characters must not collide either.
+	require.NotEqual(t,
+		HashKey([]any{`a\`, "b"}),
+		HashKey([]any{"a", `\b`}))
+}
+
+// TestHashKeyRoundTrip verifies that UnhashKeyToString recovers the exact
+// original values (correctly SQL-quoted) for components containing the
+// separator, escape characters, and edge-case values.
+func TestHashKeyRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		key  []any
+		want string
+	}{
+		{"plain single", []any{"hello"}, "'hello'"},
+		{"plain composite", []any{"a", "b"}, "('a','b')"},
+		{"separator in single key", []any{"a-#-b"}, "'a-#-b'"},
+		{"separator in composite components", []any{"a-#-b", "c"}, "('a-#-b','c')"},
+		{"separator in second component", []any{"a", "b-#-c"}, "('a','b-#-c')"},
+		{"bare hash", []any{"a#b", "c#"}, "('a#b','c#')"},
+		{"backslash", []any{`a\b`, `c\`}, `('a\\b','c\\')`}, // sqlescape doubles backslashes for SQL
+		{"backslash before hash", []any{`a\#b`}, `'a\\#b'`},
+		{"only separator", []any{"-#-"}, "'-#-'"},
+		{"empty single", []any{""}, "''"},
+		{"empty components", []any{"", ""}, "('','')"},
+		{"empty first component", []any{"", "a"}, "('','a')"},
+		{"trailing dash boundary", []any{"a-", "-b"}, "('a-','-b')"},
+		{"non-string types", []any{int64(42), "x"}, "('42','x')"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, UnhashKeyToString(HashKey(tc.key)))
+		})
+	}
+}
+
 func TestTruncateTableName(t *testing.T) {
 	// Short name that doesn't need truncation
 	require.Equal(t, "mytable", TruncateTableName("mytable", 21))


### PR DESCRIPTION
## Problem

`utils.HashKey` built composite-PK map keys by joining components with the literal separator `-#-`, and `UnhashKeyToString` split on it — with no escaping. Since go-mysql decodes VARCHAR PKs as Go strings, PK values containing `-#-` are realistic. Two failure modes:

1. **Silent change loss**: `('a-#-b', 'c')` and `('a', 'b-#-c')` produce the identical key `a-#-b-#-c`, so the second binlog event overwrites the first row's buffered change in the subscription's dedup map — one row's change is never applied (checksum is the only backstop).
2. **Permanently failing flush**: a single-column PK value containing `-#-` is split into a multi-value tuple, producing `DELETE ... WHERE (pk) IN (('a','b'))` → MySQL error 1241 "Operand should contain 1 column(s)", blocking the flush forever.

## Fix

Escape each component when hashing (`\` → `\\`, then `#` → `\#`) before joining: every user-data `#` is backslash-prefixed while the separator's `#` never is, making the split unambiguous. `UnhashKeyToString` unescapes each part before SQL-escaping, so the final SQL contains the original value, correctly quoted.

Hash keys are purely in-memory (dedup maps and applier flush paths) and never persisted to checkpoints, so resume compatibility is unaffected. Keys without special characters hash byte-identically to before.

## Testing

- Round-trip and collision unit tests (separator, bare `#`, `\`, empty components, boundary dashes, non-string types).
- `TestBufferedMapSeparatorInPKValues`: end-to-end map-mode buffered subscription with composite VARCHAR PKs; the two previously-colliding rows occupy distinct slots and flush correctly through the real applier.
- `TestSingleTargetApplierDeleteKeysSeparatorInValues`: covers the previous error-1241 case and asserts only the intended row is deleted.
- All three new tests verified to FAIL against the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)