### PR TITLE
invoke applier callbacks before removing pending work (sharded + single-target)

### DIFF
--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -334,10 +334,16 @@ func (a *ShardedApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][
 // pendingMutex), then decrements callbacksInFlight. Must be called WITHOUT
 // pendingMutex held. See the completion invariant on pendingWork.
 func (a *ShardedApplier) invokeCallback(callback ApplyCallback, affectedRows int64, err error) {
+	// Decrement in a defer so callbacksInFlight is balanced on every exit path,
+	// including a panicking callback. Without this, a recovered panic upstream
+	// would leave callbacksInFlight stuck above zero and wedge Wait() forever.
+	// The panic still propagates after the deferred decrement runs.
+	defer func() {
+		a.pendingMutex.Lock()
+		a.callbacksInFlight--
+		a.pendingMutex.Unlock()
+	}()
 	callback(affectedRows, err)
-	a.pendingMutex.Lock()
-	a.callbacksInFlight--
-	a.pendingMutex.Unlock()
 }
 
 // Wait blocks until all pending work is complete and all callbacks have been invoked.

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -32,10 +32,22 @@ type ShardedApplier struct {
 	dbConfig *dbconn.DBConfig
 	logger   *slog.Logger
 
-	// Pending work tracking (shared across all shards)
-	pendingWork  map[int64]*pendingWork
-	pendingMutex sync.Mutex
-	nextWorkID   int64 // Atomic counter for work IDs
+	// Pending work tracking (shared across all shards).
+	//
+	// Completion invariant (#765): a pendingWork entry is "claimed" by
+	// deleting it from the map AND incrementing callbacksInFlight in the
+	// same pendingMutex critical section. Exactly one path can claim an
+	// entry — the feedbackCoordinator (error or success path) or Apply's
+	// ctx-cancel cleanup — so the callback is invoked exactly once. The
+	// claimer then invokes the callback without holding the lock (callbacks
+	// may be slow or re-enter the applier) and decrements callbacksInFlight
+	// when it returns. Wait() returns only when len(pendingWork) == 0 AND
+	// callbacksInFlight == 0, so it cannot return before every callback has
+	// finished running.
+	pendingWork       map[int64]*pendingWork
+	pendingMutex      sync.Mutex
+	callbacksInFlight int   // claimed work whose callback has not returned yet; guarded by pendingMutex
+	nextWorkID        int64 // Atomic counter for work IDs
 
 	// Context management
 	cancelFunc context.CancelFunc
@@ -291,6 +303,12 @@ func (a *ShardedApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][
 	// forever, hanging Wait(). Chunklets already in shard buffers may still be
 	// processed; their completions arrive at the coordinator after pendingWork
 	// has been deleted and are dropped (logged as "unknown work").
+	//
+	// The claim (delete + callbacksInFlight increment, see the completion
+	// invariant on pendingWork) is atomic under pendingMutex, so this cleanup
+	// and the feedbackCoordinator can never both invoke the callback: if the
+	// coordinator already claimed the work (e.g. an error completion raced
+	// this cancellation), `exists` is false and we return without invoking.
 	for _, chunkletData := range allChunklets {
 		select {
 		case a.shards[chunkletData.shardID].chunkletBuffer <- chunkletData:
@@ -299,10 +317,11 @@ func (a *ShardedApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][
 			pending, exists := a.pendingWork[workID]
 			if exists {
 				delete(a.pendingWork, workID)
+				a.callbacksInFlight++
 			}
 			a.pendingMutex.Unlock()
 			if exists {
-				pending.callback(0, ctx.Err())
+				a.invokeCallback(pending.callback, 0, ctx.Err())
 			}
 			return ctx.Err()
 		}
@@ -310,7 +329,21 @@ func (a *ShardedApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][
 	return nil
 }
 
-// Wait blocks until all pending work is complete and all callbacks have been invoked
+// invokeCallback runs the callback for work the caller has already claimed
+// (deleted from pendingWork and counted in callbacksInFlight while holding
+// pendingMutex), then decrements callbacksInFlight. Must be called WITHOUT
+// pendingMutex held. See the completion invariant on pendingWork.
+func (a *ShardedApplier) invokeCallback(callback ApplyCallback, affectedRows int64, err error) {
+	callback(affectedRows, err)
+	a.pendingMutex.Lock()
+	a.callbacksInFlight--
+	a.pendingMutex.Unlock()
+}
+
+// Wait blocks until all pending work is complete and all callbacks have been invoked.
+// Checking callbacksInFlight in addition to len(pendingWork) is what upholds
+// the "all callbacks have been invoked" half of the contract: claimed work has
+// already left the map, but its callback may still be running (#765).
 func (a *ShardedApplier) Wait(ctx context.Context) error {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
@@ -318,14 +351,15 @@ func (a *ShardedApplier) Wait(ctx context.Context) error {
 	for {
 		a.pendingMutex.Lock()
 		pendingCount := len(a.pendingWork)
+		callbacksInFlight := a.callbacksInFlight
 		a.pendingMutex.Unlock()
 
-		if pendingCount == 0 {
+		if pendingCount == 0 && callbacksInFlight == 0 {
 			a.logger.Debug("Wait: all pending work complete")
 			return nil
 		}
 
-		a.logger.Debug("Wait: waiting for pending work", "pendingCount", pendingCount)
+		a.logger.Debug("Wait: waiting for pending work", "pendingCount", pendingCount, "callbacksInFlight", callbacksInFlight)
 
 		select {
 		case <-ctx.Done():
@@ -420,6 +454,14 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 		return 0, nil
 	}
 
+	// Fast path on shutdown: if ctx is already cancelled, fail the chunklet
+	// without building the (potentially large) INSERT statement or burning
+	// retries against a dead context. writeWorker relies on chunklets failing
+	// quickly after cancellation so Stop() can drain the buffer promptly.
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	// Create a context with timeout for the entire operation
 	ctx, cancel := context.WithTimeout(ctx, chunkTaskTimeout)
 	defer cancel()
@@ -494,13 +536,22 @@ func (a *ShardedApplier) feedbackCoordinator() {
 			return
 		}
 
-		// If there was an error, invoke callback immediately
+		// If there was an error, claim the work and invoke the callback
+		// immediately. The claim (delete + callbacksInFlight increment, see
+		// the completion invariant on pendingWork) is atomic under
+		// pendingMutex so that:
+		//  (a) Apply's ctx-cancel cleanup cannot find the entry and invoke
+		//      the callback a second time.
+		//  (b) Wait() — which requires pendingWork empty AND
+		//      callbacksInFlight zero — cannot return until the callback
+		//      has finished running (#765; the single-target applier was
+		//      fixed first, this mirrors it).
 		if completion.err != nil {
 			callback := pending.callback
-			// Remove the work from pending map before invoking callback
 			delete(a.pendingWork, completion.workID)
+			a.callbacksInFlight++
 			a.pendingMutex.Unlock()
-			callback(0, completion.err)
+			a.invokeCallback(callback, 0, completion.err)
 			return
 		}
 
@@ -515,16 +566,18 @@ func (a *ShardedApplier) feedbackCoordinator() {
 		if pending.completedChunklets == pending.totalChunklets {
 			a.logger.Debug("feedbackCoordinator all chunklets complete, invoking callback", "workID", completion.workID)
 
-			// Invoke the callback
 			callback := pending.callback
 			affectedRows := pending.totalAffectedRows
 
-			// Remove completed work from pending map
+			// Claim the work (delete + callbacksInFlight increment) under
+			// the lock, then invoke the callback. See the completion
+			// invariant on pendingWork and the comment in the error path
+			// above — Wait() cannot return until the callback has finished,
+			// and no other path can invoke it again.
 			delete(a.pendingWork, completion.workID)
+			a.callbacksInFlight++
 			a.pendingMutex.Unlock()
-
-			// Invoke callback outside the lock
-			callback(affectedRows, nil)
+			a.invokeCallback(callback, affectedRows, nil)
 		} else {
 			a.pendingMutex.Unlock()
 		}

--- a/pkg/applier/sharded_test.go
+++ b/pkg/applier/sharded_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
@@ -211,6 +212,134 @@ func TestShardedApplierIntegration(t *testing.T) {
 	t.Log("✓ Data correctly distributed across shards")
 	t.Logf("✓ Shard 0 (target1DB, even user_ids): %v", shard0UserIDs)
 	t.Logf("✓ Shard 1 (target2DB, odd user_ids): %v", shard1UserIDs)
+}
+
+// TestShardedApplierWaitWaitsForCallbacks verifies the Wait() contract:
+// "Wait blocks until all pending work is complete and all callbacks have been
+// invoked" (see the Applier interface). The buffered copier calls Wait() and
+// then reads state that is set *inside* the Apply callback — chunker.Feedback
+// on success, setInvalid(err) on failure — so if Wait() returns while the
+// final callback is still executing, a failed chunk can be misread as a clean
+// copy.
+//
+// The single-target applier was fixed for exactly this in issue #765; this
+// test covers the sharded applier's success and error completion paths. The
+// callback deliberately sleeps before recording completion: if Wait() returns
+// while the callback is still sleeping, the flag is unset and the test fails.
+func TestShardedApplierWaitWaitsForCallbacks(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sharded_waitcb_source")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sharded_waitcb_target1")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sharded_waitcb_target2")
+	testutils.RunSQL(t, "CREATE DATABASE sharded_waitcb_source")
+	testutils.RunSQL(t, "CREATE DATABASE sharded_waitcb_target1")
+	testutils.RunSQL(t, "CREATE DATABASE sharded_waitcb_target2")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	source := base.Clone()
+	source.DBName = "sharded_waitcb_source"
+	sourceDB, err := sql.Open("mysql", source.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(sourceDB)
+
+	target1 := base.Clone()
+	target1.DBName = "sharded_waitcb_target1"
+	target1DB, err := sql.Open("mysql", target1.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(target1DB)
+
+	target2 := base.Clone()
+	target2.DBName = "sharded_waitcb_target2"
+	target2DB, err := sql.Open("mysql", target2.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(target2DB)
+
+	createTableSQL := `
+		CREATE TABLE users (
+			id INT PRIMARY KEY,
+			user_id INT NOT NULL,
+			name VARCHAR(100)
+		)
+	`
+	ctx := t.Context()
+	_, err = sourceDB.ExecContext(ctx, createTableSQL)
+	require.NoError(t, err)
+	for _, db := range []*sql.DB{target1DB, target2DB} {
+		_, err = db.ExecContext(ctx, createTableSQL)
+		require.NoError(t, err)
+	}
+
+	sourceTable := table.NewTableInfo(sourceDB, source.DBName, "users")
+	require.NoError(t, sourceTable.SetInfo(ctx))
+	sourceTable.ShardingColumn = "user_id"
+	sourceTable.HashFunc = testutils.EvenOddHasher
+
+	target1Table := table.NewTableInfo(target1DB, target1.DBName, "users")
+	require.NoError(t, target1Table.SetInfo(ctx))
+
+	chunk := &table.Chunk{
+		Table:         sourceTable,
+		NewTable:      target1Table,
+		ColumnMapping: table.NewColumnMapping(sourceTable, target1Table, nil),
+	}
+	// user_id 102 is even -> shard 0 (target1), user_id 101 is odd -> shard 1 (target2)
+	testRows := [][]any{
+		{int64(1), int64(101), "Alice"},
+		{int64(2), int64(102), "Bob"},
+	}
+
+	// applyAndWait runs one Apply through a fresh applier with a slow callback
+	// and reports whether the callback had finished by the time Wait() returned,
+	// along with the error the callback observed.
+	applyAndWait := func(t *testing.T) (callbackFinished bool, callbackErr error) {
+		targets := []Target{
+			{DB: target1DB, KeyRange: "-80"},
+			{DB: target2DB, KeyRange: "80-"},
+		}
+		applier, err := NewShardedApplier(targets, NewApplierDefaultConfig())
+		require.NoError(t, err)
+		require.NoError(t, applier.Start(t.Context()))
+		defer func() {
+			require.NoError(t, applier.Stop())
+		}()
+
+		var finished atomic.Bool
+		var errMu sync.Mutex
+		var cbErr error
+		require.NoError(t, applier.Apply(t.Context(), chunk, testRows, func(_ int64, err error) {
+			errMu.Lock()
+			cbErr = err
+			errMu.Unlock()
+			// Simulate a consumer callback that takes a moment to run (e.g.
+			// chunker.Feedback, or the copier recording a failed chunk via
+			// setInvalid). Wait() must not return until this has completed.
+			time.Sleep(100 * time.Millisecond)
+			finished.Store(true)
+		}))
+		require.NoError(t, applier.Wait(t.Context()))
+		errMu.Lock()
+		defer errMu.Unlock()
+		return finished.Load(), cbErr
+	}
+
+	t.Run("success path", func(t *testing.T) {
+		finished, cbErr := applyAndWait(t)
+		require.True(t, finished, "Wait() returned before the success callback finished executing")
+		require.NoError(t, cbErr)
+	})
+
+	t.Run("error path", func(t *testing.T) {
+		// Drop the table on shard 1 (odd user_ids) so its chunklet fails.
+		// ERROR 1146 (no such table) is fatal — not retried — so the error
+		// completion arrives quickly while the shard 0 chunklet succeeds.
+		_, err := target2DB.ExecContext(t.Context(), "DROP TABLE users")
+		require.NoError(t, err)
+		finished, cbErr := applyAndWait(t)
+		require.True(t, finished, "Wait() returned before the error callback finished executing; "+
+			"a caller doing Wait() then checking error state would observe a clean copy despite a failed chunk")
+		require.Error(t, cbErr, "callback should have received the failed chunklet error")
+	})
 }
 
 // TestShardedApplierDeleteKeys tests the DeleteKeys method broadcasts deletes to all shards

--- a/pkg/applier/sharded_test.go
+++ b/pkg/applier/sharded_test.go
@@ -1,7 +1,9 @@
 package applier
 
 import (
+	"context"
 	"database/sql"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -908,4 +910,44 @@ func TestShardedApplierUpsertRowsEmpty(t *testing.T) {
 	affectedRows, err := applier.UpsertRows(t.Context(), table.NewColumnMapping(targetTable, targetTable, nil), []LogicalRow{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), affectedRows)
+}
+
+// TestShardedApplierCallbackPanicDecrements verifies that a panicking callback
+// still decrements callbacksInFlight, so a recovered panic upstream cannot wedge
+// Wait() forever. invokeCallback must balance the counter on every exit path,
+// not just normal return.
+func TestShardedApplierCallbackPanicDecrements(t *testing.T) {
+	a := &ShardedApplier{
+		logger:      slog.New(slog.DiscardHandler),
+		pendingWork: make(map[int64]*pendingWork),
+	}
+
+	// Claim a unit of work the way the real claim paths do: increment
+	// callbacksInFlight under pendingMutex before invoking the callback.
+	a.pendingMutex.Lock()
+	a.callbacksInFlight++
+	a.pendingMutex.Unlock()
+
+	panicking := func(affectedRows int64, err error) {
+		panic("callback boom")
+	}
+
+	// invokeCallback must propagate the panic; recover it here the way an
+	// upstream goroutine would.
+	func() {
+		defer func() {
+			require.Equal(t, "callback boom", recover())
+		}()
+		a.invokeCallback(panicking, 0, nil)
+	}()
+
+	// Despite the panic, the deferred decrement must have run, so Wait()
+	// observes a balanced counter and returns promptly.
+	a.pendingMutex.Lock()
+	require.Equal(t, 0, a.callbacksInFlight)
+	a.pendingMutex.Unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, a.Wait(ctx))
 }

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -28,10 +28,22 @@ type SingleTargetApplier struct {
 	chunkletBuffer      chan chunklet
 	chunkletCompletions chan chunkletCompletion
 
-	// Pending work tracking
-	pendingWork  map[int64]*pendingWork
-	pendingMutex sync.Mutex
-	nextWorkID   int64 // Atomic counter for work IDs
+	// Pending work tracking.
+	//
+	// Completion invariant (#765): a pendingWork entry is "claimed" by
+	// deleting it from the map AND incrementing callbacksInFlight in the
+	// same pendingMutex critical section. Exactly one path can claim an
+	// entry — the feedbackCoordinator (error or success path) or Apply's
+	// ctx-cancel cleanup — so the callback is invoked exactly once. The
+	// claimer then invokes the callback without holding the lock (callbacks
+	// may be slow or re-enter the applier) and decrements callbacksInFlight
+	// when it returns. Wait() returns only when len(pendingWork) == 0 AND
+	// callbacksInFlight == 0, so it cannot return before every callback has
+	// finished running.
+	pendingWork       map[int64]*pendingWork
+	pendingMutex      sync.Mutex
+	callbacksInFlight int   // claimed work whose callback has not returned yet; guarded by pendingMutex
+	nextWorkID        int64 // Atomic counter for work IDs
 
 	// Worker management
 	writeWorkersCount    int32
@@ -180,6 +192,12 @@ func (a *SingleTargetApplier) Apply(ctx context.Context, chunk *table.Chunk, row
 	// forever, hanging Wait(). Chunklets already in the buffer may still be
 	// processed; their completions arrive at the coordinator after pendingWork
 	// has been deleted and are dropped (logged as "unknown work").
+	//
+	// The claim (delete + callbacksInFlight increment, see the completion
+	// invariant on pendingWork) is atomic under pendingMutex, so this cleanup
+	// and the feedbackCoordinator can never both invoke the callback: if the
+	// coordinator already claimed the work (e.g. an error completion raced
+	// this cancellation), `exists` is false and we return without invoking.
 	for _, chunkletData := range chunklets {
 		select {
 		case a.chunkletBuffer <- chunkletData:
@@ -188,10 +206,11 @@ func (a *SingleTargetApplier) Apply(ctx context.Context, chunk *table.Chunk, row
 			pending, exists := a.pendingWork[workID]
 			if exists {
 				delete(a.pendingWork, workID)
+				a.callbacksInFlight++
 			}
 			a.pendingMutex.Unlock()
 			if exists {
-				pending.callback(0, ctx.Err())
+				a.invokeCallback(pending.callback, 0, ctx.Err())
 			}
 			return ctx.Err()
 		}
@@ -200,7 +219,21 @@ func (a *SingleTargetApplier) Apply(ctx context.Context, chunk *table.Chunk, row
 	return nil
 }
 
-// Wait blocks until all pending work is complete and all callbacks have been invoked
+// invokeCallback runs the callback for work the caller has already claimed
+// (deleted from pendingWork and counted in callbacksInFlight while holding
+// pendingMutex), then decrements callbacksInFlight. Must be called WITHOUT
+// pendingMutex held. See the completion invariant on pendingWork.
+func (a *SingleTargetApplier) invokeCallback(callback ApplyCallback, affectedRows int64, err error) {
+	callback(affectedRows, err)
+	a.pendingMutex.Lock()
+	a.callbacksInFlight--
+	a.pendingMutex.Unlock()
+}
+
+// Wait blocks until all pending work is complete and all callbacks have been invoked.
+// Checking callbacksInFlight in addition to len(pendingWork) is what upholds
+// the "all callbacks have been invoked" half of the contract: claimed work has
+// already left the map, but its callback may still be running (#765).
 func (a *SingleTargetApplier) Wait(ctx context.Context) error {
 	// Wait until there's no pending work
 	ticker := time.NewTicker(10 * time.Millisecond)
@@ -209,14 +242,15 @@ func (a *SingleTargetApplier) Wait(ctx context.Context) error {
 	for {
 		a.pendingMutex.Lock()
 		pendingCount := len(a.pendingWork)
+		callbacksInFlight := a.callbacksInFlight
 		a.pendingMutex.Unlock()
 
-		if pendingCount == 0 {
+		if pendingCount == 0 && callbacksInFlight == 0 {
 			a.logger.Debug("Wait: all pending work complete")
 			return nil
 		}
 
-		a.logger.Debug("Wait: waiting for pending work", "pendingCount", pendingCount)
+		a.logger.Debug("Wait: waiting for pending work", "pendingCount", pendingCount, "callbacksInFlight", callbacksInFlight)
 
 		// Wait for next tick or context cancellation
 		select {
@@ -310,6 +344,14 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 		return 0, nil
 	}
 
+	// Fast path on shutdown: if ctx is already cancelled, fail the chunklet
+	// without building the (potentially large) INSERT statement or burning
+	// retries against a dead context. writeWorker relies on chunklets failing
+	// quickly after cancellation so Stop() can drain the buffer promptly.
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	// The intersected source and target column lists are parallel — row.values[i]
 	// is a value for source column sourceColumnNames[i], which corresponds to
 	// target column at the same ordinal in targetColumnList. With column renames
@@ -383,18 +425,23 @@ func (a *SingleTargetApplier) feedbackCoordinator() {
 			return
 		}
 
-		// If there was an error, invoke callback immediately.
-		// We invoke the callback *before* removing the work from pendingWork so
-		// that Wait() — which polls len(pendingWork) — cannot return until the
-		// callback has run. Otherwise Wait could see an empty map and return
-		// while a callback is still being invoked on another goroutine.
+		// If there was an error, claim the work and invoke the callback
+		// immediately. The claim (delete + callbacksInFlight increment, see
+		// the completion invariant on pendingWork) is atomic under
+		// pendingMutex so that:
+		//  (a) Apply's ctx-cancel cleanup cannot find the entry and invoke
+		//      the callback a second time. The original #765 fix released
+		//      the lock between invoking the callback and deleting the
+		//      entry, which opened exactly that double-invocation window.
+		//  (b) Wait() — which requires pendingWork empty AND
+		//      callbacksInFlight zero — cannot return until the callback
+		//      has finished running.
 		if completion.err != nil {
 			callback := pending.callback
-			a.pendingMutex.Unlock()
-			callback(0, completion.err)
-			a.pendingMutex.Lock()
 			delete(a.pendingWork, completion.workID)
+			a.callbacksInFlight++
 			a.pendingMutex.Unlock()
+			a.invokeCallback(callback, 0, completion.err)
 			return
 		}
 
@@ -412,14 +459,15 @@ func (a *SingleTargetApplier) feedbackCoordinator() {
 			callback := pending.callback
 			affectedRows := pending.totalAffectedRows
 
-			// Invoke callback *before* removing the work from pendingWork. See
-			// the comment in the error path above — Wait() must not return
-			// until callbacks have finished running.
-			a.pendingMutex.Unlock()
-			callback(affectedRows, nil)
-			a.pendingMutex.Lock()
+			// Claim the work (delete + callbacksInFlight increment) under
+			// the lock, then invoke the callback. See the completion
+			// invariant on pendingWork and the comment in the error path
+			// above — Wait() cannot return until the callback has finished,
+			// and no other path can invoke it again.
 			delete(a.pendingWork, completion.workID)
+			a.callbacksInFlight++
 			a.pendingMutex.Unlock()
+			a.invokeCallback(callback, affectedRows, nil)
 		} else {
 			a.pendingMutex.Unlock()
 		}

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -224,10 +224,16 @@ func (a *SingleTargetApplier) Apply(ctx context.Context, chunk *table.Chunk, row
 // pendingMutex), then decrements callbacksInFlight. Must be called WITHOUT
 // pendingMutex held. See the completion invariant on pendingWork.
 func (a *SingleTargetApplier) invokeCallback(callback ApplyCallback, affectedRows int64, err error) {
+	// Decrement in a defer so callbacksInFlight is balanced on every exit path,
+	// including a panicking callback. Without this, a recovered panic upstream
+	// would leave callbacksInFlight stuck above zero and wedge Wait() forever.
+	// The panic still propagates after the deferred decrement runs.
+	defer func() {
+		a.pendingMutex.Lock()
+		a.callbacksInFlight--
+		a.pendingMutex.Unlock()
+	}()
 	callback(affectedRows, err)
-	a.pendingMutex.Lock()
-	a.callbacksInFlight--
-	a.pendingMutex.Unlock()
 }
 
 // Wait blocks until all pending work is complete and all callbacks have been invoked.

--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -3,6 +3,7 @@ package applier
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1130,4 +1131,44 @@ func TestSingleTargetApplierStartClose(t *testing.T) {
 	err = targetDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM test_table").Scan(&count)
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
+}
+
+// TestSingleTargetApplierCallbackPanicDecrements verifies that a panicking
+// callback still decrements callbacksInFlight, so a recovered panic upstream
+// cannot wedge Wait() forever. invokeCallback must balance the counter on every
+// exit path, not just normal return.
+func TestSingleTargetApplierCallbackPanicDecrements(t *testing.T) {
+	a := &SingleTargetApplier{
+		logger:      slog.New(slog.DiscardHandler),
+		pendingWork: make(map[int64]*pendingWork),
+	}
+
+	// Claim a unit of work the way the real claim paths do: increment
+	// callbacksInFlight under pendingMutex before invoking the callback.
+	a.pendingMutex.Lock()
+	a.callbacksInFlight++
+	a.pendingMutex.Unlock()
+
+	panicking := func(affectedRows int64, err error) {
+		panic("callback boom")
+	}
+
+	// invokeCallback must propagate the panic; recover it here the way an
+	// upstream goroutine would.
+	func() {
+		defer func() {
+			require.Equal(t, "callback boom", recover())
+		}()
+		a.invokeCallback(panicking, 0, nil)
+	}()
+
+	// Despite the panic, the deferred decrement must have run, so Wait()
+	// observes a balanced counter and returns promptly.
+	a.pendingMutex.Lock()
+	require.Equal(t, 0, a.callbacksInFlight)
+	a.pendingMutex.Unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, a.Wait(ctx))
 }

--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -877,9 +877,15 @@ func TestSingleTargetApplierContextCancellation(t *testing.T) {
 		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
 	}
 
-	// Start applying but cancel immediately
+	// Hold the callback open until Wait() has returned. Wait() counts an
+	// executing callback as pending work (see callbacksInFlight), so this
+	// guarantees Wait(cancelledCtx) observes pending work for the whole
+	// duration of the call and must return ctx.Err(). Without this the test
+	// is racy: the work can complete entirely before Wait's first poll, in
+	// which case Wait correctly returns nil.
+	callbackRelease := make(chan struct{})
 	callback := func(affectedRows int64, err error) {
-		// Callback may or may not be invoked depending on timing
+		<-callbackRelease
 	}
 
 	err = applier.Apply(cancelCtx, chunk, testRows, callback)
@@ -889,8 +895,114 @@ func TestSingleTargetApplierContextCancellation(t *testing.T) {
 
 	// Wait should return context cancelled error
 	err = applier.Wait(cancelCtx)
+	close(callbackRelease)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestSingleTargetApplierCancelCallbackRace stress-tests the interaction
+// between the feedbackCoordinator's error path and Apply's ctx-cancel cleanup.
+// Both paths can invoke the work's callback; the completion invariant (see the
+// pendingWork field docs) requires that exactly one of them claims the work,
+// so the callback runs exactly once.
+//
+// Historically (after the original #765 fix) the coordinator's error path
+// released pendingMutex between invoking the callback and deleting the
+// pendingWork entry. If Apply was concurrently blocked sending chunklets and
+// its ctx was cancelled inside that window, Apply's cleanup found the entry
+// still in the map, deleted it, and invoked the callback a second time. With
+// real callbacks — e.g. the checksum recopier's, which sends to a capacity-1
+// done channel and may return without draining it — the second invocation can
+// block forever on the coordinator goroutine, wedging the whole applier.
+//
+// This test forces the window deterministically: every write fails fast (the
+// target table is dropped; error 1146 is fatal and not retried), and the first
+// callback invocation cancels Apply's context — while Apply is still blocked
+// sending chunklets, because the work splits into more chunklets than the
+// buffer holds — then parks until Apply has returned. Buggy code double-invokes
+// the callback on effectively every iteration; correct code invokes it exactly
+// once.
+func TestSingleTargetApplierCancelCallbackRace(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS single_cbrace_test")
+	testutils.RunSQL(t, "CREATE DATABASE single_cbrace_test")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	target := base.Clone()
+	target.DBName = "single_cbrace_test"
+	targetDB, err := sql.Open("mysql", target.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+
+	_, err = targetDB.ExecContext(t.Context(), `CREATE TABLE test_table (id INT PRIMARY KEY, value INT)`)
+	require.NoError(t, err)
+
+	targetTable := table.NewTableInfo(targetDB, target.DBName, "test_table")
+	require.NoError(t, targetTable.SetInfo(t.Context()))
+
+	// Drop the table so that every chunklet write fails immediately with a
+	// fatal (non-retried) error, producing error completions while Apply is
+	// still sending chunklets.
+	_, err = targetDB.ExecContext(t.Context(), "DROP TABLE test_table")
+	require.NoError(t, err)
+
+	chunk := &table.Chunk{
+		Table:         targetTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
+	}
+
+	// Enough rows that Apply splits the work into more chunklets than fit in
+	// chunkletBuffer — Apply blocks mid-send, which is the precondition for
+	// its ctx-cancel cleanup path to race the coordinator.
+	rows := make([][]any, (defaultBufferSize+32)*chunkletMaxRows)
+	for i := range rows {
+		rows[i] = []any{int64(i), int64(i)}
+	}
+
+	for iteration := range 10 {
+		ctx, cancel := context.WithCancel(t.Context())
+		cfg := NewApplierDefaultConfig()
+		cfg.Threads = 1 // slow consumption so Apply stays blocked mid-send
+		applier, err := NewSingleTargetApplier(Target{DB: targetDB, Config: target}, cfg)
+		require.NoError(t, err)
+		require.NoError(t, applier.Start(ctx))
+
+		var callbackCount atomic.Int32
+		applyReturned := make(chan struct{})
+		callback := func(_ int64, err error) {
+			if callbackCount.Add(1) == 1 {
+				// First invocation: cancel Apply's ctx while it is still
+				// blocked sending chunklets, then park until Apply has
+				// returned. This holds the completion path open across
+				// Apply's cleanup, maximally exposing any window in which
+				// the work has not yet been claimed.
+				cancel()
+				<-applyReturned
+			}
+		}
+
+		applyErr := make(chan error, 1)
+		go func() {
+			applyErr <- applier.Apply(ctx, chunk, rows, callback)
+		}()
+		err = <-applyErr
+		close(applyReturned)
+		// Apply must have been interrupted by the cancel issued from the
+		// callback (the buffer cannot drain 32+ chunklets of failed writes
+		// before the first error completion is processed).
+		require.ErrorIs(t, err, context.Canceled, "iteration %d", iteration)
+
+		// Stop drains the remaining buffered chunklets (their completions
+		// are dropped as unknown work) and joins the coordinator.
+		require.NoError(t, applier.Stop())
+		require.Equal(t, int32(1), callbackCount.Load(),
+			"iteration %d: callback invoked %d times, want exactly 1 (a second invocation means the "+
+				"coordinator error path and Apply's cancel cleanup both claimed the same work)",
+			iteration, callbackCount.Load())
+		cancel()
+	}
 }
 
 // TestSingleTargetApplierWaitTimeout tests Wait with a timeout context


### PR DESCRIPTION
## Problem
The appliers track in-flight work in `pendingWork`; `Wait()` polls its length and the contract is that it blocks until all callbacks have run.
1. **ShardedApplier** deleted the entry *before* invoking the callback (`chunker.Feedback` on success, `setInvalid` on failure), so `Wait()` could return while the final callback hadn't run — a caller could observe a clean copy despite a failed chunk. Single-target was fixed for this in #765; the sharded copy was never updated.
2. **SingleTargetApplier**'s error path released the mutex between invoking the callback and deleting the entry, so a concurrent `Apply` ctx-cancel cleanup could invoke the callback a *second* time — which, with the checksum recopier's capacity-1 done channel, wedges the coordinator goroutine forever.

## Fix
Both appliers now *claim* work atomically under `pendingMutex` (delete from the map + increment a `callbacksInFlight` counter) before invoking the callback exactly once; `Wait()` blocks until the map is empty **and** no callbacks are in flight.

## Testing
Sharded: a slow-callback test asserting `Wait()` doesn't return before the callback finishes. Single-target: a cancel-race stress test (`-race`, many iterations) asserting exactly-once invocation. Both fail deterministically on the old code. Context: #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
