### PR TITLE
Seed resume progress relative to MinValue for the optimistic chunker

### DIFF
--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -272,13 +272,26 @@ func (t *chunkerOptimistic) OpenAtWatermark(cp string) error {
 	t.chunkPtr = chunk.LowerBound.Value[0]
 
 	// For the optimistic chunker, we also calculate progress (i.e. rowsCopied)
-	// Based on the progress of copying the auto_increment key.
-	// So we don't have to recover it from the checkpoint, we can just set the value
-	// from the current chunkPtr.
-	t.rowsCopied, err = strconv.ParseUint(t.chunkPtr.String(), 10, 64)
+	// based on the progress of copying the auto_increment key, so we don't have
+	// to recover it from the checkpoint. A fresh copy starts chunkPtr at
+	// MinValue() with rowsCopied at 0 and then advances both together (see
+	// Next() and Feedback()), so rowsCopied is really "distance travelled from
+	// MinValue", not the absolute key. Seed it the same way on resume so the
+	// reported progress percentage stays continuous across a stop/restart.
+	// Seeding from the absolute chunkPtr would inflate progress by
+	// MinValue/MaxValue, which is large for tables whose low keys have been
+	// purged (MIN(pk) far above 0).
+	ptrVal, err := strconv.ParseUint(t.chunkPtr.String(), 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse chunkPtr to uint64: %w", err)
 	}
+	// MinValue() may not be a non-negative integer we can subtract (e.g. a
+	// signed key holding negative values). In that case fall back to the
+	// absolute pointer rather than failing the resume.
+	if minVal, minErr := strconv.ParseUint(t.Ti.MinValue().String(), 10, 64); minErr == nil && ptrVal >= minVal {
+		ptrVal -= minVal
+	}
+	t.rowsCopied = ptrVal
 	return nil
 }
 

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -279,6 +279,47 @@ func TestOptimisticDynamicChunking(t *testing.T) {
 	require.Equal(t, "584", chunk.LowerBound.Value[0].String())
 }
 
+// TestOptimisticResumeProgressAccounting is a regression test for block/spirit#950:
+// on resume, rowsCopied was seeded from the absolute chunk pointer rather than
+// its distance from MinValue. For tables whose low keys have been purged
+// (MIN(pk) far above 0) this inflated the reported progress percentage by
+// MIN(pk)/MAX(pk) at the stop/restart boundary -- in production a jump from
+// 2.31% to 53.21%. Progress must be continuous across a resume.
+func TestOptimisticResumeProgressAccounting(t *testing.T) {
+	// Mimic a production table: minimum id ~682M (old rows purged), with an
+	// auto_increment max of ~1341M.
+	t1 := newTableInfo4Test("test", "events")
+	t1.minValue = Datum{Val: int64(682769913), Tp: signedType}
+	t1.maxValue = Datum{Val: int64(1341021280), Tp: signedType}
+	t1.EstimatedRows = 1341021280
+	t1.KeyColumns = []string{"id"}
+	t1.keyColumnsMySQLTp = []string{"bigint"}
+	t1.keyDatums = []datumTp{signedType}
+	t1.KeyIsAutoInc = true
+	t1.Columns = []string{"id", "name"}
+	t1.columnsMySQLTps = make(map[string]string)
+	t1.columnsMySQLTps["id"] = "bigint"
+
+	chunker, err := NewChunker(t1, ChunkerConfig{NewTable: t1, TargetChunkTime: 100 * time.Millisecond})
+	require.NoError(t, err)
+
+	// Resume from the real production watermark (LowerBound id=713192535).
+	watermark := `{"Key":["id"],"ChunkSize":639,"LowerBound":{"Value": ["713192535"],"Inclusive":true},"UpperBound":{"Value": ["713193174"],"Inclusive":false}}`
+	require.NoError(t, chunker.OpenAtWatermark(watermark))
+
+	rowsCopied, _, total := chunker.Progress()
+	// rowsCopied is measured relative to MinValue, matching how a fresh copy
+	// accumulates it -- NOT the absolute resume key (713192535, which produced
+	// the bogus ~53% before the fix).
+	require.Equal(t, uint64(713192535-682769913), rowsCopied)
+	require.Equal(t, uint64(1341021280), total)
+
+	// The reported percentage should be a few percent, nowhere near the ~53%
+	// the bug produced.
+	pct := float64(rowsCopied) / float64(total) * 100
+	require.Less(t, pct, 10.0)
+}
+
 func TestOptimisticPrefetchChunking(t *testing.T) {
 	db, err := sql.Open("mysql", testutils.DSN())
 	require.NoError(t, err)


### PR DESCRIPTION
## What

On resume, the optimistic chunker seeded `rowsCopied` from the **absolute** chunk pointer:

```go
t.rowsCopied, err = strconv.ParseUint(t.chunkPtr.String(), 10, 64)
```

But a fresh copy accounts `rowsCopied` as the **distance travelled from `MinValue`** — `chunkPtr` starts at `MinValue()` with `rowsCopied` at 0, then both advance together (`Next()` / `Feedback()`). So the two paths disagree by `MIN(pk)`.

For tables whose low keys have been purged (`MIN(pk)` far above 0), this inflates the reported `copy-progress` by `MIN(pk)/MAX(pk)` at the stop/restart boundary.

## Production symptom

An affected auto-increment table (`MIN(id) ≈ 682769913`, `auto_increment ≈ 1341021280`), just before stop vs. immediately after resume:

```
copy-progress=31001342/1341021280 2.31%   ... LowerBound 713192535
copy-progress=713493053/1341022526 53.21% ... resumed from 713192535
```

`713192535 − 682769913 ≈ 30.4M` ≈ the ~31M shown live; the jump is exactly `682769913 / 1341021280 ≈ 51` points.

## Fix

Seed `rowsCopied` as `chunkPtr − MinValue()` on resume, matching the fresh-copy accounting, with a fallback to the absolute pointer when `MinValue()` isn't a non-negative integer (e.g. a signed key holding negatives).

## Scope / safety

Reporting/ETA only. `rowsCopied` feeds `GetProgress()` and `GetETA()`; it does **not** drive completion (`chunkPtr >= maxValue` / `finalChunkSent`) or any correctness decision. No rows were ever skipped — the resume already continued from the correct watermark.

## Test

`TestOptimisticResumeProgressAccounting` resumes from the production watermark and asserts `rowsCopied` is relative to `MinValue` (and the percentage is single-digit, not ~53%). Verified it fails on `main` (`actual=713192535`) and passes with the fix.

Fixes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)
