### PR TITLE
preserve ON UPDATE / generated / CHECK / SRID column attributes through diff

### DIFF
--- a/pkg/statement/README.md
+++ b/pkg/statement/README.md
@@ -237,6 +237,11 @@ type Column struct {
     SetValues  []string          // For SET('x','y'), SetValues = ["x", "y"]
     Nullable   bool
     Default    *string
+    OnUpdate   *string           // ON UPDATE CURRENT_TIMESTAMP[(n)] for TIMESTAMP/DATETIME
+    GeneratedExpr   *string      // Expression for GENERATED ALWAYS AS (...) columns
+    GeneratedStored bool         // true = STORED, false = VIRTUAL
+    Check      *string           // Column-level CHECK (...) expression
+    SRID       *uint32           // SRID attribute for spatial columns
     AutoInc    bool
     PrimaryKey bool              // Column-level PRIMARY KEY
     Unique     bool              // Column-level UNIQUE

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -890,9 +890,14 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 // columnExtendedAttributesEqual compares the column attributes beyond the
 // basic type/nullability/default set: ON UPDATE (TIMESTAMP/DATETIME
 // auto-update), GENERATED ALWAYS AS expressions (including STORED vs
-// VIRTUAL), column-level CHECK constraints, and SRID. These are
-// semantically critical — omitting them from a MODIFY COLUMN silently
-// removes the behavior from the live table.
+// VIRTUAL), and SRID. These are semantically critical — omitting them from a
+// MODIFY COLUMN silently removes the behavior from the live table.
+//
+// Column-level CHECK constraints are intentionally NOT compared here: the
+// parser hoists them into table-level CreateTable.Constraints (see
+// normalizeColumnChecks), so they are diffed by diffConstraints instead. This
+// matches MySQL's SHOW CREATE TABLE, which always reports CHECKs at table
+// level, and keeps a re-diff convergent.
 func columnExtendedAttributesEqual(a, b *Column) bool {
 	if !ptrEqual(a.OnUpdate, b.OnUpdate) {
 		return false
@@ -901,9 +906,6 @@ func columnExtendedAttributesEqual(a, b *Column) bool {
 		return false
 	}
 	if a.GeneratedExpr != nil && a.GeneratedStored != b.GeneratedStored {
-		return false
-	}
-	if !ptrEqual(a.Check, b.Check) {
 		return false
 	}
 	if !ptrEqual(a.SRID, b.SRID) {
@@ -1150,11 +1152,12 @@ func formatColumnDefinition(col *Column) string {
 		parts = append(parts, fmt.Sprintf("COMMENT '%s'", sqlescape.EscapeString(*col.Comment)))
 	}
 
-	// Column-level CHECK constraint — the last clause in MySQL's
-	// column definition grammar.
-	if col.Check != nil {
-		parts = append(parts, fmt.Sprintf("CHECK (%s)", *col.Check))
-	}
+	// NOTE: column-level CHECK constraints are deliberately not emitted here.
+	// The parser hoists them into table-level constraints (see
+	// normalizeColumnChecks), so they are emitted as ADD CONSTRAINT ... CHECK
+	// by diffConstraints. Emitting them inline in a MODIFY/ADD COLUMN would
+	// make MySQL hoist them to a table-level CHECK with an auto-name, breaking
+	// re-diff convergence and risking a spurious DROP CHECK.
 
 	return strings.Join(parts, " ")
 }

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -756,6 +756,9 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	if a.DefaultIsExpr != b.DefaultIsExpr {
 		return false
 	}
+	if !columnExtendedAttributesEqual(a, b) {
+		return false
+	}
 	if a.AutoInc != b.AutoInc {
 		return false
 	}
@@ -856,6 +859,9 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 	if a.DefaultIsExpr != b.DefaultIsExpr {
 		return false
 	}
+	if !columnExtendedAttributesEqual(a, b) {
+		return false
+	}
 	if a.AutoInc != b.AutoInc {
 		return false
 	}
@@ -876,6 +882,31 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 		return false
 	}
 	if !slices.Equal(a.SetValues, b.SetValues) {
+		return false
+	}
+	return true
+}
+
+// columnExtendedAttributesEqual compares the column attributes beyond the
+// basic type/nullability/default set: ON UPDATE (TIMESTAMP/DATETIME
+// auto-update), GENERATED ALWAYS AS expressions (including STORED vs
+// VIRTUAL), column-level CHECK constraints, and SRID. These are
+// semantically critical — omitting them from a MODIFY COLUMN silently
+// removes the behavior from the live table.
+func columnExtendedAttributesEqual(a, b *Column) bool {
+	if !ptrEqual(a.OnUpdate, b.OnUpdate) {
+		return false
+	}
+	if !ptrEqual(a.GeneratedExpr, b.GeneratedExpr) {
+		return false
+	}
+	if a.GeneratedExpr != nil && a.GeneratedStored != b.GeneratedStored {
+		return false
+	}
+	if !ptrEqual(a.Check, b.Check) {
+		return false
+	}
+	if !ptrEqual(a.SRID, b.SRID) {
 		return false
 	}
 	return true
@@ -1064,6 +1095,19 @@ func formatColumnDefinition(col *Column) string {
 		}
 	}
 
+	// Generated column clause — comes directly after the data type (and any
+	// charset/collation), before the NULL/NOT NULL attribute:
+	// col_name type GENERATED ALWAYS AS (expr) STORED|VIRTUAL [NOT NULL|NULL] ...
+	if col.GeneratedExpr != nil {
+		genClause := fmt.Sprintf("GENERATED ALWAYS AS (%s)", *col.GeneratedExpr)
+		if col.GeneratedStored {
+			genClause += " STORED"
+		} else {
+			genClause += " VIRTUAL"
+		}
+		parts = append(parts, genClause)
+	}
+
 	// Nullable
 	if !col.Nullable {
 		parts = append(parts, "NOT NULL")
@@ -1071,8 +1115,14 @@ func formatColumnDefinition(col *Column) string {
 		parts = append(parts, "NULL")
 	}
 
-	// Default value
-	if col.Default != nil {
+	// SRID attribute for spatial columns. MySQL's SHOW CREATE TABLE places
+	// this after the NULL/NOT NULL attribute (as /*!80003 SRID n */).
+	if col.SRID != nil {
+		parts = append(parts, fmt.Sprintf("SRID %d", *col.SRID))
+	}
+
+	// Default value (not permitted on generated columns)
+	if col.Default != nil && col.GeneratedExpr == nil {
 		defaultVal := *col.Default
 		switch {
 		case col.DefaultIsExpr:
@@ -1085,6 +1135,11 @@ func formatColumnDefinition(col *Column) string {
 		}
 	}
 
+	// ON UPDATE (TIMESTAMP/DATETIME auto-update) — comes after DEFAULT
+	if col.OnUpdate != nil {
+		parts = append(parts, fmt.Sprintf("ON UPDATE %s", *col.OnUpdate))
+	}
+
 	// Auto increment
 	if col.AutoInc {
 		parts = append(parts, "AUTO_INCREMENT")
@@ -1093,6 +1148,12 @@ func formatColumnDefinition(col *Column) string {
 	// Comment
 	if col.Comment != nil {
 		parts = append(parts, fmt.Sprintf("COMMENT '%s'", sqlescape.EscapeString(*col.Comment)))
+	}
+
+	// Column-level CHECK constraint — the last clause in MySQL's
+	// column definition grammar.
+	if col.Check != nil {
+		parts = append(parts, fmt.Sprintf("CHECK (%s)", *col.Check))
 	}
 
 	return strings.Join(parts, " ")

--- a/pkg/statement/diff_column_options_test.go
+++ b/pkg/statement/diff_column_options_test.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/block/spirit/pkg/testutils"
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -135,23 +134,35 @@ func TestDiffColumnAttributeOptions(t *testing.T) {
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
 			expected: "",
 		},
-		// Column-level CHECK constraints
+		// Column-level CHECK constraints. The parser hoists these into
+		// table-level constraints (mirroring MySQL's SHOW CREATE TABLE), so the
+		// diff emits ADD/DROP CONSTRAINT — not an inline MODIFY COLUMN CHECK.
+		// Emitting inline would make MySQL re-hoist the CHECK under a new
+		// auto-name, breaking re-diff convergence (see #930).
 		{
 			name:     "ColumnCheckAdded",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) NULL CHECK (`b`>0)",
+			expected: "ALTER TABLE `t1` ADD CONSTRAINT `t1_chk_1` CHECK (`b`>0)",
 		},
 		{
 			name:     "ColumnCheckChanged",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 5))",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) NULL CHECK (`b`>5)",
+			expected: "ALTER TABLE `t1` DROP CHECK `t1_chk_1`, ADD CONSTRAINT `t1_chk_1` CHECK (`b`>5)",
 		},
 		{
 			name:     "ColumnCheckNoChange",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
+			expected: "",
+		},
+		{
+			// A column-level CHECK and the equivalent table-level CHECK parse to
+			// the same canonical (table-level) constraint, so no diff.
+			name:     "ColumnCheckVsTableCheckNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT, CONSTRAINT t1_chk_1 CHECK (b > 0))",
 			expected: "",
 		},
 		// ADD COLUMN must carry the attributes too
@@ -237,35 +248,56 @@ func TestParseColumnAttributeOptions(t *testing.T) {
 
 	c := ct.Columns.ByName("c")
 	require.NotNil(t, c)
-	require.NotNil(t, c.Check)
-	require.Equal(t, "`c`>0", *c.Check)
+	// Column-level CHECK is hoisted into a table-level constraint (mirroring
+	// MySQL), so Column.Check is cleared and the constraint appears in
+	// ct.Constraints with MySQL's auto-generated name.
+	require.Nil(t, c.Check)
 	require.Empty(t, c.Options)
+
+	var chk *Constraint
+	for i := range ct.Constraints {
+		if ct.Constraints[i].Type == "CHECK" {
+			chk = &ct.Constraints[i]
+		}
+	}
+	require.NotNil(t, chk, "column-level CHECK should be hoisted to a table-level constraint")
+	require.Equal(t, "t1_chk_1", chk.Name)
+	require.NotNil(t, chk.Expression)
+	require.Equal(t, "`c`>0", *chk.Expression)
 }
 
 // openScratchDB creates (or recreates) the scratch database test_w1e and
 // returns a connection scoped to it. The database is dropped on cleanup.
+//
+// The DSN is parsed with mysql.ParseDSN and only the database name (DBName) is
+// swapped, so any query parameters in MYSQL_DSN (tls, parseTime, timeout, etc.)
+// are preserved on both the root connection and the scoped connection.
 func openScratchDB(t *testing.T) *sql.DB {
 	t.Helper()
-	baseDSN := testutils.DSN()
-	lastSlash := strings.LastIndex(baseDSN, "/")
-	require.GreaterOrEqual(t, lastSlash, 0, "could not parse DSN: %s", baseDSN)
-	rootDSN := baseDSN[:lastSlash+1]
+	const scratchDB = "test_w1e"
 
-	rootDB, err := sql.Open("mysql", rootDSN)
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err, "could not parse DSN")
+
+	rootCfg := cfg.Clone()
+	rootCfg.DBName = "" // connect without selecting a database
+	rootDB, err := sql.Open("mysql", rootCfg.FormatDSN())
 	require.NoError(t, err)
 	defer func() {
 		_ = rootDB.Close()
 	}()
-	_, err = rootDB.ExecContext(t.Context(), "DROP DATABASE IF EXISTS test_w1e")
+	_, err = rootDB.ExecContext(t.Context(), "DROP DATABASE IF EXISTS "+scratchDB)
 	require.NoError(t, err)
-	_, err = rootDB.ExecContext(t.Context(), "CREATE DATABASE test_w1e")
+	_, err = rootDB.ExecContext(t.Context(), "CREATE DATABASE "+scratchDB)
 	require.NoError(t, err)
 
-	db, err := sql.Open("mysql", rootDSN+"test_w1e")
+	scopedCfg := cfg.Clone()
+	scopedCfg.DBName = scratchDB
+	db, err := sql.Open("mysql", scopedCfg.FormatDSN())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		// t.Context() is already canceled during cleanup, so use Background.
-		_, _ = db.ExecContext(context.Background(), "DROP DATABASE IF EXISTS test_w1e")
+		_, _ = db.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+scratchDB)
 		_ = db.Close()
 	})
 	return db
@@ -451,18 +483,75 @@ func TestColumnAttributeOptionsMySQL(t *testing.T) {
 		)`
 		stmts := diffLiveTable(t, db, "chk_t", target)
 		require.Len(t, stmts, 1)
+		// The column-level CHECK is hoisted to a table-level constraint, so the
+		// emitted DDL is an ADD CONSTRAINT (not an inline MODIFY COLUMN), and it
+		// must not DROP anything on a first apply.
+		require.Contains(t, stmts[0].Statement, "ADD CONSTRAINT")
 		require.Contains(t, stmts[0].Statement, "CHECK (`b`>0)")
+		require.NotContains(t, stmts[0].Statement, "DROP CHECK",
+			"adding a CHECK must never drop an existing constraint")
 		execStatements(t, db, stmts)
 
-		// MySQL hoists column-level CHECK constraints to table-level
-		// constraints with an auto-generated name, so we verify against
-		// the canonical (table-level) form rather than full convergence.
 		finalCreate := showCreateTable(t, db, "chk_t")
 		require.Contains(t, finalCreate, "CHECK ((`b` > 0))")
 		requireNoSelfDiff(t, db, "chk_t")
 
+		// Re-diffing the live (now hoisted) table against the same target must
+		// converge to no further changes — this is the regression the fix for
+		// #930 guarantees. Previously the re-diff kept emitting MODIFY COLUMN
+		// and a spurious DROP CHECK.
+		requireConverged(t, db, "chk_t", target)
+
 		// The constraint must actually be enforced.
 		_, err = db.ExecContext(t.Context(), "INSERT INTO chk_t (id, b) VALUES (1, -5)")
 		require.Error(t, err, "expected CHECK constraint violation")
+	})
+
+	t.Run("AddNamedColumnLevelCheck", func(t *testing.T) {
+		_, err := db.ExecContext(t.Context(), `CREATE TABLE named_chk_t (
+			id int NOT NULL,
+			b int,
+			PRIMARY KEY (id)
+		)`)
+		require.NoError(t, err)
+
+		target := `CREATE TABLE named_chk_t (
+			id int NOT NULL,
+			b int CONSTRAINT b_positive CHECK (b > 0),
+			PRIMARY KEY (id)
+		)`
+		stmts := diffLiveTable(t, db, "named_chk_t", target)
+		require.Len(t, stmts, 1)
+		require.Contains(t, stmts[0].Statement, "ADD CONSTRAINT `b_positive`")
+		require.NotContains(t, stmts[0].Statement, "DROP CHECK")
+		execStatements(t, db, stmts)
+
+		finalCreate := showCreateTable(t, db, "named_chk_t")
+		require.Contains(t, finalCreate, "CONSTRAINT `b_positive`")
+		requireNoSelfDiff(t, db, "named_chk_t")
+		requireConverged(t, db, "named_chk_t", target)
+	})
+
+	t.Run("MultipleColumnLevelChecksConverge", func(t *testing.T) {
+		_, err := db.ExecContext(t.Context(), `CREATE TABLE multi_chk_t (
+			id int NOT NULL,
+			a int,
+			b int,
+			PRIMARY KEY (id)
+		)`)
+		require.NoError(t, err)
+
+		target := `CREATE TABLE multi_chk_t (
+			id int NOT NULL,
+			a int CHECK (a > 0),
+			b int CHECK (b < 100),
+			PRIMARY KEY (id)
+		)`
+		stmts := diffLiveTable(t, db, "multi_chk_t", target)
+		require.Len(t, stmts, 1)
+		require.NotContains(t, stmts[0].Statement, "DROP CHECK")
+		execStatements(t, db, stmts)
+		requireNoSelfDiff(t, db, "multi_chk_t")
+		requireConverged(t, db, "multi_chk_t", target)
 	})
 }

--- a/pkg/statement/diff_column_options_test.go
+++ b/pkg/statement/diff_column_options_test.go
@@ -1,0 +1,468 @@
+package statement
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover the column attributes that were previously dropped by the
+// parser/diff pipeline: ON UPDATE CURRENT_TIMESTAMP, GENERATED ALWAYS AS
+// (STORED/VIRTUAL), column-level CHECK constraints, and SRID. Missing any of
+// these from a MODIFY COLUMN silently removes the behavior from the live
+// table, so they must round-trip through parse, compare, and emit.
+
+// TestDiffColumnAttributeOptions exercises parse + diff + emit without MySQL.
+func TestDiffColumnAttributeOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		target   string
+		expected string // empty string means no diff expected
+	}{
+		// ON UPDATE CURRENT_TIMESTAMP
+		{
+			name:     "OnUpdateAdded",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `ts` timestamp NULL DEFAULT current_timestamp ON UPDATE current_timestamp",
+		},
+		{
+			name:     "OnUpdateRemoved",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `ts` timestamp NULL DEFAULT current_timestamp",
+		},
+		{
+			name:     "OnUpdateNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)",
+			expected: "",
+		},
+		{
+			name:     "OnUpdateWithPrecisionNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP(3) NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP(3) NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3))",
+			expected: "",
+		},
+		{
+			// Regression: a comment-only change on a column with
+			// ON UPDATE CURRENT_TIMESTAMP must emit a MODIFY that still
+			// carries the ON UPDATE clause, or applying the ALTER would
+			// silently remove the auto-update behavior from the live table.
+			name:     "CommentOnlyChangePreservesOnUpdate",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'updated time')",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `ts` timestamp NULL DEFAULT current_timestamp ON UPDATE current_timestamp COMMENT 'updated time'",
+		},
+		// Generated columns (STORED/VIRTUAL)
+		{
+			name:     "GeneratedStoredAdded",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) GENERATED ALWAYS AS (`a`+1) STORED NULL",
+		},
+		{
+			name:     "GeneratedRemoved",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) NULL",
+		},
+		{
+			name:     "GeneratedNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
+			expected: "",
+		},
+		{
+			// MySQL's SHOW CREATE TABLE wraps the generated expression in an
+			// extra set of parentheses: GENERATED ALWAYS AS ((`a` + 1)).
+			// That must compare equal to the user-written form.
+			name:     "GeneratedCanonicalParensNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, `b` int GENERATED ALWAYS AS ((`a` + 1)) STORED)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
+			expected: "",
+		},
+		{
+			name:     "GeneratedStoredVsVirtual",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) VIRTUAL)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) GENERATED ALWAYS AS (`a`+1) VIRTUAL NULL",
+		},
+		{
+			name:     "GeneratedExpressionChanged",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 2) STORED)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) GENERATED ALWAYS AS (`a`+2) STORED NULL",
+		},
+		// SRID (spatial columns)
+		{
+			name:     "SridAdded",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `g` point NOT NULL SRID 4326",
+		},
+		{
+			name:     "SridRemoved",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `g` point NOT NULL",
+		},
+		{
+			name:     "SridChanged",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 3857)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `g` point NOT NULL SRID 3857",
+		},
+		{
+			name:     "SridNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
+			expected: "",
+		},
+		{
+			// MySQL's SHOW CREATE TABLE emits SRID inside a versioned
+			// comment: /*!80003 SRID 4326 */. That must compare equal to
+			// the user-written form.
+			name:     "SridCanonicalCommentFormNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, `g` point NOT NULL /*!80003 SRID 4326 */)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
+			expected: "",
+		},
+		// Column-level CHECK constraints
+		{
+			name:     "ColumnCheckAdded",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) NULL CHECK (`b`>0)",
+		},
+		{
+			name:     "ColumnCheckChanged",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 5))",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) NULL CHECK (`b`>5)",
+		},
+		{
+			name:     "ColumnCheckNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT CHECK (b > 0))",
+			expected: "",
+		},
+		// ADD COLUMN must carry the attributes too
+		{
+			name:     "AddColumnWithOnUpdate",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)",
+			expected: "ALTER TABLE `t1` ADD COLUMN `ts` timestamp NULL DEFAULT current_timestamp ON UPDATE current_timestamp",
+		},
+		{
+			name:     "AddColumnWithSrid",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, g POINT NOT NULL SRID 4326)",
+			expected: "ALTER TABLE `t1` ADD COLUMN `g` point NOT NULL SRID 4326",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ct1, err := ParseCreateTable(tt.source)
+			require.NoError(t, err)
+
+			ct2, err := ParseCreateTable(tt.target)
+			require.NoError(t, err)
+
+			stmts, err := ct1.Diff(ct2, nil)
+			require.NoError(t, err)
+
+			if tt.expected == "" {
+				require.Nil(t, stmts, "expected nil for identical tables")
+			} else {
+				require.Len(t, stmts, 1)
+				require.Equal(t, tt.expected, stmts[0].Statement)
+			}
+		})
+	}
+}
+
+// TestParseColumnAttributeOptions verifies the new Column struct fields are
+// populated by the parser (and no longer collected as opaque "option_N" keys).
+func TestParseColumnAttributeOptions(t *testing.T) {
+	ct, err := ParseCreateTable(`CREATE TABLE t1 (
+		id INT PRIMARY KEY,
+		ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		ts3 TIMESTAMP(3) NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+		a INT,
+		b INT GENERATED ALWAYS AS (a + 1) STORED,
+		v VARCHAR(20) AS (concat('x', a)) VIRTUAL,
+		g POINT NOT NULL SRID 4326,
+		c INT CHECK (c > 0)
+	)`)
+	require.NoError(t, err)
+
+	ts := ct.Columns.ByName("ts")
+	require.NotNil(t, ts)
+	require.NotNil(t, ts.OnUpdate)
+	require.Equal(t, "current_timestamp", *ts.OnUpdate)
+	require.Empty(t, ts.Options) // no longer stored as an unknown option
+
+	ts3 := ct.Columns.ByName("ts3")
+	require.NotNil(t, ts3)
+	require.NotNil(t, ts3.OnUpdate)
+	require.Equal(t, "current_timestamp(3)", *ts3.OnUpdate)
+
+	b := ct.Columns.ByName("b")
+	require.NotNil(t, b)
+	require.NotNil(t, b.GeneratedExpr)
+	require.Equal(t, "`a`+1", *b.GeneratedExpr)
+	require.True(t, b.GeneratedStored)
+	require.Empty(t, b.Options)
+
+	v := ct.Columns.ByName("v")
+	require.NotNil(t, v)
+	require.NotNil(t, v.GeneratedExpr)
+	require.Equal(t, "CONCAT('x', `a`)", *v.GeneratedExpr)
+	require.False(t, v.GeneratedStored)
+
+	g := ct.Columns.ByName("g")
+	require.NotNil(t, g)
+	require.NotNil(t, g.SRID)
+	require.Equal(t, uint32(4326), *g.SRID)
+	require.Empty(t, g.Options)
+
+	c := ct.Columns.ByName("c")
+	require.NotNil(t, c)
+	require.NotNil(t, c.Check)
+	require.Equal(t, "`c`>0", *c.Check)
+	require.Empty(t, c.Options)
+}
+
+// openScratchDB creates (or recreates) the scratch database test_w1e and
+// returns a connection scoped to it. The database is dropped on cleanup.
+func openScratchDB(t *testing.T) *sql.DB {
+	t.Helper()
+	baseDSN := testutils.DSN()
+	lastSlash := strings.LastIndex(baseDSN, "/")
+	require.GreaterOrEqual(t, lastSlash, 0, "could not parse DSN: %s", baseDSN)
+	rootDSN := baseDSN[:lastSlash+1]
+
+	rootDB, err := sql.Open("mysql", rootDSN)
+	require.NoError(t, err)
+	defer func() {
+		_ = rootDB.Close()
+	}()
+	_, err = rootDB.ExecContext(t.Context(), "DROP DATABASE IF EXISTS test_w1e")
+	require.NoError(t, err)
+	_, err = rootDB.ExecContext(t.Context(), "CREATE DATABASE test_w1e")
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", rootDSN+"test_w1e")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// t.Context() is already canceled during cleanup, so use Background.
+		_, _ = db.ExecContext(context.Background(), "DROP DATABASE IF EXISTS test_w1e")
+		_ = db.Close()
+	})
+	return db
+}
+
+// showCreateTable returns the canonical SHOW CREATE TABLE output for a table.
+func showCreateTable(t *testing.T, db *sql.DB, tableName string) string {
+	t.Helper()
+	var name, createSQL string
+	err := db.QueryRowContext(t.Context(), fmt.Sprintf("SHOW CREATE TABLE `%s`", tableName)).Scan(&name, &createSQL)
+	require.NoError(t, err)
+	return createSQL
+}
+
+// requireNoSelfDiff asserts that the canonical SHOW CREATE TABLE form of a
+// table diffs clean against itself (no-op stays empty).
+func requireNoSelfDiff(t *testing.T, db *sql.DB, tableName string) {
+	t.Helper()
+	createSQL := showCreateTable(t, db, tableName)
+	source, err := ParseCreateTable(createSQL)
+	require.NoError(t, err)
+	target, err := ParseCreateTable(createSQL)
+	require.NoError(t, err)
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts, "expected no self-diff for canonical form: %s", createSQL)
+}
+
+// diffLiveTable parses the live table's SHOW CREATE TABLE, diffs it against
+// targetSQL, and returns the generated statements.
+func diffLiveTable(t *testing.T, db *sql.DB, tableName, targetSQL string) []*AbstractStatement {
+	t.Helper()
+	source, err := ParseCreateTable(showCreateTable(t, db, tableName))
+	require.NoError(t, err)
+	target, err := ParseCreateTable(targetSQL)
+	require.NoError(t, err)
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	return stmts
+}
+
+// execStatements executes generated DDL statements against the live database.
+func execStatements(t *testing.T, db *sql.DB, stmts []*AbstractStatement) {
+	t.Helper()
+	for _, stmt := range stmts {
+		_, err := db.ExecContext(t.Context(), stmt.Statement)
+		require.NoError(t, err, "executing generated DDL: %s", stmt.Statement)
+	}
+}
+
+// requireConverged asserts that after applying the diff, the live table
+// diffs clean against the target definition.
+func requireConverged(t *testing.T, db *sql.DB, tableName, targetSQL string) {
+	t.Helper()
+	stmts := diffLiveTable(t, db, tableName, targetSQL)
+	require.Nil(t, stmts, "expected live table to have converged to target")
+}
+
+// TestColumnAttributeOptionsMySQL verifies the emitted DDL against a real
+// MySQL server: the generated ALTERs are executed and the resulting
+// SHOW CREATE TABLE is checked for the preserved attributes.
+func TestColumnAttributeOptionsMySQL(t *testing.T) {
+	db := openScratchDB(t)
+
+	t.Run("CommentOnlyModifyPreservesOnUpdate", func(t *testing.T) {
+		// Regression: applying a comment-only MODIFY must not strip
+		// ON UPDATE CURRENT_TIMESTAMP from the live table.
+		_, err := db.ExecContext(t.Context(), `CREATE TABLE on_update_t (
+			id int NOT NULL,
+			ts timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY (id)
+		)`)
+		require.NoError(t, err)
+		requireNoSelfDiff(t, db, "on_update_t")
+
+		target := `CREATE TABLE on_update_t (
+			id int NOT NULL,
+			ts timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'updated time',
+			PRIMARY KEY (id)
+		)`
+		stmts := diffLiveTable(t, db, "on_update_t", target)
+		require.Len(t, stmts, 1)
+		require.Contains(t, stmts[0].Statement, "ON UPDATE current_timestamp",
+			"comment-only MODIFY must preserve the ON UPDATE clause")
+		execStatements(t, db, stmts)
+
+		finalCreate := showCreateTable(t, db, "on_update_t")
+		require.Contains(t, finalCreate, "ON UPDATE CURRENT_TIMESTAMP")
+		require.Contains(t, finalCreate, "COMMENT 'updated time'")
+		requireConverged(t, db, "on_update_t", target)
+	})
+
+	t.Run("AddGeneratedColumns", func(t *testing.T) {
+		_, err := db.ExecContext(t.Context(), `CREATE TABLE gen_add_t (
+			id int NOT NULL,
+			a int,
+			PRIMARY KEY (id)
+		)`)
+		require.NoError(t, err)
+
+		target := `CREATE TABLE gen_add_t (
+			id int NOT NULL,
+			a int,
+			b int GENERATED ALWAYS AS (a + 1) STORED,
+			v varchar(20) GENERATED ALWAYS AS (concat('x', a)) VIRTUAL,
+			PRIMARY KEY (id)
+		)`
+		stmts := diffLiveTable(t, db, "gen_add_t", target)
+		require.Len(t, stmts, 1)
+		require.Contains(t, stmts[0].Statement, "GENERATED ALWAYS AS")
+		execStatements(t, db, stmts)
+
+		finalCreate := showCreateTable(t, db, "gen_add_t")
+		require.Contains(t, finalCreate, "GENERATED ALWAYS AS ((`a` + 1)) STORED")
+		require.Contains(t, finalCreate, "VIRTUAL")
+		requireNoSelfDiff(t, db, "gen_add_t")
+		requireConverged(t, db, "gen_add_t", target)
+	})
+
+	t.Run("ModifyPlainColumnToStoredGenerated", func(t *testing.T) {
+		_, err := db.ExecContext(t.Context(), `CREATE TABLE gen_mod_t (
+			id int NOT NULL,
+			a int,
+			b int,
+			PRIMARY KEY (id)
+		)`)
+		require.NoError(t, err)
+
+		target := `CREATE TABLE gen_mod_t (
+			id int NOT NULL,
+			a int,
+			b int GENERATED ALWAYS AS (a * 2) STORED,
+			PRIMARY KEY (id)
+		)`
+		stmts := diffLiveTable(t, db, "gen_mod_t", target)
+		require.Len(t, stmts, 1)
+		require.Contains(t, stmts[0].Statement, "MODIFY COLUMN `b`")
+		require.Contains(t, stmts[0].Statement, "GENERATED ALWAYS AS (`a`*2) STORED")
+		execStatements(t, db, stmts)
+
+		finalCreate := showCreateTable(t, db, "gen_mod_t")
+		require.Contains(t, finalCreate, "GENERATED ALWAYS AS ((`a` * 2)) STORED")
+		requireConverged(t, db, "gen_mod_t", target)
+	})
+
+	t.Run("AddSridToSpatialColumn", func(t *testing.T) {
+		_, err := db.ExecContext(t.Context(), `CREATE TABLE srid_t (
+			id int NOT NULL,
+			g point NOT NULL,
+			PRIMARY KEY (id)
+		)`)
+		require.NoError(t, err)
+
+		target := `CREATE TABLE srid_t (
+			id int NOT NULL,
+			g point NOT NULL SRID 4326,
+			PRIMARY KEY (id)
+		)`
+		stmts := diffLiveTable(t, db, "srid_t", target)
+		require.Len(t, stmts, 1)
+		require.Contains(t, stmts[0].Statement, "SRID 4326")
+		execStatements(t, db, stmts)
+
+		// MySQL emits SRID as a versioned comment in SHOW CREATE TABLE.
+		finalCreate := showCreateTable(t, db, "srid_t")
+		require.Contains(t, finalCreate, "SRID 4326")
+		requireNoSelfDiff(t, db, "srid_t")
+		requireConverged(t, db, "srid_t", target)
+	})
+
+	t.Run("AddColumnLevelCheck", func(t *testing.T) {
+		_, err := db.ExecContext(t.Context(), `CREATE TABLE chk_t (
+			id int NOT NULL,
+			b int,
+			PRIMARY KEY (id)
+		)`)
+		require.NoError(t, err)
+
+		target := `CREATE TABLE chk_t (
+			id int NOT NULL,
+			b int CHECK (b > 0),
+			PRIMARY KEY (id)
+		)`
+		stmts := diffLiveTable(t, db, "chk_t", target)
+		require.Len(t, stmts, 1)
+		require.Contains(t, stmts[0].Statement, "CHECK (`b`>0)")
+		execStatements(t, db, stmts)
+
+		// MySQL hoists column-level CHECK constraints to table-level
+		// constraints with an auto-generated name, so we verify against
+		// the canonical (table-level) form rather than full convergence.
+		finalCreate := showCreateTable(t, db, "chk_t")
+		require.Contains(t, finalCreate, "CHECK ((`b` > 0))")
+		requireNoSelfDiff(t, db, "chk_t")
+
+		// The constraint must actually be enforced.
+		_, err = db.ExecContext(t.Context(), "INSERT INTO chk_t (id, b) VALUES (1, -5)")
+		require.Error(t, err, "expected CHECK constraint violation")
+	})
+}

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -231,19 +231,19 @@ func TestDiff(t *testing.T) {
 			name:     "VirtualColumns",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, first_name VARCHAR(50), last_name VARCHAR(50))",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, first_name VARCHAR(50), last_name VARCHAR(50), full_name VARCHAR(101) AS (CONCAT(first_name, ' ', last_name)) VIRTUAL)",
-			expected: "ALTER TABLE `t1` ADD COLUMN `full_name` varchar(101) NULL",
+			expected: "ALTER TABLE `t1` ADD COLUMN `full_name` varchar(101) GENERATED ALWAYS AS (CONCAT(`first_name`, ' ', `last_name`)) VIRTUAL NULL",
 		},
 		{
 			name:     "StoredColumns",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, price DECIMAL(10,2), tax_rate DECIMAL(5,4))",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, price DECIMAL(10,2), tax_rate DECIMAL(5,4), total DECIMAL(10,2) AS (price * (1 + tax_rate)) STORED)",
-			expected: "ALTER TABLE `t1` ADD COLUMN `total` decimal(10,2) NULL",
+			expected: "ALTER TABLE `t1` ADD COLUMN `total` decimal(10,2) GENERATED ALWAYS AS (`price`*(1+`tax_rate`)) STORED NULL",
 		},
 		{
 			name:     "Timestamps1",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, updated_at TIMESTAMP)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `updated_at` timestamp NULL DEFAULT current_timestamp",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `updated_at` timestamp NULL DEFAULT current_timestamp ON UPDATE current_timestamp",
 		},
 		{
 			name:     "Timestamps2",

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -31,25 +31,30 @@ type CreateTable struct {
 
 // Column represents a table column definition
 type Column struct {
-	Raw           *ast.ColumnDef    `json:"-"`
-	Name          string            `json:"name"`
-	Type          string            `json:"type"`
-	Length        *int              `json:"length,omitempty"`
-	Precision     *int              `json:"precision,omitempty"`
-	Scale         *int              `json:"scale,omitempty"`
-	Unsigned      *bool             `json:"unsigned,omitempty"`
-	EnumValues    []string          `json:"enum_values,omitempty"` // Permitted values for ENUM type
-	SetValues     []string          `json:"set_values,omitempty"`  // Permitted values for SET type
-	Nullable      bool              `json:"nullable"`
-	Default       *string           `json:"default,omitempty"`
-	DefaultIsExpr bool              `json:"default_is_expr,omitempty"` // true when default is an expression (needs parens), e.g. DEFAULT (json_object())
-	AutoInc       bool              `json:"auto_increment"`
-	PrimaryKey    bool              `json:"primary_key"`
-	Unique        bool              `json:"unique"`
-	Comment       *string           `json:"comment,omitempty"`
-	Charset       *string           `json:"charset,omitempty"`
-	Collation     *string           `json:"collation,omitempty"`
-	Options       map[string]string `json:"options,omitempty"`
+	Raw             *ast.ColumnDef    `json:"-"`
+	Name            string            `json:"name"`
+	Type            string            `json:"type"`
+	Length          *int              `json:"length,omitempty"`
+	Precision       *int              `json:"precision,omitempty"`
+	Scale           *int              `json:"scale,omitempty"`
+	Unsigned        *bool             `json:"unsigned,omitempty"`
+	EnumValues      []string          `json:"enum_values,omitempty"` // Permitted values for ENUM type
+	SetValues       []string          `json:"set_values,omitempty"`  // Permitted values for SET type
+	Nullable        bool              `json:"nullable"`
+	Default         *string           `json:"default,omitempty"`
+	DefaultIsExpr   bool              `json:"default_is_expr,omitempty"`  // true when default is an expression (needs parens), e.g. DEFAULT (json_object())
+	OnUpdate        *string           `json:"on_update,omitempty"`        // ON UPDATE expression for TIMESTAMP/DATETIME, e.g. "current_timestamp"
+	GeneratedExpr   *string           `json:"generated_expr,omitempty"`   // Expression for GENERATED ALWAYS AS (...) columns
+	GeneratedStored bool              `json:"generated_stored,omitempty"` // true = STORED, false = VIRTUAL (only meaningful when GeneratedExpr is set)
+	Check           *string           `json:"check,omitempty"`            // Column-level CHECK (...) constraint expression
+	SRID            *uint32           `json:"srid,omitempty"`             // SRID attribute for spatial columns
+	AutoInc         bool              `json:"auto_increment"`
+	PrimaryKey      bool              `json:"primary_key"`
+	Unique          bool              `json:"unique"`
+	Comment         *string           `json:"comment,omitempty"`
+	Charset         *string           `json:"charset,omitempty"`
+	Collation       *string           `json:"collation,omitempty"`
+	Options         map[string]string `json:"options,omitempty"`
 }
 
 // IndexColumn represents a column or expression in an index
@@ -438,6 +443,16 @@ func (ct *CreateTable) parseColumn(col *ast.ColumnDef) Column {
 		Options:  make(map[string]string),
 	}
 
+	// Spatial types are parsed as TypeGeometry with a subtype; recover the
+	// specific type name (point, polygon, ...) so it round-trips correctly
+	// when emitting MODIFY/ADD COLUMN.
+	if col.Tp.GetType() == mysql.TypeGeometry {
+		geoType := col.Tp.GetGeometryType()
+		if geoStr := geoType.String(); geoStr != "" {
+			column.Type = geoStr
+		}
+	}
+
 	// Check if this is a binary type (VARBINARY, BLOB, etc.)
 	// The TiDB parser converts binary types to their text equivalents,
 	// so we need to check the binary flag and convert back
@@ -479,12 +494,16 @@ func (ct *CreateTable) parseColumn(col *ast.ColumnDef) Column {
 	}
 
 	// Extract charset and collation from the type itself
-	// (they may be overridden by column options later)
-	if charset := col.Tp.GetCharset(); charset != "" {
-		column.Charset = &charset
-	}
-	if collation := col.Tp.GetCollate(); collation != "" {
-		column.Collation = &collation
+	// (they may be overridden by column options later).
+	// Spatial types are skipped: the parser assigns them a synthetic
+	// "binary" charset/collation, which is not valid SQL to emit.
+	if col.Tp.GetType() != mysql.TypeGeometry {
+		if charset := col.Tp.GetCharset(); charset != "" {
+			column.Charset = &charset
+		}
+		if collation := col.Tp.GetCollate(); collation != "" {
+			column.Collation = &collation
+		}
 	}
 
 	// Extract ENUM/SET permitted values
@@ -549,6 +568,38 @@ func (ct *CreateTable) parseColumn(col *ast.ColumnDef) Column {
 			if opt.StrValue != "" {
 				column.Collation = &opt.StrValue
 			}
+		case ast.ColumnOptionOnUpdate:
+			// ON UPDATE CURRENT_TIMESTAMP[(n)] — only valid for TIMESTAMP/DATETIME.
+			// Reuse parseExpression so the stored form matches DEFAULT handling:
+			// lowercased, with "()" stripped from zero-arg timestamp functions.
+			if opt.Expr != nil {
+				if exprStr, ok := ct.parseExpression(opt.Expr).(string); ok && exprStr != "" {
+					column.OnUpdate = &exprStr
+				}
+			}
+		case ast.ColumnOptionGenerated:
+			// GENERATED ALWAYS AS (expr) [STORED|VIRTUAL]
+			if opt.Expr != nil {
+				if exprStr, ok := restoreExpressionText(opt.Expr); ok {
+					column.GeneratedExpr = &exprStr
+					column.GeneratedStored = opt.Stored
+				}
+			}
+		case ast.ColumnOptionCheck:
+			// Column-level CHECK (expr). Note that MySQL normalizes these to
+			// table-level constraints in SHOW CREATE TABLE output, so this is
+			// only seen when parsing user-written (non-canonical) statements.
+			if opt.Expr != nil {
+				if exprStr, ok := restoreExpressionText(opt.Expr); ok {
+					column.Check = &exprStr
+				}
+			}
+		case ast.ColumnOptionSrid:
+			// SRID n — spatial reference system id for spatial columns.
+			// SHOW CREATE TABLE emits this as /*!80003 SRID n */ which the
+			// parser unwraps as a regular column option.
+			srid := opt.Srid
+			column.SRID = &srid
 		default:
 			// Store unknown options for flexibility
 			column.Options[fmt.Sprintf("option_%d", opt.Tp)] = opt.StrValue
@@ -1062,6 +1113,31 @@ func isExpressionDefault(expr ast.ExprNode) bool {
 	default:
 		return false
 	}
+}
+
+// restoreExpressionText restores an expression AST node to its SQL text,
+// stripping redundant outer parentheses. MySQL's SHOW CREATE TABLE wraps
+// generated-column and CHECK expressions in an extra set of parentheses
+// (e.g. GENERATED ALWAYS AS ((`a` + 1))); stripping them ensures a
+// user-written `AS (a + 1)` compares equal to the canonical form.
+// Unlike parseExpression, the result is NOT lowercased and string literals
+// keep their quotes — these expressions may contain case-sensitive literals.
+func restoreExpressionText(expr ast.ExprNode) (string, bool) {
+	for {
+		paren, ok := expr.(*ast.ParenthesesExpr)
+		if !ok {
+			break
+		}
+		expr = paren.Expr
+	}
+
+	var sb strings.Builder
+	rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreStringWithoutCharset, &sb)
+	if err := expr.Restore(rCtx); err != nil {
+		return "", false
+	}
+
+	return sb.String(), true
 }
 
 // parseExpression converts an expression to a string representation

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -351,6 +351,12 @@ func (ct *CreateTable) parseToStruct() {
 		}
 	}
 
+	// Hoist column-level CHECK constraints into table-level constraints, the
+	// same way MySQL does in SHOW CREATE TABLE. This keeps the parsed form
+	// canonical so a diff against a live (already-hoisted) table converges and
+	// never tries to DROP the live CHECK. See normalizeColumnChecks.
+	ct.normalizeColumnChecks()
+
 	// Auto-generate MySQL default names for unnamed indexes
 	ct.autoNameIndexes()
 
@@ -362,6 +368,94 @@ func (ct *CreateTable) parseToStruct() {
 	// Parse partition options
 	if ct.Raw.Partition != nil {
 		ct.Partition = ct.parsePartitionOptions(ct.Raw.Partition)
+	}
+}
+
+// normalizeColumnChecks hoists column-level CHECK constraints into table-level
+// constraints, mirroring what MySQL does in SHOW CREATE TABLE. Without this,
+// a column-level CHECK lives only in Column.Check while the live table (after
+// the ALTER is applied) reports the same constraint in CreateTable.Constraints.
+// A re-diff would then (a) keep emitting MODIFY COLUMN because Column.Check
+// differs and (b) try to DROP the live CHECK because it is absent from the
+// target's Constraints. Hoisting at parse time keeps the parsed form canonical
+// so the re-diff converges and no constraint is ever dropped.
+//
+// MySQL auto-names unnamed CHECK constraints `<table>_chk_<n>`. We replicate
+// that here: user-named CHECKs keep their name; unnamed ones are numbered in
+// the order they are encountered (existing table-level CHECKs first, then the
+// hoisted column-level CHECKs in column order).
+//
+// Naming caveat: MySQL numbers CHECKs in true declaration order, interleaving
+// column-level and table-level CHECKs by their position in the statement. The
+// TiDB parser does not expose reliable per-node source offsets, so when a table
+// mixes column-level and table-level CHECKs our generated `_chk_<n>` numbers can
+// differ from MySQL's. This is purely cosmetic and never causes a constraint to
+// be dropped or a re-diff to diverge: diffConstraints pairs CHECK constraints by
+// expression when the names differ (see matchedByExpression in diffConstraints),
+// so the round-trip still converges. The common case — a table whose CHECKs are
+// all column-level — numbers identically to MySQL.
+func (ct *CreateTable) normalizeColumnChecks() {
+	// Track names already in use so generated names never collide with a
+	// user-supplied constraint name.
+	usedNames := make(map[string]bool)
+	for i := range ct.Constraints {
+		if ct.Constraints[i].Name != "" {
+			usedNames[ct.Constraints[i].Name] = true
+		}
+	}
+
+	// Append a hoisted table-level CHECK for each column-level CHECK, then
+	// clear the column-level field so it no longer participates in column
+	// equality or column-definition emission.
+	for i := range ct.Columns {
+		col := &ct.Columns[i]
+		if col.Check == nil {
+			continue
+		}
+		// Recover the user-supplied constraint name (if any) from the raw
+		// column option; unnamed ones are auto-numbered below.
+		name := ""
+		if col.Raw != nil {
+			for _, opt := range col.Raw.Options {
+				if opt.Tp == ast.ColumnOptionCheck {
+					name = opt.ConstraintName
+					break
+				}
+			}
+		}
+		expr := *col.Check
+		definition := fmt.Sprintf("CHECK (%s)", expr)
+		ct.Constraints = append(ct.Constraints, Constraint{
+			Name:       name,
+			Type:       "CHECK",
+			Expression: &expr,
+			Definition: &definition,
+		})
+		col.Check = nil
+		if name != "" {
+			usedNames[name] = true
+		}
+	}
+
+	// Number the unnamed CHECK constraints `<table>_chk_<n>`. Resolve indices
+	// (not pointers) after all appends are complete so a slice reallocation
+	// during the append loop above cannot leave us with dangling references.
+	counter := 0
+	for i := range ct.Constraints {
+		c := &ct.Constraints[i]
+		if c.Type != "CHECK" || c.Name != "" {
+			continue
+		}
+		var name string
+		for {
+			counter++
+			name = fmt.Sprintf("%s_chk_%d", ct.TableName, counter)
+			if !usedNames[name] {
+				break
+			}
+		}
+		usedNames[name] = true
+		c.Name = name
 	}
 }
 
@@ -703,8 +797,14 @@ func (ct *CreateTable) parseConstraint(constraint *ast.Constraint) Constraint {
 		constr.Type = "CHECK"
 
 		if constraint.Expr != nil {
-			expr := ct.parseExpression(constraint.Expr)
-			if exprStr, ok := expr.(string); ok {
+			// Use restoreExpressionText (not parseExpression) so the stored
+			// expression has any balanced outer parentheses stripped. MySQL's
+			// SHOW CREATE TABLE wraps the CHECK body in an extra set of parens
+			// (e.g. CHECK ((`age` >= 0))) while user-written DDL usually does
+			// not (CHECK (age >= 0)). Normalizing both to the unwrapped form
+			// (`age`>=0) lets the two compare equal so a re-diff converges
+			// instead of emitting a spurious DROP+ADD.
+			if exprStr, ok := restoreExpressionText(constraint.Expr); ok {
 				constr.Expression = &exprStr
 				// Generate definition string
 				definition := fmt.Sprintf("CHECK (%s)", exprStr)


### PR DESCRIPTION
## Problem
The CREATE TABLE parser dropped four semantically-critical column attributes — `ON UPDATE CURRENT_TIMESTAMP`, `GENERATED ALWAYS AS (...) STORED|VIRTUAL`, column-level `CHECK`, and `SRID` — into an unread `option_N` map. Consequences (all reproduced):
- **Missed diffs:** adding any of these produced no ALTER (`columnsEqualWithContext` never compared them).
- **Silent destruction:** an unrelated `MODIFY COLUMN` (e.g. a comment-only change) on a column with `ON UPDATE CURRENT_TIMESTAMP` emitted a definition *without* the clause, stripping the auto-update behavior from the live table when applied.
- **ADD COLUMN** dropped the generated/SRID clause entirely.

These are canonical `SHOW CREATE TABLE` constructs.

## Fix
Make the four attributes first-class fields flowing through parse → compare → emit, with expression normalization so canonical forms compare equal to user-written schemas, and correct MySQL clause ordering on emit. Spatial columns additionally needed the parser to recover the real subtype (`point` vs `geometry`) and drop a synthetic `binary` charset so emitted DDL is valid. Scope: only these four attribute classes — sibling PRs cover other statement findings.

## Testing
22 parse/diff cases plus a live-MySQL suite that executes the generated ALTERs and asserts on the resulting `SHOW CREATE TABLE` (comment-only MODIFY preserves `ON UPDATE`; generated/SRID/CHECK add; convergence on re-diff). Three existing tests that encoded the buggy dropped-attribute output were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
