### PR TITLE
test(checksum): fix flaky TestQueueCapBackpressure overshoot bound

### DIFF
--- a/pkg/checksum/continuous_test.go
+++ b/pkg/checksum/continuous_test.go
@@ -342,15 +342,21 @@ func TestQueueCapBackpressure(t *testing.T) {
 	stats := c.Stats()
 	require.GreaterOrEqual(t, stats.WalkerStalls, uint64(1),
 		"expected at least one walker stall while queue was at MaxQueueSize")
-	// Queue can briefly exceed MaxQueueSize: in-flight workers can finish
-	// and the resultCh buffer can hold results that haven't been processed
-	// yet, both of which become retries when the dispatcher next services
-	// the result arm. The overshoot is bounded by inflight + buffered
-	// results = 2*Concurrency in the worst case. The test cares that the
-	// queue stays bounded near MaxQueueSize, not unbounded — anything
-	// dramatically larger would be the symptom of a real back-pressure
-	// failure. See enqueueRetry's doc comment in continuous.go.
-	require.LessOrEqual(t, stats.RetryQueueDepth, cfg.MaxQueueSize+2*cfg.Concurrency,
+	// Queue can briefly exceed MaxQueueSize. Three sources of work have
+	// already passed the back-pressure gate (which only throttles fresh
+	// walker intake) by the time the queue reaches MaxQueueSize, and each
+	// becomes a retry when its result is serviced:
+	//   - in-flight workers              (up to Concurrency)
+	//   - results buffered in resultCh   (up to Concurrency)
+	//   - the single-slot pendingFresh prefetch the dispatcher stages
+	//     one-ahead of itself             (1)
+	// so the worst-case overshoot is 2*Concurrency+1, not 2*Concurrency.
+	// (Concurrency=1 here => bound 7; the +1 slot is what made the old
+	// 2*Concurrency bound flake at depth 7.) The test cares that the queue
+	// stays bounded near MaxQueueSize, not unbounded — anything dramatically
+	// larger would be the symptom of a real back-pressure failure. See
+	// enqueueRetry's doc comment in continuous.go.
+	require.LessOrEqual(t, stats.RetryQueueDepth, cfg.MaxQueueSize+2*cfg.Concurrency+1,
 		"queue depth should stay bounded under back-pressure")
 }
 


### PR DESCRIPTION
## Flaky test: `TestQueueCapBackpressure`

`pkg/checksum.TestQueueCapBackpressure` intermittently fails with:

```
continuous_test.go:353:
    Error:   "7" is not less than or equal to "6"
    Messages: queue depth should stay bounded under back-pressure
```

It showed up on the CI of several unrelated open PRs (e.g. #938) and is **not** caused by those PR changes. Reproduced locally at ~2% (4 failures / 200 runs, `-race`).

### Mechanism (test-only off-by-one, not a product bug)

The continuous checker applies back-pressure by pausing **fresh** walker intake once `queue.Len() >= MaxQueueSize`. Work that has *already passed that gate* still lands in the retry queue when its result is serviced. The test's overshoot bound counted only two such sources:

- in-flight workers (≤ `Concurrency`)
- results buffered in `resultCh` (≤ `Concurrency`)

…and asserted `RetryQueueDepth <= MaxQueueSize + 2*Concurrency`.

It missed a third source: the dispatcher's **single-slot `pendingFresh` prefetch** (it stages one fresh chunk one-ahead of itself; see `runOnePass` in `pkg/checksum/continuous.go`). That staged item is past the gate too and becomes a retry. So the real worst-case overshoot is `2*Concurrency + 1`. With `MaxQueueSize=4, Concurrency=1` the queue can legitimately reach 7, but the old bound was 6 → flake.

### Fix

Test-only: widen the bound to `MaxQueueSize + 2*Concurrency + 1` and update the comment to enumerate all three overshoot sources. The product back-pressure logic is correct and unchanged.

### Verification

- `go build ./...` and `go vet ./pkg/checksum/` clean.
- `go test ./pkg/checksum/ -run '^TestQueueCapBackpressure$' -count=150 -race` → **150/150 pass** (old assertion would have been expected to fail ~3 times at the observed ~2% rate).
- Full `go test ./pkg/checksum/ -race` passes.

### Related issues

No existing issue tracks this flake (open flaky-test issues cover other tests: #858, #809, #807, #771, #743, #628). This is newly surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)