### PR TITLE
Re-pad BINARY(N) binlog row images to their declared width

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -700,12 +700,15 @@ func (c *binlogClient) processRowsEvent(ev *replication.BinlogEvent, e *replicat
 	tbl := sub.Tables()[0]
 	eventType := parseEventType(ev.Header.EventType)
 
-	// Decode ENUM ordinals / SET bitmasks back to their string form before
-	// we hand the row image to the subscription. The binlog reader yields
-	// them as int64s; if the target column has been migrated to a non-ENUM
-	// type (e.g. VARCHAR) the applier would otherwise insert those integers
-	// as literal values. See TableInfo.DecodeBinlogRow.
-	if tbl.HasEnumOrSetColumns() {
+	// Decode ENUM ordinals / SET bitmasks back to their string form and
+	// re-pad BINARY(N) values (MySQL strips trailing 0x00 from the row
+	// image) before we hand the row image to the subscription. Without
+	// this the applier would insert ENUM/SET integers as literal values
+	// on migrated columns, and replay short BINARY values into targets
+	// that don't re-pad (e.g. VARBINARY). Padding must happen before
+	// PrimaryKeyValues below so binary PK keys match what a SELECT
+	// returns. See TableInfo.DecodeBinlogRow.
+	if tbl.NeedsBinlogRowDecoding() {
 		for _, row := range e.Rows {
 			if err := tbl.DecodeBinlogRow(row); err != nil {
 				return fmt.Errorf("decoding binlog row for %s.%s: %w", tbl.SchemaName, tbl.TableName, err)

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -603,7 +603,10 @@ func (c *gtidClient) processRowsEvent(ev *replication.BinlogEvent, e *replicatio
 	tbl := sub.Tables()[0]
 	eventType := parseEventType(ev.Header.EventType)
 
-	if tbl.HasEnumOrSetColumns() {
+	// Decode ENUM/SET integers and re-pad BINARY(N) values before key
+	// extraction and buffering — see the matching block in binlog.go's
+	// processRowsEvent and TableInfo.DecodeBinlogRow.
+	if tbl.NeedsBinlogRowDecoding() {
 		for _, row := range e.Rows {
 			if err := tbl.DecodeBinlogRow(row); err != nil {
 				return fmt.Errorf("decoding binlog row for %s.%s: %w", tbl.SchemaName, tbl.TableName, err)

--- a/pkg/change/subscription_buffered_datatypes_test.go
+++ b/pkg/change/subscription_buffered_datatypes_test.go
@@ -502,3 +502,112 @@ func fetchJSONColumnCRC(t *testing.T, col string, tbl *table.TableInfo) int64 {
 		col, col, tbl.QuotedTableName)).Scan(&ck))
 	return ck
 }
+
+// TestBufferedBinaryTrailingZerosToVarbinary is the regression test for
+// block/spirit#945 (the gh-ost #909 analog): MySQL strips trailing 0x00
+// pad bytes from BINARY(N) values in the binlog row image
+// (Field_string::pack) and expects the reader to re-pad to the declared
+// width. go-mysql returns the stripped value as-is, so without
+// DecodeBinlogRow's re-padding the buffered replay writes short values
+// into any target column that does not itself re-pad server-side.
+//
+// The destination column here is VARBINARY — the case where the
+// truncation is visible. (With a BINARY(N) destination MySQL re-pads on
+// INSERT, masking the bug; that shape is covered by datatypeCases.)
+func TestBufferedBinaryTrailingZerosToVarbinary(t *testing.T) {
+	srcDDL := `CREATE TABLE subscription_test (
+		id INT NOT NULL AUTO_INCREMENT,
+		touched INT NOT NULL DEFAULT 0,
+		val BINARY(8) NOT NULL,
+		PRIMARY KEY (id)
+	)`
+	dstDDL := `CREATE TABLE _subscription_test_new (
+		id INT NOT NULL AUTO_INCREMENT,
+		touched INT NOT NULL DEFAULT 0,
+		val VARBINARY(16) NOT NULL,
+		PRIMARY KEY (id)
+	)`
+	srcTable, dstTable := setupTestTables(t, srcDDL, dstDDL)
+	db, client := startBufferedSubscriptionFor(t, srcTable, dstTable)
+
+	// Phase 1: INSERT values whose row images are stripped to different
+	// lengths: 4 bytes + 4 trailing zeros, all zeros (stripped to
+	// nothing), interior zeros with a non-zero tail (not stripped), and
+	// no zeros at all.
+	testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO %s (val) VALUES
+		(X'aabbccdd00000000'),
+		(X'0000000000000000'),
+		(X'1122003300440055'),
+		(X'ffffffffffffffff')`, srcTable.QuotedTableName))
+	flushAndSync(t, db, client, srcTable, dstTable)
+
+	// Every destination row must hold the full 8-byte width. The <=>
+	// comparison in flushAndSync already proves equality; this assertion
+	// states the original failure mode explicitly.
+	var shortRows int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE OCTET_LENGTH(val) <> 8", dstTable.QuotedTableName)).Scan(&shortRows))
+	require.Zero(t, shortRows, "BINARY(8) values must replay into VARBINARY at their full 8-byte width")
+
+	// Phase 2: UPDATE an unrelated column so the full AFTER image drags
+	// the trailing-zero values back through the applier.
+	testutils.RunSQL(t, fmt.Sprintf("UPDATE %s SET touched = touched + 1", srcTable.QuotedTableName))
+	flushAndSync(t, db, client, srcTable, dstTable)
+
+	// Phase 3: DELETE a row.
+	testutils.RunSQL(t, fmt.Sprintf("DELETE FROM %s ORDER BY id LIMIT 1", srcTable.QuotedTableName))
+	flushAndSync(t, db, client, srcTable, dstTable)
+}
+
+// TestBufferedBinaryPKTrailingZeros covers the primary-key side of
+// block/spirit#945: when a BINARY(N) column is part of the PRIMARY KEY,
+// a stripped row image also strips the replication key. A DELETE built
+// from the stripped key (e.g. WHERE pk IN ('a')) never matches the
+// full-width row in the destination — binary comparison does not pad —
+// so deletes silently miss and the destination diverges.
+func TestBufferedBinaryPKTrailingZeros(t *testing.T) {
+	srcDDL := `CREATE TABLE subscription_test (
+		pk BINARY(8) NOT NULL,
+		val INT NOT NULL,
+		PRIMARY KEY (pk)
+	)`
+	dstDDL := `CREATE TABLE _subscription_test_new (
+		pk BINARY(8) NOT NULL,
+		val INT NOT NULL,
+		PRIMARY KEY (pk)
+	)`
+	srcTable, dstTable := setupTestTables(t, srcDDL, dstDDL)
+	db, client := startBufferedSubscriptionFor(t, srcTable, dstTable)
+
+	// Key bytes are ASCII + trailing NULs: NUL is valid UTF-8, so the
+	// quoted key literal that DeleteKeys builds stays inside what the
+	// unsafe-warning check allows. (Keys containing non-UTF8 bytes like
+	// 0xBB hit a separate pre-existing quoting limitation in DeleteKeys,
+	// unrelated to the row-image padding under test here.)
+	testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO %s (pk, val) VALUES
+		(X'6100000000000000', 1),
+		(X'6200000000000000', 2),
+		(X'6364656600000000', 3)`, srcTable.QuotedTableName))
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+
+	// UPDATE one row, DELETE another — both replicate by key.
+	testutils.RunSQL(t, fmt.Sprintf("UPDATE %s SET val = 10 WHERE pk = X'6100000000000000'", srcTable.QuotedTableName))
+	testutils.RunSQL(t, fmt.Sprintf("DELETE FROM %s WHERE pk = X'6200000000000000'", srcTable.QuotedTableName))
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+
+	var srcCount, dstCount int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", srcTable.QuotedTableName)).Scan(&srcCount))
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable.QuotedTableName)).Scan(&dstCount))
+	require.Equal(t, 2, srcCount)
+	require.Equal(t, srcCount, dstCount, "DELETE by a trailing-zero BINARY PK must replicate (stripped keys never match)")
+
+	var diff int
+	require.NoError(t, db.QueryRowContext(t.Context(), fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s s LEFT JOIN %s d ON s.pk = d.pk WHERE d.pk IS NULL OR NOT (s.val <=> d.val)",
+		srcTable.QuotedTableName, dstTable.QuotedTableName)).Scan(&diff))
+	require.Zero(t, diff, "destination rows must match source by full-width binary PK")
+}

--- a/pkg/table/binarypad.go
+++ b/pkg/table/binarypad.go
@@ -1,0 +1,80 @@
+package table
+
+import "strings"
+
+// BINARY(N) binlog re-padding.
+//
+// MySQL stores BINARY(N) values right-padded with 0x00 to exactly N
+// bytes, and a SELECT returns all N bytes. The binlog row image,
+// however, is written via Field_string::pack(), which strips trailing
+// pad bytes (0x00 for the binary charset) to save space — the reader
+// is expected to re-pad to the column width. go-mysql returns the
+// stripped value as-is, so without re-padding, spirit's buffered
+// replay writes short values into any target column that does not
+// itself re-pad (e.g. BINARY(N) -> VARBINARY(M), the gh-ost #909
+// analog — see block/spirit#945). A stripped value in a binary
+// PRIMARY KEY also breaks key matching: a DELETE built from the
+// stripped key (0xAABBCCDD) never matches the padded row in the
+// target, and watermark comparisons disagree with chunker boundaries
+// read via SELECT.
+//
+// CHAR(N) is also stripped in the row image (trailing spaces), but
+// needs no correction: a SELECT of a CHAR column strips trailing
+// spaces too, so the copier and replay paths agree.
+
+// isBinaryColumnType reports whether a column_type string from
+// information_schema is a fixed-width BINARY, e.g. "binary(20)".
+// VARBINARY/BLOB are variable-width and never pad, so they are
+// excluded.
+func isBinaryColumnType(mysqlType string) bool {
+	t := strings.ToLower(mysqlType)
+	return t == "binary" || strings.HasPrefix(t, "binary(")
+}
+
+// parseBinaryColumnWidth extracts N from a "binary(N)" column_type
+// string. A bare "binary" is BINARY(1). Returns 0 (no padding) for
+// anything malformed — fail-open is safe here because padding is an
+// optimization for correctness on *short* values; an unpadded value is
+// no worse than today's behaviour.
+func parseBinaryColumnWidth(mysqlType string) int {
+	t := strings.ToLower(mysqlType)
+	if t == "binary" {
+		return 1
+	}
+	inner, ok := strings.CutPrefix(t, "binary(")
+	if !ok {
+		return 0
+	}
+	inner, ok = strings.CutSuffix(inner, ")")
+	if !ok {
+		return 0
+	}
+	width := 0
+	for _, c := range inner {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		width = width*10 + int(c-'0')
+	}
+	return width
+}
+
+// padBinaryValue right-pads a BINARY(N) row-image value back to its
+// declared width. Values already at (or somehow above) the width, and
+// values of unexpected types (e.g. nil for NULL), are returned
+// unchanged.
+func padBinaryValue(value any, width int) any {
+	switch v := value.(type) {
+	case string:
+		if len(v) < width {
+			return v + strings.Repeat("\x00", width-len(v))
+		}
+	case []byte:
+		if len(v) < width {
+			padded := make([]byte, width)
+			copy(padded, v)
+			return padded
+		}
+	}
+	return value
+}

--- a/pkg/table/binarypad_test.go
+++ b/pkg/table/binarypad_test.go
@@ -1,0 +1,48 @@
+package table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBinaryColumnType(t *testing.T) {
+	require.True(t, isBinaryColumnType("binary(20)"))
+	require.True(t, isBinaryColumnType("BINARY(1)"))
+	require.True(t, isBinaryColumnType("binary"))
+	require.False(t, isBinaryColumnType("varbinary(20)"))
+	require.False(t, isBinaryColumnType("blob"))
+	require.False(t, isBinaryColumnType("tinyblob"))
+	require.False(t, isBinaryColumnType("char(20)"))
+	require.False(t, isBinaryColumnType("bit(8)"))
+}
+
+func TestParseBinaryColumnWidth(t *testing.T) {
+	require.Equal(t, 20, parseBinaryColumnWidth("binary(20)"))
+	require.Equal(t, 1, parseBinaryColumnWidth("binary(1)"))
+	require.Equal(t, 255, parseBinaryColumnWidth("BINARY(255)"))
+	require.Equal(t, 1, parseBinaryColumnWidth("binary")) // bare BINARY is BINARY(1)
+	// Fail-open on anything malformed: 0 means "no padding".
+	require.Equal(t, 0, parseBinaryColumnWidth("binary("))
+	require.Equal(t, 0, parseBinaryColumnWidth("binary(x)"))
+	require.Equal(t, 0, parseBinaryColumnWidth("varbinary(20)"))
+}
+
+func TestPadBinaryValue(t *testing.T) {
+	// Stripped string values are re-padded to the declared width.
+	require.Equal(t, "\xaa\xbb\x00\x00", padBinaryValue("\xaa\xbb", 4))
+	// All-zero values are stripped to the empty string by MySQL.
+	require.Equal(t, "\x00\x00\x00\x00", padBinaryValue("", 4))
+	// Full-width values are unchanged.
+	require.Equal(t, "\xaa\xbb\xcc\xdd", padBinaryValue("\xaa\xbb\xcc\xdd", 4))
+	// []byte values pad without mutating the input.
+	in := []byte{0xaa}
+	out := padBinaryValue(in, 3)
+	require.Equal(t, []byte{0xaa, 0x00, 0x00}, out)
+	require.Equal(t, []byte{0xaa}, in)
+	// NULL (nil) and unexpected types pass through.
+	require.Nil(t, padBinaryValue(nil, 4))
+	require.Equal(t, int64(7), padBinaryValue(int64(7), 4))
+	// Over-width values (shouldn't happen) are left alone.
+	require.Equal(t, "\x01\x02\x03\x04\x05", padBinaryValue("\x01\x02\x03\x04\x05", 4))
+}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -40,6 +40,7 @@ type TableInfo struct {
 	Indexes                     []string          // all the index names
 	columnsMySQLTps             map[string]string // map from column name to MySQL type
 	enumSetElements             map[int][]string  // parsed ENUM/SET element list, keyed by column ordinal; only present for ENUM/SET columns
+	binaryColumnWidths          map[int]int       // declared width of BINARY(N) columns, keyed by column ordinal; only present for fixed-width BINARY columns
 	KeyColumns                  []string          // the column names of the primaryKey
 	keyColumnsMySQLTp           []string          // the MySQL types of the primaryKey
 	KeyIsAutoInc                bool              // if pk[0] is an auto_increment column
@@ -212,6 +213,7 @@ func (t *TableInfo) setColumns(ctx context.Context) error {
 	t.NonGeneratedColumns = []string{}
 	t.columnsMySQLTps = make(map[string]string)
 	t.enumSetElements = nil
+	t.binaryColumnWidths = nil
 	for rows.Next() {
 		var col, tp, expression string
 		if err := rows.Scan(&col, &tp, &expression); err != nil {
@@ -231,6 +233,14 @@ func (t *TableInfo) setColumns(ctx context.Context) error {
 				t.enumSetElements = make(map[int][]string)
 			}
 			t.enumSetElements[len(t.Columns)-1] = elements
+		}
+		if isBinaryColumnType(tp) {
+			if width := parseBinaryColumnWidth(tp); width > 0 {
+				if t.binaryColumnWidths == nil {
+					t.binaryColumnWidths = make(map[int]int)
+				}
+				t.binaryColumnWidths[len(t.Columns)-1] = width
+			}
 		}
 	}
 	if rows.Err() != nil {
@@ -499,30 +509,51 @@ func (t *TableInfo) GetColumnMySQLType(col string) (string, bool) {
 }
 
 // HasEnumOrSetColumns reports whether any column on this table is an
-// ENUM or SET. Used to skip the per-row decoding hot path when there's
-// nothing to decode.
+// ENUM or SET.
+//
+// Deprecated: gate DecodeBinlogRow calls on NeedsBinlogRowDecoding
+// instead — DecodeBinlogRow now also re-pads BINARY(N) values, which
+// this predicate does not account for.
 func (t *TableInfo) HasEnumOrSetColumns() bool {
 	return len(t.enumSetElements) > 0
 }
 
-// DecodeBinlogRow converts ENUM and SET values in a binlog row image
-// from their integer wire format (ENUM ordinal / SET bitmask) back to
-// the string form. Mutates the slice in place.
+// NeedsBinlogRowDecoding reports whether DecodeBinlogRow would do any
+// work for this table: it has ENUM/SET columns (ordinal/bitmask
+// decoding) or fixed-width BINARY columns (trailing 0x00 re-padding).
+// Used to skip the per-row decoding hot path when there's nothing to
+// decode.
+func (t *TableInfo) NeedsBinlogRowDecoding() bool {
+	return len(t.enumSetElements) > 0 || len(t.binaryColumnWidths) > 0
+}
+
+// DecodeBinlogRow normalizes a binlog row image in place so the
+// buffered replay path can feed it to the applier as a
+// REPLACE INTO ... VALUES:
 //
-// Why: the go-mysql binlog reader yields ENUM as int64 ordinals and SET
-// as int64 bitmasks. Spirit's buffered replay path takes the row image
-// verbatim and feeds it to the applier as a REPLACE INTO ... VALUES.
-// If the target column has been migrated to a non-ENUM type
-// (e.g. VARCHAR), MySQL inserts those integers as literal values
-// instead of the original strings, corrupting data. Decoding here
-// restores the string form before the applier sees it.
+//   - ENUM and SET values are converted from their integer wire format
+//     (ENUM ordinal / SET bitmask) back to the string form. The
+//     go-mysql binlog reader yields them as int64s; if the target
+//     column has been migrated to a non-ENUM type (e.g. VARCHAR),
+//     MySQL would insert those integers as literal values instead of
+//     the original strings, corrupting data.
+//   - BINARY(N) values are right-padded with 0x00 back to their
+//     declared width. MySQL strips trailing pad bytes from the row
+//     image (Field_string::pack) and expects the reader to re-pad;
+//     without this, values with trailing zeros are replayed short into
+//     targets that don't re-pad server-side (e.g. VARBINARY), and
+//     binary primary-key lookups miss. See pkg/table/binarypad.go and
+//     block/spirit#945.
 //
-// nil values (NULL columns) and rows with no ENUM/SET columns are a
-// no-op. If the table has no ENUM/SET columns at all, callers should
-// gate with HasEnumOrSetColumns and skip the call entirely.
+// nil values (NULL columns) and rows with nothing to decode are a
+// no-op. If the table has no ENUM/SET/BINARY columns at all, callers
+// should gate with NeedsBinlogRowDecoding and skip the call entirely.
 func (t *TableInfo) DecodeBinlogRow(row []any) error {
-	if len(t.enumSetElements) == 0 {
-		return nil
+	for ord, width := range t.binaryColumnWidths {
+		if ord >= len(row) {
+			continue
+		}
+		row[ord] = padBinaryValue(row[ord], width)
 	}
 	for ord, elements := range t.enumSetElements {
 		if ord >= len(row) {


### PR DESCRIPTION
## Summary

Fixes #945 (`TestBinaryToVarbinaryConcurrentDML` flake). The flake is the visible edge of a **deterministic data-corruption bug** in the buffered replay path, not an environmental issue.

## Root cause

MySQL strips trailing `0x00` pad bytes from `BINARY(N)` values when writing the binlog row image (`Field_string::pack` trims the charset pad character; for the binary charset that is `0x00`) and expects the reader to re-pad to the declared column width. go-mysql's `decodeString` returns the stripped value as-is, and spirit's buffered replay applied it verbatim. Two consequences:

1. **`BINARY(N) → VARBINARY(M)` replays short values** (the gh-ost #909 analog). A `BINARY(N)` destination re-pads server-side on INSERT, masking the bug — which is why the existing same-type datatype tests never caught it. A `VARBINARY` destination stores the stripped bytes.
2. **Trailing-zero `BINARY` primary keys break key matching**: a replayed DELETE builds its key literal from the stripped bytes and never matches the full-width row in the target (binary comparison does not pad).

## Why it looked flaky

The checksum phase detects the divergence and recopies damaged chunks from source, so most runs pass — the corruption happens on **every** run, but is usually repaired before cutover. On `main`, every local run of `TestBinaryToVarbinaryConcurrentDML` logs:

```
WARN chunk verification failed chunk="`id` >= 1 AND `id` < 1001" reason="checksum mismatch"
     sourceChecksum=1218126469 targetChecksum=4263366559 sourceCount=640 targetCount=640
WARN inspection revealed row checksum mismatch pk=3 ...
WARN inspection revealed row checksum mismatch pk=4 ...
```

— the **exact** chunk and checksums from the failing CI runs in #945 (pks 3–4 are the test's `update-target` rows), plus a second damaged chunk full of `insert-during` rows. Rows whose replay lands after their chunk was verified (or in the post-checksum flush, which is never re-verified) keep the truncated value. Under CI load the binlog reader lags more, pushing more replays past checksum verification — hence the intermittent `OCTET_LENGTH <> 20` failures on a subset of rows.

## Fix

`TableInfo` now records the declared width of fixed-width `BINARY` columns (`setColumns`), and `DecodeBinlogRow` — which both change clients (`binlog.go`, `gtid.go`) already call per row image, **before** key extraction — right-pads short `string`/`[]byte` values back to that width. The call-site gate moves from `HasEnumOrSetColumns` to a new `NeedsBinlogRowDecoding` (ENUM/SET **or** fixed-width BINARY); `HasEnumOrSetColumns` is kept but deprecated for out-of-tree `change.Source` implementations.

Re-padding is always correct: MySQL guarantees a stored `BINARY(N)` value is exactly N bytes, so any shorter row-image value can only be a stripped image. `CHAR(N)` is also stripped in the row image (trailing spaces) but needs no correction — `SELECT` strips trailing spaces from `CHAR` too, so the copier and replay paths already agree.

## Tests

- `pkg/change/TestBufferedBinaryTrailingZerosToVarbinary` — the #945 shape (`BINARY(8)` → `VARBINARY(16)`), deterministic, no checksum to mask it. Fails on `main` ("2 destination row(s) differ"), passes with the fix.
- `pkg/change/TestBufferedBinaryPKTrailingZeros` — trailing-zero `BINARY` PK: UPDATE + DELETE replication. Fails on `main` (DELETE misses, destination diverges), passes with the fix.
- `pkg/table` unit tests for the new helpers (`isBinaryColumnType`, `parseBinaryColumnWidth`, `padBinaryValue`).
- `TestBinaryToVarbinaryConcurrentDML` passes locally (incl. `-race -count=2`) with **zero** checksum-mismatch warnings, versus mismatches in two chunks on every run of `main`.

While writing the PK test I found an adjacent pre-existing limitation: `DeleteKeys` quotes raw key bytes as a string literal, so a binary PK containing non-UTF8 bytes (e.g. `0xBB`) trips the unsafe-warning check (`Invalid utf8mb4 character string`) and fails the flush. That is independent of this fix (stripped keys hit it the same way) — I'll file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)