### PR TITLE
fix float-to-Duration truncation in force-kill grace period

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -222,10 +222,9 @@ func ForceExec(ctx context.Context, db *sql.DB, tables []*table.TableInfo, dbCon
 		}
 	}()
 
-	// The threshold is hardcoded to be at least 0.9 seconds. This should be the minimum anyway,
+	// The grace period is hardcoded to be at least 0.9 seconds. This should be the minimum anyway,
 	// since the minimum LockWaitTimeout=1 second
-	threshold := max(float64(dbConfig.LockWaitTimeout)*lockWaitTimeoutForceKillMultiplier, 0.9)
-	duration := time.Duration(threshold) * time.Second
+	duration := forceKillGracePeriod(dbConfig.LockWaitTimeout)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	timer := time.AfterFunc(duration, func() {

--- a/pkg/dbconn/kill.go
+++ b/pkg/dbconn/kill.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
@@ -30,6 +31,18 @@ var (
 
 	ErrTableLockFound = errors.New("explicit table lock found! spirit cannot proceed")
 )
+
+// forceKillGracePeriod returns how long to wait before force-killing
+// transactions that are blocking our lock acquisition. It is 90% of the
+// configured lockWaitTimeout (in seconds), with a floor of 0.9 seconds
+// since the minimum LockWaitTimeout is 1 second.
+func forceKillGracePeriod(lockWaitTimeout int) time.Duration {
+	seconds := max(float64(lockWaitTimeout)*lockWaitTimeoutForceKillMultiplier, 0.9)
+	// Multiply before converting to time.Duration: time.Duration(seconds)
+	// truncates the float (0.9 -> 0), which would fire the kill timer
+	// immediately at LockWaitTimeout=1.
+	return time.Duration(seconds * float64(time.Second))
+}
 
 const (
 	// TableLockQuery is used to find tables that are locked by a LOCK TABLES command.

--- a/pkg/dbconn/kill_test.go
+++ b/pkg/dbconn/kill_test.go
@@ -122,3 +122,25 @@ func TestKillLongRunningTransactions(t *testing.T) {
 		require.Error(t, err, "expected rollback to fail because transaction was killed")
 	}
 }
+
+func TestForceKillGracePeriod(t *testing.T) {
+	// The grace period is 90% of LockWaitTimeout with a floor of 0.9s.
+	// Fractional seconds must be preserved: converting via
+	// time.Duration(float64) * time.Second truncates 0.9 to 0, which
+	// would fire the kill timer immediately at LockWaitTimeout=1.
+	tests := []struct {
+		lockWaitTimeout int
+		expected        time.Duration
+	}{
+		{lockWaitTimeout: 1, expected: 900 * time.Millisecond},
+		{lockWaitTimeout: 2, expected: 1800 * time.Millisecond},
+		{lockWaitTimeout: 3, expected: 2700 * time.Millisecond},
+		{lockWaitTimeout: 30, expected: 27 * time.Second}, // default LockWaitTimeout
+		// The floor: values below 1 second still wait at least 0.9s.
+		{lockWaitTimeout: 0, expected: 900 * time.Millisecond},
+	}
+	for _, test := range tests {
+		require.Equal(t, test.expected, forceKillGracePeriod(test.lockWaitTimeout),
+			"forceKillGracePeriod(%d)", test.lockWaitTimeout)
+	}
+}

--- a/pkg/dbconn/tablelock.go
+++ b/pkg/dbconn/tablelock.go
@@ -56,7 +56,7 @@ func NewTableLock(ctx context.Context, db *sql.DB, tables []*table.TableInfo, co
 	}()
 	if config.ForceKill {
 		// If ForceKill is true, we will wait for 90% of the configured LockWaitTimeout
-		threshold := time.Duration(float64(config.LockWaitTimeout)*lockWaitTimeoutForceKillMultiplier) * time.Second
+		threshold := forceKillGracePeriod(config.LockWaitTimeout)
 		var wg sync.WaitGroup
 		wg.Add(1)
 		timer := time.AfterFunc(threshold, func() {


### PR DESCRIPTION
## Problem
The force-kill grace period (used when spirit kills transactions blocking its metadata-lock acquisition) was computed as `time.Duration(threshold) * time.Second`, which truncates the float64 *before* multiplying. At the minimum `LockWaitTimeout=1` the grace collapsed to **0s**, so the kill timer fired immediately — killing every connection holding a granted MDL on the target tables, even subsecond SELECTs, with no wait. Larger values lost up to a full second, and the documented 0.9s floor in `ForceExec` was dead code. Affected both `ForceExec` (dbconn.go) and `NewTableLock` (tablelock.go).

## Fix
Both sites share a new `forceKillGracePeriod` helper that multiplies before converting: `time.Duration(seconds * float64(time.Second))`. A repo-wide audit found no other instances of the truncating pattern.

## Testing
Unit test pins LWT=1→0.9s, 2→1.8s, 3→2.7s, 30→27s, and the floor — fails on the old code. Existing kill/table-lock integration tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
