### PR TITLE
fix redundant-index lint false positives (UNIQUE suffix, functional, prefix length)

### DIFF
--- a/pkg/lint/lint_redundant_indexes.go
+++ b/pkg/lint/lint_redundant_indexes.go
@@ -69,6 +69,12 @@ func (l *RedundantIndexLinter) checkTableIndexes(table *statement.CreateTable) [
 		// PRIMARY KEY itself never participates in suffix/prefix-of-PK checks
 		// against itself, and the checks below are only meaningful for
 		// secondary indexes.
+		//
+		// UNIQUE indexes are also excluded from the partial-PK-suffix branch
+		// (handled inside hasRedundantPKSuffix): a UNIQUE index's trailing
+		// columns are part of its uniqueness scope, not auto-appended PK
+		// bookkeeping, so trimming them would silently drop a data-integrity
+		// constraint.
 		if primaryKey != nil && index.Type != "PRIMARY KEY" {
 			// Check: Redundant PK suffix
 			// The index explicitly includes PK columns at its end. InnoDB
@@ -105,7 +111,7 @@ func (l *RedundantIndexLinter) checkTableIndexes(table *statement.CreateTable) [
 			}
 
 			if isRedundantToIndex(index, otherIndex) {
-				isDuplicate := len(index.Columns) == len(otherIndex.Columns)
+				isDuplicate := indexColumnsEqual(indexParts(index), indexParts(otherIndex))
 				violations = append(violations, createRedundancyViolation(
 					table.GetTableName(),
 					index,
@@ -122,9 +128,135 @@ func (l *RedundantIndexLinter) checkTableIndexes(table *statement.CreateTable) [
 	return violations
 }
 
+// indexParts returns the structured key parts of an index. The deprecated
+// Index.Columns field is a flat []string that silently drops expression key
+// parts (functional indexes) and prefix lengths (col(n)), so all comparison
+// logic in this linter operates on ColumnList instead. Index.Columns is only
+// used for human-readable violation messages.
+func indexParts(index statement.Index) []statement.IndexColumn {
+	if len(index.ColumnList) > 0 {
+		return index.ColumnList
+	}
+	// Synthesized indexes (column-level PRIMARY KEY / UNIQUE produced by
+	// GetIndexes) only populate the flat Columns slice. Build equivalent plain
+	// key parts so comparison logic still sees the columns.
+	if len(index.Columns) == 0 {
+		return nil
+	}
+	parts := make([]statement.IndexColumn, 0, len(index.Columns))
+	for _, c := range index.Columns {
+		parts = append(parts, statement.IndexColumn{Name: c})
+	}
+	return parts
+}
+
+// renderIndexPart formats a single key part for human-readable messages,
+// including prefix lengths (col(10)) and expression parts ((LOWER(name))).
+func renderIndexPart(p statement.IndexColumn) string {
+	if p.Expression != nil {
+		return "(" + *p.Expression + ")"
+	}
+	if p.Length != nil {
+		return fmt.Sprintf("%s(%d)", p.Name, *p.Length)
+	}
+	return p.Name
+}
+
+// renderIndexParts formats a list of key parts for human-readable messages.
+func renderIndexParts(parts []statement.IndexColumn) string {
+	rendered := make([]string, 0, len(parts))
+	for _, p := range parts {
+		rendered = append(rendered, renderIndexPart(p))
+	}
+	return strings.Join(rendered, ", ")
+}
+
+// renderIndexColumns formats an index's columns for human-readable messages.
+// It uses the structured key parts (which carry prefix lengths and
+// expressions), falling back to the flat Columns slice for synthesized indexes
+// (e.g. column-level PRIMARY KEY / UNIQUE) via indexParts.
+func renderIndexColumns(index statement.Index) string {
+	return renderIndexParts(indexParts(index))
+}
+
+// indexColumnPartCovers reports whether key part b can serve every lookup that
+// key part a serves, when both occupy the same position in two indexes.
+//
+// Semantics:
+//   - Expression parts are opaque: an expression is covered only by an
+//     identical expression. A plain column never covers (or is covered by) an
+//     expression.
+//   - A prefix part col(n) is covered by the full column col (no length) or by
+//     a longer-or-equal prefix col(m) where m >= n. The reverse is false: a
+//     full column is NOT covered by a shorter prefix, because the prefix lacks
+//     covering-scan and full-ordering capability.
+//   - Column-name comparison is case-insensitive, matching MySQL identifier
+//     semantics.
+func indexColumnPartCovers(a, b statement.IndexColumn) bool {
+	// Expression parts only match identical expressions.
+	if a.Expression != nil || b.Expression != nil {
+		if a.Expression == nil || b.Expression == nil {
+			return false
+		}
+		return *a.Expression == *b.Expression
+	}
+
+	// Both are plain column references.
+	if !strings.EqualFold(a.Name, b.Name) {
+		return false
+	}
+
+	// b must cover at least as much of the column as a.
+	// nil Length means the full column (covers any prefix length).
+	if b.Length == nil {
+		return true
+	}
+	if a.Length == nil {
+		// a needs the full column but b only indexes a prefix → not covered.
+		return false
+	}
+	return *b.Length >= *a.Length
+}
+
+// indexColumnsEqual reports whether two key-part lists are identical, including
+// column names (case-insensitive), prefix lengths, and expressions. This is the
+// exact-duplicate test: i1(name(10)) and i2(name) are NOT equal, and two
+// identical functional indexes ARE equal.
+func indexColumnsEqual(a, b []statement.IndexColumn) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !indexColumnPartCovers(a[i], b[i]) || !indexColumnPartCovers(b[i], a[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isColumnListPrefixCoveredBy reports whether every leading key part of a is
+// covered by the corresponding key part of b (a is a "coverable prefix" of b).
+// Used to decide whether index a is redundant to index b.
+func isColumnListPrefixCoveredBy(a, b []statement.IndexColumn) bool {
+	if len(a) > len(b) {
+		return false
+	}
+	for i := range a {
+		if !indexColumnPartCovers(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // isRedundantToIndex checks if indexA is redundant to indexB.
-// Returns true if indexA is a prefix of indexB OR if they're duplicates,
-// AND any constraint indexA enforces is also enforced by indexB.
+// Returns true if indexA is a coverable prefix of indexB OR if they're exact
+// duplicates, AND any constraint indexA enforces is also enforced by indexB.
+//
+// Comparison operates on ColumnList so that expression key parts and prefix
+// lengths are honoured: a functional index is only redundant to another index
+// carrying the identical expression part, and a prefix index col(n) is covered
+// by col but not vice versa.
 func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 	// FULLTEXT and SPATIAL indexes serve specialized purposes and are not
 	// interchangeable with B-tree indexes (or each other).
@@ -141,8 +273,11 @@ func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 		return false
 	}
 
-	// indexA cannot be redundant if it has MORE columns than indexB
-	if len(indexA.Columns) > len(indexB.Columns) {
+	partsA := indexParts(indexA)
+	partsB := indexParts(indexB)
+
+	// indexA cannot be redundant if it has MORE key parts than indexB.
+	if len(partsA) > len(partsB) {
 		return false
 	}
 
@@ -152,7 +287,7 @@ func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 	// therefore only redundant when an exact-column-set duplicate also
 	// enforces uniqueness over those columns.
 	if indexA.Type == "UNIQUE" {
-		if len(indexA.Columns) != len(indexB.Columns) {
+		if len(partsA) != len(partsB) {
 			return false
 		}
 		if indexB.Type != "UNIQUE" && indexB.Type != "PRIMARY KEY" {
@@ -160,18 +295,17 @@ func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 		}
 	}
 
-	// Check if all columns of indexA match the prefix of indexB in exact order
-	for i := range indexA.Columns {
-		if indexA.Columns[i] != indexB.Columns[i] {
-			return false
-		}
-	}
+	// indexA is redundant when it is a coverable prefix of (or exact duplicate
+	// of) indexB.
+	return isColumnListPrefixCoveredBy(partsA, partsB)
+}
 
-	// At this point, indexA is either:
-	// - A prefix of indexB (len(indexA) < len(indexB)), OR
-	// - A duplicate of indexB (len(indexA) == len(indexB))
-	// Both cases are redundant!
-	return true
+// isPlainPKColumn reports whether index key part p is a plain column reference
+// (no prefix length, no expression) whose name matches the given PK column.
+// InnoDB auto-appends the *full* PK column to secondary indexes, so a prefixed
+// or expression key part does not stand in for a PK column.
+func isPlainPKColumn(p statement.IndexColumn, pkColumn string) bool {
+	return p.Expression == nil && p.Length == nil && strings.EqualFold(p.Name, pkColumn)
 }
 
 // hasRedundantPKPrefix checks if a secondary index leads with the full
@@ -192,11 +326,12 @@ func hasRedundantPKPrefix(index statement.Index, primaryKey statement.Index) (bo
 	if pkLen == 0 {
 		return false, 0
 	}
-	if len(index.Columns) <= pkLen {
+	parts := indexParts(index)
+	if len(parts) <= pkLen {
 		return false, 0
 	}
 	for i := range pkLen {
-		if index.Columns[i] != primaryKey.Columns[i] {
+		if !isPlainPKColumn(parts[i], primaryKey.Columns[i]) {
 			return false, 0
 		}
 	}
@@ -209,23 +344,30 @@ func hasRedundantPKPrefix(index statement.Index, primaryKey statement.Index) (bo
 //
 // In InnoDB, secondary indexes automatically include PK columns, so explicitly
 // adding them at the end is redundant.
+//
+// UNIQUE indexes are excluded from the *partial*-PK-suffix branch: the trailing
+// columns of a UNIQUE index are part of its uniqueness scope (UNIQUE (x, y, a)
+// is not implied by PK (a, b)), so trimming them would drop a data-integrity
+// constraint. A full-PK suffix on a UNIQUE index is still flagged because the
+// PK already guarantees uniqueness, making the spelled-out suffix vacuous.
 func hasRedundantPKSuffix(index statement.Index, primaryKey statement.Index) (bool, int) {
 	if len(primaryKey.Columns) == 0 {
 		return false, 0
 	}
 
-	// Index must be longer than PK to have a suffix
-	if len(index.Columns) <= len(primaryKey.Columns) {
+	parts := indexParts(index)
+	pkLen := len(primaryKey.Columns)
+	indexLen := len(parts)
+
+	// Index must be longer than PK to have a suffix.
+	if indexLen <= pkLen {
 		return false, 0
 	}
 
-	pkLen := len(primaryKey.Columns)
-	indexLen := len(index.Columns)
-
-	// Try to match the full PK at the end
+	// Try to match the full PK at the end.
 	fullMatch := true
 	for i := range pkLen {
-		if index.Columns[indexLen-pkLen+i] != primaryKey.Columns[i] {
+		if !isPlainPKColumn(parts[indexLen-pkLen+i], primaryKey.Columns[i]) {
 			fullMatch = false
 			break
 		}
@@ -235,12 +377,19 @@ func hasRedundantPKSuffix(index statement.Index, primaryKey statement.Index) (bo
 		return true, pkLen // Full PK suffix is redundant
 	}
 
+	// A partial PK suffix on a UNIQUE index is part of its uniqueness scope,
+	// not redundant auto-append bookkeeping. Only the full-PK case above is
+	// vacuous for UNIQUE; stop here.
+	if index.Type == "UNIQUE" {
+		return false, 0
+	}
+
 	// Check if index ends with a PREFIX of PK
 	// e.g., PK (a, b, c) and INDEX (x, a, b) - the (a, b) suffix is redundant
 	for prefixLen := pkLen - 1; prefixLen > 0; prefixLen-- {
 		match := true
 		for i := range prefixLen {
-			if index.Columns[indexLen-prefixLen+i] != primaryKey.Columns[i] {
+			if !isPlainPKColumn(parts[indexLen-prefixLen+i], primaryKey.Columns[i]) {
 				match = false
 				break
 			}
@@ -257,12 +406,15 @@ func hasRedundantPKSuffix(index statement.Index, primaryKey statement.Index) (bo
 func createRedundancyViolation(tableName string, redundantIndex statement.Index, coveringIndex statement.Index, isDuplicate bool, redundantToPK bool) Violation {
 	var message, suggestion string
 
+	redundantCols := renderIndexColumns(redundantIndex)
+	coveringCols := renderIndexColumns(coveringIndex)
+
 	if isDuplicate {
 		if redundantToPK {
 			message = fmt.Sprintf(
 				"Index '%s' on columns (%s) is a duplicate of the PRIMARY KEY",
 				redundantIndex.Name,
-				strings.Join(redundantIndex.Columns, ", "),
+				redundantCols,
 			)
 			suggestion = fmt.Sprintf(
 				"Drop index '%s' as it duplicates the PRIMARY KEY. "+
@@ -273,7 +425,7 @@ func createRedundancyViolation(tableName string, redundantIndex statement.Index,
 			message = fmt.Sprintf(
 				"Index '%s' on columns (%s) is a duplicate of index '%s'",
 				redundantIndex.Name,
-				strings.Join(redundantIndex.Columns, ", "),
+				redundantCols,
 				coveringIndex.Name,
 			)
 			suggestion = fmt.Sprintf(
@@ -289,8 +441,8 @@ func createRedundancyViolation(tableName string, redundantIndex statement.Index,
 			message = fmt.Sprintf(
 				"Index '%s' on columns (%s) is redundant - covered by PRIMARY KEY on columns (%s)",
 				redundantIndex.Name,
-				strings.Join(redundantIndex.Columns, ", "),
-				strings.Join(coveringIndex.Columns, ", "),
+				redundantCols,
+				coveringCols,
 			)
 			suggestion = fmt.Sprintf(
 				"Consider dropping index '%s' as it is fully covered by the PRIMARY KEY. "+
@@ -301,9 +453,9 @@ func createRedundancyViolation(tableName string, redundantIndex statement.Index,
 			message = fmt.Sprintf(
 				"Index '%s' on columns (%s) is redundant - covered by index '%s' on columns (%s)",
 				redundantIndex.Name,
-				strings.Join(redundantIndex.Columns, ", "),
+				redundantCols,
 				coveringIndex.Name,
-				strings.Join(coveringIndex.Columns, ", "),
+				coveringCols,
 			)
 			suggestion = fmt.Sprintf(
 				"Consider dropping index '%s' as it is fully covered by '%s'. "+
@@ -331,9 +483,16 @@ func createRedundancyViolation(tableName string, redundantIndex statement.Index,
 
 // createPKSuffixViolation creates a violation for redundant PRIMARY KEY suffix
 func createPKSuffixViolation(tableName string, index statement.Index, primaryKey statement.Index, redundantColCount int) Violation {
-	redundantSuffix := index.Columns[len(index.Columns)-redundantColCount:]
-	usefulPrefix := index.Columns[:len(index.Columns)-redundantColCount]
+	// Slice over the structured key parts so prefix lengths / expression parts
+	// are positioned correctly even when the flat Columns slice would drop them.
+	parts := indexParts(index)
+	redundantSuffix := parts[len(parts)-redundantColCount:]
+	usefulPrefix := parts[:len(parts)-redundantColCount]
 	pkCols := primaryKey.Columns[:redundantColCount]
+
+	fullCols := renderIndexParts(parts)
+	redundantSuffixStr := renderIndexParts(redundantSuffix)
+	usefulPrefixStr := renderIndexParts(usefulPrefix)
 
 	var message, suggestion string
 
@@ -343,15 +502,15 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 			"Index '%s' on columns (%s) has redundant PRIMARY KEY suffix (%s). "+
 				"InnoDB automatically appends PK columns to secondary indexes.",
 			index.Name,
-			strings.Join(index.Columns, ", "),
-			strings.Join(redundantSuffix, ", "),
+			fullCols,
+			redundantSuffixStr,
 		)
 		suggestion = fmt.Sprintf(
 			"Redefine index '%s' as INDEX (%s). "+
 				"InnoDB will automatically append the PK columns (%s) internally, "+
 				"so explicitly including them wastes space and provides no benefit.",
 			index.Name,
-			strings.Join(usefulPrefix, ", "),
+			usefulPrefixStr,
 			strings.Join(pkCols, ", "),
 		)
 	} else {
@@ -360,15 +519,15 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 			"Index '%s' on columns (%s) has redundant PRIMARY KEY prefix suffix (%s). "+
 				"InnoDB automatically appends full PK columns (%s) to secondary indexes.",
 			index.Name,
-			strings.Join(index.Columns, ", "),
-			strings.Join(redundantSuffix, ", "),
+			fullCols,
+			redundantSuffixStr,
 			strings.Join(primaryKey.Columns, ", "),
 		)
 		suggestion = fmt.Sprintf(
 			"Redefine index '%s' as INDEX (%s). "+
 				"InnoDB will automatically append the full PK (%s) internally.",
 			index.Name,
-			strings.Join(usefulPrefix, ", "),
+			usefulPrefixStr,
 			strings.Join(primaryKey.Columns, ", "),
 		)
 	}
@@ -382,8 +541,8 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 		Context: map[string]any{
 			"index_name":          index.Name,
 			"full_columns":        index.Columns,
-			"useful_columns":      usefulPrefix,
-			"redundant_suffix":    redundantSuffix,
+			"useful_columns":      usefulPrefixStr,
+			"redundant_suffix":    redundantSuffixStr,
 			"primary_key_columns": primaryKey.Columns,
 			"redundant_col_count": redundantColCount,
 		},
@@ -393,22 +552,27 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 // createPKPrefixViolation creates a violation for a secondary index that
 // leads with the full PRIMARY KEY.
 func createPKPrefixViolation(tableName string, index statement.Index, primaryKey statement.Index, redundantColCount int) Violation {
-	redundantPrefix := index.Columns[:redundantColCount]
-	usefulSuffix := index.Columns[redundantColCount:]
+	parts := indexParts(index)
+	redundantPrefix := parts[:redundantColCount]
+	usefulSuffix := parts[redundantColCount:]
+
+	fullCols := renderIndexParts(parts)
+	redundantPrefixStr := renderIndexParts(redundantPrefix)
+	usefulSuffixStr := renderIndexParts(usefulSuffix)
 
 	message := fmt.Sprintf(
 		"Index '%s' on columns (%s) leads with PRIMARY KEY columns (%s). "+
 			"Point and equality lookups by PRIMARY KEY are served by the clustered index directly, "+
 			"and InnoDB appends PK columns to secondary indexes — the leading PK columns add no capability.",
 		index.Name,
-		strings.Join(index.Columns, ", "),
-		strings.Join(redundantPrefix, ", "),
+		fullCols,
+		redundantPrefixStr,
 	)
 	suggestion := fmt.Sprintf(
 		"Redefine index '%s' as INDEX (%s) — InnoDB will append PRIMARY KEY (%s) internally — "+
 			"or drop it entirely if the PRIMARY KEY alone covers the queries that use it.",
 		index.Name,
-		strings.Join(usefulSuffix, ", "),
+		usefulSuffixStr,
 		strings.Join(primaryKey.Columns, ", "),
 	)
 
@@ -421,8 +585,8 @@ func createPKPrefixViolation(tableName string, index statement.Index, primaryKey
 		Context: map[string]any{
 			"index_name":          index.Name,
 			"full_columns":        index.Columns,
-			"redundant_prefix":    redundantPrefix,
-			"useful_columns":      usefulSuffix,
+			"redundant_prefix":    redundantPrefixStr,
+			"useful_columns":      usefulSuffixStr,
 			"primary_key_columns": primaryKey.Columns,
 			"redundant_col_count": redundantColCount,
 		},

--- a/pkg/lint/lint_redundant_indexes.go
+++ b/pkg/lint/lint_redundant_indexes.go
@@ -281,18 +281,22 @@ func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 		return false
 	}
 
-	// A UNIQUE index enforces uniqueness over its exact column set. A wider
-	// covering index (UNIQUE or PK on more columns) enforces a *different*
-	// uniqueness scope and so does not subsume the constraint. UNIQUE is
-	// therefore only redundant when an exact-column-set duplicate also
-	// enforces uniqueness over those columns.
+	// A UNIQUE index enforces uniqueness over its exact key parts. Dropping it
+	// is only safe when another index enforces an *identical* uniqueness
+	// guarantee, which requires an EXACT key-part match — same columns, same
+	// prefix lengths, same expressions, same order. Prefix coverage is NOT
+	// sufficient here: UNIQUE(name) does not enforce uniqueness of a 10-char
+	// prefix, so UNIQUE(name(10)) is not redundant to it even though name(10)
+	// is "covered" by name for read purposes. Likewise a wider covering index
+	// (UNIQUE or PK on more columns) enforces a different uniqueness scope and
+	// does not subsume the constraint.
 	if indexA.Type == "UNIQUE" {
-		if len(partsA) != len(partsB) {
-			return false
-		}
 		if indexB.Type != "UNIQUE" && indexB.Type != "PRIMARY KEY" {
 			return false
 		}
+		// Exact key-part equality is required so dropping indexA never drops a
+		// uniqueness guarantee that indexB does not also provide.
+		return indexColumnsEqual(partsA, partsB)
 	}
 
 	// indexA is redundant when it is a coverable prefix of (or exact duplicate
@@ -516,8 +520,9 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 	} else {
 		// Prefix of PK is redundant
 		message = fmt.Sprintf(
-			"Index '%s' on columns (%s) has redundant PRIMARY KEY prefix suffix (%s). "+
-				"InnoDB automatically appends full PK columns (%s) to secondary indexes.",
+			"Index '%s' on columns (%s) has a redundant PRIMARY KEY suffix (%s) — a leading prefix of the PRIMARY KEY appearing at the end of the index. "+
+				"InnoDB automatically appends the full PK columns (%s) to secondary indexes, "+
+				"so spelling out part of the PK at the end of the index is redundant.",
 			index.Name,
 			fullCols,
 			redundantSuffixStr,

--- a/pkg/lint/lint_redundant_indexes_test.go
+++ b/pkg/lint/lint_redundant_indexes_test.go
@@ -1331,6 +1331,54 @@ func TestRedundantIndexLinter_PrefixLengths(t *testing.T) {
 		require.NotContains(t, shortMsg, "duplicate", "differing prefix lengths are not duplicates")
 		require.False(t, longViolated, "name(20) must NOT be covered by name(10)")
 	})
+
+	t.Run("UNIQUE prefix index NOT redundant to UNIQUE full-column index", func(t *testing.T) {
+		// UNIQUE(name(10)) enforces uniqueness over the first 10 characters of
+		// name; UNIQUE(name) enforces uniqueness over the WHOLE column. The two
+		// constraints are different: dropping UNIQUE(name(10)) would stop
+		// rejecting rows that collide on their first 10 chars but differ
+		// overall. Redundancy for a UNIQUE candidate-for-removal therefore
+		// requires EXACT key-part equality (including prefix length), not the
+		// read-side prefix coverage that name(10) has under name. Neither index
+		// may be flagged.
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			UNIQUE KEY u_prefix (name(10)),
+			UNIQUE KEY u_full (name)
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		prefixViolated, prefixMsg := indexViolated(violations, "u_prefix")
+		fullViolated, fullMsg := indexViolated(violations, "u_full")
+		require.False(t, prefixViolated,
+			"UNIQUE(name(10)) must NOT be redundant to UNIQUE(name) — it enforces prefix uniqueness the full-column index does not; got: %s", prefixMsg)
+		require.False(t, fullViolated,
+			"UNIQUE(name) must NOT be redundant to UNIQUE(name(10)); got: %s", fullMsg)
+	})
+
+	t.Run("exact-duplicate UNIQUE prefix indexes ARE still flagged", func(t *testing.T) {
+		// Two UNIQUE indexes with the IDENTICAL prefix length enforce the exact
+		// same uniqueness guarantee, so one is a genuine duplicate of the other
+		// and must still be reported.
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			UNIQUE KEY u1 (name(10)),
+			UNIQUE KEY u2 (name(10))
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		violated, msg := indexViolated(violations, "u2")
+		require.True(t, violated, "exact-duplicate UNIQUE prefix indexes should be flagged, violations: %v", violations)
+		require.Contains(t, msg, "duplicate")
+	})
 }
 
 // TestRedundantIndexLinter_CaseInsensitiveColumns verifies that column-name

--- a/pkg/lint/lint_redundant_indexes_test.go
+++ b/pkg/lint/lint_redundant_indexes_test.go
@@ -1108,6 +1108,252 @@ func TestRedundantIndexLinter_PostStateEvaluation(t *testing.T) {
 	require.True(t, flaggedAtAdd, "ADD INDEX should surface the leading-PK warning at the time the index is introduced")
 }
 
+// indexViolated is a small helper that reports whether the linter flagged
+// indexName, and returns the matching message when it did.
+func indexViolated(violations []Violation, indexName string) (bool, string) {
+	for _, v := range violations {
+		if v.Location != nil && v.Location.Index != nil && *v.Location.Index == indexName {
+			return true, v.Message
+		}
+	}
+	return false, ""
+}
+
+// TestRedundantIndexLinter_UniquePartialPKSuffix is a regression test for the
+// bug where a UNIQUE index whose trailing columns happened to be a (partial)
+// prefix of the PRIMARY KEY was flagged with a redundant-PK-suffix warning. The
+// suggested rewrite would have dropped real uniqueness columns from the index.
+//
+// A FULL-PK suffix on a UNIQUE index remains flagged (uniqueness is already
+// guaranteed by the PK, so the spelled-out suffix is vacuous), and non-unique
+// indexes with a partial-PK suffix are still flagged.
+func TestRedundantIndexLinter_UniquePartialPKSuffix(t *testing.T) {
+	tests := []struct {
+		name           string
+		createTable    string
+		index          string
+		expectViolated bool
+	}{
+		{
+			// UNIQUE (x, y, a) is NOT implied by PK (a, b). The trailing `a` is
+			// part of the uniqueness scope, not redundant PK bookkeeping.
+			name: "UNIQUE with partial-PK suffix NOT flagged",
+			createTable: `CREATE TABLE t1 (
+				a INT, b INT, x INT, y INT,
+				PRIMARY KEY (a, b),
+				UNIQUE KEY ux (x, y, a)
+			)`,
+			index:          "ux",
+			expectViolated: false,
+		},
+		{
+			// UNIQUE (x, a, b) ends with the FULL PK (a, b). Uniqueness over
+			// (x, a, b) is already guaranteed because (a, b) alone is unique, so
+			// spelling out the PK suffix is vacuous and is still flagged.
+			name: "UNIQUE with full-PK suffix still flagged",
+			createTable: `CREATE TABLE t1 (
+				a INT, b INT, x INT,
+				PRIMARY KEY (a, b),
+				UNIQUE KEY ux (x, a, b)
+			)`,
+			index:          "ux",
+			expectViolated: true,
+		},
+		{
+			// Non-unique INDEX (x, y, a) with PK (a, b): partial-PK suffix `a`
+			// is genuinely redundant (InnoDB auto-appends the PK), so still flag.
+			name: "non-unique with partial-PK suffix still flagged",
+			createTable: `CREATE TABLE t1 (
+				a INT, b INT, x INT, y INT,
+				PRIMARY KEY (a, b),
+				INDEX idx (x, y, a)
+			)`,
+			index:          "idx",
+			expectViolated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := &RedundantIndexLinter{}
+			ct, err := statement.ParseCreateTable(tt.createTable)
+			require.NoError(t, err)
+
+			violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+
+			violated, msg := indexViolated(violations, tt.index)
+			if tt.expectViolated {
+				require.True(t, violated, "expected %s to be flagged, violations: %v", tt.index, violations)
+				require.Contains(t, msg, "suffix")
+			} else {
+				require.False(t, violated, "expected %s NOT to be flagged, got: %s", tt.index, msg)
+			}
+		})
+	}
+}
+
+// TestRedundantIndexLinter_FunctionalIndexes is a regression test for the bug
+// where functional (expression) indexes were treated as zero-column indexes
+// (because the deprecated Index.Columns slice drops expression key parts) and
+// were therefore always reported as redundant to any ordinary index.
+func TestRedundantIndexLinter_FunctionalIndexes(t *testing.T) {
+	t.Run("functional index NOT redundant to ordinary index", func(t *testing.T) {
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			INDEX idx_name (name),
+			INDEX functional_index ((LOWER(name)))
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		require.Empty(t, violations, "expression index must not be redundant to an ordinary column index: %v", violations)
+	})
+
+	t.Run("two identical functional indexes flagged as duplicates", func(t *testing.T) {
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			INDEX f1 ((LOWER(name))),
+			INDEX f2 ((LOWER(name)))
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		violated, msg := indexViolated(violations, "f2")
+		require.True(t, violated, "identical functional indexes should be flagged as duplicates, violations: %v", violations)
+		require.Contains(t, msg, "duplicate")
+	})
+
+	t.Run("functional index redundant to same-expression-plus-more", func(t *testing.T) {
+		// INDEX ((LOWER(name))) is a coverable prefix of
+		// INDEX ((LOWER(name)), other): the leading expression key part is
+		// identical, so the shorter index is redundant to the longer one. The
+		// trailing column is deliberately NOT a PRIMARY KEY column so the only
+		// possible finding is the prefix-redundancy we are testing.
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			other INT,
+			INDEX f_short ((LOWER(name))),
+			INDEX f_long ((LOWER(name)), other)
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		shortViolated, shortMsg := indexViolated(violations, "f_short")
+		longViolated, _ := indexViolated(violations, "f_long")
+		require.True(t, shortViolated, "f_short should be redundant to f_long, violations: %v", violations)
+		require.Contains(t, shortMsg, "f_long")
+		require.False(t, longViolated, "f_long must NOT be flagged")
+	})
+
+	t.Run("different expressions NOT redundant", func(t *testing.T) {
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			INDEX f_lower ((LOWER(name))),
+			INDEX f_upper ((UPPER(name)))
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		require.Empty(t, violations, "distinct expression indexes must not be redundant: %v", violations)
+	})
+}
+
+// TestRedundantIndexLinter_PrefixLengths is a regression test for the bug where
+// prefix lengths were ignored (Index.Columns drops the (n) in col(n)), so a
+// prefix index col(10) and the full-column index col were reported as exact
+// duplicates of each other, including an (unsafe) suggestion to drop the full
+// index in favor of the prefix index.
+func TestRedundantIndexLinter_PrefixLengths(t *testing.T) {
+	t.Run("prefix index redundant to full-column index, not vice versa", func(t *testing.T) {
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			INDEX i1 (name(10)),
+			INDEX i2 (name)
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		i1Violated, i1Msg := indexViolated(violations, "i1")
+		i2Violated, _ := indexViolated(violations, "i2")
+		require.True(t, i1Violated, "i1 (name(10)) should be redundant to i2 (name), violations: %v", violations)
+		require.Contains(t, i1Msg, "redundant")
+		require.False(t, i2Violated, "i2 (full column) must NOT be flagged as redundant to a prefix index")
+	})
+
+	t.Run("equal prefix lengths are duplicates", func(t *testing.T) {
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			INDEX i1 (name(10)),
+			INDEX i2 (name(10))
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		violated, msg := indexViolated(violations, "i2")
+		require.True(t, violated, "equal-prefix indexes should be duplicates, violations: %v", violations)
+		require.Contains(t, msg, "duplicate")
+	})
+
+	t.Run("longer prefix covers shorter prefix but not the reverse", func(t *testing.T) {
+		// name(20) covers name(10); name(10) does NOT cover name(20).
+		createTable := `CREATE TABLE t1 (
+			id INT PRIMARY KEY,
+			name VARCHAR(255),
+			INDEX i_short (name(10)),
+			INDEX i_long (name(20))
+		)`
+		linter := &RedundantIndexLinter{}
+		ct, err := statement.ParseCreateTable(createTable)
+		require.NoError(t, err)
+
+		violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+		shortViolated, shortMsg := indexViolated(violations, "i_short")
+		longViolated, _ := indexViolated(violations, "i_long")
+		require.True(t, shortViolated, "name(10) should be covered by name(20), violations: %v", violations)
+		require.NotContains(t, shortMsg, "duplicate", "differing prefix lengths are not duplicates")
+		require.False(t, longViolated, "name(20) must NOT be covered by name(10)")
+	})
+}
+
+// TestRedundantIndexLinter_CaseInsensitiveColumns verifies that column-name
+// comparison is case-insensitive (MySQL identifiers are case-insensitive), so
+// INDEX (A) is recognised as redundant to INDEX (a, b).
+func TestRedundantIndexLinter_CaseInsensitiveColumns(t *testing.T) {
+	createTable := `CREATE TABLE t1 (
+		id INT PRIMARY KEY,
+		a INT,
+		b INT,
+		INDEX i1 (A),
+		INDEX i2 (a, b)
+	)`
+	linter := &RedundantIndexLinter{}
+	ct, err := statement.ParseCreateTable(createTable)
+	require.NoError(t, err)
+
+	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
+	violated, msg := indexViolated(violations, "i1")
+	require.True(t, violated, "INDEX (A) should be redundant to INDEX (a, b) (case-insensitive), violations: %v", violations)
+	require.Contains(t, msg, "redundant")
+}
+
 // TestRedundantIndexLinter_AlterTableComplex tests a complex scenario
 // with multiple tables and ALTER statements.
 func TestRedundantIndexLinter_AlterTableComplex(t *testing.T) {


### PR DESCRIPTION
## Problem
The `redundant_indexes` linter compared indexes through the deprecated `Index.Columns` flat string slice (which discards expression key parts and prefix lengths) and applied the partial-PK-suffix rule to UNIQUE indexes. Three wrong, in two cases data-unsafe, findings:
1. A UNIQUE index ending in a *partial* PK prefix (`PK(a,b)` + `UNIQUE(x,y,a)`) was flagged with a suggestion that would **drop a uniqueness constraint**.
2. Functional/expression indexes (`Columns == []`) were treated as zero-column and always reported redundant.
3. `col(n)` vs `col` were reported as mutual exact duplicates, suggesting dropping the full-column index for the prefix one.

## Fix
Move all comparison logic onto `ColumnList` with proper coverage semantics — expressions match only identical expressions; a prefix `col(n)` is covered by `col`/`col(m≥n)` but not the reverse; duplicate detection requires identical prefixes/expressions. Exclude UNIQUE indexes from the partial-PK-suffix branch (full-PK suffix still flagged as vacuous). Column-name comparisons are now case-insensitive to match MySQL semantics, and violation messages render prefix lengths/expressions correctly.

## Testing
New parser-based tests for each case (UNIQUE partial/full-PK suffix, functional vs ordinary, identical functional duplicates, prefix-length coverage, case-insensitivity), each confirmed to fail against the pre-fix code. Full pkg/lint suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
