### PR TITLE
add inter-column separator to checksum expression

### DIFF
--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -14,7 +14,10 @@ import (
 )
 
 var (
-	// Query template for row checksums
+	// Query template for row checksums. The first %s is the column expression
+	// list from table.ColumnMapping.ChecksumExprs(), which already interleaves
+	// a '#' separator between values so content cannot shift across column
+	// boundaries undetected.
 	queryTemplate = "SELECT CRC32(CONCAT(%s)) as row_checksum, CONCAT_WS(',', %s) as pk FROM %s WHERE %s"
 
 	// ErrYieldTimeout is returned by runChecksum when the yield timeout expires.

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -458,3 +458,46 @@ func TestFromWatermark(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, checker.Run(t.Context()))
 }
+
+// TestColumnBoundaryShift is a regression test for the missing inter-column
+// separator in the checksum expression. Without a separator, CONCAT() lets
+// content shift across adjacent column boundaries undetected: the rows
+// ('x0', 'y') and ('x', '0y') concatenate to the same string ("x00y0",
+// including the ISNULL digits) and therefore the same CRC32. The checksum
+// must report these rows as different.
+func TestColumnBoundaryShift(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS colshift_t1, _colshift_t1_new, _colshift_t1_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE colshift_t1 (id INT NOT NULL, a VARCHAR(255), b VARCHAR(255), PRIMARY KEY (id))")
+	testutils.RunSQL(t, "CREATE TABLE _colshift_t1_new (id INT NOT NULL, a VARCHAR(255), b VARCHAR(255), PRIMARY KEY (id))")
+	testutils.RunSQL(t, "CREATE TABLE _colshift_t1_chkpnt (a INT)") // for binlog advancement
+	// The trailing '0' of column a has migrated to the front of column b
+	// in the target table. The data is different, so the checksum must fail.
+	testutils.RunSQL(t, "INSERT INTO colshift_t1 VALUES (1, 'x0', 'y')")
+	testutils.RunSQL(t, "INSERT INTO _colshift_t1_new VALUES (1, 'x', '0y')")
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "colshift_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_colshift_t1_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	checker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, NewCheckerDefaultConfig())
+	require.NoError(t, err)
+	singleChecker, ok := checker.(*SingleChecker)
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	err = singleChecker.runChecksum(t.Context())
+	require.ErrorContains(t, err, "checksum mismatch")
+}

--- a/pkg/table/column_mapping.go
+++ b/pkg/table/column_mapping.go
@@ -103,10 +103,23 @@ func (m *ColumnMapping) ColumnsSlice() (sourceColumns, targetColumns []string) {
 	return m.sourceColumns, m.targetColumns
 }
 
-// ChecksumExprs returns two comma-separated checksum column expressions for
-// source and target, wrapping each column in IFNULL(), ISNULL() and CAST.
-// The CAST type always comes from the target table's type definition.
-// When there are no renames, both expressions are identical.
+// checksumSeparator is interleaved between every value in the checksum
+// CONCAT() so that content cannot shift across adjacent column boundaries
+// undetected. Without it, the rows ('x0','y') and ('x','0y') concatenate to
+// the same string and produce identical CRC32 values. This is the same reason
+// pt-table-checksum uses CONCAT_WS with a '#' separator. A value containing
+// '#' can still theoretically produce an ambiguous concatenation, but the
+// fixed value/ISNULL-digit/separator structure makes an accidental collision
+// require precisely-placed separator-and-digit patterns inside the diverged
+// data — far weaker than the previous any-boundary-shift collision, and well
+// below the CRC32 collision floor the checksum already accepts.
+const checksumSeparator = ", '#', "
+
+// ChecksumExprs returns two checksum column expressions (argument lists for
+// CONCAT()) for source and target, wrapping each column in IFNULL(), ISNULL()
+// and CAST, with a '#' separator literal between every value (see
+// checksumSeparator). The CAST type always comes from the target table's type
+// definition. When there are no renames, both expressions are identical.
 func (m *ColumnMapping) ChecksumExprs() (source, target string, err error) {
 	sourceExprs := make([]string, len(m.sourceColumns))
 	targetExprs := make([]string, len(m.targetColumns))
@@ -123,10 +136,10 @@ func (m *ColumnMapping) ChecksumExprs() (source, target string, err error) {
 		if err != nil {
 			return "", "", err
 		}
-		sourceExprs[i] = "IFNULL(" + srcCast + ",''), ISNULL(`" + m.sourceColumns[i] + "`)"
-		targetExprs[i] = "IFNULL(" + tgtCast + ",''), ISNULL(`" + m.targetColumns[i] + "`)"
+		sourceExprs[i] = "IFNULL(" + srcCast + ",'')" + checksumSeparator + "ISNULL(`" + m.sourceColumns[i] + "`)"
+		targetExprs[i] = "IFNULL(" + tgtCast + ",'')" + checksumSeparator + "ISNULL(`" + m.targetColumns[i] + "`)"
 	}
-	return strings.Join(sourceExprs, ", "), strings.Join(targetExprs, ", "), nil
+	return strings.Join(sourceExprs, checksumSeparator), strings.Join(targetExprs, checksumSeparator), nil
 }
 
 // SourceColumnIndices returns the indices into sourceTable.NonGeneratedColumns


### PR DESCRIPTION
## Problem
The row checksum concatenated per-column `IFNULL(CAST(col),''), ISNULL(col)` fragments with no separator, so content shifting across adjacent column boundaries was undetectable. Verified live on MySQL 8.0: rows `(a='x0', b='y')` and `(a='x', b='0y')` produce identical CRC32s under the exact generated expression. pt-table-checksum uses `CONCAT_WS('#', ...)` for precisely this reason.

## Fix
Interleave a `'#'` literal between every value in `ColumnMapping.ChecksumExprs()` (byte-identical to `CONCAT_WS('#', ...)`, but keeping plain `CONCAT()` since the fragments are never NULL). Centralizing in the expression generator fixes all three checkers and the row-inspection query from one point of truth; both sides use the same generator. The `ISNULL` digit still distinguishes NULL from empty string. No persisted state crosses the format boundary — checkpoints store chunk watermarks, never CRC values. A value containing `'#'` can still theoretically collide, but a collision now requires separator-plus-ISNULL-digit patterns at exact offsets in the diverged data (below the 2^-32 CRC32 floor), versus *any* adjacent boundary shift before.

## Testing
Regression test with the exact colliding pair — fails on the old expression, passes with the fix. Existing checksum suites (NULL-vs-empty, all datatypes) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
