### PR TITLE
handle BeginTx error in NewTrxPool to prevent nil-pointer panic

### DIFF
--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -22,16 +22,18 @@ type TrxPool struct {
 // NewTrxPool creates a pool of transactions which have already
 // had their read-view created in REPEATABLE READ isolation.
 func NewTrxPool(ctx context.Context, db *sql.DB, count int, config *DBConfig) (*TrxPool, error) {
-	checksumTxns := make([]*sql.Tx, 0, count)
+	pool := &TrxPool{trxs: make([]*sql.Tx, 0, count)}
 	for range count {
-		trx, _ := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
-		_, err := trx.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT")
+		trx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 		if err != nil {
-			return nil, err
+			return nil, errors.Join(err, pool.Close())
 		}
-		checksumTxns = append(checksumTxns, trx)
+		pool.trxs = append(pool.trxs, trx)
+		if _, err := trx.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT"); err != nil {
+			return nil, errors.Join(err, pool.Close())
+		}
 	}
-	return &TrxPool{trxs: checksumTxns}, nil
+	return pool, nil
 }
 
 // Get gets a transaction from the pool.

--- a/pkg/dbconn/trxpool_test.go
+++ b/pkg/dbconn/trxpool_test.go
@@ -1,8 +1,10 @@
 package dbconn
 
 import (
+	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
@@ -62,4 +64,53 @@ func TestTrxPool(t *testing.T) {
 	pool.Put(trx3)
 
 	require.NoError(t, pool.Close())
+}
+
+// TestTrxPoolBeginError verifies that NewTrxPool returns an error
+// (rather than panicking on a nil *sql.Tx) when BeginTx fails while the
+// context is still live, e.g. because the database is closed/unreachable.
+// Note: a non-context error is required to reproduce the historical panic,
+// because a nil (*sql.Tx).ExecContext checks ctx.Done() before it
+// dereferences the receiver.
+func TestTrxPoolBeginError(t *testing.T) {
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(t.Context()))
+	require.NoError(t, db.Close()) // BeginTx now fails with "sql: database is closed"
+
+	config := NewDBConfig()
+	pool, err := NewTrxPool(t.Context(), db, 2, config)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "database is closed")
+	require.Nil(t, pool)
+}
+
+// TestTrxPoolBeginErrorMidLoop verifies that when BeginTx fails partway
+// through pool creation, NewTrxPool returns an error and the transactions
+// created by earlier iterations are rolled back (no connection leak).
+func TestTrxPoolBeginErrorMidLoop(t *testing.T) {
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(t.Context()))
+
+	config := NewDBConfig()
+	// Allow only 2 connections but request 3 transactions. The first two
+	// BeginTx calls succeed and hold both connections; the third blocks
+	// waiting for a free connection until the context times out, so the
+	// failure deterministically happens mid-loop.
+	db.SetMaxOpenConns(2)
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	pool, err := NewTrxPool(ctx, db, 3, config)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, pool)
+
+	// The two transactions created before the failure must have been
+	// rolled back and their connections returned to the pool. The rollback
+	// of context-bound transactions can complete asynchronously, so poll.
+	require.Eventually(t, func() bool {
+		return db.Stats().InUse == 0
+	}, 5*time.Second, 50*time.Millisecond, "transactions leaked: %d connections still in use", db.Stats().InUse)
 }


### PR DESCRIPTION
## Problem
`NewTrxPool` discarded the error from `db.BeginTx`, so when `BeginTx` failed for a non-context reason (server gone, pool closed) the subsequent `ExecContext` on the nil `*sql.Tx` panicked with a nil-pointer dereference — crashing the process mid-checksum instead of returning an error. Both checksum checkers build their consistent-snapshot pools through this under the table lock. Secondary: a later-iteration failure abandoned previously-created transactions without rollback (connection leak).

## Fix
Return the `BeginTx` error, and on any error mid-loop roll back all previously created transactions via the pool's existing Close helper (which tolerates `sql.ErrTxDone`) so no connections leak.

## Testing
Deterministic regression tests: a closed `*sql.DB` reproduces the historical panic, and a 2-conn pool with a 3-trx request plus a short context timeout exercises the mid-loop failure and leak cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
