### PR TITLE
fix retryable error classification in RetryableTransaction

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -4,6 +4,7 @@ package dbconn
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -18,12 +19,24 @@ import (
 )
 
 const (
-	errLockWaitTimeout  = 1205
-	errDeadlock         = 1213
-	errCannotConnect    = 2003
-	errConnLost         = 2013
+	errLockWaitTimeout = 1205
+	errDeadlock        = 1213
+	// errCannotConnect (2003) and errConnLost (2013) are client-library CR_*
+	// codes: go-sql-driver itself never returns them as a *mysql.MySQLError
+	// (client-side failures surface as driver.ErrBadConn or
+	// mysql.ErrInvalidConn, handled separately in canRetryError). They are
+	// kept here because proxies (e.g. ProxySQL, RDS Proxy) can relay them
+	// inside real server error packets.
+	errCannotConnect = 2003
+	errConnLost      = 2013
+	// errReadOnly (1290) and errReadOnlyMode (1836) are usually consumed by
+	// go-sql-driver when RejectReadOnly is enabled (the spirit default) and
+	// converted to driver.ErrBadConn. They are kept here for the case where
+	// RejectReadOnly is disabled, e.g. the move runner disables it for
+	// read-only sources (see DBConfig.RejectReadOnly).
 	errReadOnly         = 1290
-	errQueryKilled      = 1836
+	errReadOnlyMode     = 1836
+	errQueryInterrupted = 1317 // ER_QUERY_INTERRUPTED: query was killed (e.g. KILL QUERY)
 	errCapacityExceeded = 3170
 	errFoundDuppKey     = 1062 // yes I know there's a typo
 )
@@ -74,14 +87,26 @@ func NewDBConfig() *DBConfig {
 // This is because it gets complicated in cases where the statement could
 // succeed but then there is a deadlock later on.
 func canRetryError(err error) bool {
-	var errNumber uint16
-	var val *mysql.MySQLError
-	if errors.As(err, &val) {
-		errNumber = val.Number
+	// Connection-level failures never surface as a *mysql.MySQLError:
+	// go-sql-driver returns driver.ErrBadConn when it is safe to retry on a
+	// new connection (nothing was written yet), and mysql.ErrInvalidConn when
+	// the connection died mid-statement (e.g. a network blip, the connection
+	// was killed, or an Aurora failover with RejectReadOnly enabled — the
+	// driver converts read-only errors 1290/1792/1836 into driver.ErrBadConn
+	// and discards the connection). Both are safe to retry here: every
+	// statement run through RetryableTransaction is idempotent (INSERT
+	// IGNORE / REPLACE / DELETE), and each retry starts a fresh transaction
+	// — database/sql hands BeginTx a new connection if the old one is dead.
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) {
+		return true
 	}
-	switch errNumber {
+	var val *mysql.MySQLError
+	if !errors.As(err, &val) {
+		return false
+	}
+	switch val.Number {
 	case errLockWaitTimeout, errDeadlock, errCannotConnect,
-		errConnLost, errReadOnly, errQueryKilled:
+		errConnLost, errReadOnly, errReadOnlyMode, errQueryInterrupted:
 		return true
 	default:
 		return false

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -29,13 +29,15 @@ const (
 	// inside real server error packets.
 	errCannotConnect = 2003
 	errConnLost      = 2013
-	// errReadOnly (1290) and errReadOnlyMode (1836) are usually consumed by
-	// go-sql-driver when RejectReadOnly is enabled (the spirit default) and
-	// converted to driver.ErrBadConn. They are kept here for the case where
-	// RejectReadOnly is disabled, e.g. the move runner disables it for
-	// read-only sources (see DBConfig.RejectReadOnly).
-	errReadOnly         = 1290
-	errReadOnlyMode     = 1836
+	// errReadOnly (1290), errReadOnlyTransaction (1792) and errReadOnlyMode
+	// (1836) are usually consumed by go-sql-driver when RejectReadOnly is
+	// enabled (the spirit default) and converted to driver.ErrBadConn. They
+	// are kept here for the case where RejectReadOnly is disabled, e.g. the
+	// move runner disables it for read-only sources (see
+	// DBConfig.RejectReadOnly).
+	errReadOnly            = 1290
+	errReadOnlyTransaction = 1792 // ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
+	errReadOnlyMode        = 1836
 	errQueryInterrupted = 1317 // ER_QUERY_INTERRUPTED: query was killed (e.g. KILL QUERY)
 	errCapacityExceeded = 3170
 	errFoundDuppKey     = 1062 // yes I know there's a typo
@@ -93,10 +95,12 @@ func canRetryError(err error) bool {
 	// the connection died mid-statement (e.g. a network blip, the connection
 	// was killed, or an Aurora failover with RejectReadOnly enabled — the
 	// driver converts read-only errors 1290/1792/1836 into driver.ErrBadConn
-	// and discards the connection). Both are safe to retry here: every
-	// statement run through RetryableTransaction is idempotent (INSERT
-	// IGNORE / REPLACE / DELETE), and each retry starts a fresh transaction
-	// — database/sql hands BeginTx a new connection if the old one is dead.
+	// and discards the connection). Retrying is safe because each retry starts
+	// a fresh transaction — database/sql hands BeginTx a new connection if the
+	// old one is dead. Note this function does not itself enforce idempotency;
+	// callers are responsible for routing only idempotent statements through
+	// RetryableTransaction. Spirit's own callers do so (INSERT IGNORE /
+	// REPLACE / DELETE by PK), but the function does not verify it.
 	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) {
 		return true
 	}
@@ -106,7 +110,8 @@ func canRetryError(err error) bool {
 	}
 	switch val.Number {
 	case errLockWaitTimeout, errDeadlock, errCannotConnect,
-		errConnLost, errReadOnly, errReadOnlyMode, errQueryInterrupted:
+		errConnLost, errReadOnly, errReadOnlyTransaction, errReadOnlyMode,
+		errQueryInterrupted:
 		return true
 	default:
 		return false

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -38,9 +38,9 @@ const (
 	errReadOnly            = 1290
 	errReadOnlyTransaction = 1792 // ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
 	errReadOnlyMode        = 1836
-	errQueryInterrupted = 1317 // ER_QUERY_INTERRUPTED: query was killed (e.g. KILL QUERY)
-	errCapacityExceeded = 3170
-	errFoundDuppKey     = 1062 // yes I know there's a typo
+	errQueryInterrupted    = 1317 // ER_QUERY_INTERRUPTED: query was killed (e.g. KILL QUERY)
+	errCapacityExceeded    = 3170
+	errFoundDuppKey        = 1062 // yes I know there's a typo
 )
 
 type DBConfig struct {

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -3,6 +3,9 @@ package dbconn
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -11,6 +14,8 @@ import (
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -112,6 +117,111 @@ func TestRetryableTrx(t *testing.T) {
 	require.Error(t, err)
 	err = trx.Rollback() // now we can rollback.
 	require.NoError(t, err)
+}
+
+func TestCanRetryError(t *testing.T) {
+	// Server-side errors that are retryable.
+	require.True(t, canRetryError(&mysql.MySQLError{Number: 1205})) // lock wait timeout
+	require.True(t, canRetryError(&mysql.MySQLError{Number: 1213})) // deadlock
+	require.True(t, canRetryError(&mysql.MySQLError{Number: 1317})) // query interrupted (killed query)
+	require.True(t, canRetryError(&mysql.MySQLError{Number: 1290})) // read only (only seen if RejectReadOnly is disabled)
+	require.True(t, canRetryError(&mysql.MySQLError{Number: 1836})) // read only mode (only seen if RejectReadOnly is disabled)
+
+	// Connection-level failures from go-sql-driver are plain errors, not
+	// *mysql.MySQLError, and must be classified as retryable: this is how a
+	// lost connection, killed connection, or Aurora failover (with
+	// RejectReadOnly enabled) surfaces to spirit.
+	require.True(t, canRetryError(driver.ErrBadConn))
+	require.True(t, canRetryError(mysql.ErrInvalidConn))
+
+	// Wrapped variants must also be detected.
+	require.True(t, canRetryError(fmt.Errorf("exec failed: %w", &mysql.MySQLError{Number: 1213})))
+	require.True(t, canRetryError(fmt.Errorf("exec failed: %w", driver.ErrBadConn)))
+	require.True(t, canRetryError(fmt.Errorf("exec failed: %w", mysql.ErrInvalidConn)))
+
+	// Fatal errors must not be retried.
+	require.False(t, canRetryError(nil))
+	require.False(t, canRetryError(errors.New("not a mysql error")))
+	require.False(t, canRetryError(&mysql.MySQLError{Number: 1064})) // syntax error
+	require.False(t, canRetryError(&mysql.MySQLError{Number: 1062})) // duplicate key
+}
+
+// testRetryableTrxSurvivesKill blocks an UPDATE behind a row lock, kills it
+// with killStmtFmt ("KILL QUERY %d" or "KILL %d"), releases the lock, and
+// asserts that RetryableTransaction retries and ultimately succeeds.
+func testRetryableTrxSurvivesKill(t *testing.T, tableName, killStmtFmt string) {
+	config := NewDBConfig()
+	// Give plenty of headroom so the first attempt fails because it is
+	// killed (the behavior under test) rather than hitting a (similarly
+	// retryable) innodb lock wait timeout first.
+	config.InnodbLockWaitTimeout = 15
+	db, err := New(testutils.DSN(), config)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	require.NoError(t, Exec(t.Context(), db, "DROP TABLE IF EXISTS %n", tableName))
+	require.NoError(t, Exec(t.Context(), db, "CREATE TABLE %n (id INT NOT NULL PRIMARY KEY, colb INT)", tableName))
+	require.NoError(t, Exec(t.Context(), db, "INSERT INTO %n (id, colb) VALUES (1, 0)", tableName))
+
+	// Hold a row lock so the UPDATE below blocks, giving us time to find it
+	// in the processlist and kill it.
+	blocker, err := db.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = blocker.ExecContext(t.Context(), fmt.Sprintf("SELECT * FROM `%s` WHERE id = 1 FOR UPDATE", tableName))
+	require.NoError(t, err)
+
+	updateStmt := fmt.Sprintf("UPDATE `%s` SET colb = 99 WHERE id = 1", tableName)
+	killDone := make(chan struct{})
+	go func() {
+		defer close(killDone)
+		// Find the blocked UPDATE in the processlist.
+		var pid int
+		for range 200 {
+			err := db.QueryRowContext(t.Context(),
+				"SELECT processlist_id FROM performance_schema.threads WHERE processlist_info = ?",
+				updateStmt).Scan(&pid)
+			if err == nil {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		if pid == 0 {
+			t.Error("timed out waiting for the UPDATE to appear in the processlist")
+			_ = blocker.Rollback()
+			return
+		}
+		_, err := db.ExecContext(t.Context(), fmt.Sprintf(killStmtFmt, pid))
+		assert.NoError(t, err)
+		// Release the row lock so the retry can succeed.
+		assert.NoError(t, blocker.Rollback())
+	}()
+
+	// The first attempt is killed mid-statement. RetryableTransaction must
+	// classify the failure as retryable and succeed on a later attempt.
+	_, err = RetryableTransaction(t.Context(), db, false, config, updateStmt)
+	<-killDone
+	require.NoError(t, err)
+
+	var colb int
+	require.NoError(t, db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT colb FROM `%s` WHERE id = 1", tableName)).Scan(&colb))
+	require.Equal(t, 99, colb)
+	require.NoError(t, Exec(t.Context(), db, "DROP TABLE IF EXISTS %n", tableName))
+}
+
+// TestRetryableTrxRetriesKilledQuery covers ER_QUERY_INTERRUPTED (1317):
+// KILL QUERY aborts the statement but leaves the connection intact. This is
+// what spirit's own force-kill machinery and DBA-issued KILL QUERY produce.
+func TestRetryableTrxRetriesKilledQuery(t *testing.T) {
+	testRetryableTrxSurvivesKill(t, "retry_kill_query", "KILL QUERY %d")
+}
+
+// TestRetryableTrxRetriesKilledConnection covers a connection that dies
+// mid-statement. The driver reports this as mysql.ErrInvalidConn (or
+// driver.ErrBadConn), not as a *mysql.MySQLError — the same shape as a
+// network blip or an Aurora failover. The retry begins a fresh transaction,
+// for which database/sql transparently provides a new connection.
+func TestRetryableTrxRetriesKilledConnection(t *testing.T) {
+	testRetryableTrxSurvivesKill(t, "retry_kill_conn", "KILL %d")
 }
 
 func TestForceExec(t *testing.T) {

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -125,6 +125,7 @@ func TestCanRetryError(t *testing.T) {
 	require.True(t, canRetryError(&mysql.MySQLError{Number: 1213})) // deadlock
 	require.True(t, canRetryError(&mysql.MySQLError{Number: 1317})) // query interrupted (killed query)
 	require.True(t, canRetryError(&mysql.MySQLError{Number: 1290})) // read only (only seen if RejectReadOnly is disabled)
+	require.True(t, canRetryError(&mysql.MySQLError{Number: 1792})) // can't execute in read-only transaction (only seen if RejectReadOnly is disabled)
 	require.True(t, canRetryError(&mysql.MySQLError{Number: 1836})) // read only mode (only seen if RejectReadOnly is disabled)
 
 	// Connection-level failures from go-sql-driver are plain errors, not


### PR DESCRIPTION
## Problem
`canRetryError` listed six retryable MySQL error codes, but only deadlock (1213) and lock-wait timeout (1205) could ever match:
- **2003/2013** are libmysqlclient CR_* codes; go-sql-driver surfaces lost connections as `driver.ErrBadConn`/`mysql.ErrInvalidConn` (plain errors), never `*mysql.MySQLError`, so the `errors.As` extraction fails → fatal.
- **1290/1836** are converted to `driver.ErrBadConn` by the driver *before* spirit sees them, because spirit defaults `RejectReadOnly: true`. Inside a `Tx`, database/sql does not retry `ErrBadConn`.
- **errQueryKilled was 1836** (ER_READ_ONLY_MODE); a killed query is actually 1317 (ER_QUERY_INTERRUPTED), which wasn't listed.

Net effect: a 2-second network blip, an Aurora failover, or a killed query mid-chunk aborted the migration instead of retrying — defeating the documented purpose of `RejectReadOnly`.

## Fix
Classify `driver.ErrBadConn` and `mysql.ErrInvalidConn` as retryable, and add 1317. Retries are safe because every statement routed through `RetryableTransaction` is idempotent (INSERT IGNORE / REPLACE / DELETE by PK — verified at all callers), and database/sql supplies a fresh connection on the next `BeginTx`.

## Testing
Unit coverage for the classifier (real MySQLError 1205/1213/1317, ErrBadConn, ErrInvalidConn, wrapped variants, fatal 1064/1062) plus two integration tests that kill a statement mid-transaction (KILL QUERY → 1317; KILL → dead connection) and assert the retry succeeds. Both integration tests fail against the old logic. Verified against go-sql-driver v1.10.0 source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)