### PR TITLE
Build DELETE key literals from typed values, not the reversed hash (#948)

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
@@ -56,11 +57,11 @@ type Applier interface {
 	// For the subscription: callback will update binlog coordinates
 	Apply(ctx context.Context, chunk *table.Chunk, rows [][]any, callback ApplyCallback) error
 
-	// DeleteKeys deletes rows by their key values synchronously.
-	// The keys are hashed key strings (from utils.HashKey).
-	// If lock is non-nil, the delete is executed under the table lock.
-	// Returns the number of rows affected and any error.
-	DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys []string, lock *dbconn.TableLock) (int64, error)
+	// DeleteKeys deletes rows by their key values synchronously. Each entry
+	// in keys is one key tuple of the original (typed) column values, in
+	// sourceTable.KeyColumns order. If lock is non-nil, the delete runs
+	// under the table lock. Returns the number of rows affected.
+	DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys [][]any, lock *dbconn.TableLock) (int64, error)
 
 	// UpsertRows performs an upsert (INSERT ... ON DUPLICATE KEY UPDATE) synchronously.
 	// The rows are LogicalRow structs containing the row images.
@@ -88,6 +89,46 @@ type Applier interface {
 type LogicalRow struct {
 	IsDeleted bool
 	RowImage  []any
+}
+
+// deleteKeysInClause renders key value tuples into the element list of a
+// `(keycols) IN (...)` clause. Values go through table.Datum so binary
+// keys are hex-encoded; a quoted non-UTF-8 literal would trip MySQL's
+// utf8mb4 warning (block/spirit#948). Single-column keys render as a bare
+// literal, composite keys as a parenthesized tuple.
+func deleteKeysInClause(sourceTable *table.TableInfo, keys [][]any) (string, error) {
+	// Resolve each key column's type once, not per key: parsing the type
+	// string is the dominant cost of building a Datum.
+	colTypes := make([]table.ColumnType, len(sourceTable.KeyColumns))
+	for j, colName := range sourceTable.KeyColumns {
+		typeStr, ok := sourceTable.GetColumnMySQLType(colName)
+		if !ok {
+			return "", fmt.Errorf("key column %s not found in table %s", colName, sourceTable.TableName)
+		}
+		colTypes[j] = table.NewColumnType(typeStr)
+	}
+
+	pkValues := make([]string, 0, len(keys))
+	for _, keyTuple := range keys {
+		if len(keyTuple) != len(colTypes) {
+			return "", fmt.Errorf("delete key has %d component(s) but table %s has %d key column(s)",
+				len(keyTuple), sourceTable.TableName, len(colTypes))
+		}
+		parts := make([]string, len(keyTuple))
+		for j := range keyTuple {
+			datum, err := table.NewDatumFromValueWithType(keyTuple[j], colTypes[j])
+			if err != nil {
+				return "", fmt.Errorf("failed to convert delete key value for column %s: %w", sourceTable.KeyColumns[j], err)
+			}
+			parts[j] = datum.String()
+		}
+		if len(parts) == 1 {
+			pkValues = append(pkValues, parts[0])
+		} else {
+			pkValues = append(pkValues, "("+strings.Join(parts, ",")+")")
+		}
+	}
+	return strings.Join(pkValues, ","), nil
 }
 
 type ApplierConfig struct {

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
-	"github.com/block/spirit/pkg/utils"
 )
 
 // ShardedApplier applies rows to multiple target databases based on a Vitess-style vindex.
@@ -566,7 +565,8 @@ func (a *ShardedApplier) feedbackCoordinator() {
 }
 
 // DeleteKeys deletes rows by their key values synchronously, broadcasting to all shards.
-// The keys are hashed key strings (from utils.HashKey).
+// Each entry in keys is one primary-key tuple of the original (typed)
+// column values, in sourceTable.KeyColumns order.
 // If lock is non-nil, operations are executed under table locks (one per shard).
 //
 // Note: we only track modifications by PRIMARY KEY, not by shard key (aka primary vindex).
@@ -577,7 +577,7 @@ func (a *ShardedApplier) feedbackCoordinator() {
 // Note: the sharded applier does not allow any transformations!
 // The targetTable argument is intentionally ignored.
 // This also means that table names between source and target must be the same.
-func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.TableInfo, keys []string, lock *dbconn.TableLock) (int64, error) {
+func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.TableInfo, keys [][]any, lock *dbconn.TableLock) (int64, error) {
 	if len(keys) == 0 {
 		return 0, nil
 	}
@@ -586,10 +586,11 @@ func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.T
 	ctx, cancel := context.WithTimeout(ctx, chunkTaskTimeout)
 	defer cancel()
 
-	// Convert hashed keys to row value constructor format
-	var pkValues []string
-	for _, key := range keys {
-		pkValues = append(pkValues, utils.UnhashKeyToString(key))
+	// Render the key tuples into the IN(...) element list via table.Datum,
+	// the same type-aware path UpsertRows uses (see deleteKeysInClause).
+	inClause, err := deleteKeysInClause(sourceTable, keys)
+	if err != nil {
+		return 0, err
 	}
 
 	// Build DELETE statement
@@ -598,7 +599,7 @@ func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.T
 	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (%s)",
 		sourceTable.QuotedTableName,
 		table.QuoteColumns(sourceTable.KeyColumns),
-		strings.Join(pkValues, ","),
+		inClause,
 	)
 
 	// Execute deletes on all shards in parallel (broadcast)

--- a/pkg/applier/sharded_test.go
+++ b/pkg/applier/sharded_test.go
@@ -296,9 +296,9 @@ func TestShardedApplierDeleteKeys(t *testing.T) {
 
 	// Delete keys by PRIMARY KEY (id=2 and id=4)
 	// Note: DeleteKeys broadcasts to ALL shards since we track by PK, not vindex
-	keysToDelete := []string{
-		utils.HashKey([]any{int64(2)}),
-		utils.HashKey([]any{int64(4)}),
+	keysToDelete := [][]any{
+		{int64(2)},
+		{int64(4)},
 	}
 
 	affectedRows, err := applier.DeleteKeys(t.Context(), sourceTable, target1Table, keysToDelete, nil)
@@ -377,7 +377,7 @@ func TestShardedApplierDeleteKeysEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete with empty keys
-	affectedRows, err := applier.DeleteKeys(t.Context(), targetTable, targetTable, []string{}, nil)
+	affectedRows, err := applier.DeleteKeys(t.Context(), targetTable, targetTable, [][]any{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), affectedRows)
 }

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
-	"github.com/block/spirit/pkg/utils"
 )
 
 // SingleTargetApplier applies rows to a single target database.
@@ -439,9 +438,10 @@ func (a *SingleTargetApplier) feedbackCoordinator() {
 }
 
 // DeleteKeys deletes rows by their key values synchronously.
-// The keys are hashed key strings (from utils.HashKey).
+// Each entry in keys is one primary-key tuple of the original (typed)
+// column values, in sourceTable.KeyColumns order.
 // If lock is non-nil, the delete is executed under the table lock.
-func (a *SingleTargetApplier) DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys []string, lock *dbconn.TableLock) (int64, error) {
+func (a *SingleTargetApplier) DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys [][]any, lock *dbconn.TableLock) (int64, error) {
 	if len(keys) == 0 {
 		return 0, nil
 	}
@@ -449,17 +449,18 @@ func (a *SingleTargetApplier) DeleteKeys(ctx context.Context, sourceTable, targe
 	if targetTable == nil {
 		targetTable = sourceTable
 	}
-	// Convert hashed keys to row value constructor format
-	var pkValues []string
-	for _, key := range keys {
-		pkValues = append(pkValues, utils.UnhashKeyToString(key))
+	// Render the key tuples into the IN(...) element list via table.Datum,
+	// the same type-aware path UpsertRows uses (see deleteKeysInClause).
+	inClause, err := deleteKeysInClause(sourceTable, keys)
+	if err != nil {
+		return 0, err
 	}
 
 	// Build DELETE statement
 	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (%s)",
 		targetTable.QuotedTableName,
 		table.QuoteColumns(sourceTable.KeyColumns),
-		strings.Join(pkValues, ","),
+		inClause,
 	)
 
 	a.logger.Debug("executing delete", "keyCount", len(keys), "table", targetTable.TableName)

--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -422,9 +422,9 @@ func TestSingleTargetApplierDeleteKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete keys 2 and 4
-	keysToDelete := []string{
-		utils.HashKey([]any{int64(2)}),
-		utils.HashKey([]any{int64(4)}),
+	keysToDelete := [][]any{
+		{int64(2)},
+		{int64(4)},
 	}
 
 	affectedRows, err := applier.DeleteKeys(t.Context(), targetTable, targetTable, keysToDelete, nil)
@@ -465,11 +465,13 @@ func TestSingleTargetApplierDeleteKeys(t *testing.T) {
 }
 
 // TestSingleTargetApplierDeleteKeysSeparatorInValues tests DeleteKeys with
-// string PK values containing the hash-key separator "-#-". Before hash-key
-// components were escaped, a single-column PK value containing "-#-" was
-// split into multiple values, producing DELETE ... WHERE (pk) IN (('a','b'))
-// — MySQL error 1241 "Operand should contain 1 column(s)" — which blocked
-// the flush forever.
+// string PK values containing the hash-key separator "-#-". DeleteKeys now
+// receives the original typed key tuples directly (not a hashed string),
+// so the separator cannot corrupt the DELETE arity — but a single-column
+// PK value containing "-#-" must still delete exactly one row, and a
+// composite PK must delete exactly the intended tuple. (The hash-key
+// escaping that keeps these distinct as *map keys* is covered in
+// pkg/utils.)
 func TestSingleTargetApplierDeleteKeysSeparatorInValues(t *testing.T) {
 	testutils.RunSQL(t, "DROP DATABASE IF EXISTS single_delete_sep_test")
 	testutils.RunSQL(t, "CREATE DATABASE single_delete_sep_test")
@@ -502,9 +504,9 @@ func TestSingleTargetApplierDeleteKeysSeparatorInValues(t *testing.T) {
 	applier, err := NewSingleTargetApplier(tar, NewApplierDefaultConfig())
 	require.NoError(t, err)
 
-	keysToDelete := []string{
-		utils.HashKey([]any{"a-#-b"}),
-		utils.HashKey([]any{"-#-"}),
+	keysToDelete := [][]any{
+		{"a-#-b"},
+		{"-#-"},
 	}
 	affectedRows, err := applier.DeleteKeys(t.Context(), targetTable, targetTable, keysToDelete, nil)
 	require.NoError(t, err)
@@ -529,7 +531,7 @@ func TestSingleTargetApplierDeleteKeysSeparatorInValues(t *testing.T) {
 	require.NoError(t, compositeTable.SetInfo(t.Context()))
 
 	affectedRows, err = applier.DeleteKeys(t.Context(), compositeTable, compositeTable,
-		[]string{utils.HashKey([]any{"a-#-b", "c"})}, nil)
+		[][]any{{"a-#-b", "c"}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), affectedRows, "only ('a-#-b','c') must be deleted, not ('a','b-#-c')")
 
@@ -573,7 +575,7 @@ func TestSingleTargetApplierDeleteKeysEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete with empty keys
-	affectedRows, err := applier.DeleteKeys(t.Context(), targetTable, targetTable, []string{}, nil)
+	affectedRows, err := applier.DeleteKeys(t.Context(), targetTable, targetTable, [][]any{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), affectedRows)
 }

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -87,6 +87,10 @@ type bufferedChange struct {
 type queuedChange struct {
 	key        string
 	logicalRow applier.LogicalRow
+	// originalKey is the typed PK tuple. Deletes need it to build the
+	// DELETE statement via the applier's type-aware path; upserts use
+	// logicalRow.RowImage instead, but we store it uniformly.
+	originalKey []any
 }
 
 type bufferedMap struct {
@@ -172,9 +176,10 @@ const (
 
 	// queuedChangeOverhead is the fixed per-element cost for an item
 	// in s.queue beyond estimateRowSize's contribution: the key
-	// string header (~16 B) and the LogicalRow struct (~32 B). Slice
-	// amortized-growth overhead is not explicitly accounted for.
-	queuedChangeOverhead = 48
+	// string header (~16 B), the LogicalRow struct (~32 B), and the
+	// originalKey slice header (~24 B). Slice amortized-growth overhead
+	// is not explicitly accounted for.
+	queuedChangeOverhead = 72
 )
 
 // BufferedSubscriptionConfig configures NewBufferedSubscription.
@@ -275,7 +280,7 @@ func sizeOfBufferedChange(hashedKey string, c bufferedChange) int64 {
 }
 
 func sizeOfQueuedChange(c queuedChange) int64 {
-	return queuedChangeOverhead + int64(len(c.key)) + estimateRowSize(c.logicalRow.RowImage)
+	return queuedChangeOverhead + int64(len(c.key)) + estimateRowSize(c.logicalRow.RowImage) + estimateRowSize(c.originalKey)
 }
 
 // Assert that bufferedMap implements subscription
@@ -359,7 +364,7 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 	}
 
 	if s.queueModeActive() {
-		qc := queuedChange{key: hashedKey, logicalRow: logicalRow}
+		qc := queuedChange{key: hashedKey, logicalRow: logicalRow, originalKey: key}
 		s.queue = append(s.queue, qc)
 		s.sizeBytes += sizeOfQueuedChange(qc)
 		s.keysAdded.Add(1)
@@ -427,7 +432,7 @@ func (s *bufferedMap) Flush(ctx context.Context, underLock bool, lock *dbconn.Ta
 // store we are about to abandon. underLock (cutover) implies bypass for the
 // same reason.
 func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *dbconn.TableLock, bypassWatermark bool) (bool, error) {
-	var deleteKeys []string
+	var deleteKeys [][]any
 	var upsertRows []applier.LogicalRow
 	var keysFlushed []string
 	var i int
@@ -451,9 +456,9 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 			continue
 		}
 		i++
-		keysFlushed = append(keysFlushed, key) // we are going to flush this key
+		keysFlushed = append(keysFlushed, key) // we are going to flush this key (hashed map key)
 		if change.logicalRow.IsDeleted {
-			deleteKeys = append(deleteKeys, key)
+			deleteKeys = append(deleteKeys, change.originalKey)
 		} else {
 			upsertRows = append(upsertRows, change.logicalRow)
 		}
@@ -485,8 +490,10 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, lock *
 }
 
 // flushBatch flushes a batch of deletes and upserts using the applier.
+// deleteKeys holds the typed PK tuples of the rows to delete (one tuple
+// per entry, in KeyColumns order).
 // If lock is non-nil, the operations are executed under the table lock.
-func (s *bufferedMap) flushBatch(ctx context.Context, deleteKeys []string, upsertRows []applier.LogicalRow, lock *dbconn.TableLock) error {
+func (s *bufferedMap) flushBatch(ctx context.Context, deleteKeys [][]any, upsertRows []applier.LogicalRow, lock *dbconn.TableLock) error {
 	if len(deleteKeys) == 0 && len(upsertRows) == 0 {
 		return nil
 	}
@@ -545,7 +552,7 @@ func (s *bufferedMap) flushQueueLocked(ctx context.Context, underLock bool, lock
 		lockToUse = lock
 	}
 
-	var deleteKeys []string
+	var deleteKeys [][]any
 	var upsertRows []applier.LogicalRow
 	flushSegment := func() error {
 		if err := s.flushBatch(ctx, deleteKeys, upsertRows, lockToUse); err != nil {
@@ -567,7 +574,7 @@ func (s *bufferedMap) flushQueueLocked(ctx context.Context, underLock bool, lock
 			}
 		}
 		if change.logicalRow.IsDeleted {
-			deleteKeys = append(deleteKeys, change.key)
+			deleteKeys = append(deleteKeys, change.originalKey)
 		} else {
 			upsertRows = append(upsertRows, change.logicalRow)
 		}

--- a/pkg/change/subscription_buffered_datatypes_test.go
+++ b/pkg/change/subscription_buffered_datatypes_test.go
@@ -581,9 +581,10 @@ func TestBufferedBinaryPKTrailingZeros(t *testing.T) {
 
 	// Key bytes are ASCII + trailing NULs: NUL is valid UTF-8, so the
 	// quoted key literal that DeleteKeys builds stays inside what the
-	// unsafe-warning check allows. (Keys containing non-UTF8 bytes like
-	// 0xBB hit a separate pre-existing quoting limitation in DeleteKeys,
-	// unrelated to the row-image padding under test here.)
+	// unsafe-warning check allows. Keys containing non-UTF8 bytes like
+	// 0xBB are covered separately by TestBufferedBinaryPKNonUTF8 (the
+	// block/spirit#948 fix), which is independent of the row-image
+	// padding under test here.
 	testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO %s (pk, val) VALUES
 		(X'6100000000000000', 1),
 		(X'6200000000000000', 2),
@@ -610,4 +611,59 @@ func TestBufferedBinaryPKTrailingZeros(t *testing.T) {
 		"SELECT COUNT(*) FROM %s s LEFT JOIN %s d ON s.pk = d.pk WHERE d.pk IS NULL OR NOT (s.val <=> d.val)",
 		srcTable.QuotedTableName, dstTable.QuotedTableName)).Scan(&diff))
 	require.Zero(t, diff, "destination rows must match source by full-width binary PK")
+}
+
+// TestBufferedBinaryPKNonUTF8 pins block/spirit#948: a BINARY(N) primary
+// key whose bytes are not valid UTF-8 (e.g. 0xBB) must replicate through
+// the buffered DELETE / PK-changing UPDATE paths. The fix renders DELETE
+// key tuples through table.Datum (hex-encoding binary), the same way the
+// upsert path does; the previous reverse-the-hash path quoted every
+// component as a '...' string literal, so a non-UTF8 key tripped MySQL's
+// "Invalid utf8mb4 character string" warning, which dbconn escalates to
+// an error and aborts the flush. This is independent of the #945
+// trailing-zero stripping covered by TestBufferedBinaryPKTrailingZeros.
+func TestBufferedBinaryPKNonUTF8(t *testing.T) {
+	srcDDL := `CREATE TABLE subscription_test (
+		pk BINARY(8) NOT NULL,
+		val INT NOT NULL,
+		PRIMARY KEY (pk)
+	)`
+	dstDDL := `CREATE TABLE _subscription_test_new (
+		pk BINARY(8) NOT NULL,
+		val INT NOT NULL,
+		PRIMARY KEY (pk)
+	)`
+	srcTable, dstTable := setupTestTables(t, srcDDL, dstDDL)
+	db, client := startBufferedSubscriptionFor(t, srcTable, dstTable)
+
+	// 0xBB is not valid UTF-8. The third row is full-width (no trailing
+	// 0x00 to strip) so the failure is purely about quoting, not padding.
+	testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO %s (pk, val) VALUES
+		(X'bb00000000000000', 1),
+		(X'cc00000000000000', 2),
+		(X'bbccddeeff112233', 3)`, srcTable.QuotedTableName))
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+
+	// DELETE one row by its non-UTF8 key.
+	testutils.RunSQL(t, fmt.Sprintf("DELETE FROM %s WHERE pk = X'cc00000000000000'", srcTable.QuotedTableName))
+	// PK-changing UPDATE: emits a DELETE for the old (non-UTF8) PK plus an
+	// INSERT for the new one — exercises the delete-of-old-PK path too.
+	testutils.RunSQL(t, fmt.Sprintf("UPDATE %s SET pk = X'aa00000000000000' WHERE pk = X'bb00000000000000'", srcTable.QuotedTableName))
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+
+	var srcCount, dstCount int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", srcTable.QuotedTableName)).Scan(&srcCount))
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable.QuotedTableName)).Scan(&dstCount))
+	require.Equal(t, 2, srcCount)
+	require.Equal(t, srcCount, dstCount, "DELETE/UPDATE by a non-UTF8 BINARY PK must replicate")
+
+	var diff int
+	require.NoError(t, db.QueryRowContext(t.Context(), fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s s LEFT JOIN %s d ON s.pk = d.pk WHERE d.pk IS NULL OR NOT (s.val <=> d.val)",
+		srcTable.QuotedTableName, dstTable.QuotedTableName)).Scan(&diff))
+	require.Zero(t, diff, "destination rows must match source by non-UTF8 binary PK")
 }

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -345,7 +345,7 @@ func (d *delayedCallbackApplier) Apply(ctx context.Context, chunk *table.Chunk, 
 	return d.realApplier.Apply(ctx, chunk, rows, wrappedCallback)
 }
 
-func (d *delayedCallbackApplier) DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys []string, lock *dbconn.TableLock) (int64, error) {
+func (d *delayedCallbackApplier) DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys [][]any, lock *dbconn.TableLock) (int64, error) {
 	return d.realApplier.DeleteKeys(ctx, sourceTable, targetTable, keys, lock)
 }
 

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -178,16 +178,41 @@ func newDatumFromMySQL(val string, mysqlTp string) (Datum, error) {
 	return d, nil
 }
 
+// ColumnType is a MySQL column type pre-resolved for datum construction.
+// Resolving it (parsing the type string) is the dominant cost of
+// NewDatumFromValue, so callers that convert many values of the same
+// column type should resolve once with NewColumnType and reuse it via
+// NewDatumFromValueWithType.
+type ColumnType struct {
+	tp    datumTp
+	isBit bool
+}
+
+// NewColumnType resolves a MySQL column type string (e.g. "int",
+// "binary(8)", "bit(8)") into a reusable ColumnType.
+func NewColumnType(mysqlType string) ColumnType {
+	return ColumnType{
+		tp:    mySQLTypeToDatumTp(mysqlType),
+		isBit: isBITType(mysqlType),
+	}
+}
+
 // NewDatumFromValue creates a Datum from a value and MySQL column type.
 // This is useful for converting values from the database driver (which may be []byte, int, string, etc.)
 // into a Datum that can be formatted as SQL.
 func NewDatumFromValue(value any, mysqlType string) (Datum, error) {
+	return NewDatumFromValueWithType(value, NewColumnType(mysqlType))
+}
+
+// NewDatumFromValueWithType is NewDatumFromValue with the column type
+// already resolved (see ColumnType), for hot paths that convert many
+// values of the same column type.
+func NewDatumFromValueWithType(value any, ct ColumnType) (Datum, error) {
 	if value == nil {
-		tp := mySQLTypeToDatumTp(mysqlType)
-		return NewNilDatum(tp), nil
+		return NewNilDatum(ct.tp), nil
 	}
 
-	tp := mySQLTypeToDatumTp(mysqlType)
+	tp := ct.tp
 
 	// BIT(N) is classified as unsignedType, but its wire form depends on
 	// the source: the Go MySQL driver returns []byte (big-endian bit
@@ -195,7 +220,7 @@ func NewDatumFromValue(value any, mysqlType string) (Datum, error) {
 	// here so the generic unsignedType path below sees a numeric value
 	// and doesn't try to ParseUint on raw bit bytes (which would fail on
 	// any byte that isn't an ASCII decimal digit).
-	if b, ok := value.([]byte); ok && isBITType(mysqlType) {
+	if b, ok := value.([]byte); ok && ct.isBit {
 		var u uint64
 		for _, by := range b {
 			u = (u << 8) | uint64(by)

--- a/pkg/table/datum_test.go
+++ b/pkg/table/datum_test.go
@@ -407,3 +407,36 @@ func TestNewDatumFromValueBinaryString(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "\"hello\"", d.String())
 }
+
+// TestNewDatumFromValueWithType pins that resolving the column type once
+// (NewColumnType) and reusing it via NewDatumFromValueWithType produces a
+// Datum identical to NewDatumFromValue, across the type classifications
+// and wire forms that matter: numeric, binary (forceHexEncode), text, the
+// BIT []byte decode path, and nil. This is the fast path used by the
+// applier's DELETE builder (block/spirit#948); it must not diverge from
+// the per-value parse it replaces.
+func TestNewDatumFromValueWithType(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   any
+		mysqlTp string
+	}{
+		{"signed int64", int64(42), "int"},
+		{"signed from string", "42", "bigint"},
+		{"binary []byte non-utf8", []byte{0xbb, 0x00, 0x10}, "binary(3)"},
+		{"binary string utf8", "abc", "varbinary(8)"},
+		{"varchar", "hello", "varchar(255)"},
+		{"bit from bytes", []byte{0x01, 0x00}, "bit(16)"},
+		{"nil binary", nil, "binary(8)"},
+		{"nil int", nil, "int"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want, errWant := NewDatumFromValue(tc.value, tc.mysqlTp)
+			got, errGot := NewDatumFromValueWithType(tc.value, NewColumnType(tc.mysqlTp))
+			require.Equal(t, errWant, errGot)
+			require.Equal(t, want, got)
+			require.Equal(t, want.String(), got.String())
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,8 +4,6 @@ package utils
 import (
 	"fmt"
 	"strings"
-
-	"github.com/block/spirit/pkg/dbconn/sqlescape"
 )
 
 const (
@@ -15,12 +13,14 @@ const (
 	MaxTableNameLength = 64
 )
 
-// HashKey is used to convert a composite key into a string
-// so that it can be placed in a map.
-// Each component is escaped before joining so that values containing
-// the separator cannot collide with key boundaries: without escaping,
-// ("a-#-b", "c") and ("a", "b-#-c") would hash to the same string,
-// causing one row's buffered change to silently overwrite another's.
+// HashKey converts a composite key into a string so that it can be used
+// as a map key. The result is an opaque map key only — it is never
+// reversed back into SQL (the applier builds DELETE literals from the
+// original typed values, not from this string). Each component is escaped
+// before joining so that values containing the separator cannot collide
+// with key boundaries: without escaping, ("a-#-b", "c") and ("a", "b-#-c")
+// would hash to the same string, causing one row's buffered change to
+// silently overwrite another's.
 func HashKey(key []any) string {
 	pk := make([]string, 0, len(key))
 	for _, v := range key {
@@ -37,39 +37,6 @@ func HashKey(key []any) string {
 func escapeHashComponent(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	return strings.ReplaceAll(s, `#`, `\#`)
-}
-
-// unescapeHashComponent reverses escapeHashComponent: each backslash
-// escapes the byte that follows it.
-func unescapeHashComponent(s string) string {
-	if !strings.Contains(s, `\`) {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); i++ {
-		// defensive: HashKey output never ends in a lone backslash, so the
-		// bound only guards against indexing past a malformed input.
-		if s[i] == '\\' && i+1 < len(s) {
-			i++
-		}
-		b.WriteByte(s[i])
-	}
-	return b.String()
-}
-
-// UnhashKeyToString converts a hashed key to a string that can be used in a query.
-// Components are unescaped (reversing HashKey's escaping) before being
-// SQL-escaped, so the resulting SQL contains the original values.
-func UnhashKeyToString(key string) string {
-	str := strings.Split(key, PrimaryKeySeparator)
-	if len(str) == 1 {
-		return "'" + sqlescape.EscapeString(unescapeHashComponent(str[0])) + "'"
-	}
-	for i, v := range str {
-		str[i] = "'" + sqlescape.EscapeString(unescapeHashComponent(v)) + "'"
-	}
-	return "(" + strings.Join(str, ",") + ")"
 }
 
 // TruncateTableName truncates a table name to fit within MySQL's 64-character limit,

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -12,21 +12,11 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
-func TestHashAndUnhashKey(t *testing.T) {
+func TestHashKey(t *testing.T) {
 	// This func helps put composite keys in a map.
-	key := []any{"1234", "ACDC", "12"}
-	hashed := HashKey(key)
-	require.Equal(t, "1234-#-ACDC-#-12", hashed)
-	unhashed := UnhashKeyToString(hashed)
-	// unhashed returns as a string, not the original any
-	require.Equal(t, "('1234','ACDC','12')", unhashed)
-
+	require.Equal(t, "1234-#-ACDC-#-12", HashKey([]any{"1234", "ACDC", "12"}))
 	// This also works on single keys.
-	key = []any{"1234"}
-	hashed = HashKey(key)
-	require.Equal(t, "1234", hashed)
-	unhashed = UnhashKeyToString(hashed)
-	require.Equal(t, "'1234'", unhashed)
+	require.Equal(t, "1234", HashKey([]any{"1234"}))
 }
 
 // TestHashKeySeparatorCollision pins the fix for hash-key collisions:
@@ -48,34 +38,41 @@ func TestHashKeySeparatorCollision(t *testing.T) {
 		HashKey([]any{"a", `\b`}))
 }
 
-// TestHashKeyRoundTrip verifies that UnhashKeyToString recovers the exact
-// original values (correctly SQL-quoted) for components containing the
-// separator, escape characters, and edge-case values.
-func TestHashKeyRoundTrip(t *testing.T) {
-	tests := []struct {
-		name string
-		key  []any
-		want string
-	}{
-		{"plain single", []any{"hello"}, "'hello'"},
-		{"plain composite", []any{"a", "b"}, "('a','b')"},
-		{"separator in single key", []any{"a-#-b"}, "'a-#-b'"},
-		{"separator in composite components", []any{"a-#-b", "c"}, "('a-#-b','c')"},
-		{"separator in second component", []any{"a", "b-#-c"}, "('a','b-#-c')"},
-		{"bare hash", []any{"a#b", "c#"}, "('a#b','c#')"},
-		{"backslash", []any{`a\b`, `c\`}, `('a\\b','c\\')`}, // sqlescape doubles backslashes for SQL
-		{"backslash before hash", []any{`a\#b`}, `'a\\#b'`},
-		{"only separator", []any{"-#-"}, "'-#-'"},
-		{"empty single", []any{""}, "''"},
-		{"empty components", []any{"", ""}, "('','')"},
-		{"empty first component", []any{"", "a"}, "('','a')"},
-		{"trailing dash boundary", []any{"a-", "-b"}, "('a-','-b')"},
-		{"non-string types", []any{int64(42), "x"}, "('42','x')"},
+// TestHashKeyInjective verifies that HashKey produces a distinct map key
+// for components containing the separator, escape characters, binary
+// bytes, and edge-case values. Injectivity is the only property the
+// buffered map relies on — two different key tuples must never hash to
+// the same string (which would let one row's change silently overwrite
+// another's). The hash is never reversed back into SQL, so round-tripping
+// no longer matters; the applier builds DELETE literals from the original
+// typed values instead (see block/spirit#948).
+func TestHashKeyInjective(t *testing.T) {
+	keys := [][]any{
+		{"hello"},
+		{"a", "b"},
+		{"a-#-b"},
+		{"a-#-b", "c"},
+		{"a", "b-#-c"},
+		{"a#b", "c#"},
+		{`a\b`, `c\`},
+		{`a\#b`},
+		{"-#-"},
+		{""},
+		{"", ""},
+		{"", "a"},
+		{"a-", "-b"},
+		{int64(42), "x"},
+		// Binary / non-UTF8 key components must hash distinctly too.
+		{"\xbb\x00\x00\x00\x00\x00\x00\x00"},
+		{"\xbb\x00", "abc"},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, UnhashKeyToString(HashKey(tc.key)))
-		})
+	seen := make(map[string][]any, len(keys))
+	for _, k := range keys {
+		h := HashKey(k)
+		if prev, ok := seen[h]; ok {
+			t.Errorf("hash collision: %#v and %#v both hash to %q", prev, k, h)
+		}
+		seen[h] = k
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #948.

The buffered replay's DELETE path built its SQL by **reversing the map hash**: `Applier.DeleteKeys` received hashed key strings and ran them through `utils.UnhashKeyToString`, which quoted every key component as a `'...'` string literal. For a `BINARY(N)` primary key whose bytes are not valid UTF-8 (e.g. `0xBB`), that literal tripped MySQL's `Invalid utf8mb4 character string` warning, which dbconn escalates to an error:

```
failed to delete keys: failed to execute delete: unsafe warning: Invalid utf8mb4 character string: 'BB0000'
```

The flush then failed, and retries failed identically — so a migration of a table with a non-UTF8 binary PK aborted as soon as a DELETE (or a PK-changing UPDATE, which emits a delete for the old PK) flowed through replication.

## Root cause

The hash string did double duty as a **map key** *and* as a **SQL source**. `HashKey` stringifies each component with `fmt.Sprintf("%v", ...)`, so the round-trip erased the datum type and `UnhashKeyToString` had no way to know a component should be hex-encoded. The upsert path never had this problem — it renders the original values through `table.Datum`, which hex-encodes binary.

## Fix

Stop reversing the hash:

- `Applier.DeleteKeys` now takes the original **typed key tuples** (`[][]any`) and renders each value through `table.NewDatumFromValue(...).String()` — the identical path `UpsertRows` uses — so binary keys are emitted as `0x...` hex literals **by construction**, byte-identical to the upsert path.
- `HashKey` remains the opaque map key (its separator escaping is still needed for injectivity) but is **never reversed**; `UnhashKeyToString` and `unescapeHashComponent` are deleted.
- The buffered/queue flush paths carry `originalKey` through to the applier (`queuedChange` now stores it).

Net `−131 / +208`, removing the duplicated hash-reversal SQL emitter entirely.

One behavioral nicety falls out: integer keys now render as `42` instead of `'42'` (matching the upsert path) — strictly more correct, and existing `DeleteKeys` tests confirm the right rows are still deleted.

## Tests

- Adds **`TestBufferedBinaryPKNonUTF8`** — the issue's exact repro: a `0xBB` `BINARY(8)` PK driven through DELETE and a PK-changing UPDATE. Verified it **fails** with the issue's error when the old string-quoting is restored, and passes with the fix.
- Refocuses the `pkg/utils` hash test on **injectivity** (the only property that still matters now that the hash is never reversed).

## Stacking

This was developed on top of #945 (the BINARY(N) row-image re-padding fix); now that #945 has merged, this branch is rebased onto `main` and stands alone as a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)