### PR TITLE
fix double-escaped and unquoted string-literal defaults in diffs

### DIFF
--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -737,16 +737,18 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 		return false
 	}
 	// Normalize default values for nullable columns:
-	// For nullable columns, nil and "NULL" are semantically equivalent.
-	// User might write `VARCHAR(255) NULL` but MySQL outputs `VARCHAR(255) DEFAULT NULL`.
+	// For nullable columns, nil and the NULL *keyword* are semantically
+	// equivalent. User might write `VARCHAR(255) NULL` but MySQL outputs
+	// `VARCHAR(255) DEFAULT NULL`. A quoted string literal 'NULL'
+	// (DefaultIsString) is NOT the keyword and must not collapse — it is a
+	// real default that differs from no-default.
 	sourceDefault := a.Default
 	targetDefault := b.Default
 	if a.Nullable {
-		// Normalize: treat nil and "NULL" as equivalent for nullable columns
-		if sourceDefault != nil && *sourceDefault == "NULL" {
+		if sourceDefault != nil && *sourceDefault == "NULL" && !a.DefaultIsString {
 			sourceDefault = nil
 		}
-		if targetDefault != nil && *targetDefault == "NULL" {
+		if targetDefault != nil && *targetDefault == "NULL" && !b.DefaultIsString {
 			targetDefault = nil
 		}
 	}
@@ -757,6 +759,12 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 		return false
 	}
 	if !columnExtendedAttributesEqual(a, b) {
+		return false
+	}
+	// A quoted string literal default ('TRUE') is a different value than the
+	// same text as a keyword/number default (TRUE), even when the stored
+	// strings match — so quotedness is part of column identity.
+	if a.DefaultIsString != b.DefaultIsString {
 		return false
 	}
 	if a.AutoInc != b.AutoInc {
@@ -840,16 +848,16 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 		return false
 	}
 	// Normalize default values for nullable columns:
-	// For nullable columns, nil and "NULL" are semantically equivalent.
-	// User might write `VARCHAR(255) NULL` but MySQL outputs `VARCHAR(255) DEFAULT NULL`.
+	// For nullable columns, nil and the NULL *keyword* are semantically
+	// equivalent. A quoted string literal 'NULL' (DefaultIsString) is NOT
+	// the keyword and must not collapse.
 	sourceDefault := a.Default
 	targetDefault := b.Default
 	if a.Nullable {
-		// Normalize: treat nil and "NULL" as equivalent for nullable columns
-		if sourceDefault != nil && *sourceDefault == "NULL" {
+		if sourceDefault != nil && *sourceDefault == "NULL" && !a.DefaultIsString {
 			sourceDefault = nil
 		}
-		if targetDefault != nil && *targetDefault == "NULL" {
+		if targetDefault != nil && *targetDefault == "NULL" && !b.DefaultIsString {
 			targetDefault = nil
 		}
 	}
@@ -860,6 +868,9 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 		return false
 	}
 	if !columnExtendedAttributesEqual(a, b) {
+		return false
+	}
+	if a.DefaultIsString != b.DefaultIsString {
 		return false
 	}
 	if a.AutoInc != b.AutoInc {
@@ -1130,6 +1141,13 @@ func formatColumnDefinition(col *Column) string {
 		case col.DefaultIsExpr:
 			// Expression defaults must be wrapped in parentheses, e.g. DEFAULT (json_object())
 			parts = append(parts, fmt.Sprintf("DEFAULT (%s)", defaultVal))
+		case col.DefaultIsString:
+			// Quoted string literal. The stored value is the true raw value
+			// (unescaped at parse time), so quote+escape exactly once. This
+			// must bypass the needsQuotes heuristic: a literal 'TRUE' or
+			// 'NULL' or '2020' has to stay quoted, otherwise MySQL would
+			// store the keyword/number instead of the string.
+			parts = append(parts, fmt.Sprintf("DEFAULT '%s'", sqlescape.EscapeString(defaultVal)))
 		case needsQuotes(defaultVal):
 			parts = append(parts, fmt.Sprintf("DEFAULT '%s'", sqlescape.EscapeString(defaultVal)))
 		default:

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -144,10 +144,14 @@ func TestDiff(t *testing.T) {
 			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int(11) NOT NULL COMMENT 'Line1\\nLine2\\rLine3'",
 		},
 		{
-			name:     "ColumnCommentRogueValues2",
-			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
-			target:   `CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(50) DEFAULT "O'Brien")`,
-			expected: "ALTER TABLE `t1` ADD COLUMN `name` varchar(50) NULL DEFAULT 'O\\'\\'Brien'",
+			name:   "ColumnCommentRogueValues2",
+			source: "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target: `CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(50) DEFAULT "O'Brien")`,
+			// The true default is O'Brien (one apostrophe); it is escaped
+			// exactly once on emission. The previous expectation
+			// 'O\'\'Brien' was the double-escaping bug (parse left the
+			// value escaped, then emission escaped it again).
+			expected: "ALTER TABLE `t1` ADD COLUMN `name` varchar(50) NULL DEFAULT 'O\\'Brien'",
 		},
 
 		{

--- a/pkg/statement/literal_roundtrip_test.go
+++ b/pkg/statement/literal_roundtrip_test.go
@@ -1,0 +1,324 @@
+package statement
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// scratchDB is the dedicated database these round-trip tests run against.
+// It is created on first use and tables are dropped per-test.
+const scratchDB = "test_w3e"
+
+// openScratch connects to the scratch database, creating it if necessary.
+func openScratch(t *testing.T) *sql.DB {
+	t.Helper()
+	// Create the scratch database via a server-scoped connection.
+	rootDB, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() { _ = rootDB.Close() }()
+	_, err = rootDB.ExecContext(t.Context(), "CREATE DATABASE IF NOT EXISTS "+scratchDB)
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", testutils.DSNForDatabase(scratchDB))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// showCreate returns the SHOW CREATE TABLE output for a table in the scratch DB.
+func showCreate(t *testing.T, db *sql.DB, table string) string {
+	t.Helper()
+	var name, createSQL string
+	err := db.QueryRowContext(t.Context(), "SHOW CREATE TABLE "+quoteIdent(table)).Scan(&name, &createSQL)
+	require.NoError(t, err)
+	return createSQL
+}
+
+// columnDefault returns the COLUMN_DEFAULT stored by MySQL for a column. The
+// returned bool reports whether the default is non-NULL (a real value).
+func columnDefault(t *testing.T, db *sql.DB, table, column string) (string, bool) {
+	t.Helper()
+	var def sql.NullString
+	err := db.QueryRowContext(t.Context(),
+		`SELECT COLUMN_DEFAULT FROM information_schema.COLUMNS
+		 WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+		scratchDB, table, column).Scan(&def)
+	require.NoError(t, err)
+	return def.String, def.Valid
+}
+
+// columnComment returns the COLUMN_COMMENT stored by MySQL for a column.
+func columnComment(t *testing.T, db *sql.DB, table, column string) string {
+	t.Helper()
+	var comment string
+	err := db.QueryRowContext(t.Context(),
+		`SELECT COLUMN_COMMENT FROM information_schema.COLUMNS
+		 WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+		scratchDB, table, column).Scan(&comment)
+	require.NoError(t, err)
+	return comment
+}
+
+// applyAndConverge parses the source/target CREATE TABLE statements, applies
+// the resulting ALTER against MySQL, and asserts that re-diffing the
+// now-altered table against the target produces no further statements
+// (convergence). It returns the post-apply SHOW CREATE TABLE.
+func applyAndConverge(t *testing.T, db *sql.DB, table, createSQL, targetSQL string) string {
+	t.Helper()
+
+	// Start from a clean slate.
+	_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+quoteIdent(table))
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(), createSQL)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+quoteIdent(table))
+	})
+
+	source, err := ParseCreateTable(showCreate(t, db, table))
+	require.NoError(t, err)
+	target, err := ParseCreateTable(targetSQL)
+	require.NoError(t, err)
+
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1, "expected exactly one ALTER")
+
+	// The emitted ALTER must apply cleanly against real MySQL.
+	_, err = db.ExecContext(t.Context(), stmts[0].Statement)
+	require.NoError(t, err, "emitted ALTER failed to apply: %s", stmts[0].Statement)
+
+	// Convergence: re-diff the altered table against the target -> nil.
+	afterCreate := showCreate(t, db, table)
+	after, err := ParseCreateTable(afterCreate)
+	require.NoError(t, err)
+	converge, err := after.Diff(target, nil)
+	require.NoError(t, err)
+	require.Nil(t, converge, "expected convergence (nil diff) after applying; got: %+v", converge)
+
+	return afterCreate
+}
+
+// TestRoundTrip_DefaultQuotedString verifies that string-literal defaults
+// containing quotes/backslashes survive a parse -> emit -> apply round trip
+// and are stored byte-for-byte correctly by MySQL. This is the regression
+// test for the double-escaping bug: the parser used to leave the value in
+// its escaped form, and emission escaped it a second time.
+func TestRoundTrip_DefaultQuotedString(t *testing.T) {
+	db := openScratch(t)
+
+	cases := []struct {
+		name      string
+		targetSQL string
+		// wantStored is the exact value MySQL must report via
+		// information_schema.COLUMN_DEFAULT (information_schema strips the
+		// surrounding quotes and reports the raw value).
+		wantStored string
+	}{
+		{
+			name:       "doubled_single_quote",
+			targetSQL:  "CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20) DEFAULT 'it''s')",
+			wantStored: "it's",
+		},
+		{
+			name:       "backslash_escaped_quote",
+			targetSQL:  `CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20) DEFAULT 'a\'b')`,
+			wantStored: "a'b",
+		},
+		{
+			name:       "embedded_backslash",
+			targetSQL:  `CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20) DEFAULT 'a\\b')`,
+			wantStored: `a\b`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyAndConverge(t, db, "rt",
+				"CREATE TABLE rt (id INT PRIMARY KEY)", tc.targetSQL)
+
+			stored, ok := columnDefault(t, db, "rt", "c")
+			require.True(t, ok, "expected a non-NULL default")
+			require.Equal(t, tc.wantStored, stored)
+		})
+	}
+}
+
+// TestRoundTrip_CommentQuotedString verifies a column COMMENT containing a
+// single quote round-trips and is stored exactly.
+func TestRoundTrip_CommentQuotedString(t *testing.T) {
+	db := openScratch(t)
+
+	applyAndConverge(t, db, "rt",
+		"CREATE TABLE rt (id INT PRIMARY KEY)",
+		"CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20) COMMENT 'x''y')")
+
+	require.Equal(t, "x'y", columnComment(t, db, "rt", "c"))
+}
+
+// TestRoundTrip_KeywordLikeStringDefault verifies that a string literal that
+// looks like a keyword ('TRUE') is emitted quoted and stored as the literal
+// string "TRUE" (not coerced to the boolean 1), while a bare keyword default
+// (DEFAULT TRUE) continues to be stored as 1.
+func TestRoundTrip_KeywordLikeStringDefault(t *testing.T) {
+	db := openScratch(t)
+
+	t.Run("string_TRUE_stays_string", func(t *testing.T) {
+		applyAndConverge(t, db, "rt",
+			"CREATE TABLE rt (id INT PRIMARY KEY)",
+			"CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20) DEFAULT 'TRUE')")
+
+		stored, ok := columnDefault(t, db, "rt", "c")
+		require.True(t, ok)
+		require.Equal(t, "TRUE", stored, "literal 'TRUE' must be stored as the string, not the boolean 1")
+	})
+
+	t.Run("bare_TRUE_still_boolean", func(t *testing.T) {
+		// A bare keyword default is NOT a string literal, so it must emit
+		// unquoted and store the boolean 1. We don't drive this through
+		// applyAndConverge because MySQL canonicalizes BOOL DEFAULT TRUE to
+		// tinyint(1) DEFAULT '1' (a separate keyword-normalization concern);
+		// instead we assert the emitted ADD COLUMN is unquoted and applies.
+		source, err := ParseCreateTable("CREATE TABLE rt (id INT PRIMARY KEY)")
+		require.NoError(t, err)
+		target, err := ParseCreateTable("CREATE TABLE rt (id INT PRIMARY KEY, c BOOL DEFAULT TRUE)")
+		require.NoError(t, err)
+
+		// The parsed default must NOT be flagged as a string literal.
+		col := target.Columns.ByName("c")
+		require.NotNil(t, col)
+		require.False(t, col.DefaultIsString, "bare keyword TRUE must not be flagged as a string literal")
+
+		stmts, err := source.Diff(target, nil)
+		require.NoError(t, err)
+		require.Len(t, stmts, 1)
+		require.Contains(t, stmts[0].Statement, "DEFAULT TRUE", "bare keyword default must emit unquoted")
+
+		_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS rt")
+		require.NoError(t, err)
+		_, err = db.ExecContext(t.Context(), "CREATE TABLE rt (id INT PRIMARY KEY)")
+		require.NoError(t, err)
+		t.Cleanup(func() { _, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS rt") })
+		_, err = db.ExecContext(t.Context(), stmts[0].Statement)
+		require.NoError(t, err, "emitted ALTER failed: %s", stmts[0].Statement)
+
+		stored, ok := columnDefault(t, db, "rt", "c")
+		require.True(t, ok)
+		require.Equal(t, "1", stored, "bare keyword DEFAULT TRUE stores the boolean 1")
+	})
+}
+
+// TestRoundTrip_StringNullDefaultProducesDiff verifies that a quoted string
+// literal default 'NULL' is treated as a real default that differs from a
+// column with no default. Before the fix the nullable-NULL normalization
+// collapsed 'NULL' to no-default and the diff was empty.
+func TestRoundTrip_StringNullDefaultProducesDiff(t *testing.T) {
+	db := openScratch(t)
+
+	source, err := ParseCreateTable(
+		"CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20))")
+	require.NoError(t, err)
+	target, err := ParseCreateTable(
+		"CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20) DEFAULT 'NULL')")
+	require.NoError(t, err)
+
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1, "string literal DEFAULT 'NULL' must differ from no-default")
+
+	// And the emitted ALTER must apply and store the literal string "NULL".
+	applyAndConverge(t, db, "rt",
+		"CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20))",
+		"CREATE TABLE rt (id INT PRIMARY KEY, c VARCHAR(20) DEFAULT 'NULL')")
+
+	stored, ok := columnDefault(t, db, "rt", "c")
+	require.True(t, ok, "literal DEFAULT 'NULL' is a real (non-NULL) default")
+	require.Equal(t, "NULL", stored)
+}
+
+// TestRoundTrip_PartitionStringValuesWithQuotes verifies that LIST COLUMNS
+// partition values on a string column round-trip, including a value that
+// looks numeric ('2020') and one containing a quote ('o”hare'). Before the
+// fix the numeric-looking value was emitted bare (MySQL error 1654) and the
+// quoted value lost its escaping.
+//
+// The source table is already partitioned with the same columns so the only
+// difference is the partition definitions — this keeps the emitted ALTER a
+// pure PARTITION BY reorganization (TiDB's parser, which Diff re-parses the
+// generated ALTER through, rejects mixing MODIFY COLUMN clauses with a
+// PARTITION BY clause in a single statement).
+func TestRoundTrip_PartitionStringValuesWithQuotes(t *testing.T) {
+	db := openScratch(t)
+
+	// Create the source table partitioned with a single placeholder
+	// partition, then build the target by re-parsing the source's exact
+	// SHOW CREATE TABLE and swapping only the partition definitions. Reusing
+	// MySQL's canonical column text guarantees the only difference is the
+	// partition values, so the emitted ALTER is a pure PARTITION BY reorg.
+	_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS rt")
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(),
+		"CREATE TABLE rt (id INT, region VARCHAR(20), PRIMARY KEY (id, region)) "+
+			"PARTITION BY LIST COLUMNS(region) (PARTITION pInit VALUES IN ('init'))")
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS rt") })
+
+	sourceCreate := showCreate(t, db, "rt")
+	source, err := ParseCreateTable(sourceCreate)
+	require.NoError(t, err)
+
+	// Build the target from the parsed source, replacing the partition
+	// definitions with values that exercise the fix: a numeric-looking
+	// string ('2020', would error 1654 if emitted bare) and a quoted value.
+	target, err := ParseCreateTable(sourceCreate)
+	require.NoError(t, err)
+	target.Partition.Definitions = []PartitionDefinition{
+		{
+			Name: "pA",
+			Values: &PartitionValues{
+				Type:   "IN",
+				Values: []any{partitionStringLiteral("2020"), partitionStringLiteral("asia")},
+			},
+		},
+		{
+			Name: "pB",
+			Values: &PartitionValues{
+				Type:   "IN",
+				Values: []any{partitionStringLiteral("o'hare")},
+			},
+		},
+	}
+
+	// A partition-definition change is emitted as REMOVE PARTITIONING
+	// followed by a fresh PARTITION BY clause; apply each in order.
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, stmts)
+	for _, s := range stmts {
+		_, err = db.ExecContext(t.Context(), s.Statement)
+		require.NoError(t, err, "emitted partition ALTER failed to apply: %s", s.Statement)
+	}
+
+	afterCreate := showCreate(t, db, "rt")
+	// The stored partition values must include the quoted forms, including
+	// the numeric-looking '2020' (which must NOT be rendered bare).
+	require.Contains(t, afterCreate, "'2020'")
+	require.Contains(t, afterCreate, "'asia'")
+	require.Contains(t, afterCreate, "'o''hare'")
+
+	// Convergence: the emitted DDL must be stable — re-parsing the
+	// post-apply SHOW CREATE and diffing it against itself yields nil. (We
+	// can't diff against the synthetic target directly because it lacks the
+	// per-partition ENGINE clause MySQL adds to its canonical form; that's
+	// unrelated to literal quoting.)
+	after, err := ParseCreateTable(afterCreate)
+	require.NoError(t, err)
+	again, err := ParseCreateTable(afterCreate)
+	require.NoError(t, err)
+	converge, err := after.Diff(again, nil)
+	require.NoError(t, err)
+	require.Nil(t, converge, "expected convergence (nil diff) after applying partition ALTER")
+}

--- a/pkg/statement/literal_roundtrip_test.go
+++ b/pkg/statement/literal_roundtrip_test.go
@@ -241,7 +241,8 @@ func TestRoundTrip_StringNullDefaultProducesDiff(t *testing.T) {
 
 // TestRoundTrip_PartitionStringValuesWithQuotes verifies that LIST COLUMNS
 // partition values on a string column round-trip, including a value that
-// looks numeric ('2020') and one containing a quote ('o”hare'). Before the
+// looks numeric ('2020') and one whose value contains an apostrophe (o'hare,
+// doubled in SQL). Before the
 // fix the numeric-looking value was emitted bare (MySQL error 1654) and the
 // quoted value lost its escaping.
 //

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -1209,7 +1209,8 @@ func (ct *CreateTable) parseSubPartitionDefinition(sub *ast.SubPartitionDefiniti
 }
 
 // stringLiteralValue returns the true, fully-unescaped value of a quoted
-// string-literal AST node (e.g. the value behind DEFAULT 'it”s' or a
+// string-literal AST node (e.g. the value behind a single-quoted DEFAULT
+// whose inner apostrophe is doubled in SQL, or a
 // COMMENT containing escaped quotes) along with true. For any other
 // expression kind it returns ("", false).
 //

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -1209,17 +1209,21 @@ func (ct *CreateTable) parseSubPartitionDefinition(sub *ast.SubPartitionDefiniti
 }
 
 // stringLiteralValue returns the true, fully-unescaped value of a quoted
-// string-literal AST node (e.g. the value behind a single-quoted DEFAULT
-// whose inner apostrophe is doubled in SQL, or a
-// COMMENT containing escaped quotes) along with true. For any other
-// expression kind it returns ("", false).
+// string-literal AST node (for example the value behind a single-quoted
+// DEFAULT, or a COMMENT, whose contents include escaped quote or backslash
+// characters) along with true. For any other expression kind it returns an
+// empty string and false.
 //
 // This is the load-bearing fix for the string round-trip bugs: the TiDB
-// parser's Restore() re-emits a string literal in its *escaped* form
-// (inner quotes doubled, backslashes preserved), so the previous approach
-// of Restore-then-strip-outer-quotes left the value still escaped. Reading
-// the literal's value directly off the AST gives us the raw bytes, which
-// we can then escape exactly once at emission time.
+// parser's Restore re-emits a string literal in its re-escaped, still-quoted
+// form rather than as the raw value, so the previous approach of
+// Restore-then-strip-outer-quotes left the inner escaping in place. Reading
+// the literal's value directly off the AST yields the raw bytes, which we
+// then escape exactly once at emission time via sqlescape (backslash
+// escaping, which MySQL accepts in its default sql_mode). Note MySQL renders
+// a literal quote in SHOW CREATE TABLE as a doubled quote, which the parser
+// also accepts; the doubled and backslash forms are equivalent in the
+// default sql_mode.
 func stringLiteralValue(expr ast.ExprNode) (string, bool) {
 	if v, ok := expr.(*driver.ValueExpr); ok && v.Kind() == driver.KindString {
 		return v.GetString(), true

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	driver "github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/pingcap/tidb/pkg/parser/types"
 )
 
@@ -42,12 +43,13 @@ type Column struct {
 	SetValues       []string          `json:"set_values,omitempty"`  // Permitted values for SET type
 	Nullable        bool              `json:"nullable"`
 	Default         *string           `json:"default,omitempty"`
-	DefaultIsExpr   bool              `json:"default_is_expr,omitempty"`  // true when default is an expression (needs parens), e.g. DEFAULT (json_object())
-	OnUpdate        *string           `json:"on_update,omitempty"`        // ON UPDATE expression for TIMESTAMP/DATETIME, e.g. "current_timestamp"
-	GeneratedExpr   *string           `json:"generated_expr,omitempty"`   // Expression for GENERATED ALWAYS AS (...) columns
-	GeneratedStored bool              `json:"generated_stored,omitempty"` // true = STORED, false = VIRTUAL (only meaningful when GeneratedExpr is set)
-	Check           *string           `json:"check,omitempty"`            // Column-level CHECK (...) constraint expression
-	SRID            *uint32           `json:"srid,omitempty"`             // SRID attribute for spatial columns
+	DefaultIsExpr   bool              `json:"default_is_expr,omitempty"`   // true when default is an expression (needs parens), e.g. DEFAULT (json_object())
+	DefaultIsString bool              `json:"default_is_string,omitempty"` // true when the default is a quoted string literal (so it must be re-quoted on emission, even if it looks like a keyword/number)
+	OnUpdate        *string           `json:"on_update,omitempty"`         // ON UPDATE expression for TIMESTAMP/DATETIME, e.g. "current_timestamp"
+	GeneratedExpr   *string           `json:"generated_expr,omitempty"`    // Expression for GENERATED ALWAYS AS (...) columns
+	GeneratedStored bool              `json:"generated_stored,omitempty"`  // true = STORED, false = VIRTUAL (only meaningful when GeneratedExpr is set)
+	Check           *string           `json:"check,omitempty"`             // Column-level CHECK (...) constraint expression
+	SRID            *uint32           `json:"srid,omitempty"`              // SRID attribute for spatial columns
 	AutoInc         bool              `json:"auto_increment"`
 	PrimaryKey      bool              `json:"primary_key"`
 	Unique          bool              `json:"unique"`
@@ -144,6 +146,15 @@ type PartitionValues struct {
 	Type   string `json:"type"`   // "LESS_THAN", "IN", "MAXVALUE"
 	Values []any  `json:"values"` // The actual values
 }
+
+// partitionStringLiteral wraps a partition value that originated from a
+// quoted string literal (e.g. LIST COLUMNS on a VARCHAR column:
+// VALUES IN ('2020', 'asia')). Wrapping it in a distinct type preserves
+// the "this was a string" fact through the []any storage so emission can
+// quote it unconditionally — without it, a numeric-looking string value
+// like '2020' would be rendered bare and rejected by MySQL (error 1654).
+// Numeric/expression partition values remain plain Go strings.
+type partitionStringLiteral string
 
 // SubPartitionOptions represents subpartitioning configuration
 type SubPartitionOptions struct {
@@ -632,30 +643,28 @@ func (ct *CreateTable) parseColumn(col *ast.ColumnDef) Column {
 				// We track this so we can reproduce the correct syntax when generating ALTERs.
 				column.DefaultIsExpr = isExpressionDefault(opt.Expr)
 
-				defaultVal := ct.parseExpression(opt.Expr)
-				if defaultStr, ok := defaultVal.(string); ok && defaultStr != "" {
-					// Remove surrounding quotes if present for string literals
-					if len(defaultStr) >= 2 && defaultStr[0] == '\'' && defaultStr[len(defaultStr)-1] == '\'' {
-						defaultStr = defaultStr[1 : len(defaultStr)-1]
-					}
-
-					column.Default = &defaultStr
+				if literal, isStr := stringLiteralValue(opt.Expr); isStr {
+					// Quoted string literal default. Store the true, raw
+					// (fully-unescaped) value off the AST and remember it
+					// was a string so we re-quote it on emission — even if
+					// the value looks like a keyword (TRUE/NULL) or a
+					// number. Escaping happens exactly once, at emit time.
+					column.Default = &literal
+					column.DefaultIsString = true
 				} else {
-					// For non-string defaults (e.g., numeric, functions), use the raw expression
-					defaultRaw := fmt.Sprintf("%v", defaultVal)
+					// Non-string defaults (numeric, functions, expressions):
+					// keep the Restored text representation.
+					defaultRaw := fmt.Sprintf("%v", ct.parseExpression(opt.Expr))
 					column.Default = &defaultRaw
 				}
 			}
 		case ast.ColumnOptionComment:
 			if opt.Expr != nil {
-				comment := ct.parseExpression(opt.Expr)
-				if commentStr, ok := comment.(string); ok && commentStr != "" {
-					// Remove surrounding quotes if present
-					if len(commentStr) >= 2 && commentStr[0] == '\'' && commentStr[len(commentStr)-1] == '\'' {
-						commentStr = commentStr[1 : len(commentStr)-1]
-					}
-
-					column.Comment = &commentStr
+				// A column comment is always a string literal; read its true
+				// value directly off the AST so quotes/backslashes survive
+				// the round-trip and are escaped exactly once on emission.
+				if literal, isStr := stringLiteralValue(opt.Expr); isStr && literal != "" {
+					column.Comment = &literal
 				}
 			}
 		case ast.ColumnOptionCollate:
@@ -1080,8 +1089,7 @@ func (ct *CreateTable) parsePartitionClause(clause ast.PartitionDefinitionClause
 			Values: make([]any, 0, len(c.Exprs)),
 		}
 		for _, expr := range c.Exprs {
-			val := ct.parseExpression(expr)
-			values.Values = append(values.Values, val)
+			values.Values = append(values.Values, ct.parsePartitionValue(expr))
 		}
 
 		return values
@@ -1092,14 +1100,12 @@ func (ct *CreateTable) parsePartitionClause(clause ast.PartitionDefinitionClause
 		}
 		for _, valList := range c.Values {
 			if len(valList) == 1 {
-				val := ct.parseExpression(valList[0])
-				values.Values = append(values.Values, val)
+				values.Values = append(values.Values, ct.parsePartitionValue(valList[0]))
 			} else {
 				// Multiple values in a single clause
 				subValues := make([]any, 0, len(valList))
 				for _, expr := range valList {
-					val := ct.parseExpression(expr)
-					subValues = append(subValues, val)
+					subValues = append(subValues, ct.parsePartitionValue(expr))
 				}
 
 				values.Values = append(values.Values, subValues...)
@@ -1116,6 +1122,18 @@ func (ct *CreateTable) parsePartitionClause(clause ast.PartitionDefinitionClause
 	default:
 		return nil
 	}
+}
+
+// parsePartitionValue parses a single partition value expression. String
+// literals (LIST/RANGE COLUMNS on a string column) are wrapped in
+// partitionStringLiteral carrying their true raw value, so emission can
+// quote them unconditionally. Numeric literals and expressions (e.g.
+// YEAR(col)) fall back to the Restored text form as plain strings.
+func (ct *CreateTable) parsePartitionValue(expr ast.ExprNode) any {
+	if literal, isStr := stringLiteralValue(expr); isStr {
+		return partitionStringLiteral(literal)
+	}
+	return ct.parseExpression(expr)
 }
 
 // parseSubPartitionOptions converts subpartition options to SubPartitionOptions
@@ -1188,6 +1206,24 @@ func (ct *CreateTable) parseSubPartitionDefinition(sub *ast.SubPartitionDefiniti
 	}
 
 	return subDef
+}
+
+// stringLiteralValue returns the true, fully-unescaped value of a quoted
+// string-literal AST node (e.g. the value behind DEFAULT 'it”s' or a
+// COMMENT containing escaped quotes) along with true. For any other
+// expression kind it returns ("", false).
+//
+// This is the load-bearing fix for the string round-trip bugs: the TiDB
+// parser's Restore() re-emits a string literal in its *escaped* form
+// (inner quotes doubled, backslashes preserved), so the previous approach
+// of Restore-then-strip-outer-quotes left the value still escaped. Reading
+// the literal's value directly off the AST gives us the raw bytes, which
+// we can then escape exactly once at emission time.
+func stringLiteralValue(expr ast.ExprNode) (string, bool) {
+	if v, ok := expr.(*driver.ValueExpr); ok && v.Kind() == driver.KindString {
+		return v.GetString(), true
+	}
+	return "", false
 }
 
 // isExpressionDefault returns true when the default value expression should be

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -422,15 +422,17 @@ func TestSchemaAnalyzer_PartitionSupport(t *testing.T) {
 					{
 						Name: "p_north",
 						Values: &PartitionValues{
-							Type:   "IN",
-							Values: []any{"north", "northeast"},
+							Type: "IN",
+							// String-literal partition values are stored as
+							// partitionStringLiteral so emission re-quotes them.
+							Values: []any{partitionStringLiteral("north"), partitionStringLiteral("northeast")},
 						},
 					},
 					{
 						Name: "p_south",
 						Values: &PartitionValues{
 							Type:   "IN",
-							Values: []any{"south"},
+							Values: []any{partitionStringLiteral("south")},
 						},
 					},
 				},

--- a/pkg/statement/utils.go
+++ b/pkg/statement/utils.go
@@ -43,19 +43,21 @@ var numericPartitionValueRe = regexp.MustCompile(`^-?(0|[1-9]\d*)(\.\d+)?$`)
 // previous fmt.Sprintf("%v", v) form generated broken SQL when a string
 // partition value contained a single quote.
 //
-// Caveat: parsePartitionClause currently restores every value to a Go
-// string regardless of whether the source SQL had it as a numeric or
-// string literal — so we can't simply quote on (v is string). We use
-// the numericPartitionValueRe heuristic instead: strings that match
-// render unquoted (matching RANGE/LIST partitions on integer
-// expressions like YEAR(...) or hash columns); anything else is
-// treated as a string literal and quote+escaped. The heuristic
-// deliberately excludes ParseFloat-accepting curiosities (NaN, Inf,
-// "1e10") and zero-prefix forms ("01") that would silently change
-// semantics. A real type-aware fix requires preserving the AST literal
-// kind through parsePartitionClause; this is a targeted patch on the
-// SQL-emission side only.
+// A partitionStringLiteral carries the "this was a quoted string literal"
+// fact straight from the parser, so it is always quote+escaped — this is
+// what stops a numeric-looking LIST COLUMNS value like '2020' on a VARCHAR
+// column from being emitted bare and rejected by MySQL (error 1654).
+//
+// For plain Go strings (numeric literals and expressions the parser
+// Restored to text, e.g. YEAR(col)) we fall back to the
+// numericPartitionValueRe heuristic: values that match render unquoted;
+// anything else is quote+escaped. The heuristic deliberately excludes
+// ParseFloat-accepting curiosities (NaN, Inf, "1e10") and zero-prefix
+// forms ("01").
 func formatPartitionValue(v any) string {
+	if sl, ok := v.(partitionStringLiteral); ok {
+		return "'" + sqlescape.EscapeString(string(sl)) + "'"
+	}
 	if s, ok := v.(string); ok {
 		if numericPartitionValueRe.MatchString(s) {
 			return s


### PR DESCRIPTION
## Problem
The parser stripped only the outer quotes of a TiDB-Restored string literal, leaving the inner escaping intact and discarding the "this was a quoted string" fact. Three resulting bugs:
1. **Double-escaping:** `DEFAULT 'it''s'` emitted as `DEFAULT 'it\'\'s'`, writing the wrong value on every emitted ALTER (same for comments and partition values).
2. **Keyword-like string defaults emitted unquoted:** `DEFAULT 'TRUE'` emitted `DEFAULT TRUE` (stores `1`); `DEFAULT 'NULL'` collapsed via the nullable-NULL normalization so it diffed as equal to no-default.
3. **Numeric-looking string partition values emitted bare:** `VALUES IN ('2020', ...)` on a varchar column emitted `VALUES IN (2020, ...)` → MySQL error 1654 at apply.

## Fix
Read each literal's true value directly off the AST (`ValueExpr.GetString()`) and escape it exactly once on emission; thread a `DefaultIsString` flag (and a `partitionStringLiteral` wrapper) so quotedness drives emission and column-equality instead of a fragile heuristic. Scope: literal value storage/quoting — sibling PRs cover other statement findings.

## Testing
New live-MySQL tests apply the emitted DDL and assert the exact stored value via `information_schema`/`SHOW CREATE TABLE`, including convergence on re-diff: `it's`, `a'b`, embedded backslash, quoted comment, `'TRUE'` stored as string + bare `TRUE` as `1`, `'NULL'` now produces a diff, quoted partition values round-trip. Two existing buggy expectations were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
