### PR TITLE
require recopy-free pass before continuous-checksum first clean pass

### DIFF
--- a/pkg/checksum/continuous.go
+++ b/pkg/checksum/continuous.go
@@ -10,9 +10,11 @@
 // # Convergence model
 //
 // A "pass" walks every chunk once, then drains a delayed-retry queue to
-// empty. The pass completes (cleanly) only when every chunk has gone clean
-// at least once — either on its initial read, or on a retry, or via a
-// recopy when stable divergence is detected.
+// empty. The pass completes only when every chunk has resolved — either
+// READ-verified (its source and target CRCs observed equal on the initial
+// read or on a retry), or repaired via a recopy when stable divergence is
+// detected. A completed pass is "clean" only if it contained zero
+// recopies; see the first-clean-pass section below.
 //
 // First-attempt failures are common — the target legitimately lags the
 // source — so failures are not noisy events. They go through a retry queue:
@@ -30,8 +32,11 @@
 //     - Else (newSrcCRC == originalSrcCRC, target still wrong) → stable
 //       divergence. With a Recopier configured (production case), invoke
 //       it to overwrite the chunk on the target from the source; on
-//       success the chunk counts as passed (in the per-pass "recopies"
-//       bucket). Without a Recopier the run returns ErrPermanentDivergence.
+//       success the chunk counts as resolved for pass-completion purposes
+//       (in the per-pass "recopies" bucket), but the pass is no longer
+//       clean — the repaired rows were never observed equal, so they are
+//       re-verified by the next pass's fresh walk. Without a Recopier the
+//       run returns ErrPermanentDivergence.
 //
 // Hot chunks slow but do not block pass completion: they cycle to the back
 // of the FIFO while other entries resolve. A genuinely permanently-hot row
@@ -41,8 +46,15 @@
 // # First-clean-pass signal
 //
 // FirstCleanPass returns a channel that is closed the first time a pass
-// completes with every chunk having gone clean. The signal is monotonic:
-// once fired it stays fired, even if subsequent passes detect new drift.
+// completes with every chunk READ-verified equal AND zero recopies. A
+// recopy is a repair, not a verification: the rewritten rows were never
+// observed equal, and the recopy can race the live replication feed
+// (re-inserting a row whose concurrent delete the feed already applied,
+// leaving an orphan no future binlog event will remove). A pass that
+// contained any recopy is therefore ineligible; the repaired ranges are
+// re-read on the next pass's fresh walk, and the signal fires only once
+// a full pass needs no repairs at all. The signal is monotonic: once
+// fired it stays fired, even if subsequent passes detect new drift.
 // Downstream consumers (e.g. the import feature that gates on "data is
 // known consistent") read this channel; ongoing drift after that point is
 // observable via Stats.
@@ -142,7 +154,10 @@ type ContinuousCheckerConfig struct {
 // ContinuousCheckerStats is a snapshot of the checker's counters. All
 // fields are point-in-time; for monotonic totals, sample successively.
 type ContinuousCheckerStats struct {
-	// PassesCompleted is the number of clean passes finished so far.
+	// PassesCompleted is the number of passes finished so far. A pass
+	// completes when every chunk has resolved (READ-verified or recopied);
+	// only a pass with zero recopies counts as clean for the
+	// FirstCleanPass signal.
 	PassesCompleted uint64
 
 	// CurrentPass is the 1-indexed pass number in flight (0 before the
@@ -178,7 +193,10 @@ type ContinuousCheckerStats struct {
 	// unchanged across the retry window, target still wrong) and the
 	// configured Recopier rewrote the chunk from source. Zero when no
 	// Recopier is configured (those failures surface as
-	// ErrPermanentDivergence and abort the run instead).
+	// ErrPermanentDivergence and abort the run instead). A pass with
+	// RecopiesThisPass > 0 cannot be the first clean pass — recopied
+	// chunks are repaired, not verified, and are re-read on the next
+	// pass before FirstCleanPass can fire.
 	RecopiesThisPass uint64
 
 	// RetryQueueDepth is the current size of the delayed-retry queue.
@@ -306,14 +324,17 @@ type workItem struct {
 type workResult struct {
 	item *workItem
 
-	// passed is true iff the chunk satisfied the pass criterion (initial
-	// match, retry match against original or new source CRC, or a
-	// successful recopy).
+	// passed is true iff the chunk resolved for pass-completion purposes
+	// (initial match, retry match against original or new source CRC, or
+	// a successful recopy). Note a recopy "passes" only in the sense that
+	// the pass can finish — it also marks the pass ineligible to fire
+	// FirstCleanPass (see recopied below).
 	passed bool
 
 	// recopied is true iff this result represents a successful Recopy
 	// (passed=true also set). Distinguishes "passed via retry" from
-	// "passed via recopy" in the per-pass histogram.
+	// "repaired via recopy" in the per-pass histogram; any recopy makes
+	// the containing pass not-clean for the FirstCleanPass criterion.
 	recopied bool
 
 	// newSrcCRC / newTgtCRC are the values just read. Used by the driver
@@ -456,7 +477,25 @@ func (c *ContinuousChecker) Run(ctx context.Context) error {
 		}
 
 		c.passesCompleted.Add(1)
-		c.signalFirstCleanPass()
+		// A pass is "clean" — and eligible to fire FirstCleanPass — only if
+		// it contained zero recopies. A recopy is a repair, not a
+		// verification: the rewritten rows were never observed equal, and
+		// the recopy itself can race the live replication feed (its source
+		// SELECT can include a row whose concurrent delete the feed has
+		// already applied to the target, re-inserting an orphan that no
+		// future binlog event will remove). The repaired chunk's range is
+		// re-read by the next pass's fresh walk, so the signal fires only
+		// once a full pass needs no repairs at all. This mirrors the
+		// differencesFound == 0 follow-up-pass rule in SingleChecker /
+		// DistributedChecker.
+		if recopies := c.recopiesThisPass.Load(); recopies == 0 {
+			c.signalFirstCleanPass()
+		} else {
+			c.cfg.Logger.Info("continuous checksum: pass contained recopies; repaired chunks will be re-verified next pass",
+				"pass_number", passNum,
+				"recopies", recopies,
+			)
+		}
 		c.cfg.Logger.Info("continuous checksum pass complete",
 			"pass_number", passNum,
 			"total_chunks", c.chunksThisPass.Load(),
@@ -966,9 +1005,12 @@ func (c *ContinuousChecker) Stats() ContinuousCheckerStats {
 }
 
 // FirstCleanPass returns a channel that is closed the first time a pass
-// completes with every chunk having gone clean. The signal is monotonic:
-// once closed it stays closed. Callers that need a "data is known
-// consistent" gate should select on this channel. Safe to call
+// completes with every chunk READ-verified equal and zero recopies. A
+// pass containing a recopy does not qualify: the repaired rows were
+// never observed equal, so the signal waits for a follow-up pass that
+// re-reads them (and everything else) with no repairs needed. The signal
+// is monotonic: once closed it stays closed. Callers that need a "data
+// is known consistent" gate should select on this channel. Safe to call
 // concurrently with Run.
 func (c *ContinuousChecker) FirstCleanPass() <-chan struct{} {
 	return c.firstCleanPassCh

--- a/pkg/checksum/continuous_test.go
+++ b/pkg/checksum/continuous_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -434,8 +435,9 @@ func (r *fakeRecopier) callCount() int {
 
 // TestRecopyOnStableDivergence: a chunk mismatches twice with the source
 // CRC unchanged. With a Recopier configured, the checker calls Recopy
-// instead of returning ErrPermanentDivergence; the pass completes cleanly
-// and the chunk is counted in the recopies bucket.
+// instead of returning ErrPermanentDivergence; the pass completes with
+// the chunk counted in the recopies bucket, and FirstCleanPass fires on
+// the follow-up pass that re-verifies the repaired chunks.
 func TestRecopyOnStableDivergence(t *testing.T) {
 	chunker := newTestChunker(2)
 	// The fake recopier "fixes" the chunk so subsequent reads pass. We
@@ -469,6 +471,128 @@ func TestRecopyOnStableDivergence(t *testing.T) {
 	stats := c.Stats()
 	require.Equal(t, uint64(0), stats.PermanentFailures, "with a Recopier, no permanent failures")
 	require.GreaterOrEqual(t, recopier.callCount(), 2, "both chunks should have been recopied")
+
+	err := stop()
+	require.True(t, errors.Is(err, context.Canceled) || err == nil)
+}
+
+// TestRecopyPassDoesNotFireFirstCleanPass: a chunk stably diverges and is
+// recopied. The pass containing the recopy must NOT fire FirstCleanPass —
+// a recopy is a repair, not a verification (the rewritten rows were never
+// observed equal, and the recopy itself can race the live replication
+// feed). The signal must fire only after the following pass re-reads
+// every chunk clean with zero recopies.
+func TestRecopyPassDoesNotFireFirstCleanPass(t *testing.T) {
+	chunker := newTestChunker(1)
+	var recopied sync.Map
+	recopier := &fakeRecopier{
+		recopyFn: func(ctx context.Context, chunk *table.Chunk) error {
+			recopied.Store(chunk, true)
+			return nil
+		},
+	}
+	cfg := fastConfig()
+	cfg.Recopier = recopier
+
+	// gate blocks the first post-recopy read (pass 2's fresh read) until
+	// the test has asserted that pass 1 completed without firing the
+	// signal. Without it there would be a race between "pass 1 done" and
+	// "pass 2 instantly completes and legitimately fires".
+	gate := make(chan struct{})
+	c := newTestChecker(t, chunker, cfg,
+		func(ctx context.Context, chunk *table.Chunk, attempt int) (int64, int64, uint64, error) {
+			if _, ok := recopied.Load(chunk); ok {
+				select {
+				case <-gate:
+				case <-ctx.Done():
+					return 0, 0, 0, ctx.Err()
+				}
+				return 42, 42, 1000, nil // post-recopy reads verify clean
+			}
+			return 100, 99, 1000, nil // stable divergence: src constant, tgt wrong
+		},
+	)
+
+	stop, _ := runUntil(t, c)
+
+	// Wait for pass 1 — the pass containing the recopy — to complete.
+	deadline := time.After(2 * time.Second)
+	for c.Stats().PassesCompleted < 1 {
+		select {
+		case <-deadline:
+			t.Fatalf("pass 1 did not complete in time; stats=%+v", c.Stats())
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	require.Equal(t, 1, recopier.callCount(), "chunk should have been recopied in pass 1")
+
+	// Pass 1 contained a recopy, so it must not satisfy the
+	// first-clean-pass criterion. Pass 2's read is parked on the gate, so
+	// this check cannot race a legitimate later signal.
+	select {
+	case <-c.FirstCleanPass():
+		t.Fatal("FirstCleanPass fired in the pass containing the recopy — recopied data was never read-verified")
+	default:
+	}
+
+	// Release pass 2's read: the recopied chunk re-verifies equal, the
+	// pass completes with zero recopies, and the signal fires.
+	close(gate)
+	select {
+	case <-c.FirstCleanPass():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("FirstCleanPass did not fire on the follow-up clean pass; stats=%+v", c.Stats())
+	}
+	stats := c.Stats()
+	require.GreaterOrEqual(t, stats.PassesCompleted, uint64(2),
+		"signal requires the follow-up pass, so at least 2 passes must have completed")
+	require.Equal(t, uint64(0), stats.PermanentFailures)
+
+	err := stop()
+	require.True(t, errors.Is(err, context.Canceled) || err == nil)
+}
+
+// TestRecopiedChunkReverifiedBeforeCleanPass: by the time FirstCleanPass
+// fires, the recopied chunk's range must have been re-read and observed
+// equal. The re-read happens on the next pass's fresh walk; the signal
+// cannot fire before that pass completes, so observing the signal
+// guarantees the re-read happened (happens-before via the pass barrier).
+func TestRecopiedChunkReverifiedBeforeCleanPass(t *testing.T) {
+	chunker := newTestChunker(2)
+	divergent := chunker.chunks[0] // only this chunk diverges
+	var recopied sync.Map
+	var readAfterRecopy atomic.Bool
+	recopier := &fakeRecopier{
+		recopyFn: func(ctx context.Context, chunk *table.Chunk) error {
+			recopied.Store(chunk, true)
+			return nil
+		},
+	}
+	cfg := fastConfig()
+	cfg.Recopier = recopier
+
+	c := newTestChecker(t, chunker, cfg,
+		func(ctx context.Context, chunk *table.Chunk, attempt int) (int64, int64, uint64, error) {
+			if _, ok := recopied.Load(chunk); ok {
+				readAfterRecopy.Store(true)
+				return 42, 42, 1000, nil // post-recopy read verifies clean
+			}
+			if chunk == divergent {
+				return 100, 99, 1000, nil // stable divergence until recopied
+			}
+			return 42, 42, 1000, nil
+		},
+	)
+
+	stop, _ := runUntil(t, c)
+	select {
+	case <-c.FirstCleanPass():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("FirstCleanPass did not fire; stats=%+v calls=%d", c.Stats(), recopier.callCount())
+	}
+	require.Equal(t, 1, recopier.callCount(), "exactly one chunk should have been recopied")
+	require.True(t, readAfterRecopy.Load(),
+		"recopied chunk was never re-read before FirstCleanPass fired")
 
 	err := stop()
 	require.True(t, errors.Is(err, context.Canceled) || err == nil)

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -591,10 +591,13 @@ func (r *Runner) buildContinuousChunker() (table.Chunker, error) {
 }
 
 // FirstCleanPass returns a channel that is closed the first time the
-// continuous checksum completes a clean pass — i.e. every chunk has gone
-// clean at least once, including via retry. Programmatic callers that
-// gate on "data is known consistent" (e.g. the import feature) should
-// block on this channel.
+// continuous checksum completes a clean pass — i.e. every chunk was
+// READ-verified equal (on its initial read or via retry) and no chunk
+// needed a recopy. A pass that repaired chunks via recopy does not
+// qualify; the repaired ranges are re-verified by the following pass
+// before the signal can fire. Programmatic callers that gate on "data
+// is known consistent" (e.g. the import feature) should block on this
+// channel.
 //
 // The accessor is non-blocking: it returns immediately with a channel
 // the caller can wait on. The Runner-owned channel is closed by an


### PR DESCRIPTION
## Problem
The continuous checksum marked a recopied chunk as `passed` without ever re-reading it. `Recopy`'s DELETE/SELECT/Apply sequence (three separate READ COMMITTED transactions) can race the live replication feed and re-insert a row on the target whose source-side delete was already applied — an orphan no future binlog event will remove. If that chunk was the last unresolved one, the pass completed "clean" and `FirstCleanPass` — the "data is known consistent" gate consumed by `pkg/datasync` — fired before the corruption could be observed. The single and distributed checkers avoid this by requiring a follow-up `differencesFound == 0` pass; the continuous checker had no equivalent.

## Fix
Gate the first-clean-pass criterion on zero recopies: a pass containing any recopy still completes normally, but `FirstCleanPass` waits for a follow-up pass that re-reads everything (including repaired ranges) with zero differences and zero recopies. The dispatcher/worker/walker termination and back-pressure logic is untouched — the only behavioral change is the signal gate.

## Testing
Harness tests (same swapped-`readChunk` pattern as the existing suite): one asserts `FirstCleanPass` does not fire in the recopy pass but does on the following clean pass; another asserts the recopied chunk is re-read before the gate opens. Both fail against the old code. pkg/datasync (the consumer) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)