### PR TITLE
compare per-chunk row counts in all checksum checkers

### DIFF
--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -36,6 +37,55 @@ var (
 	// enough for legitimate large/slow recopies on busy or distant replicas.
 	fixChunkTimeout = 10 * time.Minute
 )
+
+// chunkMismatch describes why a chunk's source and target disagreed. It is
+// returned by compareChunk so the caller can log a debuggable reason while
+// treating any mismatch (checksum OR row count) identically — same retry,
+// recopy, and differencesFound accounting.
+type chunkMismatch struct {
+	// checksumDiffers is true when the (aggregated) source and target CRC
+	// differ.
+	checksumDiffers bool
+	// countDiffers is true when the (aggregated) source and target row
+	// counts differ. This is the defense-in-depth signal that the CRC alone
+	// can miss: BIT_XOR is pair-cancelling, so a row duplicated across two
+	// sources (violating disjointness) or a row whose CRC32 happens to be 0
+	// contributes nothing to the XOR, yet the count still moves.
+	countDiffers bool
+}
+
+// mismatched reports whether the chunk is divergent for any reason.
+func (m chunkMismatch) mismatched() bool {
+	return m.checksumDiffers || m.countDiffers
+}
+
+// reason returns a human-readable description distinguishing a checksum
+// mismatch from a row-count mismatch (and reporting both when both differ)
+// for log/error debuggability. Only meaningful when mismatched() is true.
+func (m chunkMismatch) reason(srcCount, tgtCount uint64) string {
+	switch {
+	case m.checksumDiffers && m.countDiffers:
+		return fmt.Sprintf("checksum mismatch and row count mismatch (src=%d, target=%d)", srcCount, tgtCount)
+	case m.countDiffers:
+		return fmt.Sprintf("row count mismatch (src=%d, target=%d)", srcCount, tgtCount)
+	default:
+		return "checksum mismatch"
+	}
+}
+
+// compareChunk is the central decision function used by every checker to
+// decide whether a chunk's source and target agree. It compares BOTH the
+// (aggregated) CRC and the (aggregated) row count. Comparing the count is
+// free — the count is already returned alongside the CRC in the same query —
+// and it closes a defense-in-depth gap where the CRC alone is insufficient
+// (see chunkMismatch.countDiffers). A count mismatch is treated exactly like
+// a checksum mismatch by callers.
+func compareChunk(srcCRC, tgtCRC int64, srcCount, tgtCount uint64) chunkMismatch {
+	return chunkMismatch{
+		checksumDiffers: srcCRC != tgtCRC,
+		countDiffers:    srcCount != tgtCount,
+	}
+}
 
 type Checker interface {
 	// Run performs the checksum operation.

--- a/pkg/checksum/compare_test.go
+++ b/pkg/checksum/compare_test.go
@@ -1,0 +1,85 @@
+package checksum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompareChunk unit-tests the central comparison decision function. The
+// key case is (equalCRC, unequalCounts): the CRCs match but the row counts
+// differ, which the checksum alone would miss but compareChunk catches. This
+// is the deterministic core of the defense-in-depth fix.
+func TestCompareChunk(t *testing.T) {
+	tests := []struct {
+		name             string
+		srcCRC, tgtCRC   int64
+		srcCnt, tgtCnt   uint64
+		wantMismatched   bool
+		wantChecksumDiff bool
+		wantCountDiff    bool
+		wantReason       string
+	}{
+		{
+			name:   "all equal",
+			srcCRC: 12345, tgtCRC: 12345,
+			srcCnt: 10, tgtCnt: 10,
+			wantMismatched: false,
+		},
+		{
+			name:   "checksum differs, counts equal",
+			srcCRC: 12345, tgtCRC: 99999,
+			srcCnt: 10, tgtCnt: 10,
+			wantMismatched:   true,
+			wantChecksumDiff: true,
+			wantCountDiff:    false,
+			wantReason:       "checksum mismatch",
+		},
+		{
+			// The headline defense-in-depth case: identical CRC, different
+			// counts. BIT_XOR pair-cancellation (duplicate rows) or a row
+			// whose CRC32 is 0 can leave the checksum matching while the
+			// count diverges.
+			name:   "checksum equal, counts differ",
+			srcCRC: 12345, tgtCRC: 12345,
+			srcCnt: 11, tgtCnt: 10,
+			wantMismatched:   true,
+			wantChecksumDiff: false,
+			wantCountDiff:    true,
+			wantReason:       "row count mismatch (src=11, target=10)",
+		},
+		{
+			name:   "both differ",
+			srcCRC: 12345, tgtCRC: 99999,
+			srcCnt: 0, tgtCnt: 2,
+			wantMismatched:   true,
+			wantChecksumDiff: true,
+			wantCountDiff:    true,
+			wantReason:       "checksum mismatch and row count mismatch (src=0, target=2)",
+		},
+		{
+			// Zero-CRC pair-cancellation flavor: both sides report CRC 0
+			// (e.g. a single row whose CRC32 is 0 on one side, none on the
+			// other), so the XOR matches but the count exposes the gap.
+			name:   "zero crc both sides, count differs",
+			srcCRC: 0, tgtCRC: 0,
+			srcCnt: 1, tgtCnt: 0,
+			wantMismatched:   true,
+			wantChecksumDiff: false,
+			wantCountDiff:    true,
+			wantReason:       "row count mismatch (src=1, target=0)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := compareChunk(tc.srcCRC, tc.tgtCRC, tc.srcCnt, tc.tgtCnt)
+			require.Equal(t, tc.wantMismatched, m.mismatched())
+			require.Equal(t, tc.wantChecksumDiff, m.checksumDiffers)
+			require.Equal(t, tc.wantCountDiff, m.countDiffers)
+			if tc.wantMismatched {
+				require.Equal(t, tc.wantReason, m.reason(tc.srcCnt, tc.tgtCnt))
+			}
+		})
+	}
+}

--- a/pkg/checksum/continuous.go
+++ b/pkg/checksum/continuous.go
@@ -275,28 +275,43 @@ type ContinuousChecker struct {
 	firstCleanPassCh   chan struct{}
 
 	// readChunk performs the source+target CRC read for a single chunk and
-	// returns the new source CRC, new target CRC, and target row count
-	// (used for chunker feedback). Production wires this to readChunkCRC
-	// against sourceDB/targetDB; tests swap it to return deterministic
-	// CRCs without standing up two databases.
-	readChunk func(ctx context.Context, chunk *table.Chunk) (srcCRC, tgtCRC int64, tgtCount uint64, err error)
+	// returns the new source CRC, new target CRC, source row count, and
+	// target row count. The two counts are compared as a defense-in-depth
+	// check alongside the CRC (a row whose CRC32 is 0 is invisible to the
+	// XOR but visible to the count); tgtCount also feeds chunker feedback.
+	// Production wires this to readChunkCRC against sourceDB/targetDB; tests
+	// swap it to return deterministic CRCs/counts without standing up two
+	// databases.
+	readChunk func(ctx context.Context, chunk *table.Chunk) (srcCRC, tgtCRC int64, srcCount, tgtCount uint64, err error)
+}
+
+// chunkSig is the comparison identity for one side of a chunk: its CRC AND
+// its row count. The continuous checker compares whole signatures rather than
+// CRCs alone so a row-count mismatch is caught even when the CRC happens to
+// match (a row whose CRC32 is 0 is invisible to the BIT_XOR but moves the
+// count). "source changed" / "target caught up" decisions all operate on
+// signatures.
+type chunkSig struct {
+	crc   int64
+	count uint64
 }
 
 // retryEntry tracks one chunk that failed and is awaiting re-verification.
-// originalSrcCRC is updated each time we observe the source change while
-// the chunk is still pending — see the "hot chunk" path in the package doc.
+// originalSrc is updated each time we observe the source change while the
+// chunk is still pending — see the "hot chunk" path in the package doc.
 type retryEntry struct {
 	chunk *table.Chunk
 
-	originalSrcCRC int64
-	originalTgtCRC int64
+	originalSrc chunkSig
+	originalTgt chunkSig
 
 	// notBefore is the earliest wall-clock time this entry may be retried.
 	// Set to now + RetryDelay on enqueue and on each re-enqueue.
 	notBefore time.Time
 
-	// consecutiveSrcChanged counts retries on which the source CRC differed
-	// from the previous attempt. Surfaced as Stats.HotChunkCount when >=2.
+	// consecutiveSrcChanged counts retries on which the source signature
+	// differed from the previous attempt. Surfaced as Stats.HotChunkCount
+	// when >=2.
 	consecutiveSrcChanged int
 
 	// attempts is the number of times this entry has been re-read. Used
@@ -313,8 +328,8 @@ type workItem struct {
 	isRetry bool
 
 	// Only valid when isRetry is true:
-	originalSrcCRC        int64
-	originalTgtCRC        int64
+	originalSrc           chunkSig
+	originalTgt           chunkSig
 	consecutiveSrcChanged int
 	attempts              int
 }
@@ -325,10 +340,10 @@ type workResult struct {
 	item *workItem
 
 	// passed is true iff the chunk resolved for pass-completion purposes
-	// (initial match, retry match against original or new source CRC, or
-	// a successful recopy). Note a recopy "passes" only in the sense that
-	// the pass can finish — it also marks the pass ineligible to fire
-	// FirstCleanPass (see recopied below).
+	// (initial match, retry match against the original or new source
+	// signature, or a successful recopy). Note a recopy "passes" only in
+	// the sense that the pass can finish — it also marks the pass
+	// ineligible to fire FirstCleanPass (see recopied below).
 	passed bool
 
 	// recopied is true iff this result represents a successful Recopy
@@ -337,11 +352,10 @@ type workResult struct {
 	// the containing pass not-clean for the FirstCleanPass criterion.
 	recopied bool
 
-	// newSrcCRC / newTgtCRC are the values just read. Used by the driver
-	// to populate a re-enqueued retryEntry on the hot-chunk path.
-	newSrcCRC int64
-	newTgtCRC int64
-	newCount  uint64
+	// newSrc / newTgt are the signatures (CRC + count) just read. Used by
+	// the driver to populate a re-enqueued retryEntry on the hot-chunk path.
+	newSrc chunkSig
+	newTgt chunkSig
 
 	// permanent is true iff this is a retry that failed with the source
 	// CRC unchanged AND no Recopier is configured — i.e. real divergence
@@ -396,10 +410,7 @@ func NewContinuousChecker(
 		feed:             feed,
 		firstCleanPassCh: make(chan struct{}),
 	}
-	c.readChunk = func(ctx context.Context, chunk *table.Chunk) (int64, int64, uint64, error) {
-		src, tgt, _, tgtCnt, err := readChunkCRC(ctx, sourceDB, targetDB, chunk)
-		return src, tgt, tgtCnt, err
-	}
+	c.readChunk = readChunkCRC2(sourceDB, targetDB)
 	return c, nil
 }
 
@@ -579,8 +590,8 @@ func (c *ContinuousChecker) runOnePass(ctx context.Context, workCh chan<- *workI
 					emit = &workItem{
 						chunk:                 e.chunk,
 						isRetry:               true,
-						originalSrcCRC:        e.originalSrcCRC,
-						originalTgtCRC:        e.originalTgtCRC,
+						originalSrc:           e.originalSrc,
+						originalTgt:           e.originalTgt,
 						consecutiveSrcChanged: e.consecutiveSrcChanged,
 						attempts:              e.attempts,
 					}
@@ -759,14 +770,15 @@ func (c *ContinuousChecker) executeWork(ctx context.Context, item *workItem) *wo
 	res := &workResult{item: item}
 
 	start := time.Now()
-	srcCRC, tgtCRC, tgtCount, err := c.readChunk(ctx, item.chunk)
+	srcCRC, tgtCRC, srcCount, tgtCount, err := c.readChunk(ctx, item.chunk)
 	if err != nil {
 		res.err = fmt.Errorf("read chunk %s: %w", item.chunk.String(), err)
 		return res
 	}
-	res.newSrcCRC = srcCRC
-	res.newTgtCRC = tgtCRC
-	res.newCount = tgtCount
+	newSrc := chunkSig{crc: srcCRC, count: srcCount}
+	newTgt := chunkSig{crc: tgtCRC, count: tgtCount}
+	res.newSrc = newSrc
+	res.newTgt = newTgt
 
 	// Feed chunker stats for fresh-walk reads so chunk sizing adapts. We
 	// deliberately skip retry reads — they re-evaluate the same chunk and
@@ -777,7 +789,10 @@ func (c *ContinuousChecker) executeWork(ctx context.Context, item *workItem) *wo
 		c.chunker.Feedback(item.chunk, time.Since(start), tgtCount)
 	}
 
-	if srcCRC == tgtCRC {
+	// Compare the full signatures (CRC AND row count), not the CRC alone.
+	// A row-count mismatch is treated identically to a checksum mismatch:
+	// it flows through the same retry/recopy machinery below.
+	if newSrc == newTgt {
 		res.passed = true
 		return res
 	}
@@ -788,13 +803,15 @@ func (c *ContinuousChecker) executeWork(ctx context.Context, item *workItem) *wo
 		return res
 	}
 
-	// Retry: apply the pass criterion of pkg-doc step 2.
-	if tgtCRC == item.originalSrcCRC || tgtCRC == srcCRC {
+	// Retry: apply the pass criterion of pkg-doc step 2, comparing whole
+	// signatures. The target passes if it has caught up to any witnessed
+	// source signature (the original one, or the current one).
+	if newTgt == item.originalSrc || newTgt == newSrc {
 		// Target has caught up to a witnessed source version.
 		res.passed = true
 		return res
 	}
-	if srcCRC != item.originalSrcCRC {
+	if newSrc != item.originalSrc {
 		// Hot chunk — source kept changing. Re-enqueued with new state by
 		// the dispatcher; res.passed stays false, res.permanent stays false.
 		return res
@@ -811,11 +828,13 @@ func (c *ContinuousChecker) executeWork(ctx context.Context, item *workItem) *wo
 		}
 		// The Recopier already logs the user-facing "chunk recopied" line
 		// (with row count + elapsed). Add a Debug companion with the CRC +
-		// attempt context that the recopier doesn't see.
+		// count + attempt context that the recopier doesn't see.
 		c.cfg.Logger.Debug("continuous checksum: recopy completed",
 			"chunk", item.chunk.String(),
 			"sourceCRC", srcCRC,
 			"targetCRC", tgtCRC,
+			"sourceCount", srcCount,
+			"targetCount", tgtCount,
 			"attempts_before_recopy", item.attempts+1,
 		)
 		res.passed = true
@@ -843,12 +862,14 @@ func (c *ContinuousChecker) handleResult(res *workResult, enqueueRetry func(*ret
 		c.permanentFailures.Add(1)
 		c.cfg.Logger.Error("continuous checksum: permanent divergence",
 			"chunk", res.item.chunk.String(),
-			"sourceCRC", res.newSrcCRC,
-			"targetCRC", res.newTgtCRC,
-			"originalSourceCRC", res.item.originalSrcCRC,
+			"sourceCRC", res.newSrc.crc,
+			"targetCRC", res.newTgt.crc,
+			"sourceCount", res.newSrc.count,
+			"targetCount", res.newTgt.count,
+			"originalSourceCRC", res.item.originalSrc.crc,
 		)
-		return fmt.Errorf("%w: chunk %s (source=%d target=%d)", ErrPermanentDivergence,
-			res.item.chunk.String(), res.newSrcCRC, res.newTgtCRC)
+		return fmt.Errorf("%w: chunk %s (source crc=%d count=%d, target crc=%d count=%d)", ErrPermanentDivergence,
+			res.item.chunk.String(), res.newSrc.crc, res.newSrc.count, res.newTgt.crc, res.newTgt.count)
 	}
 
 	// Mismatch — enqueue a retry. Either a fresh-walk first-time mismatch,
@@ -861,34 +882,38 @@ func (c *ContinuousChecker) handleResult(res *workResult, enqueueRetry func(*ret
 		c.mismatchesThisPass.Add(1)
 		c.cfg.Logger.Debug("continuous checksum: chunk mismatch, queuing retry",
 			"chunk", res.item.chunk.String(),
-			"sourceCRC", res.newSrcCRC,
-			"targetCRC", res.newTgtCRC,
+			"sourceCRC", res.newSrc.crc,
+			"targetCRC", res.newTgt.crc,
+			"sourceCount", res.newSrc.count,
+			"targetCount", res.newTgt.count,
 		)
 		return enqueueRetry(&retryEntry{
-			chunk:          res.item.chunk,
-			originalSrcCRC: res.newSrcCRC,
-			originalTgtCRC: res.newTgtCRC,
-			notBefore:      time.Now().Add(c.cfg.RetryDelay),
-			attempts:       1,
+			chunk:       res.item.chunk,
+			originalSrc: res.newSrc,
+			originalTgt: res.newTgt,
+			notBefore:   time.Now().Add(c.cfg.RetryDelay),
+			attempts:    1,
 		})
 	}
 
 	// Hot chunk: source changed across retry windows. Replace the
-	// "original" with the current source CRC so a future retry can match
-	// against this newer witnessed version, and re-enqueue at the tail.
+	// "original" with the current source signature so a future retry can
+	// match against this newer witnessed version, and re-enqueue at the tail.
 	newConsecutive := res.item.consecutiveSrcChanged + 1
 	c.cfg.Logger.Debug("continuous checksum: hot chunk, re-queuing",
 		"chunk", res.item.chunk.String(),
-		"sourceCRC", res.newSrcCRC,
-		"targetCRC", res.newTgtCRC,
-		"originalSourceCRC", res.item.originalSrcCRC,
+		"sourceCRC", res.newSrc.crc,
+		"targetCRC", res.newTgt.crc,
+		"sourceCount", res.newSrc.count,
+		"targetCount", res.newTgt.count,
+		"originalSourceCRC", res.item.originalSrc.crc,
 		"consecutiveSourceChanged", newConsecutive,
 		"attempts", res.item.attempts+1,
 	)
 	return enqueueRetry(&retryEntry{
 		chunk:                 res.item.chunk,
-		originalSrcCRC:        res.newSrcCRC,
-		originalTgtCRC:        res.newTgtCRC,
+		originalSrc:           res.newSrc,
+		originalTgt:           res.newTgt,
 		notBefore:             time.Now().Add(c.cfg.RetryDelay),
 		consecutiveSrcChanged: newConsecutive,
 		attempts:              res.item.attempts + 1,
@@ -965,6 +990,16 @@ func readChunkCRC(
 		return 0, 0, 0, 0, err
 	}
 	return srcCRC, tgtCRC, srcCount, tgtCount, nil
+}
+
+// readChunkCRC2 adapts readChunkCRC to the readChunk field signature,
+// returning BOTH row counts so the checker can compare them. (readChunkCRC
+// already computes srcCount; the continuous checker previously discarded it,
+// which is the defense-in-depth gap this closes.)
+func readChunkCRC2(sourceDB, targetDB *sql.DB) func(ctx context.Context, chunk *table.Chunk) (int64, int64, uint64, uint64, error) {
+	return func(ctx context.Context, chunk *table.Chunk) (int64, int64, uint64, uint64, error) {
+		return readChunkCRC(ctx, sourceDB, targetDB, chunk)
+	}
 }
 
 // signalFirstCleanPass closes firstCleanPassCh on the first call and

--- a/pkg/checksum/continuous_test.go
+++ b/pkg/checksum/continuous_test.go
@@ -113,7 +113,38 @@ func newTestChecker(t *testing.T, chunker table.Chunker, cfg ContinuousCheckerCo
 	require.NoError(t, err)
 
 	attempts := sync.Map{}
-	c.readChunk = func(ctx context.Context, chunk *table.Chunk) (int64, int64, uint64, error) {
+	c.readChunk = func(ctx context.Context, chunk *table.Chunk) (int64, int64, uint64, uint64, error) {
+		var n int
+		if v, ok := attempts.Load(chunk); ok {
+			n = v.(int) + 1
+		} else {
+			n = 1
+		}
+		attempts.Store(chunk, n)
+		srcCRC, tgtCRC, count, err := read(ctx, chunk, n)
+		// The legacy 3-value read hook supplies a single row count that
+		// applies to BOTH source and target — these tests exercise CRC-only
+		// divergence with matching counts. Tests that need divergent counts
+		// use newTestCheckerSig below.
+		return srcCRC, tgtCRC, count, count, err
+	}
+	return c
+}
+
+// newTestCheckerSig is like newTestChecker but the read hook returns full
+// signatures (CRC + count) for source and target independently, so tests can
+// exercise row-count divergence with matching CRCs (the defense-in-depth gap
+// this comparison closes).
+func newTestCheckerSig(t *testing.T, chunker table.Chunker, cfg ContinuousCheckerConfig,
+	read func(ctx context.Context, chunk *table.Chunk, attempt int) (srcCRC, tgtCRC int64, srcCount, tgtCount uint64, err error),
+) *ContinuousChecker {
+	t.Helper()
+	srcDB, tgtDB := &sql.DB{}, &sql.DB{}
+	c, err := NewContinuousChecker(srcDB, tgtDB, chunker, nil, cfg)
+	require.NoError(t, err)
+
+	attempts := sync.Map{}
+	c.readChunk = func(ctx context.Context, chunk *table.Chunk) (int64, int64, uint64, uint64, error) {
 		var n int
 		if v, ok := attempts.Load(chunk); ok {
 			n = v.(int) + 1
@@ -675,6 +706,74 @@ func TestRecopyNotCalledForHotChunk(t *testing.T) {
 	require.Equal(t, uint64(0), c.Stats().PermanentFailures)
 	err := stop()
 	require.True(t, errors.Is(err, context.Canceled) || err == nil)
+}
+
+// TestRecopyOnRowCountMismatch is the continuous-checker analog of the
+// defense-in-depth fix: the source and target CRCs MATCH on every read, but
+// the row counts differ and stay stable. Before the fix this passed silently
+// (CRC equality alone). Now the count divergence is treated like a checksum
+// mismatch: it enqueues a retry, the retry sees stable divergence (source
+// signature unchanged, target signature still wrong), and the configured
+// Recopier is invoked. After recopy the signatures match and the pass
+// completes cleanly.
+func TestRecopyOnRowCountMismatch(t *testing.T) {
+	chunker := newTestChunker(2)
+	var recopied sync.Map // chunk pointer → recopied? (bool)
+	recopier := &fakeRecopier{
+		recopyFn: func(ctx context.Context, chunk *table.Chunk) error {
+			recopied.Store(chunk, true)
+			return nil
+		},
+	}
+	cfg := fastConfig()
+	cfg.Recopier = recopier
+
+	c := newTestCheckerSig(t, chunker, cfg,
+		func(ctx context.Context, chunk *table.Chunk, attempt int) (int64, int64, uint64, uint64, error) {
+			if _, ok := recopied.Load(chunk); ok {
+				// Post-recopy: CRCs AND counts match.
+				return 42, 42, 10, 10, nil
+			}
+			// Pre-recopy: CRCs are IDENTICAL (the checksum-only check would
+			// pass!) but the source has one more row than the target. Stable
+			// across the retry window so it becomes a recopy, not a hot chunk.
+			return 42, 42, 11, 10, nil
+		},
+	)
+
+	stop, _ := runUntil(t, c)
+	select {
+	case <-c.FirstCleanPass():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("FirstCleanPass did not fire; stats=%+v calls=%d", c.Stats(), recopier.callCount())
+	}
+	stats := c.Stats()
+	require.Equal(t, uint64(0), stats.PermanentFailures)
+	require.Equal(t, uint64(2), stats.MismatchesDetected, "both chunks mismatch on row count despite equal CRC")
+	require.GreaterOrEqual(t, recopier.callCount(), 2, "both row-count-divergent chunks should have been recopied")
+
+	err := stop()
+	require.True(t, errors.Is(err, context.Canceled) || err == nil)
+}
+
+// TestPermanentDivergenceOnRowCount: with matching CRCs but a stable row-count
+// difference and NO Recopier, the continuous checker must surface
+// ErrPermanentDivergence — the count mismatch is a real divergence, not a
+// silent pass.
+func TestPermanentDivergenceOnRowCount(t *testing.T) {
+	chunker := newTestChunker(1)
+	c := newTestCheckerSig(t, chunker, fastConfig(),
+		func(ctx context.Context, chunk *table.Chunk, attempt int) (int64, int64, uint64, uint64, error) {
+			// CRCs always match; source always has one extra row.
+			return 100, 100, 6, 5, nil
+		},
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := c.Run(ctx)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPermanentDivergence), "expected ErrPermanentDivergence, got %v", err)
+	require.Equal(t, uint64(1), c.Stats().PermanentFailures)
 }
 
 // TestMultiplePassesResetCounters: after a clean pass, counters reset for

--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -135,14 +135,14 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		// The source and target do not match, so we first need
 		// to inspect closely and report on the differences.
 		c.differencesFound.Add(1)
-		c.logger.Warn("checksum mismatch for chunk", "chunk", chunk.String(),
+		c.logger.Warn("chunk verification failed", "chunk", chunk.String(),
 			"reason", mismatch.reason(sourceCount, targetCount),
 			"sourceChecksum", sourceChecksum, "targetChecksum", targetChecksum,
 			"sourceCount", sourceCount, "targetCount", targetCount)
 
 		// For distributed case, we can't easily inspect differences across multiple sources/targets
 		// So we'll just log the mismatch and proceed to fix
-		c.logger.Warn("distributed checksum mismatch detected, will recopy chunk")
+		c.logger.Warn("distributed chunk verification failed, will recopy chunk")
 
 		// Are we allowed to fix the differences? If not, return an error.
 		// This is mostly used by the test-suite.

--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -123,11 +123,20 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		"sourceChecksum", sourceChecksum, "sourceCount", sourceCount,
 		"targetChecksum", targetChecksum, "targetCount", targetCount)
 
-	if sourceChecksum != targetChecksum {
-		// The checksums do not match, so we first need
+	// Compare BOTH the aggregated checksum and the summed row count. Comparing
+	// the count is free (it is summed from the same per-source/per-target
+	// queries above) and it is critical in the distributed case: BIT_XOR is
+	// pair-cancelling, so if the SAME row exists on two source shards (a
+	// resharding bug that violates shard disjointness) its CRCs cancel to
+	// zero — a target with ZERO copies of that row would still match on the
+	// checksum alone. The summed counts (src=2, target=0) catch it. A count
+	// mismatch is treated identically to a checksum mismatch.
+	if mismatch := compareChunk(sourceChecksum, targetChecksum, sourceCount, targetCount); mismatch.mismatched() {
+		// The source and target do not match, so we first need
 		// to inspect closely and report on the differences.
 		c.differencesFound.Add(1)
 		c.logger.Warn("checksum mismatch for chunk", "chunk", chunk.String(),
+			"reason", mismatch.reason(sourceCount, targetCount),
 			"sourceChecksum", sourceChecksum, "targetChecksum", targetChecksum,
 			"sourceCount", sourceCount, "targetCount", targetCount)
 

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -298,3 +298,109 @@ func TestDistributedChecksumNtoM(t *testing.T) {
 	// Run the checksum — should pass since the merged source data matches merged target data.
 	require.NoError(t, checker.Run(t.Context()))
 }
+
+// TestDistributedChecksumPairCancellation exercises the BIT_XOR
+// pair-cancellation defense-in-depth gap. The SAME row exists on BOTH source
+// shards (a resharding bug violating shard disjointness) and is MISSING from
+// the target. Because BIT_XOR is pair-cancelling, the duplicated row's CRC
+// cancels to zero on the source side, so the aggregated source checksum
+// matches a target that has ZERO copies of that row. The checksum alone is
+// blind to this; only the summed row counts (src=2, target=0) catch it.
+//
+// With the row-count comparison in place this MUST fail. (On unfixed code —
+// checksum comparison only — it PASSES, which is the bug.)
+//
+// Table names are prefixed w3f per the unique-naming requirement.
+func TestDistributedChecksumPairCancellation(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	// Two source shards and one target. Each source shard holds the SAME
+	// single row (id=1) — the disjointness violation. The target is empty.
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS w3f_paircancel_src_0`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS w3f_paircancel_src_1`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS w3f_paircancel_tgt_0`)
+	testutils.RunSQL(t, `CREATE DATABASE w3f_paircancel_src_0`)
+	testutils.RunSQL(t, `CREATE DATABASE w3f_paircancel_src_1`)
+	testutils.RunSQL(t, `CREATE DATABASE w3f_paircancel_tgt_0`)
+	testutils.RunSQL(t, `CREATE TABLE w3f_paircancel_src_0.w3f_t1 (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL)`)
+	testutils.RunSQL(t, `CREATE TABLE w3f_paircancel_src_1.w3f_t1 (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL)`)
+	testutils.RunSQL(t, `CREATE TABLE w3f_paircancel_tgt_0.w3f_t1 (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL)`)
+
+	// The identical duplicated row on both source shards. Its CRC cancels in
+	// the source-side BIT_XOR.
+	testutils.RunSQL(t, `INSERT INTO w3f_paircancel_src_0.w3f_t1 VALUES (1, 'dup')`)
+	testutils.RunSQL(t, `INSERT INTO w3f_paircancel_src_1.w3f_t1 VALUES (1, 'dup')`)
+	// Target intentionally left empty (zero copies of id=1).
+
+	// DB connections.
+	src0Cfg := cfg.Clone()
+	src0Cfg.DBName = "w3f_paircancel_src_0"
+	src0DB, err := dbconn.New(src0Cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(src0DB)
+
+	src1Cfg := cfg.Clone()
+	src1Cfg.DBName = "w3f_paircancel_src_1"
+	src1DB, err := dbconn.New(src1Cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(src1DB)
+
+	tgt0Cfg := cfg.Clone()
+	tgt0Cfg.DBName = "w3f_paircancel_tgt_0"
+	tgt0DB, err := dbconn.New(tgt0Cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(tgt0DB)
+
+	// TableInfo per source. Sharding column is required by the applier even
+	// though we only ever read here (FixDifferences=false).
+	src0Table := table.NewTableInfo(src0DB, "w3f_paircancel_src_0", "w3f_t1")
+	require.NoError(t, src0Table.SetInfo(t.Context()))
+	src0Table.ShardingColumn = "id"
+	src0Table.HashFunc = testutils.EvenOddHasher
+
+	src1Table := table.NewTableInfo(src1DB, "w3f_paircancel_src_1", "w3f_t1")
+	require.NoError(t, src1Table.SetInfo(t.Context()))
+	src1Table.ShardingColumn = "id"
+	src1Table.HashFunc = testutils.EvenOddHasher
+
+	// Single target covering the full key range.
+	targets := []applier.Target{
+		{DB: tgt0DB, KeyRange: "-", Config: tgt0Cfg},
+	}
+	shardedApplier, err := applier.NewShardedApplier(targets, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	logger := slog.Default()
+	feed0 := change.NewBinlogClient(src0DB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, change.NewClientDefaultConfig())
+	defer feed0.Close()
+	chunker0, err := table.NewChunker(src0Table, table.ChunkerConfig{NewTable: src0Table})
+	require.NoError(t, err)
+	require.NoError(t, feed0.AddSubscription(src0Table, src0Table, chunker0))
+	require.NoError(t, feed0.Start(t.Context()))
+
+	feed1 := change.NewBinlogClient(src1DB, cfg.Addr, cfg.User, cfg.Passwd, shardedApplier, change.NewClientDefaultConfig())
+	defer feed1.Close()
+	chunker1, err := table.NewChunker(src1Table, table.ChunkerConfig{Logger: logger})
+	require.NoError(t, err)
+	require.NoError(t, feed1.AddSubscription(src1Table, src1Table, chunker1))
+	require.NoError(t, feed1.Start(t.Context()))
+	multiChunker := table.NewMultiChunker(chunker0, chunker1)
+	require.NoError(t, multiChunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.Applier = shardedApplier
+	config.FixDifferences = false // we want the mismatch to surface as an error
+
+	checker, err := NewChecker([]*sql.DB{src0DB, src1DB}, multiChunker, []change.Source{feed0, feed1}, config)
+	require.NoError(t, err)
+
+	// The aggregated source CRC cancels to match the empty target (both 0),
+	// but src count=2 and target count=0. The row-count comparison must
+	// catch this and fail. (Pre-fix, the checksum-only comparison passes —
+	// that is the defense-in-depth gap.) With FixDifferences=false the
+	// mismatch surfaces directly as the "checksum mismatch" error.
+	err = checker.Run(t.Context())
+	require.Error(t, err, "row-count mismatch from pair-cancellation must be detected")
+	require.ErrorContains(t, err, "checksum mismatch")
+}

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -76,11 +76,16 @@ func (c *SingleChecker) ChecksumChunk(ctx context.Context, trxPool *dbconn.TrxPo
 	if err != nil {
 		return err
 	}
-	if sourceChecksum != targetChecksum {
-		// The checksums do not match, so we first need
+	// Compare BOTH the checksum and the row count. The row count is already
+	// returned by the query above, so comparing it is free, and it closes a
+	// defense-in-depth gap: a row whose CRC32 is 0 contributes nothing to the
+	// BIT_XOR, so its absence is invisible to the checksum but visible to the
+	// count. A count mismatch is treated identically to a checksum mismatch.
+	if mismatch := compareChunk(sourceChecksum, targetChecksum, sourceCount, targetCount); mismatch.mismatched() {
+		// The source and target do not match, so we first need
 		// to inspect closely and report on the differences.
 		c.differencesFound.Add(1)
-		c.logger.Warn("checksum mismatch for chunk", "chunk", chunk.String(), "sourceChecksum", sourceChecksum, "targetChecksum", targetChecksum, "sourceCount", sourceCount, "targetCount", targetCount)
+		c.logger.Warn("checksum mismatch for chunk", "chunk", chunk.String(), "reason", mismatch.reason(sourceCount, targetCount), "sourceChecksum", sourceChecksum, "targetChecksum", targetChecksum, "sourceCount", sourceCount, "targetCount", targetCount)
 		if err := c.inspectDifferences(ctx, trx, chunk); err != nil {
 			return err
 		}

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -85,7 +85,7 @@ func (c *SingleChecker) ChecksumChunk(ctx context.Context, trxPool *dbconn.TrxPo
 		// The source and target do not match, so we first need
 		// to inspect closely and report on the differences.
 		c.differencesFound.Add(1)
-		c.logger.Warn("checksum mismatch for chunk", "chunk", chunk.String(), "reason", mismatch.reason(sourceCount, targetCount), "sourceChecksum", sourceChecksum, "targetChecksum", targetChecksum, "sourceCount", sourceCount, "targetCount", targetCount)
+		c.logger.Warn("chunk verification failed", "chunk", chunk.String(), "reason", mismatch.reason(sourceCount, targetCount), "sourceChecksum", sourceChecksum, "targetChecksum", targetChecksum, "sourceCount", sourceCount, "targetCount", targetCount)
 		if err := c.inspectDifferences(ctx, trx, chunk); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Problem
All three checksum checkers fetched per-chunk row counts alongside the CRC but never compared them — a defense-in-depth gap. `BIT_XOR` is pair-cancelling, so a row duplicated across two source shards (a resharding disjointness violation) cancels to zero and a target missing that row still matches the checksum alone; any row whose CRC32 is 0 is similarly invisible to the XOR. `sourceCount` vs `targetCount` would catch both instantly, and the counts are already computed in the same queries.

## Fix
A shared `compareChunk` helper compares both the CRC and the row count, treating a count mismatch identically to a checksum mismatch across all three checkers' retry/recopy/difference-reporting paths, with messages that distinguish "checksum mismatch" from "row count mismatch (src=N, target=M)". The continuous checker, which had explicitly discarded the source count, now threads it through.

## Testing
Deterministic unit test of the decision function, plus a distributed integration test reproducing the pair-cancellation scenario (passes silently pre-fix, fails now) and a continuous-checker count-mismatch recopy test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
