### PR TITLE
narrow PREFERRED TLS fallback and normalize tls-mode case

### DIFF
--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strconv"
@@ -307,6 +308,22 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	return cfg.FormatDSN(), nil
 }
 
+// isTLSUnsupportedByServer reports whether err indicates that the MySQL server
+// does not support TLS at all — i.e. the server's handshake advertised no
+// CLIENT_SSL capability while the client requested TLS. go-sql-driver returns
+// the sentinel mysql.ErrNoTLS ("TLS requested but server does not support TLS")
+// in exactly this case (see packets.go handleAuthResult / readHandshakePacket).
+//
+// This is the ONLY condition under which PREFERRED mode is allowed to silently
+// downgrade the connection to plaintext. Every other failure — a network
+// timeout, max_connections exhaustion, bad credentials (1045), or a
+// certificate-verification failure (which is how PREFERRED behaves against RDS
+// hosts, where it uses the fully-verifying rds config) — is a genuine error
+// that must propagate, not be papered over with an unencrypted connection.
+func isTLSUnsupportedByServer(err error) bool {
+	return errors.Is(err, mysql.ErrNoTLS)
+}
+
 // New is similar to sql.Open except we take the inputDSN and
 // append additional options to it to standardize the connection.
 // It will also ping the connection to ensure it is valid.
@@ -316,6 +333,15 @@ func New(inputDSN string, config *DBConfig) (db *sql.DB, err error) {
 
 // NewWithConnectionType is like New but includes context about the connection type for better error messages
 func NewWithConnectionType(inputDSN string, config *DBConfig, connectionType string) (db *sql.DB, err error) {
+	// Normalize the TLS mode once, up front, so every comparison and switch
+	// below (and in newDSN) is case-insensitive. The CLI documents --tls-mode
+	// as case-insensitive, so e.g. "preferred" must behave exactly like
+	// "PREFERRED" rather than falling through to a default branch.
+	if config != nil {
+		configNorm := *config
+		configNorm.TLSMode = strings.ToUpper(config.TLSMode)
+		config = &configNorm
+	}
 	dsn, err := newDSN(inputDSN, config)
 	if err != nil {
 		return nil, err
@@ -335,14 +361,30 @@ func NewWithConnectionType(inputDSN string, config *DBConfig, connectionType str
 		db, err := sql.Open("mysql", dsn)
 		if err == nil {
 			//nolint: noctx // requires too much refactoring
-			if err := db.Ping(); err == nil {
+			if pingErr := db.Ping(); pingErr == nil {
 				// TLS connection successful
 				return db, nil
+			} else {
+				_ = db.Close()
+				// Only fall back to plaintext when the server genuinely does
+				// not support TLS. Any other ping failure (timeout, auth,
+				// max_connections, certificate verification) must propagate —
+				// silently downgrading the whole pool to plaintext on those
+				// would be a security regression and would mask real errors.
+				if !isTLSUnsupportedByServer(pingErr) {
+					return nil, fmt.Errorf("[%s-CONNECTION] ping failed: %w", strings.ToUpper(strings.ReplaceAll(connectionType, " ", "-")), pingErr)
+				}
+				slog.Warn("server does not support TLS; PREFERRED mode is downgrading this connection to plaintext",
+					"connection_type", connectionType)
 			}
-			_ = db.Close()
+		} else {
+			// sql.Open only validates the DSN; a non-nil error here means the
+			// DSN itself is bad, so there is nothing to ping or fall back to.
+			return nil, fmt.Errorf("failed to open %s connection: %w", connectionType, err)
 		}
 
-		// TLS failed, try without TLS by rebuilding the DSN with TLS disabled.
+		// TLS is unsupported by the server, try without TLS by rebuilding the
+		// DSN with TLS disabled.
 		// We must use newDSN (not createFallbackDSN on the raw inputDSN) so that
 		// all critical session variables (sql_mode, time_zone, charset, rejectReadOnly, etc.)
 		// are included in the fallback connection.
@@ -384,7 +426,9 @@ func NewWithConnectionType(inputDSN string, config *DBConfig, connectionType str
 // This allows replica connections to inherit TLS settings from the main connection
 // while still respecting explicit TLS configuration in the DSN.
 func EnhanceDSNWithTLS(inputDSN string, config *DBConfig) (string, error) {
-	if config == nil || config.TLSMode == "DISABLED" {
+	// TLSMode is documented as case-insensitive; compare on the upper-cased
+	// value so a lowercase "disabled" is honored here too.
+	if config == nil || strings.ToUpper(config.TLSMode) == "DISABLED" {
 		return inputDSN, nil
 	}
 
@@ -470,13 +514,25 @@ func addTLSParametersToDSN(dsn string, config *DBConfig) (string, error) {
 // GetTLSConfigForBinlog creates a TLS config for binary log connections
 // using the same logic as main database connections
 func GetTLSConfigForBinlog(config *DBConfig, host string) (*tls.Config, error) {
-	if config == nil || config.TLSMode == "DISABLED" {
+	// TLSMode is documented as case-insensitive, so compare on the
+	// upper-cased value. A lowercase "disabled" previously fell through the
+	// exact "DISABLED" check below and into the default branch, which built a
+	// PREFERRED-style TLS config for the binlog connection — that then failed
+	// confusingly against a TLS-less server while the main pool worked.
+	if config == nil || strings.ToUpper(config.TLSMode) == "DISABLED" {
 		return nil, nil
 	}
 
 	var tlsConfig *tls.Config
 
 	switch strings.ToUpper(config.TLSMode) {
+	case "DISABLED":
+		// No TLS for the binlog connection. (Unreachable in practice because
+		// the early return above handles DISABLED, but kept explicit so the
+		// switch covers every documented mode rather than treating DISABLED as
+		// an unknown mode that falls into the PREFERRED-style default.)
+		return nil, nil
+
 	case "PREFERRED":
 		// For PREFERRED mode, we need to setup custom TLS config
 		if err := initCustomTLS(config); err != nil {

--- a/pkg/dbconn/conn_tls_fix_test.go
+++ b/pkg/dbconn/conn_tls_fix_test.go
@@ -1,0 +1,191 @@
+package dbconn
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsTLSUnsupportedByServer pins the error-classification used by the
+// PREFERRED fallback. Only the go-sql-driver sentinel mysql.ErrNoTLS (returned
+// when the server's handshake advertises no TLS capability) is allowed to
+// trigger a silent downgrade to plaintext. Every other error — timeouts, auth
+// failures, certificate-verification failures — must NOT classify as
+// "TLS unsupported" so that PREFERRED propagates them instead of papering over
+// them with an unencrypted connection.
+//
+// The local MySQL used by the integration suite has TLS enabled (8.0 default),
+// so the genuine no-TLS-server path cannot be exercised against a live server;
+// we therefore exercise the classifier directly here.
+func TestIsTLSUnsupportedByServer(t *testing.T) {
+	// The exact sentinel from go-sql-driver.
+	require.True(t, isTLSUnsupportedByServer(mysql.ErrNoTLS))
+	// Wrapped sentinel must still match (database/sql / fmt.Errorf wrapping).
+	require.True(t, isTLSUnsupportedByServer(fmt.Errorf("ping failed: %w", mysql.ErrNoTLS)))
+
+	// Everything that is NOT the no-TLS sentinel must be treated as a real
+	// error and propagate rather than downgrade the pool.
+	require.False(t, isTLSUnsupportedByServer(nil))
+	require.False(t, isTLSUnsupportedByServer(errors.New("dial tcp: i/o timeout")))
+	require.False(t, isTLSUnsupportedByServer(&mysql.MySQLError{Number: 1045, Message: "Access denied for user"}))
+	require.False(t, isTLSUnsupportedByServer(&mysql.MySQLError{Number: 1040, Message: "Too many connections"}))
+	require.False(t, isTLSUnsupportedByServer(errors.New("x509: certificate signed by unknown authority")))
+	// A *different* sentinel must not match.
+	require.False(t, isTLSUnsupportedByServer(mysql.ErrInvalidConn))
+}
+
+// TestGetTLSConfigForBinlogCaseInsensitive verifies that GetTLSConfigForBinlog
+// treats the documented mode strings case-insensitively, in particular that a
+// lowercase "disabled" returns a nil TLS config (no TLS) exactly like the
+// uppercase "DISABLED" does.
+//
+// The case-sensitivity bug was masked for non-RDS hosts (NewCustomTLSConfig
+// itself returns nil for DISABLED, so the default branch coincidentally yielded
+// nil), but surfaced for RDS hosts: a lowercase "disabled" fell through the
+// exact "DISABLED" check, hit the default branch (nil config), then the
+// post-switch `if tlsConfig == nil && IsRDSHost(host)` block silently turned it
+// into a non-nil RDS TLS config. We assert nil for BOTH host kinds.
+func TestGetTLSConfigForBinlogCaseInsensitive(t *testing.T) {
+	const (
+		nonRDSHost = "mysql.internal.example"
+		rdsHost    = "mydb.us-west-2.rds.amazonaws.com"
+	)
+
+	// DISABLED in any case must produce no TLS config for the binlog conn,
+	// regardless of whether the host is an RDS host.
+	for _, host := range []string{nonRDSHost, rdsHost} {
+		for _, mode := range []string{"DISABLED", "disabled", "Disabled", "DiSaBlEd"} {
+			t.Run(fmt.Sprintf("disabled_%s_%s", mode, host), func(t *testing.T) {
+				cfg := &DBConfig{TLSMode: mode}
+				tlsConfig, err := GetTLSConfigForBinlog(cfg, host)
+				require.NoError(t, err)
+				require.Nil(t, tlsConfig, "DISABLED (case %q, host %q) must yield a nil binlog TLS config", mode, host)
+			})
+		}
+	}
+
+	// PREFERRED/REQUIRED in any case must produce a non-nil TLS config, and the
+	// ServerName must be set to the host. We assert lowercase behaves like
+	// uppercase.
+	for _, mode := range []string{"PREFERRED", "preferred", "Preferred", "REQUIRED", "required", "Required"} {
+		t.Run("enabled_"+mode, func(t *testing.T) {
+			cfg := &DBConfig{TLSMode: mode}
+			tlsConfig, err := GetTLSConfigForBinlog(cfg, nonRDSHost)
+			require.NoError(t, err)
+			require.NotNil(t, tlsConfig, "mode %q should yield a TLS config", mode)
+			require.Equal(t, nonRDSHost, tlsConfig.ServerName)
+		})
+	}
+}
+
+// TestGetTLSConfigForBinlogDISABLEDReturnsNil is the explicit regression test
+// called for in the task: it pins that the binlog TLS config for a lowercase
+// "disabled" mode is nil. It uses an RDS host because that is where the
+// case-sensitivity bug actually surfaces. On the UNFIXED code this FAILS:
+// lowercase "disabled" misses the exact "DISABLED" early return, falls into the
+// default branch (nil), and the post-switch RDS block promotes it to a non-nil
+// *tls.Config — exactly the confusing TLS-on-a-DISABLED-binlog-connection the
+// fix prevents.
+func TestGetTLSConfigForBinlogDISABLEDReturnsNil(t *testing.T) {
+	cfg := &DBConfig{TLSMode: "disabled"}
+	tlsConfig, err := GetTLSConfigForBinlog(cfg, "mydb.us-west-2.rds.amazonaws.com")
+	require.NoError(t, err)
+	require.Nil(t, tlsConfig, "lowercase 'disabled' must return a nil binlog TLS config (no TLS), even for RDS hosts")
+}
+
+// TestNewWithConnectionTypeCaseInsensitivePool verifies that lowercase and
+// mixed-case TLS mode strings drive the same DSN/TLS decision in the pool
+// constructor as their uppercase forms. We don't need a live server for this:
+// newDSN is the chokepoint, and we assert the generated TLS config name.
+func TestNewWithConnectionTypeCaseInsensitivePool(t *testing.T) {
+	const nonRDSHost = "root:password@tcp(mysql.internal.example:3306)/test"
+
+	cases := []struct {
+		mode        string
+		expectTLS   string // substring expected in DSN, "" means no tls= param
+		description string
+	}{
+		{"DISABLED", "", "uppercase disabled"},
+		{"disabled", "", "lowercase disabled"},
+		{"Disabled", "", "mixedcase disabled"},
+		{"PREFERRED", "tls=custom", "uppercase preferred"},
+		{"preferred", "tls=custom", "lowercase preferred"},
+		{"Preferred", "tls=custom", "mixedcase preferred"},
+		{"REQUIRED", "tls=required", "uppercase required"},
+		{"required", "tls=required", "lowercase required"},
+		{"Required", "tls=required", "mixedcase required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := NewDBConfig()
+			cfg.TLSMode = tc.mode
+			// newDSN upper-cases internally, so this already proves the
+			// chokepoint is case-insensitive for DSN generation.
+			dsn, err := newDSN(nonRDSHost, cfg)
+			require.NoError(t, err)
+			if tc.expectTLS == "" {
+				require.NotContains(t, dsn, "tls=", tc.description)
+			} else {
+				require.Contains(t, dsn, tc.expectTLS, tc.description)
+			}
+		})
+	}
+}
+
+// TestNewWithConnectionTypePreferredLowercaseLive proves that lowercase
+// "preferred" connects to the live local MySQL exactly like uppercase
+// "PREFERRED" (which is the default). Before the fix, config.TLSMode was
+// compared with == "PREFERRED" (case-sensitive), so a lowercase "preferred"
+// skipped the PREFERRED branch entirely and used the standard connection path;
+// the connection still worked but did not exercise the documented
+// case-insensitive contract. This test pins that both succeed.
+func TestNewWithConnectionTypePreferredLowercaseLive(t *testing.T) {
+	for _, mode := range []string{"PREFERRED", "preferred", "Preferred"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := NewDBConfig()
+			cfg.TLSMode = mode
+			db, err := New(testutils.DSN(), cfg)
+			require.NoError(t, err)
+			require.NotNil(t, db)
+			defer utils.CloseAndLog(db)
+
+			var resp int
+			err = db.QueryRowContext(t.Context(), "SELECT 1").Scan(&resp)
+			require.NoError(t, err)
+			require.Equal(t, 1, resp)
+		})
+	}
+}
+
+// TestPreferredNonTLSErrorPropagates verifies that under PREFERRED mode a ping
+// failure that is NOT "server does not support TLS" propagates as an error
+// instead of silently downgrading the whole pool to plaintext. We use a
+// deterministic non-TLS failure: a syntactically valid DSN pointing at the
+// live server but with wrong credentials. The TLS attempt fails with an auth
+// error (1045), which is not mysql.ErrNoTLS, so New must return an error
+// rather than retrying plaintext and connecting.
+//
+// (Against the local TLS-enabled server, the genuine no-TLS-server fallback
+// path is unreachable; the error-classification itself is covered directly by
+// TestIsTLSUnsupportedByServer above.)
+func TestPreferredNonTLSErrorPropagates(t *testing.T) {
+	// Reuse the live host/port but with bad credentials so the failure is a
+	// deterministic auth error, not a network or TLS error.
+	liveCfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	badDSN := fmt.Sprintf("nosuchuser:wrongpassword@tcp(%s)/%s", liveCfg.Addr, liveCfg.DBName)
+
+	cfg := NewDBConfig()
+	cfg.TLSMode = "PREFERRED"
+	db, err := New(badDSN, cfg)
+	require.Error(t, err, "PREFERRED must propagate a non-TLS ping failure instead of downgrading to plaintext")
+	require.Nil(t, db)
+	// The error must reflect the original (auth) failure, not a fallback ping.
+	require.NotContains(t, err.Error(), "FALLBACK",
+		"a non-TLS failure must not reach the plaintext fallback path")
+}


### PR DESCRIPTION
## Problem
Two TLS bugs in `pkg/dbconn`:
1. **PREFERRED silently downgrades the whole pool to plaintext on ANY ping failure** — a transient blip, exhausted connections, bad credentials, or a certificate-verification failure all quietly dropped TLS for the rest of the migration with no log line. PREFERRED is the default mode.
2. **TLS mode strings are documented case-insensitive but matched exact-case** in several places; most importantly `GetTLSConfigForBinlog` turned a lowercase `disabled` into a non-nil TLS config for the binlog/replication connection on RDS hosts while the main pool ran plaintext.

## Fix
Narrow the PREFERRED fallback to the one case it was designed for, detected via go-sql-driver's `mysql.ErrNoTLS` sentinel (the only error meaning "server doesn't support TLS"); everything else propagates as an error and the genuine downgrade is logged at warn level. Normalize `TLSMode` at the entry points and add an explicit `DISABLED` case to the binlog switch.

## Testing
Unit test for the error classifier; case-insensitivity across pool creation and binlog config (DISABLED → nil); the narrowed fallback returns an error on a non-TLS failure. The binlog-DISABLED-on-RDS test was verified to fail on the unfixed code. Full pkg/dbconn and pkg/change suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
