### PR TITLE
Auto-scale replication write threads from throttler feedback

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -19,6 +19,7 @@ spirit migrate --host mydb:3306 --username root --password secret \
 - [conf](#conf)
 - [database](#database)
 - [defer-cutover](#defer-cutover)
+- [enable-experimental-autoscaling](#enable-experimental-autoscaling)
 - [gtid](#gtid)
 - [host](#host)
 - [lint](#lint)
@@ -386,7 +387,7 @@ Internal to Spirit, the database pool size is set to `threads + write-threads + 
 
 You may want to wrap `threads` in automation and set it to a percentage of the cores of your database server. For example, if you have a 32-core machine you may choose to set this to `8`. Approximately 25% is a good starting point, making sure you always leave plenty of free cores for regular database operations. If your migration is IO bound and/or your IO latency is high (such as Aurora) you may even go higher than 25%.
 
-Note that Spirit does not support dynamically adjusting the number of threads while running, but it does support automatically resuming from a checkpoint if it is killed. This means that if you find that you've misjudged the number of threads (or [target-chunk-time](#target-chunk-time)), you can simply kill the Spirit process and start it again with different values.
+By default Spirit does not dynamically adjust the number of threads while running, but it does support automatically resuming from a checkpoint if it is killed. This means that if you find that you've misjudged the number of threads (or [target-chunk-time](#target-chunk-time)), you can simply kill the Spirit process and start it again with different values. The experimental [enable-experimental-autoscaling](#enable-experimental-autoscaling) flag opts into dynamic write-thread scaling driven by throttler feedback.
 
 ### write-threads
 
@@ -395,7 +396,24 @@ Note that Spirit does not support dynamically adjusting the number of threads wh
 
 Sets the parallelism of the **replication applier** — the number of concurrent write threads used to apply changes (read from the binlog) to the new table. Copier and checksum parallelism are controlled separately by [threads](#threads).
 
-A value of `0` means **auto**: on Aurora, Spirit sets `write-threads` to the instance vCPU count (read from `@@innodb_purge_threads`). On non-Aurora targets there is no reliable vCPU signal, so `0` is rejected with an error and you must set an explicit value. Because the default is `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+A value of `0` means **auto**: on Aurora, Spirit sets `write-threads` to the instance vCPU count (read from `@@innodb_purge_threads`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+
+### enable-experimental-autoscaling
+
+- Type: Boolean
+- Default value: `false`
+
+**Experimental.** When enabled, Spirit dynamically adjusts the number of replication-applier write threads while the copy is running, based on feedback from the throttlers. Each throttler reports a continuous *utilization* signal (0 = idle, 1.0 = the point at which it would hard-stop the copy); the controller takes the highest signal across all throttlers and steers the write-thread count to keep it in a comfortable band:
+
+- **Below 50% utilization** it adds one thread at a time (cautiously, with a ~15s cooldown between increases).
+- **At or above 90% utilization** it halves the thread count — immediately on the first breach (even mid-cooldown after an increase), then at most once per ~15s so the signal can reflect each cut — backing off before the hard-stop throttle engages.
+- In between it holds steady.
+
+With this flag, [write-threads](#write-threads) becomes the *starting* value; the upper bound is fixed at **twice the starting value** and the lower bound is always 1. The connection pool is pre-sized for the maximum so scaled-up threads never starve on connections.
+
+The signal comes from the Aurora throttlers — active-threads and commit-latency (see [max-commit-latency](#max-commit-latency)) — which are auto-enabled on Aurora. Replica lag ([replica-dsn](#replica-dsn)) deliberately contributes **no** continuous signal: lag is a budget, not a load gauge, and steering on it would park replicas well behind. Replicas remain protected by the hard-stop throttle only. If no continuous signal is available at all (for example a non-Aurora target), autoscaling does not engage: a warning is logged and write threads stay fixed at the starting value.
+
+This flag only applies to the default buffered copier; with [unbuffered](#unbuffered) it is ignored (with a warning). Autoscaling is not yet supported by `spirit move`.
 
 ### tls-ca
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -119,4 +119,6 @@ How many chunks to copy in parallel from the source.
 
 How many concurrent write threads to use per target when inserting rows. This controls the fan-out parallelism of the buffered copier's write side.
 
-A value of `0` means **auto**: on Aurora, the value is set to the target instance's vCPU count (read from `@@innodb_purge_threads`). On non-Aurora targets there is no reliable vCPU signal, so `0` is rejected with an error and you must set an explicit value. Because the default is `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+A value of `0` means **auto**: on Aurora, the value is set to the target instance's vCPU count (read from `@@innodb_purge_threads`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+
+Move does not support the experimental write-thread autoscaling available in [`spirit migrate`](migrate.md#enable-experimental-autoscaling).

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -44,14 +44,23 @@ type SingleTargetApplier struct {
 	callbacksInFlight int   // claimed work whose callback has not returned yet; guarded by pendingMutex
 	nextWorkID        int64 // Atomic counter for work IDs
 
-	// Worker management
-	writeWorkersCount    int32
-	writeWorkersFinished int32
-	workerIDCounter      int32
+	// Worker management. writeWorkersCount is the initial worker count, set at
+	// construction from ApplierConfig.Threads; the *live* count can change at
+	// runtime via SetWriteWorkers (driven by the copier's autoscaler). The
+	// fields below workerIDCounter are all guarded by scaleMu.
+	writeWorkersCount int32        // initial worker count (start value)
+	workerIDCounter   atomic.Int32 // monotonic worker id, for debug logging only
+
+	scaleMu       sync.Mutex      // guards the worker pool: workerCtx, workerQuits, scalingClosed, and spawn/park
+	workerCtx     context.Context // ctx the workers run under; set in Start
+	workerQuits   []chan struct{} // one quit channel per live worker — closing one parks (exits) that worker
+	activeWorkers atomic.Int32    // current live worker count
+	scalingClosed bool            // set true when Stop begins, to block new spawns
+	workersWg     sync.WaitGroup  // tracks write workers only
 
 	// Context management
 	cancelFunc context.CancelFunc
-	wg         sync.WaitGroup
+	wg         sync.WaitGroup // tracks the feedbackCoordinator goroutine only
 
 	// State management to make Start/Stop idempotent
 	started bool
@@ -104,8 +113,9 @@ func NewSingleTargetApplier(target Target, cfg *ApplierConfig) (*SingleTargetApp
 // Lifecycle: callers MUST call Stop() to terminate the write workers and
 // feedbackCoordinator. Cancelling the ctx passed here does NOT by itself
 // shut down the goroutine pipeline — it only aborts in-flight writes.
-// Workers exit when chunkletBuffer is closed (by Stop), and the coordinator
-// exits when chunkletCompletions is closed (by the last worker's defer).
+// Workers exit when chunkletBuffer is closed (by Stop) or when their quit
+// channel is closed (by SetWriteWorkers scaling down), and the coordinator
+// exits when chunkletCompletions is closed (by Stop, after all workers exit).
 // Failing to call Stop() will leak goroutines.
 func (a *SingleTargetApplier) Start(ctx context.Context) error {
 	a.Lock()
@@ -122,8 +132,7 @@ func (a *SingleTargetApplier) Start(ctx context.Context) error {
 		a.logger.Info("restarting SingleTargetApplier after previous stop")
 		a.chunkletBuffer = make(chan chunklet, defaultBufferSize)
 		a.chunkletCompletions = make(chan chunkletCompletion, defaultBufferSize)
-		a.writeWorkersFinished = 0
-		a.workerIDCounter = 0
+		a.workerIDCounter.Store(0)
 		a.stopped = false
 	}
 
@@ -133,15 +142,24 @@ func (a *SingleTargetApplier) Start(ctx context.Context) error {
 	a.started = true
 	a.logger.Info("starting SingleTargetApplier", "writeWorkers", a.writeWorkersCount)
 
-	// Start write workers
-	for range a.writeWorkersCount {
-		a.wg.Add(1)
-		go a.writeWorker(workerCtx)
-	}
+	// Reset the worker pool bookkeeping and record the context workers run
+	// under, so SetWriteWorkers can spawn more later.
+	a.scaleMu.Lock()
+	a.workerCtx = workerCtx
+	a.workerQuits = nil
+	a.activeWorkers.Store(0)
+	a.scalingClosed = false
+	a.scaleMu.Unlock()
 
-	// Start feedback coordinator
+	// Start feedback coordinator before workers so completions are always
+	// drained.
 	a.wg.Add(1)
 	go a.feedbackCoordinator()
+
+	// Spawn the initial worker pool. SetWriteWorkers only takes scaleMu, so
+	// calling it while holding the main lock is safe (no lock nesting on the
+	// same mutex).
+	a.SetWriteWorkers(int(a.writeWorkersCount))
 
 	return nil
 }
@@ -288,9 +306,6 @@ func (a *SingleTargetApplier) Stop() error {
 		a.cancelFunc()
 	}
 
-	// Close the chunklet buffer to signal no more work
-	close(a.chunkletBuffer)
-
 	// Mark as stopped before releasing lock
 	a.stopped = true
 	a.started = false
@@ -298,49 +313,118 @@ func (a *SingleTargetApplier) Stop() error {
 	// Release the lock before waiting for workers to finish
 	a.Unlock()
 
-	// Wait for all workers to finish
+	// Close scaling first and wait out any in-flight SetWriteWorkers, so no new
+	// worker is spawned (no workersWg.Add) after we begin shutdown. Acquiring
+	// scaleMu guarantees any concurrent scale call has finished its Adds before
+	// we Wait below.
+	a.scaleMu.Lock()
+	a.scalingClosed = true
+	a.scaleMu.Unlock()
+
+	// Close the chunklet buffer to signal no more work. Workers blocked in their
+	// select see the closed buffer (ok == false) and return; workers mid-write
+	// finish, send their completion, then return.
+	close(a.chunkletBuffer)
+
+	// Wait for all write workers to exit, THEN close the completions channel.
+	// This is now the sole owner of that close — decoupled from worker count,
+	// which is what lets the count move at runtime. The coordinator drains any
+	// remaining completions and exits when the channel closes.
+	a.workersWg.Wait()
+	close(a.chunkletCompletions)
 	a.wg.Wait()
 
 	a.logger.Info("SingleTargetApplier stopped")
 	return nil
 }
 
-// writeWorker processes chunklets from the buffer
-func (a *SingleTargetApplier) writeWorker(ctx context.Context) {
-	defer a.wg.Done()
-	workerID := atomic.AddInt32(&a.workerIDCounter, 1)
+// SetWriteWorkers reconciles the live write-worker count to n, spawning new
+// workers or parking existing ones as needed. It is idempotent and safe to call
+// repeatedly from the autoscaler. n is clamped to a minimum of 1 so the applier
+// always makes some progress. Calls after Stop() begins are no-ops.
+//
+// Parking is cooperative: closing a worker's quit channel makes it exit the next
+// time it returns to its select (after finishing any chunklet currently in
+// flight), so no completion is ever lost.
+func (a *SingleTargetApplier) SetWriteWorkers(n int) {
+	if n < 1 {
+		n = 1
+	}
+	a.scaleMu.Lock()
+	defer a.scaleMu.Unlock()
 
-	defer func() {
-		finishedCount := atomic.AddInt32(&a.writeWorkersFinished, 1)
-		a.logger.Debug("writeWorker finished", "workerID", workerID, "finishedCount", finishedCount, "totalWorkers", a.writeWorkersCount)
+	// No-op before Start has recorded the worker context (the exported API may
+	// be called too early) or once Stop has begun shutting down. In both states
+	// we must not spawn workers: a nil workerCtx would panic the worker on its
+	// first writeChunklet (ctx.Err()), and post-shutdown spawns would race the
+	// workersWg.Wait() in Stop.
+	if a.workerCtx == nil || a.scalingClosed {
+		return
+	}
 
-		// If all write workers are finished, close the completions channel
-		if finishedCount == a.writeWorkersCount {
-			a.logger.Debug("writeWorker all write workers finished, closing completions channel", "workerID", workerID)
-			close(a.chunkletCompletions)
+	cur := len(a.workerQuits)
+	switch {
+	case n > cur:
+		for range n - cur {
+			quit := make(chan struct{})
+			a.workerQuits = append(a.workerQuits, quit)
+			a.activeWorkers.Add(1)
+			a.workersWg.Add(1)
+			go a.writeWorker(a.workerCtx, quit)
 		}
-	}()
+		a.logger.Info("scaled write workers up", "from", cur, "to", n)
+	case n < cur:
+		// Park the most-recently-added workers by closing their quit channels.
+		for i := cur - 1; i >= n; i-- {
+			close(a.workerQuits[i])
+		}
+		a.workerQuits = a.workerQuits[:n]
+		a.logger.Info("scaled write workers down", "from", cur, "to", n)
+	}
+}
 
-	// Drain chunkletBuffer until it is closed by Stop(). We deliberately do not
-	// select on ctx.Done() here: every chunklet that made it into the buffer was
-	// already registered in pendingWork by Apply(), so it MUST produce a
-	// completion or Wait() will hang. If ctx is cancelled, writeChunklet returns
-	// quickly with ctx.Err() and we forward that as an error completion — the
-	// feedbackCoordinator then invokes the callback with the error and clears
-	// pendingWork. Stop() is the canonical shutdown path: it cancels ctx (so
-	// in-flight writes abort) and closes chunkletBuffer (so workers exit).
-	for chunkletData := range a.chunkletBuffer {
-		a.logger.Debug("writeWorker processing chunklet", "workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
+// ActiveWriteWorkers returns the current number of live write workers.
+func (a *SingleTargetApplier) ActiveWriteWorkers() int {
+	return int(a.activeWorkers.Load())
+}
 
-		affectedRows, err := a.writeChunklet(ctx, chunkletData)
+// writeWorker processes chunklets from the buffer until either its quit channel
+// is closed (scale-down) or the buffer is closed by Stop().
+func (a *SingleTargetApplier) writeWorker(ctx context.Context, quit <-chan struct{}) {
+	defer a.workersWg.Done()
+	defer a.activeWorkers.Add(-1)
+	workerID := a.workerIDCounter.Add(1)
 
-		a.chunkletCompletions <- chunkletCompletion{
-			workID:       chunkletData.workID,
-			affectedRows: affectedRows,
-			err:          err,
+	// Every chunklet that made it into the buffer was already registered in
+	// pendingWork by Apply(), so it MUST produce a completion or Wait() will
+	// hang. If ctx is cancelled, writeChunklet returns quickly with ctx.Err()
+	// and we forward that as an error completion — the feedbackCoordinator then
+	// invokes the callback with the error and clears pendingWork. Stop() is the
+	// canonical shutdown path: it cancels ctx (so in-flight writes abort) and
+	// closes chunkletBuffer (so workers exit). The quit channel is the
+	// scale-down path: a parked worker stops pulling new chunklets but any
+	// chunklet already in flight still completes.
+	for {
+		select {
+		case <-quit:
+			a.logger.Debug("writeWorker parked (scale-down), exiting", "workerID", workerID)
+			return
+		case chunkletData, ok := <-a.chunkletBuffer:
+			if !ok {
+				a.logger.Debug("writeWorker channel closed, exiting", "workerID", workerID)
+				return
+			}
+			a.logger.Debug("writeWorker processing chunklet", "workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
+
+			affectedRows, err := a.writeChunklet(ctx, chunkletData)
+
+			a.chunkletCompletions <- chunkletCompletion{
+				workID:       chunkletData.workID,
+				affectedRows: affectedRows,
+				err:          err,
+			}
 		}
 	}
-	a.logger.Debug("writeWorker channel closed, exiting", "workerID", workerID)
 }
 
 // writeChunklet writes a single chunklet (up to chunkletMaxRows or chunkletMaxSize)

--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -1136,6 +1136,89 @@ func TestSingleTargetApplierStartClose(t *testing.T) {
 	require.Equal(t, 2, count)
 }
 
+// TestSingleTargetApplierDynamicScaling exercises SetWriteWorkers: the live
+// worker count moves up and down at runtime, data is applied correctly under
+// both, the count clamps at a minimum of 1, and shutdown stays clean (goleak in
+// TestMain catches any leaked worker).
+func TestSingleTargetApplierDynamicScaling(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS single_scaling_test")
+	testutils.RunSQL(t, "CREATE DATABASE single_scaling_test")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	target := base.Clone()
+	target.DBName = "single_scaling_test"
+	// The pool must cover the peak worker count we scale to.
+	target.Params = map[string]string{}
+	targetDB, err := sql.Open("mysql", target.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+	targetDB.SetMaxOpenConns(10)
+
+	_, err = targetDB.ExecContext(t.Context(), `CREATE TABLE test_table (id INT PRIMARY KEY, val INT)`)
+	require.NoError(t, err)
+
+	targetTable := table.NewTableInfo(targetDB, target.DBName, "test_table")
+	require.NoError(t, targetTable.SetInfo(t.Context()))
+
+	tar := Target{DB: targetDB, Config: target, KeyRange: "0"}
+	cfg := NewApplierDefaultConfig()
+	cfg.Threads = 2 // start value
+	appl, err := NewSingleTargetApplier(tar, cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, appl.Start(t.Context()))
+	defer func() { require.NoError(t, appl.Stop()) }()
+
+	// Initial pool matches the start value (spawn increments synchronously).
+	require.Equal(t, 2, appl.ActiveWriteWorkers())
+
+	chunk := &table.Chunk{
+		Table:         targetTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(targetTable, targetTable, nil),
+	}
+
+	// applyN applies rows [start, start+n) and waits for them to land.
+	applyN := func(start, n int) {
+		rows := make([][]any, n)
+		for i := range n {
+			rows[i] = []any{int64(start + i), int64(start + i)}
+		}
+		var cbErr error
+		var done atomic.Bool
+		require.NoError(t, appl.Apply(t.Context(), chunk, rows, func(_ int64, err error) {
+			cbErr = err
+			done.Store(true)
+		}))
+		require.NoError(t, appl.Wait(t.Context()))
+		require.True(t, done.Load())
+		require.NoError(t, cbErr)
+	}
+
+	// Scale up, then apply work under the larger pool.
+	appl.SetWriteWorkers(6)
+	require.Equal(t, 6, appl.ActiveWriteWorkers())
+	applyN(0, 1500) // > chunkletMaxRows so it splits across workers
+
+	// Scale down. Parked workers exit asynchronously (after finishing any
+	// in-flight chunklet), so the count converges rather than dropping instantly.
+	appl.SetWriteWorkers(1)
+	require.Eventually(t, func() bool {
+		return appl.ActiveWriteWorkers() == 1
+	}, 5*time.Second, 5*time.Millisecond)
+	applyN(1500, 500)
+
+	// Clamp: requesting < 1 holds at 1.
+	appl.SetWriteWorkers(0)
+	require.Equal(t, 1, appl.ActiveWriteWorkers())
+
+	// All rows from both batches must be present.
+	var count int
+	require.NoError(t, targetDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM test_table").Scan(&count))
+	require.Equal(t, 2000, count)
+}
+
 // TestSingleTargetApplierUnderLock verifies the under-lock write path:
 // with one lock the statements execute on the lock's own transaction, and
 // supplying more than one lock is rejected (the single-target applier
@@ -1239,4 +1322,16 @@ func TestSingleTargetApplierCallbackPanicDecrements(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 	require.NoError(t, a.Wait(ctx))
+}
+
+// TestSingleTargetApplierSetWriteWorkersBeforeStart verifies the exported
+// SetWriteWorkers is a safe no-op when called before Start(): workerCtx is
+// still nil, so spawning a worker would panic on its first writeChunklet
+// (ctx.Err()). It must spawn nothing rather than panic.
+func TestSingleTargetApplierSetWriteWorkersBeforeStart(t *testing.T) {
+	a := &SingleTargetApplier{
+		logger: slog.New(slog.DiscardHandler),
+	}
+	require.NotPanics(t, func() { a.SetWriteWorkers(4) })
+	require.Equal(t, 0, a.ActiveWriteWorkers(), "no workers should be spawned before Start")
 }

--- a/pkg/copier/autoscaler.go
+++ b/pkg/copier/autoscaler.go
@@ -1,0 +1,179 @@
+package copier
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/block/spirit/pkg/metrics"
+	"github.com/block/spirit/pkg/throttler"
+)
+
+// AIMD (additive-increase / multiplicative-decrease) tunables. The shape is
+// "cautious up, fast down": we add one thread at a time and only after a
+// cooldown, but halve as soon as load approaches the hard-stop (further
+// halvings then wait out the cooldown so the signal can catch up). See
+// issue #831.
+const (
+	// acTick is how often the controller re-evaluates. Aligned with the
+	// throttler poll interval (5s) — sampling faster than the signal updates
+	// just adds noise.
+	acTick = 5 * time.Second
+	// acLowWatermark: below this utilization there is headroom on every signal,
+	// so we may add a thread (subject to cooldown). acHighWatermark: at or above
+	// this we back off immediately. The band between them is the dead-zone where
+	// we hold steady. High is below 1.0 so we ease off *before* tripping the
+	// hard-stop BlockWait rather than relying on it.
+	acLowWatermark  = 0.5
+	acHighWatermark = 0.9
+	// acCooldownTicks is how many ticks a direction holds after a change before
+	// it may fire again: a change at tick T allows the next at tick T+3, i.e.
+	// 15s apart at acTick, giving the change time to register in the signal
+	// first. Increases and decreases hold independent cooldowns — see tick().
+	acCooldownTicks = 2
+)
+
+// writeScaler is the optional capability the autoscaler drives. The
+// SingleTargetApplier implements it; the ShardedApplier does not (yet), so the
+// copier type-asserts it and skips autoscaling when it's absent.
+type writeScaler interface {
+	SetWriteWorkers(n int)
+}
+
+// autoScaler runs an AIMD control loop that adjusts the applier's live
+// write-worker count based on the throttler's continuous utilization signal.
+// It never touches the binary BlockWait() hard-stop, which remains the safety
+// net underneath — the controller's goal is to keep utilization parked in the
+// [low, high) dead-band so the hard-stop is rarely hit.
+type autoScaler struct {
+	throttler throttler.GradualThrottler
+	scaler    writeScaler
+	min, max  int
+	current   int
+	low, high float64
+	// upCooldown gates increases; downCooldown gates decreases. They are
+	// separate so a fresh overload can halve immediately even right after an
+	// increase (which likely caused it), while consecutive halvings are still
+	// spaced out enough for the signal to reflect the previous cut.
+	upCooldown, downCooldown int
+	logger                   *slog.Logger
+	metricsSink              metrics.Sink
+}
+
+// newAutoScaler builds a controller. start is the resolved write-thread count
+// (the applier was started at this value); maxThreads is the cap. The minimum
+// is always 1 so the copy keeps making progress. Requiring a GradualThrottler
+// (not just a Throttler) is what guarantees there is a continuous signal to
+// control on — the caller asserts for it and skips autoscaling otherwise.
+func newAutoScaler(t throttler.GradualThrottler, s writeScaler, start, maxThreads int, logger *slog.Logger, sink metrics.Sink) *autoScaler {
+	if maxThreads < start {
+		maxThreads = start
+	}
+	return &autoScaler{
+		throttler:   t,
+		scaler:      s,
+		min:         1,
+		max:         maxThreads,
+		current:     start,
+		low:         acLowWatermark,
+		high:        acHighWatermark,
+		logger:      logger,
+		metricsSink: sink,
+	}
+}
+
+// run drives the control loop until ctx is cancelled.
+func (a *autoScaler) run(ctx context.Context) {
+	ticker := time.NewTicker(acTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.tick(ctx)
+		}
+	}
+}
+
+// tick performs a single control step. Split out so tests can drive it directly
+// without real time.
+func (a *autoScaler) tick(ctx context.Context) {
+	util := a.throttler.Utilization()
+
+	acted := false
+	switch {
+	case util >= a.high:
+		// Multiplicative backoff, at most once per cooldown window. The first
+		// breach halves immediately — it is never delayed by an increase's
+		// cooldown, since the increase likely caused the overload. Consecutive
+		// halvings wait out the window: the signal updates on the same ~5s
+		// cadence we tick on, so reacting to every tick would halve repeatedly
+		// on one stale window. If load keeps climbing in the meantime, the
+		// BlockWait hard-stop at 1.0 remains the emergency brake.
+		if a.downCooldown == 0 {
+			a.set(ceilDiv(a.current, 2))
+			a.downCooldown = acCooldownTicks
+			a.upCooldown = acCooldownTicks
+			acted = true
+		}
+	case util < a.low && a.upCooldown == 0:
+		// Cautious, cooldown-gated additive increase.
+		a.set(a.current + 1)
+		a.upCooldown = acCooldownTicks
+		acted = true
+	}
+	if !acted {
+		// Dead-band, or waiting out a cooldown after a recent change.
+		if a.upCooldown > 0 {
+			a.upCooldown--
+		}
+		if a.downCooldown > 0 {
+			a.downCooldown--
+		}
+	}
+
+	a.emit(ctx, util)
+}
+
+// set clamps target to [min, max] and applies it only when it actually changes,
+// logging the transition at Info.
+func (a *autoScaler) set(target int) {
+	if target < a.min {
+		target = a.min
+	}
+	if target > a.max {
+		target = a.max
+	}
+	if target == a.current {
+		return
+	}
+	a.logger.Info("autoscaler adjusting write threads",
+		"from", a.current, "to", target, "min", a.min, "max", a.max)
+	a.current = target
+	a.scaler.SetWriteWorkers(target)
+}
+
+// emit reports the current thread count and observed utilization every tick.
+func (a *autoScaler) emit(ctx context.Context, util float64) {
+	if a.metricsSink == nil {
+		return
+	}
+	m := &metrics.Metrics{
+		Values: []metrics.MetricValue{
+			{Name: metrics.WriteThreadsMetricName, Type: metrics.GAUGE, Value: float64(a.current)},
+			{Name: metrics.ThrottlerUtilizationMetricName, Type: metrics.GAUGE, Value: util},
+		},
+	}
+	sendCtx, cancel := context.WithTimeout(ctx, metrics.SinkTimeout)
+	defer cancel()
+	if err := a.metricsSink.Send(sendCtx, m); err != nil {
+		a.logger.Debug("autoscaler metrics send failed", "error", err)
+	}
+}
+
+// ceilDiv returns ceil(n/d) for positive integers — used for the multiplicative
+// halving so that, e.g., 3 backs off to 2 rather than 1.
+func ceilDiv(n, d int) int {
+	return (n + d - 1) / d
+}

--- a/pkg/copier/autoscaler_test.go
+++ b/pkg/copier/autoscaler_test.go
@@ -1,0 +1,180 @@
+package copier
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/metrics"
+	"github.com/block/spirit/pkg/throttler"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeScaler records SetWriteWorkers calls and reports them back.
+type fakeScaler struct {
+	n int
+}
+
+func (f *fakeScaler) SetWriteWorkers(n int) { f.n = n }
+
+// utilThrottler is a GradualThrottler stub whose Utilization is scripted by
+// the test. Only Utilization is exercised by the autoscaler; the rest satisfy
+// the interface.
+type utilThrottler struct{ util float64 }
+
+var _ throttler.GradualThrottler = &utilThrottler{}
+
+func (u *utilThrottler) Open(context.Context) error      { return nil }
+func (u *utilThrottler) Close() error                    { return nil }
+func (u *utilThrottler) IsThrottled() bool               { return u.util >= 1.0 }
+func (u *utilThrottler) Utilization() float64            { return u.util }
+func (u *utilThrottler) BlockWait(context.Context)       {}
+func (u *utilThrottler) UpdateLag(context.Context) error { return nil }
+
+// fakeScalingApplier satisfies applier.Applier (embedded, never called) plus
+// the writeScaler capability, mimicking the SingleTargetApplier for gate tests.
+type fakeScalingApplier struct {
+	applier.Applier
+	fakeScaler
+}
+
+func newTestScaler(start, max int) (*autoScaler, *fakeScaler, *utilThrottler) {
+	fs := &fakeScaler{n: start}
+	ut := &utilThrottler{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	as := newAutoScaler(ut, fs, start, max, logger, &metrics.NoopSink{})
+	return as, fs, ut
+}
+
+func TestAutoScaler_IncreasesBelowLowWatermarkAfterCooldown(t *testing.T) {
+	as, fs, ut := newTestScaler(2, 8)
+	ut.util = 0.2 // well below low watermark
+
+	// First sub-low tick increases immediately (cooldown starts at 0).
+	as.tick(t.Context())
+	require.Equal(t, 3, as.current)
+	require.Equal(t, 3, fs.n)
+
+	// Cooldown is now in effect: the next ticks hold despite continued headroom.
+	as.tick(t.Context())
+	require.Equal(t, 3, as.current, "should hold during cooldown tick 1")
+	as.tick(t.Context())
+	require.Equal(t, 3, as.current, "should hold during cooldown tick 2")
+
+	// Cooldown elapsed → increase again.
+	as.tick(t.Context())
+	require.Equal(t, 4, as.current)
+}
+
+func TestAutoScaler_DecreasesImmediatelyAtHighWatermark(t *testing.T) {
+	as, fs, ut := newTestScaler(8, 16)
+	ut.util = 0.95 // at/above high watermark
+
+	as.tick(t.Context())
+	require.Equal(t, 4, as.current, "8 should halve to 4 immediately")
+	require.Equal(t, 4, fs.n)
+
+	// Consecutive halvings are cooldown-spaced: the signal updates on the same
+	// cadence we tick on, so reacting every tick would halve repeatedly on one
+	// stale window. Sustained overload halves again only after the cooldown.
+	as.tick(t.Context())
+	require.Equal(t, 4, as.current, "should hold during cooldown tick 1")
+	as.tick(t.Context())
+	require.Equal(t, 4, as.current, "should hold during cooldown tick 2")
+
+	as.tick(t.Context())
+	require.Equal(t, 2, as.current, "cooldown elapsed, halve again")
+}
+
+func TestAutoScaler_DecreaseNotBlockedByIncreaseCooldown(t *testing.T) {
+	// An increase's cooldown must not delay a backoff: if the increase tipped
+	// the server over the high watermark, the very next tick halves.
+	as, _, ut := newTestScaler(4, 8)
+	ut.util = 0.2
+	as.tick(t.Context())
+	require.Equal(t, 5, as.current, "increase under low watermark")
+
+	ut.util = 0.95
+	as.tick(t.Context())
+	require.Equal(t, 3, as.current, "halve immediately despite increase cooldown: ceil(5/2)=3")
+}
+
+func TestAutoScaler_HoldsInDeadBand(t *testing.T) {
+	as, _, ut := newTestScaler(4, 16)
+	ut.util = 0.7 // between low (0.5) and high (0.9)
+
+	for range 5 {
+		as.tick(t.Context())
+	}
+	require.Equal(t, 4, as.current, "dead-band should hold steady")
+}
+
+func TestAutoScaler_ClampsAtMax(t *testing.T) {
+	as, _, ut := newTestScaler(3, 4)
+	ut.util = 0.0 // maximum headroom, always wants to increase
+
+	// Drive many ticks; should climb to the cap and stop.
+	for range 30 {
+		as.tick(t.Context())
+	}
+	require.Equal(t, 4, as.current)
+}
+
+func TestAutoScaler_ClampsAtMinOne(t *testing.T) {
+	as, _, ut := newTestScaler(2, 8)
+	ut.util = 1.5 // way over
+
+	for range 10 {
+		as.tick(t.Context())
+	}
+	require.Equal(t, 1, as.current, "must never drop below 1")
+}
+
+func TestAutoScaler_MaxFlooredAtStart(t *testing.T) {
+	// A max below the start value is nonsensical; it must be floored at start so
+	// we never scale below where we began except via the >high backoff path.
+	as, _, _ := newTestScaler(6, 2)
+	require.Equal(t, 6, as.max)
+}
+
+func TestCeilDiv(t *testing.T) {
+	require.Equal(t, 1, ceilDiv(1, 2))
+	require.Equal(t, 1, ceilDiv(2, 2))
+	require.Equal(t, 2, ceilDiv(3, 2))
+	require.Equal(t, 2, ceilDiv(4, 2))
+	require.Equal(t, 3, ceilDiv(5, 2))
+}
+
+// TestAutoscalerIfEnabled_Gating covers the three conditions that must all
+// hold for the autoscaler to engage: the flag is on, the applier supports
+// dynamic write threads, and the throttler provides a continuous load signal
+// (GradualThrottler). Missing any one of them means a fixed pool.
+func TestAutoscalerIfEnabled_Gating(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gradual := &utilThrottler{}
+	scalingApplier := &fakeScalingApplier{}
+
+	// Disabled (the default): no autoscaler.
+	c := &buffered{logger: logger, throttler: gradual, applier: scalingApplier}
+	require.Nil(t, c.autoscalerIfEnabled())
+
+	// Enabled + scaling applier + gradual throttler: engages with the
+	// configured bounds.
+	c.autoscale = AutoscaleConfig{Enabled: true, StartThreads: 2, MaxThreads: 4}
+	as := c.autoscalerIfEnabled()
+	require.NotNil(t, as)
+	require.Equal(t, 2, as.current)
+	require.Equal(t, 4, as.max)
+
+	// Binary-only throttler (Noop here; replica lag and Mock behave the same):
+	// no continuous signal to control on, so the pool stays fixed.
+	c.throttler = &throttler.Noop{}
+	require.Nil(t, c.autoscalerIfEnabled())
+
+	// Applier without the dynamic-scaling capability: stays fixed.
+	c.throttler = gradual
+	c.applier = nil
+	require.Nil(t, c.autoscalerIfEnabled())
+}

--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -43,6 +43,7 @@ type buffered struct {
 	logger           *slog.Logger
 	metricsSink      metrics.Sink
 	copierEtaHistory *copierEtaHistory
+	autoscale        AutoscaleConfig
 }
 
 // Assert that buffered implements the Copier interface
@@ -126,6 +127,15 @@ func (c *buffered) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to start applier: %w", err)
 	}
 
+	// Experimental: start the write-thread autoscaler. It runs for the lifetime
+	// of the copy and stops when ctx is cancelled (deferred above). It only
+	// engages when the applier supports dynamic scaling (SingleTargetApplier)
+	// AND the throttler provides a continuous load signal (GradualThrottler);
+	// otherwise the pool stays fixed.
+	if as := c.autoscalerIfEnabled(); as != nil {
+		go as.run(ctx)
+	}
+
 	// Start read workers
 	g, errGrpCtx := errgroup.WithContext(ctx)
 	c.logger.Info("starting read workers", "count", c.concurrency)
@@ -161,6 +171,34 @@ func (c *buffered) Run(ctx context.Context) error {
 		err = c.getFirstErr()
 	}
 	return err
+}
+
+// autoscalerIfEnabled returns the experimental write-thread autoscaler to run
+// for this copy, or nil when it should not engage: autoscaling disabled, an
+// applier without dynamic scaling (ShardedApplier), or a throttler without a
+// continuous load signal. Only GradualThrottler implementations (the Aurora
+// throttlers, or a multi-throttler containing one) provide that signal —
+// binary throttlers like replica lag protect via the hard-stop only, and
+// scaling blind against them would just ramp to the maximum unguided.
+func (c *buffered) autoscalerIfEnabled() *autoScaler {
+	if !c.autoscale.Enabled {
+		return nil
+	}
+	scaler, ok := c.applier.(writeScaler)
+	if !ok {
+		c.logger.Info("autoscaling enabled but this applier does not support dynamic write threads; running with a fixed pool")
+		return nil
+	}
+	gradual, ok := c.throttler.(throttler.GradualThrottler)
+	if !ok {
+		c.logger.Warn("autoscaling enabled but no continuous load signal is available (requires an Aurora target); write threads stay fixed at the starting value",
+			"write_threads", c.autoscale.StartThreads)
+		return nil
+	}
+	c.logger.Info("starting experimental write-thread autoscaler",
+		"start", c.autoscale.StartThreads, "max", c.autoscale.MaxThreads,
+		"low_watermark", acLowWatermark, "high_watermark", acHighWatermark)
+	return newAutoScaler(gradual, scaler, c.autoscale.StartThreads, c.autoscale.MaxThreads, c.logger, c.metricsSink)
 }
 
 // readWorker reads chunks and sends them to the applier

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -57,6 +57,24 @@ type CopierConfig struct {
 	// Applier. NewCopierDefaultConfig leaves this false (buffered), matching the
 	// production default.
 	Unbuffered bool
+	// Autoscale configures experimental dynamic write-thread scaling. When
+	// disabled (the default) the copier behaves exactly as before. See
+	// AutoscaleConfig and issue #831.
+	Autoscale AutoscaleConfig
+}
+
+// AutoscaleConfig controls the experimental write-thread autoscaler driven by
+// throttler utilization. It only applies to the buffered copier whose Applier
+// implements the dynamic-scaling capability (SingleTargetApplier).
+type AutoscaleConfig struct {
+	// Enabled gates the whole feature (the --enable-experimental-autoscaling
+	// flag). Off by default.
+	Enabled bool
+	// StartThreads is the resolved write-thread count the applier was started
+	// at; the controller scales from here.
+	StartThreads int
+	// MaxThreads is the cap the controller may scale up to.
+	MaxThreads int
 }
 
 // NewCopierDefaultConfig returns a default config for the copier. It defaults
@@ -110,5 +128,6 @@ func NewCopier(db *sql.DB, chunker table.Chunker, config *CopierConfig) (Copier,
 		dbConfig:         config.DBConfig,
 		copierEtaHistory: newcopierEtaHistory(),
 		applier:          config.Applier,
+		autoscale:        config.Autoscale,
 	}, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,6 +20,11 @@ const (
 	ChunkProcessingTimeMetricName    = "chunk_processing_time"
 	ChunkLogicalRowsCountMetricName  = "chunk_num_logical_rows"
 	ChunkAffectedRowsCountMetricName = "chunk_num_affected_rows"
+	// WriteThreadsMetricName reports the live write-thread (apply-worker) count
+	// chosen by the autoscaler. ThrottlerUtilizationMetricName reports the
+	// continuous load signal (0..>1) the autoscaler controls on.
+	WriteThreadsMetricName         = "write_threads"
+	ThrottlerUtilizationMetricName = "throttler_utilization"
 )
 
 // Metrics are collection of MetricValues.

--- a/pkg/migration/helpers_test.go
+++ b/pkg/migration/helpers_test.go
@@ -75,6 +75,14 @@ func WithWriteThreads(n int) RunnerOption {
 	}
 }
 
+// WithAutoscaling enables the experimental write-thread autoscaler.
+// WriteThreads acts as the starting value; the cap is fixed at 2x that.
+func WithAutoscaling() RunnerOption {
+	return func(m *Migration) {
+		m.EnableExperimentalAutoscaling = true
+	}
+}
+
 // WithTable sets the table name for the migration.
 func WithTable(name string) RunnerOption {
 	return func(m *Migration) {

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -26,25 +26,31 @@ var (
 )
 
 type Migration struct {
-	Host                 string        `name:"host" help:"Hostname" optional:""`
-	Username             string        `name:"username" help:"User" optional:""`
-	Password             *string       `name:"password" help:"Password" optional:""`
-	Database             string        `name:"database" help:"Database" optional:""`
-	ConfFile             string        `name:"conf" help:"MySQL conf file" optional:"" type:"existingfile"`
-	Table                string        `name:"table" help:"Table" optional:""`
-	Alter                string        `name:"alter" help:"The alter statement to run on the table" optional:""`
-	Threads              int           `name:"threads" help:"Number of concurrent threads for copy and checksum tasks" optional:"" default:"4"`
-	WriteThreads         int           `name:"write-threads" help:"Number of concurrent apply (write) threads. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" optional:"" default:"4"`
-	TargetChunkTime      time.Duration `name:"target-chunk-time" help:"The target copy time for each chunk" optional:"" default:"500ms"`
-	ReplicaDSN           string        `name:"replica-dsn" help:"DSN(s) for replica(s) used for lag checking. Multiple replicas can be comma-separated; Spirit throttles on the slowest." optional:""`
-	ReplicaMaxLag        time.Duration `name:"replica-max-lag" help:"The maximum lag allowed on the replica before the migration throttles." optional:"" default:"120s"`
-	LockWaitTimeout      time.Duration `name:"lock-wait-timeout" help:"The DDL lock_wait_timeout required for checksum and cutover" optional:"" default:"30s"`
-	SkipDropAfterCutover bool          `name:"skip-drop-after-cutover" help:"Keep old table after completing cutover" optional:"" default:"false"`
-	DeferCutOver         bool          `name:"defer-cutover" help:"Defer cutover (and checksum) until sentinel table is dropped" optional:"" default:"false"`
-	SkipForceKill        bool          `name:"skip-force-kill" help:"Disable killing long-running transactions in order to acquire metadata lock (MDL) at checksum and cutover time" optional:"" default:"false"`
-	Statement            string        `name:"statement" help:"The SQL statement to run (replaces --table and --alter)" optional:"" default:""`
-	Lint                 bool          `name:"lint" help:"Run lint checks before running migration" optional:""`
-	LintOnly             bool          `name:"lint-only" help:"Run lint checks and exit without performing migration" optional:""`
+	Host         string  `name:"host" help:"Hostname" optional:""`
+	Username     string  `name:"username" help:"User" optional:""`
+	Password     *string `name:"password" help:"Password" optional:""`
+	Database     string  `name:"database" help:"Database" optional:""`
+	ConfFile     string  `name:"conf" help:"MySQL conf file" optional:"" type:"existingfile"`
+	Table        string  `name:"table" help:"Table" optional:""`
+	Alter        string  `name:"alter" help:"The alter statement to run on the table" optional:""`
+	Threads      int     `name:"threads" help:"Number of concurrent threads for copy and checksum tasks" optional:"" default:"4"`
+	WriteThreads int     `name:"write-threads" help:"Number of concurrent apply (write) threads. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" optional:"" default:"4"`
+
+	// EnableExperimentalAutoscaling turns on dynamic write-thread scaling driven
+	// by throttler feedback; WriteThreads becomes the starting value and the
+	// cap is fixed at 2x that (deliberately not configurable for now, to keep
+	// the experimental surface small). See issue #831.
+	EnableExperimentalAutoscaling bool          `name:"enable-experimental-autoscaling" help:"EXPERIMENTAL: dynamically scale write threads between the starting value and 2x that, based on throttler feedback" optional:"" default:"false"`
+	TargetChunkTime               time.Duration `name:"target-chunk-time" help:"The target copy time for each chunk" optional:"" default:"500ms"`
+	ReplicaDSN                    string        `name:"replica-dsn" help:"DSN(s) for replica(s) used for lag checking. Multiple replicas can be comma-separated; Spirit throttles on the slowest." optional:""`
+	ReplicaMaxLag                 time.Duration `name:"replica-max-lag" help:"The maximum lag allowed on the replica before the migration throttles." optional:"" default:"120s"`
+	LockWaitTimeout               time.Duration `name:"lock-wait-timeout" help:"The DDL lock_wait_timeout required for checksum and cutover" optional:"" default:"30s"`
+	SkipDropAfterCutover          bool          `name:"skip-drop-after-cutover" help:"Keep old table after completing cutover" optional:"" default:"false"`
+	DeferCutOver                  bool          `name:"defer-cutover" help:"Defer cutover (and checksum) until sentinel table is dropped" optional:"" default:"false"`
+	SkipForceKill                 bool          `name:"skip-force-kill" help:"Disable killing long-running transactions in order to acquire metadata lock (MDL) at checksum and cutover time" optional:"" default:"false"`
+	Statement                     string        `name:"statement" help:"The SQL statement to run (replaces --table and --alter)" optional:"" default:""`
+	Lint                          bool          `name:"lint" help:"Run lint checks before running migration" optional:""`
+	LintOnly                      bool          `name:"lint-only" help:"Run lint checks and exit without performing migration" optional:""`
 
 	// TLS Configuration
 	TLSMode            string `name:"tls-mode" help:"TLS connection mode (case insensitive): DISABLED, PREFERRED (default), REQUIRED, VERIFY_CA, VERIFY_IDENTITY" optional:""`

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -98,6 +98,30 @@ func TestE2ENullAlter1Row(t *testing.T) {
 	require.NoError(t, m.Run())
 }
 
+// TestE2EAutoscalingEnabled runs a full migration with the experimental
+// write-thread autoscaler turned on. The local (non-Aurora) target has no
+// GradualThrottler, so this exercises the downgrade path end-to-end: the
+// autoscaler declines to engage (a warning is logged), write threads stay at
+// the starting value, the connection pool is still sized for the ceiling, and
+// the migration completes correctly (goleak in TestMain catches leaks). The
+// engaged path is covered by the autoscaler unit tests.
+func TestE2EAutoscalingEnabled(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "t1autoscale", `CREATE TABLE t1autoscale (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	testutils.RunSQL(t, `INSERT INTO t1autoscale (name) VALUES ('a'), ('b'), ('c'), ('d'), ('e')`)
+	m := NewTestMigration(t, WithTable("t1autoscale"), WithAlter("ENGINE=InnoDB"),
+		WithWriteThreads(2), WithAutoscaling())
+	require.NoError(t, m.Run())
+
+	var count int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM t1autoscale").Scan(&count))
+	require.Equal(t, 5, count)
+}
+
 func TestE2ENullAlterWithReplicas(t *testing.T) {
 	t.Parallel()
 	replicaDSN := os.Getenv("REPLICA_DSN")

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -503,10 +503,25 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Finalize the pool now that WriteThreads is known: threads + write-threads
-	// + 1 (see the MaxOpenConnections doc in Run). This is a no-op unless
-	// WriteThreads was auto-sized up from 0; the pool only ever grows.
-	if poolSize := r.migration.Threads + r.migration.WriteThreads + 1; poolSize > r.dbConfig.MaxOpenConnections {
+	// Autoscaling drives the buffered copier's applier worker pool; the legacy
+	// unbuffered copier has no such pool, so the combination downgrades to a
+	// fixed thread count with a warning rather than silently doing nothing.
+	autoscale := r.migration.EnableExperimentalAutoscaling
+	if autoscale && r.migration.Unbuffered {
+		r.logger.Warn("--enable-experimental-autoscaling has no effect with --unbuffered; write threads stay fixed",
+			"write_threads", r.migration.WriteThreads)
+		autoscale = false
+	}
+	// Resolve the autoscaler's upper bound. When autoscaling is disabled this
+	// equals WriteThreads (no movement); when enabled it's fixed at 2x the
+	// start value.
+	maxWrite := throttler.ResolveMaxWriteThreads(r.migration.WriteThreads, autoscale)
+	// Finalize the pool now that WriteThreads (and its autoscale ceiling) is
+	// known: threads + maxWrite + 1 (see the MaxOpenConnections doc in Run).
+	// Sizing for maxWrite ensures a scaled-up applier never starves on
+	// connections. This is a no-op unless WriteThreads was auto-sized up from 0
+	// or autoscaling raised the ceiling; the pool only ever grows.
+	if poolSize := r.migration.Threads + maxWrite + 1; poolSize > r.dbConfig.MaxOpenConnections {
 		r.dbConfig.MaxOpenConnections = poolSize
 		r.db.SetMaxOpenConns(poolSize)
 	}
@@ -546,6 +561,11 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 		DBConfig:        r.dbConfig,
 		Applier:         appl,
 		Unbuffered:      r.migration.Unbuffered,
+		Autoscale: copier.AutoscaleConfig{
+			Enabled:      autoscale,
+			StartThreads: r.migration.WriteThreads,
+			MaxThreads:   maxWrite,
+		},
 	})
 	if err != nil {
 		return err

--- a/pkg/throttler/aurora_activethreads.go
+++ b/pkg/throttler/aurora_activethreads.go
@@ -110,6 +110,18 @@ func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int, logger 
 	return auroraVCPUs(ctx, db)
 }
 
+// ResolveMaxWriteThreads resolves the upper bound the write-thread autoscaler
+// may scale to. When autoscaling is disabled the cap equals start, so the
+// thread count cannot move. When enabled the cap is fixed at 2 × start —
+// deliberately not configurable for now, to keep the experimental surface
+// small. See issue #831.
+func ResolveMaxWriteThreads(start int, autoscaleEnabled bool) int {
+	if !autoscaleEnabled {
+		return start
+	}
+	return 2 * start
+}
+
 // activeThreadsPollInterval mirrors commitLatencyPollInterval — we want fast
 // enough to catch sustained CPU pressure without hammering the perf-schema
 // join. Var (not const) so tests can shorten it.
@@ -149,7 +161,7 @@ type ActiveThreads struct {
 	lastActiveThreads atomic.Int64
 }
 
-var _ Throttler = (*ActiveThreads)(nil)
+var _ GradualThrottler = (*ActiveThreads)(nil)
 
 // NewActiveThreadsThrottler returns a Throttler that polls performance_schema
 // to count on-CPU query threads and throttles when that count exceeds the
@@ -203,6 +215,16 @@ func (a *ActiveThreads) Close() error {
 
 func (a *ActiveThreads) IsThrottled() bool {
 	return a.isThrottled.Load()
+}
+
+// Utilization reports the most recent active-CPU-thread count as a fraction of
+// the instance vCPU count. 1.0 means active threads equal vCPUs (the point at
+// which one more thread trips IsThrottled). Returns 0 if vCPUs is not yet known.
+func (a *ActiveThreads) Utilization() float64 {
+	if a.vCPUs <= 0 {
+		return 0
+	}
+	return float64(a.lastActiveThreads.Load()) / float64(a.vCPUs)
 }
 
 // BlockWait blocks until active CPU threads fall to or below vCPUs, or up to

--- a/pkg/throttler/aurora_activethreads_test.go
+++ b/pkg/throttler/aurora_activethreads_test.go
@@ -52,6 +52,23 @@ func TestActiveThreads_RecoversBelowVCPUs(t *testing.T) {
 	require.False(t, a.IsThrottled())
 }
 
+func TestActiveThreads_Utilization(t *testing.T) {
+	a := newTestActiveThreads(t, 8)
+	a.applySample(4)
+	require.InDelta(t, 0.5, a.Utilization(), 1e-9)
+	a.applySample(8) // exactly at vCPUs => 1.0
+	require.InDelta(t, 1.0, a.Utilization(), 1e-9)
+	a.applySample(12) // oversubscribed => >1.0
+	require.InDelta(t, 1.5, a.Utilization(), 1e-9)
+}
+
+func TestActiveThreads_UtilizationZeroVCPUs(t *testing.T) {
+	// vCPUs unknown (Open not yet called) must not divide by zero.
+	a := newTestActiveThreads(t, 0)
+	a.applySample(4)
+	require.Zero(t, a.Utilization())
+}
+
 func TestActiveThreads_BlockWaitReturnsImmediatelyWhenUnthrottled(t *testing.T) {
 	a := newTestActiveThreads(t, 8)
 	start := time.Now()
@@ -139,6 +156,15 @@ func TestResolveWriteThreads_NonAuroraUsesDefault_LocalMySQL(t *testing.T) {
 	n, err := ResolveWriteThreads(t.Context(), db, 0, discardLogger())
 	require.NoError(t, err)
 	require.Equal(t, DefaultWriteThreads, n)
+}
+
+func TestResolveMaxWriteThreads(t *testing.T) {
+	// Disabled: cap equals start so the count cannot move.
+	require.Equal(t, 4, ResolveMaxWriteThreads(4, false))
+
+	// Enabled: the cap is fixed at 2x the start value (not configurable).
+	require.Equal(t, 8, ResolveMaxWriteThreads(4, true))
+	require.Equal(t, 10, ResolveMaxWriteThreads(5, true))
 }
 
 func TestAuroraVCPUs_LocalMySQL(t *testing.T) {

--- a/pkg/throttler/aurora_commitlatency.go
+++ b/pkg/throttler/aurora_commitlatency.go
@@ -87,7 +87,7 @@ type CommitLatency struct {
 	avgLatencyUs atomic.Int64
 }
 
-var _ Throttler = (*CommitLatency)(nil)
+var _ GradualThrottler = (*CommitLatency)(nil)
 
 // NewCommitLatencyThrottler returns a Throttler that polls Aurora's commit
 // counters and throttles when window-averaged commit latency >= threshold.
@@ -141,6 +141,18 @@ func (c *CommitLatency) Close() error {
 
 func (c *CommitLatency) IsThrottled() bool {
 	return c.isThrottled.Load()
+}
+
+// Utilization reports the most recent window-averaged commit latency as a
+// fraction of the configured threshold. 1.0 means latency equals the threshold
+// (the point at which IsThrottled trips). Returns 0 if the threshold is
+// non-positive (which NewCommitLatencyThrottler already rejects).
+func (c *CommitLatency) Utilization() float64 {
+	thresholdUs := c.threshold.Microseconds()
+	if thresholdUs <= 0 {
+		return 0
+	}
+	return float64(c.avgLatencyUs.Load()) / float64(thresholdUs)
 }
 
 // BlockWait blocks until commit latency falls below the threshold, or up to

--- a/pkg/throttler/aurora_commitlatency_test.go
+++ b/pkg/throttler/aurora_commitlatency_test.go
@@ -101,6 +101,21 @@ func TestCommitLatency_CounterResetClearsThrottle(t *testing.T) {
 	require.Equal(t, int64(0), c.avgLatencyUs.Load())
 }
 
+func TestCommitLatency_Utilization(t *testing.T) {
+	c := newTestCommitLatency(t, 100*time.Millisecond)
+
+	c.applySample(1_000_000, 2_000_000_000) // baseline, no Δ yet
+	require.Zero(t, c.Utilization())
+
+	// 1000 commits, +50_000_000us latency → 50ms avg → 0.5 of a 100ms threshold.
+	c.applySample(1_001_000, 2_050_000_000)
+	require.InDelta(t, 0.5, c.Utilization(), 1e-9)
+
+	// 1000 commits, +200_000_000us latency → 200ms avg → 2.0 of threshold.
+	c.applySample(1_002_000, 2_250_000_000)
+	require.InDelta(t, 2.0, c.Utilization(), 1e-9)
+}
+
 func TestCommitLatency_BlockWaitReturnsImmediatelyWhenUnthrottled(t *testing.T) {
 	c := newTestCommitLatency(t, 100*time.Millisecond)
 	start := time.Now()

--- a/pkg/throttler/mock.go
+++ b/pkg/throttler/mock.go
@@ -5,6 +5,9 @@ import (
 	"time"
 )
 
+// Mock is an always-throttled test throttler. It is deliberately binary (no
+// GradualThrottler): tests that exercise the autoscaler's continuous signal
+// use their own GradualThrottler stub instead.
 type Mock struct {
 }
 

--- a/pkg/throttler/multi.go
+++ b/pkg/throttler/multi.go
@@ -15,18 +15,50 @@ type multiThrottler struct {
 
 var _ Throttler = &multiThrottler{}
 
+// gradualMultiThrottler is the multiThrottler variant returned when at least
+// one child implements GradualThrottler, so that asserting GradualThrottler on
+// the composite reflects whether a continuous signal actually exists inside.
+type gradualMultiThrottler struct {
+	*multiThrottler
+}
+
+var _ GradualThrottler = &gradualMultiThrottler{}
+
+// Utilization returns the maximum utilization across the gradual children —
+// the most-loaded signal is the bottleneck and governs scaling decisions.
+// Binary-only children (e.g. replica lag) contribute nothing here; they
+// protect via the IsThrottled/BlockWait hard-stop.
+func (g *gradualMultiThrottler) Utilization() float64 {
+	var maxUtil float64
+	for _, t := range g.throttlers {
+		if gt, ok := t.(GradualThrottler); ok {
+			if u := gt.Utilization(); u > maxUtil {
+				maxUtil = u
+			}
+		}
+	}
+	return maxUtil
+}
+
 // NewMultiThrottler creates a throttler that wraps multiple child throttlers.
-// If zero throttlers are provided, it returns a Noop. If one is provided,
-// it is returned directly without wrapping.
+// If zero throttlers are provided, it returns a Noop. If one is provided, it
+// is returned directly without wrapping. With more than one, the returned
+// composite implements GradualThrottler if and only if at least one child
+// does.
 func NewMultiThrottler(throttlers ...Throttler) Throttler {
 	switch len(throttlers) {
 	case 0:
 		return &Noop{}
 	case 1:
 		return throttlers[0]
-	default:
-		return &multiThrottler{throttlers: throttlers}
 	}
+	mt := &multiThrottler{throttlers: throttlers}
+	for _, t := range throttlers {
+		if _, ok := t.(GradualThrottler); ok {
+			return &gradualMultiThrottler{multiThrottler: mt}
+		}
+	}
+	return mt
 }
 
 func (m *multiThrottler) Open(ctx context.Context) error {

--- a/pkg/throttler/multi_test.go
+++ b/pkg/throttler/multi_test.go
@@ -3,6 +3,7 @@ package throttler
 import (
 	"context"
 	"errors"
+	"math"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -26,7 +27,8 @@ func TestNewMultiThrottler_Multiple(t *testing.T) {
 	require.IsType(t, &multiThrottler{}, throttler)
 }
 
-// testThrottler is a configurable throttler for testing.
+// testThrottler is a configurable binary throttler for testing. It does NOT
+// implement GradualThrottler — see gradualTestThrottler for that.
 type testThrottler struct {
 	throttled    atomic.Bool
 	openErr      error
@@ -65,6 +67,23 @@ func (t *testThrottler) BlockWait(ctx context.Context) {
 
 func (t *testThrottler) UpdateLag(_ context.Context) error {
 	return t.updateLagErr
+}
+
+// gradualTestThrottler extends testThrottler with a scripted continuous
+// signal, making it a GradualThrottler.
+type gradualTestThrottler struct {
+	testThrottler
+	util atomic.Uint64 // float64 bits, set via setUtilization
+}
+
+var _ GradualThrottler = &gradualTestThrottler{}
+
+func (t *gradualTestThrottler) setUtilization(u float64) {
+	t.util.Store(math.Float64bits(u))
+}
+
+func (t *gradualTestThrottler) Utilization() float64 {
+	return math.Float64frombits(t.util.Load())
 }
 
 func TestMultiThrottler_Open(t *testing.T) {
@@ -154,6 +173,38 @@ func TestMultiThrottler_IsThrottled_AllThrottled(t *testing.T) {
 	t2.throttled.Store(true)
 	multi := NewMultiThrottler(t1, t2)
 
+	require.True(t, multi.IsThrottled())
+}
+
+func TestMultiThrottler_GradualOnlyWhenAChildIs(t *testing.T) {
+	// All-binary children: the composite must NOT advertise a continuous
+	// signal it doesn't have — the autoscaler gates on this assertion.
+	binary := NewMultiThrottler(&testThrottler{}, &testThrottler{})
+	_, ok := binary.(GradualThrottler)
+	require.False(t, ok, "all-binary multi must not implement GradualThrottler")
+
+	// One gradual child is enough to make the composite gradual.
+	mixed := NewMultiThrottler(&testThrottler{}, &gradualTestThrottler{})
+	_, ok = mixed.(GradualThrottler)
+	require.True(t, ok, "multi with a gradual child must implement GradualThrottler")
+}
+
+func TestMultiThrottler_Utilization_ReturnsMaxOfGradualChildren(t *testing.T) {
+	t1 := &gradualTestThrottler{}
+	t1.setUtilization(0.3)
+	t2 := &gradualTestThrottler{}
+	t2.setUtilization(0.8)
+	// A binary child (e.g. replica lag) contributes nothing to the signal,
+	// even while throttled — it protects via the hard-stop only.
+	t3 := &testThrottler{}
+	t3.throttled.Store(true)
+	multi := NewMultiThrottler(t1, t2, t3)
+
+	gradual, ok := multi.(GradualThrottler)
+	require.True(t, ok)
+	// The most-loaded gradual child governs.
+	require.InDelta(t, 0.8, gradual.Utilization(), 1e-9)
+	// The binary child still drives the hard-stop.
 	require.True(t, multi.IsThrottled())
 }
 

--- a/pkg/throttler/replica.go
+++ b/pkg/throttler/replica.go
@@ -87,6 +87,14 @@ func (l *Replica) IsThrottled() bool {
 	return atomic.LoadInt64(&l.currentLagInMs) >= l.lagTolerance.Milliseconds()
 }
 
+// Replica deliberately does NOT implement GradualThrottler: replication lag
+// is an SLO-style budget, not a load gauge — normalizing it against the
+// tolerance (typically 120s) would make the autoscaler treat half the lag
+// budget as headroom and park replicas a minute behind. It is also coarse and
+// bistable (near 0 when healthy, climbing without bound when not). Replica
+// protection stays binary: IsThrottled/BlockWait hard-stop the copy at the
+// tolerance.
+
 // BlockWait blocks until the lag is within the tolerance, or up to 60s
 // to allow some progress to be made. It respects context cancellation.
 func (l *Replica) BlockWait(ctx context.Context) {

--- a/pkg/throttler/throttler.go
+++ b/pkg/throttler/throttler.go
@@ -16,6 +16,24 @@ type Throttler interface {
 	UpdateLag(ctx context.Context) error
 }
 
+// GradualThrottler is an optional extension implemented by throttlers whose
+// underlying signal is continuous, not just a binary stop/go. The write-thread
+// autoscaler type-asserts for it and only engages when it is present.
+//
+// The Aurora throttlers (ActiveThreads, CommitLatency) implement it. The
+// replica-lag throttler deliberately does not: lag is an SLO-style budget,
+// not a load gauge — normalizing it would make the autoscaler treat half the
+// lag budget as headroom and park replicas a minute behind. Signals like that
+// stay binary, protecting via the IsThrottled/BlockWait hard-stop only.
+type GradualThrottler interface {
+	Throttler
+	// Utilization reports current load relative to this throttler's throttle
+	// point: 0 = idle, 1.0 = exactly where IsThrottled() flips true, >1.0 =
+	// over. It is the smooth, continuous signal the autoscaler controls on;
+	// IsThrottled() remains the binary hard-stop.
+	Utilization() float64
+}
+
 // NewReplicationThrottler returns a Throttler for MySQL 8.0+ replicas.
 // It uses performance_schema to monitor replication lag.
 func NewReplicationThrottler(replica *sql.DB, lagTolerance time.Duration, logger *slog.Logger) (Throttler, error) {

--- a/pkg/throttler/throttler_test.go
+++ b/pkg/throttler/throttler_test.go
@@ -55,6 +55,20 @@ func TestNoopThrottler(t *testing.T) {
 	require.NoError(t, throttler.Close())
 }
 
+// TestGradualThrottlerImplementations locks in which throttlers provide the
+// continuous utilization signal the autoscaler controls on. The Aurora
+// throttlers implement GradualThrottler (asserted at compile time in their
+// files); everything else is deliberately binary — in particular Replica,
+// because lag is an SLO-style budget, not a load gauge, and steering on it
+// would park replicas well behind. Binary throttlers protect via the
+// IsThrottled/BlockWait hard-stop only.
+func TestGradualThrottlerImplementations(t *testing.T) {
+	for _, tc := range []Throttler{&Replica{}, &Noop{}, &Mock{}} {
+		_, ok := tc.(GradualThrottler)
+		require.False(t, ok, "%T must stay binary (no GradualThrottler)", tc)
+	}
+}
+
 func TestMockThrottler(t *testing.T) {
 	throttler := &Mock{}
 


### PR DESCRIPTION
Fixes #831.

## Summary

Adds an **experimental** AIMD controller that adjusts the replication applier's live write-thread count *during* the copy, driven by a continuous "utilization" signal from the Aurora throttlers. Opt in with `--enable-experimental-autoscaling`; off by default, so existing behaviour is unchanged.

The shape is **cautious up, fast down**: add one write thread at a time below 50% utilization (with a ~15s cooldown), and halve at/above 90% — immediately on the first breach, then at most once per cooldown so the signal can reflect each cut. The binary `BlockWait()` hard-stop remains the safety net underneath.

## How it fits together

- **throttler** — `Throttler` is split into the binary base interface and a new `GradualThrottler` extension exposing `Utilization()` (0 = idle, 1.0 = exactly the hard-stop point). `ActiveThreads` and `CommitLatency` implement it; replica lag **deliberately does not** — lag is an SLO-style budget, not a load gauge, and steering on it would park replicas well behind. A multi-throttler is gradual iff at least one child is.
- **applier** — `SingleTargetApplier` gains `SetWriteWorkers()` to spawn/park write workers at runtime. `Stop()` now owns closing the completions channel (previously the last worker's defer did), which is what lets the worker count move without ever losing a completion.
- **copier** — the buffered copier engages the autoscaler only when the applier supports dynamic scaling **and** a `GradualThrottler` is present; otherwise the pool stays fixed at the starting value (with a warning). Scaling blind against a binary-only signal would just ramp to the max unguided, so we don't.
- **migration** — `--enable-experimental-autoscaling` opts in. `--write-threads` becomes the *starting* value; the upper bound is fixed at **2× that** (deliberately not configurable for now, to keep the experimental surface small) and the lower bound is always 1. The connection pool is pre-sized for the cap.

## Also in here

- `--write-threads 0` (auto-size) on a **non-Aurora** target now falls back to the default of 4 instead of erroring.

## Not in scope

- `spirit move` does **not** support autoscaling yet (it wires no Aurora throttler, so there'd be no signal). The flag is migrate-only.
- The `--unbuffered` copier has no applier worker pool; combining it with the flag logs a warning and stays fixed.

## Testing

- Autoscaler policy unit tests (increase/backoff/dead-band/clamps, the two independent cooldowns, and the engage/skip gating across all three conditions).
- `GradualThrottler` interface tests: which throttlers are gradual vs binary, and that a multi-throttler maxes over only its gradual children while a binary child still drives the hard-stop.
- Dynamic worker scaling against a real MySQL under `-race`.
- End-to-end migration with the flag on (exercises the no-signal downgrade path + pool sizing + clean goroutine shutdown via goleak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)