### PR TITLE
register auto_inc_capacity linter and fix overflow + FLOAT panic

### DIFF
--- a/pkg/lint/lint_auto_inc_capacity.go
+++ b/pkg/lint/lint_auto_inc_capacity.go
@@ -2,12 +2,17 @@ package lint
 
 import (
 	"fmt"
+	"math/bits"
 	"strconv"
 	"strings"
 
 	"github.com/block/spirit/pkg/statement"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 )
+
+func init() {
+	Register(&AutoIncCapacityLinter{threshold: 85})
+}
 
 type AutoIncCapacityLinter struct {
 	threshold uint64
@@ -51,6 +56,13 @@ func (l *AutoIncCapacityLinter) String() string {
 // AUTO_INCREMENT or widens the column type is linted against the table's
 // final shape rather than the pre-ALTER snapshot.
 func (l *AutoIncCapacityLinter) Lint(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
+	if l.threshold == 0 {
+		// Not configured (e.g. obtained via Get() and used directly):
+		// fall back to the default configuration.
+		if err := l.Configure(l.DefaultConfig()); err != nil {
+			panic(err)
+		}
+	}
 	for _, ct := range PostState(existingTables, changes) {
 		if ct.TableOptions == nil || ct.TableOptions.AutoIncrement == nil {
 			// If the table definition doesn't include an AUTO_INCREMENT clause we can't check anything
@@ -80,16 +92,20 @@ func (l *AutoIncCapacityLinter) Lint(existingTables []*statement.CreateTable, ch
 			case mysql.TypeLonglong: // bigint
 				bytes = 64
 			default:
-				// Unknown type, this can't happen!
+				// Non-integer auto-increment column (e.g. legacy FLOAT/DOUBLE
+				// AUTO_INCREMENT). We can't compute a capacity for it, so
+				// report it and skip the capacity check for this column.
 				violations = append(violations, Violation{
 					Linter: l,
 					Location: &Location{
 						Table:  ct.TableName,
 						Column: &col.Name,
 					},
-					Message:  fmt.Sprintf("unknown column type %q (%d). this is a bug!", col.Type, col.Raw.Tp.GetType()),
+					Message:  fmt.Sprintf("unsupported column type %q (%d) for an auto-increment column; capacity cannot be checked", col.Type, col.Raw.Tp.GetType()),
 					Severity: SeverityWarning,
 				})
+
+				continue
 			}
 
 			// Adjust for signed types
@@ -106,8 +122,17 @@ func (l *AutoIncCapacityLinter) Lint(existingTables []*statement.CreateTable, ch
 				suggestions = append(suggestions, "consider using BIGINT for auto-increment columns")
 			}
 
-			// Check if auto_increment value exceeds threshold
-			threshold := maxValue * l.threshold / 100
+			// Check if auto_increment value exceeds threshold. The product
+			// maxValue*threshold can exceed 64 bits when maxValue is 2^64-1
+			// (BIGINT UNSIGNED), so compute it with a 128-bit intermediate
+			// via math/bits. The result is exact: identical to the naive
+			// maxValue*l.threshold/100 wherever that doesn't overflow, so
+			// the pass/fail boundaries for narrower types are unchanged.
+			// bits.Div64 cannot panic here because l.threshold <= 100
+			// (validated in Configure), which bounds the high word of the
+			// product below the divisor.
+			hi, lo := bits.Mul64(maxValue, l.threshold)
+			threshold, _ := bits.Div64(hi, lo, 100)
 			if autoInc > threshold {
 				violations = append(violations, Violation{
 					Severity: SeverityError,

--- a/pkg/lint/lint_auto_inc_capacity.go
+++ b/pkg/lint/lint_auto_inc_capacity.go
@@ -57,8 +57,12 @@ func (l *AutoIncCapacityLinter) String() string {
 // final shape rather than the pre-ALTER snapshot.
 func (l *AutoIncCapacityLinter) Lint(existingTables []*statement.CreateTable, changes []*statement.AbstractStatement) (violations []Violation) {
 	if l.threshold == 0 {
-		// Not configured (e.g. obtained via Get() and used directly):
-		// fall back to the default configuration.
+		// A zero threshold means this linter was constructed directly
+		// (e.g. &AutoIncCapacityLinter{}) without calling Configure, or the
+		// field was manually reset. Instances obtained via Get() always carry
+		// the non-zero default registered in init(), and Configure rejects a
+		// zero threshold, so this only guards against direct construction.
+		// Fall back to the default configuration in that case.
 		if err := l.Configure(l.DefaultConfig()); err != nil {
 			panic(err)
 		}

--- a/pkg/lint/lint_auto_inc_capacity_test.go
+++ b/pkg/lint/lint_auto_inc_capacity_test.go
@@ -729,6 +729,175 @@ func TestAutoIncCapacity_EmptySlices(t *testing.T) {
 	require.Empty(t, violations)
 }
 
+// Test registration
+
+func TestAutoIncCapacity_Registered(t *testing.T) {
+	l, err := Get("auto_inc_capacity")
+	require.NoError(t, err)
+	require.Equal(t, "auto_inc_capacity", l.Name())
+	require.Contains(t, List(), "auto_inc_capacity")
+}
+
+func TestAutoIncCapacity_RunLinters_ReadmeExample(t *testing.T) {
+	// The README documents this exact example as a violation, and documents
+	// the linter as enabled by default — so RunLinters with an empty config
+	// must report it.
+	stmts, err := statement.New(`CREATE TABLE users (
+		id INT UNSIGNED PRIMARY KEY AUTO_INCREMENT
+	) AUTO_INCREMENT=4000000000`)
+	require.NoError(t, err)
+
+	violations, err := RunLinters(nil, stmts, Config{})
+	require.NoError(t, err)
+
+	filtered := FilterByLinter(violations, "auto_inc_capacity")
+	require.Len(t, filtered, 1)
+	require.Equal(t, SeverityError, filtered[0].Severity)
+	require.Contains(t, filtered[0].Message, "AUTO_INCREMENT")
+
+	// Explicitly enabling it must work too.
+	violations, err = RunLinters(nil, stmts, Config{
+		Enabled: map[string]bool{"auto_inc_capacity": true},
+	})
+	require.NoError(t, err)
+	require.Len(t, FilterByLinter(violations, "auto_inc_capacity"), 1)
+}
+
+// Test overflow-safety of the threshold calculation. maxValue*threshold
+// overflows uint64 for BIGINT (and BIGINT UNSIGNED) capacities, which used to
+// shrink the effective threshold to ~1% and falsely flag near-empty tables.
+
+func TestAutoIncCapacity_BigIntUnsigned_LowValue_NotFlagged(t *testing.T) {
+	// 2*10^17 is ~1.08% of the BIGINT UNSIGNED capacity (2^64-1). The naive
+	// maxValue*85 wraps mod 2^64 and produces an effective threshold of ~1%
+	// of capacity, which falsely flags this value.
+	sql := `CREATE TABLE users (
+		id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255)
+	) AUTO_INCREMENT=200000000000000000`
+
+	ct, err := statement.ParseCreateTable(sql)
+	require.NoError(t, err)
+
+	linter := &AutoIncCapacityLinter{threshold: 85}
+	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+	require.Empty(t, violations)
+}
+
+func TestAutoIncCapacity_BigIntUnsigned_HighValue_Flagged(t *testing.T) {
+	// 1.7*10^19 is ~92% of the BIGINT UNSIGNED capacity (2^64-1).
+	sql := `CREATE TABLE users (
+		id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255)
+	) AUTO_INCREMENT=17000000000000000000`
+
+	ct, err := statement.ParseCreateTable(sql)
+	require.NoError(t, err)
+
+	linter := &AutoIncCapacityLinter{threshold: 85}
+	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+	require.Len(t, violations, 1)
+	require.Equal(t, SeverityError, violations[0].Severity)
+}
+
+func TestAutoIncCapacity_BigIntUnsigned_ExactBoundary(t *testing.T) {
+	// floor((2^64-1) * 85 / 100) = 15679732462653118872, so that value
+	// passes and one more fails. Locks in that the 128-bit math is exact.
+	linter := &AutoIncCapacityLinter{threshold: 85}
+
+	ctPass, err := statement.ParseCreateTable(`CREATE TABLE users (
+		id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY
+	) AUTO_INCREMENT=15679732462653118872`)
+	require.NoError(t, err)
+	require.Empty(t, linter.Lint([]*statement.CreateTable{ctPass}, nil))
+
+	ctFail, err := statement.ParseCreateTable(`CREATE TABLE users (
+		id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY
+	) AUTO_INCREMENT=15679732462653118873`)
+	require.NoError(t, err)
+	require.Len(t, linter.Lint([]*statement.CreateTable{ctFail}, nil), 1)
+}
+
+func TestAutoIncCapacity_SignedBigInt_LowValue_NotFlagged(t *testing.T) {
+	// 10^17 is ~1.08% of the signed BIGINT capacity (2^63-1). The naive
+	// maxValue*85 also wraps for signed BIGINT (effective threshold ~1%).
+	sql := `CREATE TABLE users (
+		id BIGINT AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255)
+	) AUTO_INCREMENT=100000000000000000`
+
+	ct, err := statement.ParseCreateTable(sql)
+	require.NoError(t, err)
+
+	linter := &AutoIncCapacityLinter{threshold: 85}
+	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+	require.Empty(t, violations)
+}
+
+func TestAutoIncCapacity_SignedBigInt_HighValue_Flagged(t *testing.T) {
+	// 8*10^18 is ~86.7% of the signed BIGINT capacity (2^63-1).
+	sql := `CREATE TABLE users (
+		id BIGINT AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255)
+	) AUTO_INCREMENT=8000000000000000000`
+
+	ct, err := statement.ParseCreateTable(sql)
+	require.NoError(t, err)
+
+	linter := &AutoIncCapacityLinter{threshold: 85}
+	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+	require.Len(t, violations, 1)
+	require.Contains(t, *violations[0].Suggestion, "UNSIGNED")
+}
+
+func TestAutoIncCapacity_IntUnsigned_ExactBoundary(t *testing.T) {
+	// floor((2^32-1) * 85 / 100) = 3650722200, so that value passes and one
+	// more fails. The overflow-safe math must not move this boundary.
+	linter := &AutoIncCapacityLinter{threshold: 85}
+
+	ctPass, err := statement.ParseCreateTable(`CREATE TABLE users (
+		id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY
+	) AUTO_INCREMENT=3650722200`)
+	require.NoError(t, err)
+	require.Empty(t, linter.Lint([]*statement.CreateTable{ctPass}, nil))
+
+	ctFail, err := statement.ParseCreateTable(`CREATE TABLE users (
+		id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY
+	) AUTO_INCREMENT=3650722201`)
+	require.NoError(t, err)
+	require.Len(t, linter.Lint([]*statement.CreateTable{ctFail}, nil), 1)
+}
+
+// Test unsupported (non-integer) auto-increment column types. FLOAT/DOUBLE
+// AUTO_INCREMENT is legal legacy MySQL; it must produce exactly one
+// unsupported-type warning, not panic (signed used to hit a negative shift)
+// or emit a bogus second capacity violation (unsigned).
+
+func TestAutoIncCapacity_FloatDoubleAutoInc_NoPanic(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"float_signed", `CREATE TABLE t (f FLOAT AUTO_INCREMENT, PRIMARY KEY(f)) AUTO_INCREMENT=10`},
+		{"float_unsigned", `CREATE TABLE t (f FLOAT UNSIGNED AUTO_INCREMENT, PRIMARY KEY(f)) AUTO_INCREMENT=10`},
+		{"double_signed", `CREATE TABLE t (f DOUBLE AUTO_INCREMENT, PRIMARY KEY(f)) AUTO_INCREMENT=10`},
+		{"double_unsigned", `CREATE TABLE t (f DOUBLE UNSIGNED AUTO_INCREMENT, PRIMARY KEY(f)) AUTO_INCREMENT=10`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ct, err := statement.ParseCreateTable(tc.sql)
+			require.NoError(t, err)
+
+			linter := &AutoIncCapacityLinter{threshold: 85}
+			violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+
+			require.Len(t, violations, 1)
+			require.Equal(t, SeverityWarning, violations[0].Severity)
+			require.Contains(t, violations[0].Message, "unsupported column type")
+		})
+	}
+}
+
 // Test complex table structures
 
 func TestAutoIncCapacity_ComplexTable_Pass(t *testing.T) {


### PR DESCRIPTION
## Problem
Three compounding bugs in the `auto_inc_capacity` linter:
1. **Never registered:** it had no `init()`/`Register`, so `List()`/`Get()` didn't know it and `RunLinters` silently skipped it — despite the README documenting it as default-enabled. Its unit tests constructed the struct directly, hiding the gap.
2. **uint64 overflow:** `maxValue * threshold / 100` wrapped mod 2^64 for BIGINT, making the effective threshold ~1% instead of 85% → false-positive ERRORs (an AUTO_INCREMENT at ~1% of BIGINT UNSIGNED capacity was flagged).
3. **Panic on FLOAT/DOUBLE auto-inc:** the unsupported-type `default:` branch lacked a `continue`, so `1<<bytes` with `bytes = -1` panicked with a negative shift. `FLOAT AUTO_INCREMENT` is legal legacy MySQL.

Registering alone would have shipped (2) and (3), so all three are fixed together.

## Fix
Add `init()`/`Register`; use 128-bit intermediates (`math/bits`) for the threshold — exact, so the existing INT UNSIGNED boundary is unmoved; add the missing `continue` so unsupported types report exactly one warning.

## Testing
Registration via `Get`/`RunLinters` with the README's own example; overflow boundaries for signed/unsigned BIGINT and the exact INT UNSIGNED boundary; FLOAT/DOUBLE no-panic. Overflow and panic tests were verified to fail/panic against the unfixed code. Full pkg/lint suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
