### PR TITLE
move: port three safety fixes from the migration runner

### DIFF
--- a/docs/move.md
+++ b/docs/move.md
@@ -13,6 +13,7 @@ This will copy all tables from the source database to the target database, verif
 
 ## Configuration
 
+- [checkpoint-max-age](#checkpoint-max-age)
 - [create-sentinel](#create-sentinel)
 - [defer-secondary-indexes](#defer-secondary-indexes)
 - [gtid](#gtid)
@@ -21,6 +22,17 @@ This will copy all tables from the source database to the target database, verif
 - [target-dsn](#target-dsn)
 - [threads](#threads)
 - [write-threads](#write-threads)
+
+### checkpoint-max-age
+
+- Type: Duration
+- Default value: `168h` (7 days)
+
+The maximum age of a checkpoint before Move refuses to resume from it. Replaying many days of accumulated binary logs can be slower than re-copying, and the binary logs may have been purged in the meantime.
+
+Unlike [migrate](migrate.md#checkpoint-max-age), Move does **not** fall back to a fresh copy when the checkpoint is too old: the target tables already contain rows (which is why the resume path was selected), so silently restarting is not possible. Instead the move fails with a `checkpoint is too old to safely resume` error. To proceed, either re-run with a larger `--checkpoint-max-age`, or wipe the target tables (including the `_spirit_checkpoint` table) and restart the move from scratch.
+
+The same caveats about [resuming across Spirit binary versions](migrate.md#resuming-across-spirit-binary-versions) apply to Move, with one difference: where migrate silently discards an unreadable checkpoint and starts fresh, Move fails the run.
 
 ### create-sentinel
 

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -17,6 +17,7 @@ type Move struct {
 	WriteThreads          int           `name:"write-threads" help:"How many concurrent write threads to use per target. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" default:"4"`
 	CreateSentinel        bool          `name:"create-sentinel" help:"Create a sentinel table on the source database to block after table copy" default:"false"`
 	DeferSecondaryIndexes bool          `name:"defer-secondary-indexes" help:"Create target tables without secondary indexes, add them before cutover" default:"false"`
+	CheckpointMaxAge      time.Duration `name:"checkpoint-max-age" help:"Maximum age of a checkpoint before refusing to resume from it" optional:"" default:"168h"`
 
 	// GTID switches the change source from binlog file+position to MySQL GTIDs.
 	// EXPERIMENTAL — see pkg/change/gtid.go. Requires gtid_mode=ON and

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
@@ -96,6 +97,15 @@ type Runner struct {
 	cancelFunc context.CancelFunc
 	dbConfig   *dbconn.DBConfig
 
+	// fatalOnce makes fatalError idempotent. Move wires N repl clients
+	// (one per source) to the same fatalError callback, so a concurrent
+	// burst of fatal events is realistic and without Once could
+	// double-drop the checkpoint and double-cancel the context. The
+	// individual operations underneath are idempotent, but routing
+	// everything through Once keeps the side-effect set small enough to
+	// reason about and avoids racing with Close() teardown.
+	fatalOnce sync.Once
+
 	// watchTaskWait blocks until the WatchTask goroutines have exited.
 	// Set in startBackgroundRoutines and invoked from Close() so that
 	// late status/checkpoint goroutine activity cannot race with teardown.
@@ -105,6 +115,16 @@ type Runner struct {
 var _ status.Task = (*Runner)(nil)
 
 func NewRunner(m *Move) (*Runner, error) {
+	// Normalize CheckpointMaxAge here rather than in a Validate hook:
+	// orchestration callers construct Move programmatically (bypassing the
+	// Kong default of 168h), so a zero value means "use the default". This
+	// mirrors Migration.normalizeOptions in pkg/migration.
+	if m.CheckpointMaxAge < 0 {
+		return nil, fmt.Errorf("checkpoint-max-age must be non-negative, got %s", m.CheckpointMaxAge)
+	}
+	if m.CheckpointMaxAge == 0 {
+		m.CheckpointMaxAge = 7 * 24 * time.Hour // 7 days, same as migrate
+	}
 	r := &Runner{
 		move:   m,
 		logger: slog.Default(),
@@ -124,9 +144,14 @@ func (r *Runner) Close() error {
 	if r.watchTaskWait != nil {
 		r.watchTaskWait()
 	}
+	// Run every cleanup step unconditionally and collect errors with
+	// errors.Join. Previously the first failing step short-circuited the
+	// rest, leaking the remaining repl clients' binlog reader goroutines
+	// and the target DB handles.
+	var errs []error
 	if r.copyChunker != nil {
 		if err := r.copyChunker.Close(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	for i := range r.sources {
@@ -135,11 +160,14 @@ func (r *Runner) Close() error {
 		}
 	}
 	for _, target := range r.targets {
+		if target.DB == nil {
+			continue
+		}
 		if err := target.DB.Close(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // getTables connects to a source DB and fetches the list of tables.
@@ -330,14 +358,39 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	}
 
 	// Read checkpoint from targets[0] by convention.
+	// A checkpoint table without the created_at column was written by an
+	// older spirit version; the read fails and the move aborts (we do not
+	// support cross-version resume).
 	tgt0 := &r.targets[0]
-	query := fmt.Sprintf("SELECT id, copier_watermark, checksum_watermark, binlog_positions, statement FROM `%s`.`%s` ORDER BY id DESC LIMIT 1",
+	query := fmt.Sprintf("SELECT id, copier_watermark, checksum_watermark, binlog_positions, statement, created_at FROM `%s`.`%s` ORDER BY id DESC LIMIT 1",
 		tgt0.Config.DBName, checkpointTableName)
-	var copierWatermark, binlogPositionsJSON, stmt string
+	var copierWatermark, binlogPositionsJSON, stmt, createdAtStr string
 	var id int
-	err = tgt0.DB.QueryRowContext(ctx, query).Scan(&id, &copierWatermark, &r.checksumWatermark, &binlogPositionsJSON, &stmt)
+	err = tgt0.DB.QueryRowContext(ctx, query).Scan(&id, &copierWatermark, &r.checksumWatermark, &binlogPositionsJSON, &stmt, &createdAtStr)
 	if err != nil {
 		return fmt.Errorf("could not read from checkpoint table '%s' on target: %w", checkpointTableName, err)
+	}
+
+	// Check if the checkpoint is too old to safely resume — replaying many
+	// days of binary logs can be slower than re-copying, and the binlogs may
+	// have been purged anyway. This must happen before any destructive step
+	// (deleteAboveWatermark below modifies the targets). Unlike migrate,
+	// move cannot silently fall back to a fresh copy: the target tables are
+	// non-empty (that is exactly why setup() chose the resume path), so we
+	// fail loudly and leave the decision to the operator.
+	// The connection uses time_zone="+00:00", so timestamps are in UTC.
+	createdAt, parseErr := time.Parse(time.DateTime, createdAtStr)
+	if parseErr != nil {
+		return fmt.Errorf("could not parse checkpoint created_at timestamp: %w", parseErr)
+	}
+	checkpointAge := time.Since(createdAt)
+	if checkpointAge >= r.move.CheckpointMaxAge {
+		return fmt.Errorf("%w: checkpoint is %s old (max allowed: %s). To proceed, either re-run with a larger --checkpoint-max-age, or wipe the target tables (including '%s') and restart the move from scratch",
+			status.ErrCheckpointTooOld,
+			checkpointAge.Round(time.Second),
+			r.move.CheckpointMaxAge,
+			checkpointTableName,
+		)
 	}
 
 	// Parse per-source positions (opaque strings owned by the source impl),
@@ -573,7 +626,8 @@ func (r *Runner) createCheckpointTable(ctx context.Context) error {
 	copier_watermark TEXT,
 	checksum_watermark TEXT,
 	binlog_positions TEXT,
-	statement TEXT
+	statement TEXT,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`,
 		tgt0.Config.DBName, checkpointTableName); err != nil {
 		return err
@@ -812,23 +866,38 @@ func (r *Runner) startBackgroundRoutines(ctx context.Context) {
 // when the error should be treated as fatal (and replication should be
 // terminated and cleaned up), and false when the error should not be treated
 // as fatal (in which case the client may continue without logging the DDL).
+//
+// fatalError is safe to call concurrently — every source's repl client is
+// wired to this same callback, so a burst of fatal events from multiple
+// binlog goroutines is realistic. fatalOnce makes the invalidate-and-cancel
+// side effects idempotent and prevents racing with Close() teardown of
+// r.checkpointTable / r.targets / r.cancelFunc.
 func (r *Runner) fatalError() bool {
 	if r.status.Get() >= status.CutOver {
 		return false
 	}
-	r.status.Set(status.ErrCleanup)
-	// Invalidate the checkpoint, so we don't try to resume.
-	// If we don't do this, the move will permanently be blocked from proceeding.
-	// Letting it start again is the better choice.
-	// Use a background context since the move context may already be cancelled.
-	if r.checkpointTable != nil && len(r.targets) > 0 {
-		if err := dbconn.Exec(context.Background(), r.targets[0].DB, "DROP TABLE IF EXISTS %n.%n", r.checkpointTable.SchemaName, r.checkpointTable.TableName); err != nil {
-			r.logger.Error("could not remove checkpoint",
-				"error", err,
-			)
+	r.fatalOnce.Do(func() {
+		r.status.Set(status.ErrCleanup)
+		// Invalidate the checkpoint, so we don't try to resume.
+		// If we don't do this, the move will permanently be blocked from proceeding.
+		// Letting it start again is the better choice.
+		// Use a background context since the move context may already be
+		// cancelled. checkpointTable can still be nil if fatalError fires
+		// during early setup, before createCheckpointTable runs — skip the
+		// drop in that case.
+		if r.checkpointTable != nil && len(r.targets) > 0 && r.targets[0].DB != nil {
+			if err := dbconn.Exec(context.Background(), r.targets[0].DB, "DROP TABLE IF EXISTS %n.%n", r.checkpointTable.SchemaName, r.checkpointTable.TableName); err != nil {
+				r.logger.Error("could not remove checkpoint",
+					"error", err,
+				)
+			}
 		}
-	}
-	r.cancelFunc() // cancel the move context
+		// cancelFunc can be nil during early setup or in test paths that
+		// bypass Run; nil-check before calling.
+		if r.cancelFunc != nil {
+			r.cancelFunc() // cancel the move context
+		}
+	})
 	return true
 }
 
@@ -1173,15 +1242,18 @@ func (r *Runner) Progress() status.Progress {
 	}
 }
 
-// createSentinelTable creates sentinel table on SOURCE (not target).
+// createSentinelTable creates the sentinel table on SOURCE (not target) if
+// it does not already exist. The sentinel name (_spirit_sentinel) is shared
+// with every other spirit process in the schema — including --defer-cutover
+// migrations — so creation must be idempotent and must never pass through a
+// "table absent" state: a concurrent process polls its sentinel wait every
+// sentinelCheckInterval, and a DROP+CREATE pair here opens a window in which
+// that poll observes the sentinel as missing and proceeds to cutover without
+// operator approval. The table is contentless and only its existence
+// matters, so adopting an existing sentinel is equivalent to creating a
+// fresh one.
 func (r *Runner) createSentinelTable(ctx context.Context) error {
-	if err := dbconn.Exec(ctx, r.sources[0].db, "DROP TABLE IF EXISTS %n.%n", r.sources[0].config.DBName, sentinelTableName); err != nil {
-		return err
-	}
-	if err := dbconn.Exec(ctx, r.sources[0].db, "CREATE TABLE %n.%n (id int NOT NULL PRIMARY KEY)", r.sources[0].config.DBName, sentinelTableName); err != nil {
-		return err
-	}
-	return nil
+	return dbconn.Exec(ctx, r.sources[0].db, "CREATE TABLE IF NOT EXISTS %n.%n (id int NOT NULL PRIMARY KEY)", r.sources[0].config.DBName, sentinelTableName)
 }
 
 // sentinelTableExists checks if sentinel table exists on SOURCE (not target).

--- a/pkg/move/runner_close_test.go
+++ b/pkg/move/runner_close_test.go
@@ -1,0 +1,185 @@
+package move
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests mirror pkg/migration/runner_close_test.go: the move runner
+// forked from the migration runner and its fatalError/Close paths must
+// uphold the same contracts. The exposure is larger here — move wires one
+// repl client per source to the same fatalError callback, so concurrent
+// invocation is realistic, not just theoretical.
+
+// TestFatalErrorIsIdempotent pins the invariant that fatalError's side
+// effects (status transition + context cancel) run at most once, even
+// under a burst of fatal events. After the first call the status sits at
+// ErrCleanup, which is numerically greater than CutOver, so the
+// early-return path swallows subsequent calls — but if a second caller
+// races the first past the status check, fatalOnce still prevents the
+// side effects from running twice.
+//
+// The test uses a minimal Runner constructed by hand: targets and
+// checkpointTable are left empty/nil so the (now-guarded) checkpoint-drop
+// path is a no-op. cancelFunc is a counter we observe.
+func TestFatalErrorIsIdempotent(t *testing.T) {
+	var cancelCalls atomic.Int32
+	r := &Runner{
+		logger:     slog.Default(),
+		cancelFunc: func() { cancelCalls.Add(1) },
+	}
+
+	require.True(t, r.fatalError(), "first call must return true")
+	require.Equal(t, int32(1), cancelCalls.Load(), "first call must cancel once")
+	require.Equal(t, status.ErrCleanup, r.status.Get(), "status must transition to ErrCleanup")
+
+	// Subsequent calls: status (ErrCleanup) > CutOver, so the early
+	// return kicks in. cancel must not be re-invoked.
+	require.False(t, r.fatalError(), "subsequent call returns false via the past-cutover guard")
+	require.False(t, r.fatalError(), "and again")
+	require.Equal(t, int32(1), cancelCalls.Load(), "cancel must not be re-invoked")
+}
+
+// TestFatalErrorConcurrentRace exercises the fatalOnce guard directly:
+// many goroutines call fatalError in parallel before any has finished
+// setting status, simulating N repl clients (one per source) hitting a
+// fatal stream error at the same time. The Once ensures cancelFunc fires
+// exactly once even when the racing callers all pass the pre-CutOver
+// status check. Run with -race.
+func TestFatalErrorConcurrentRace(t *testing.T) {
+	var cancelCalls atomic.Int32
+	r := &Runner{
+		logger:     slog.Default(),
+		cancelFunc: func() { cancelCalls.Add(1) },
+	}
+
+	const goroutines = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			r.fatalError()
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, int32(1), cancelCalls.Load(),
+		"cancelFunc must fire exactly once regardless of concurrent fatalError calls")
+}
+
+// TestFatalErrorPastCutoverIsNoop pins the existing contract that
+// fatalError is a no-op once the move is at or past cutover: Spirit's own
+// RENAME TABLE DDL is expected at that point and must not invalidate the
+// (already-irrelevant) checkpoint.
+func TestFatalErrorPastCutoverIsNoop(t *testing.T) {
+	var cancelCalls atomic.Int32
+	r := &Runner{
+		logger:     slog.Default(),
+		cancelFunc: func() { cancelCalls.Add(1) },
+	}
+	r.status.Set(status.CutOver)
+
+	require.False(t, r.fatalError(), "fatalError at/past cutover must return false")
+	require.Equal(t, int32(0), cancelCalls.Load(), "must not cancel at/past cutover")
+	require.Equal(t, status.CutOver, r.status.Get(), "status must not transition")
+}
+
+// TestFatalErrorSafeWithoutCancelFunc verifies fatalError tolerates a nil
+// cancelFunc (early setup / test paths that bypass Run). Without the
+// nil-check it nil-derefs.
+func TestFatalErrorSafeWithoutCancelFunc(t *testing.T) {
+	r := &Runner{
+		logger: slog.Default(),
+		// cancelFunc intentionally nil
+	}
+	require.NotPanics(t, func() {
+		require.True(t, r.fatalError())
+	})
+}
+
+// fakeChangeSource is a minimal change.Source used to observe that
+// Close() reaches every repl client even when an earlier cleanup step
+// failed.
+type fakeChangeSource struct {
+	closed atomic.Bool
+}
+
+func (f *fakeChangeSource) AddSubscription(_, _ *table.TableInfo, _ table.MappedChunker) error {
+	return nil
+}
+func (f *fakeChangeSource) Start(_ context.Context) error                       { return nil }
+func (f *fakeChangeSource) StartFromPosition(_ context.Context, _ string) error { return nil }
+func (f *fakeChangeSource) Position() string                                    { return "" }
+func (f *fakeChangeSource) Flush(_ context.Context) error                       { return nil }
+func (f *fakeChangeSource) FlushUnderTableLock(_ context.Context, _ []*dbconn.TableLock) error {
+	return nil
+}
+func (f *fakeChangeSource) BlockWait(_ context.Context) error { return nil }
+func (f *fakeChangeSource) GetDeltaLen() int                  { return 0 }
+func (f *fakeChangeSource) SetWatermarkOptimization(_ context.Context, _ bool) error {
+	return nil
+}
+func (f *fakeChangeSource) StartPeriodicFlush(_ context.Context, _ time.Duration) {}
+func (f *fakeChangeSource) StopPeriodicFlush()                                    {}
+func (f *fakeChangeSource) AllChangesFlushed() bool                               { return true }
+func (f *fakeChangeSource) Close()                                                { f.closed.Store(true) }
+
+// TestCloseRunsAllClosersOnError pins the Close() aggregation contract:
+// every cleanup step runs even when an early one fails. Previously the
+// first failing step short-circuited the rest, leaking the remaining repl
+// clients' binlog reader goroutines and the target DB handles. The
+// chunker is rigged to fail Close(); the repl clients and target DBs must
+// still be closed, and the chunker's error must surface in the joined
+// result.
+func TestCloseRunsAllClosersOnError(t *testing.T) {
+	chunkerErr := errors.New("chunker close failed")
+	mockChunker := table.NewMockChunker("t1", 100)
+	require.NoError(t, mockChunker.Open())
+	mockChunker.SetCloseError(chunkerErr)
+
+	repl1 := &fakeChangeSource{}
+	repl2 := &fakeChangeSource{}
+
+	db1, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	db2, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+
+	r := &Runner{
+		logger:      slog.Default(),
+		copyChunker: mockChunker,
+		sources: []sourceInfo{
+			{replClient: repl1},
+			{replClient: repl2},
+		},
+		targets: []applier.Target{
+			{KeyRange: "0", DB: db1},
+			{KeyRange: "1", DB: db2},
+		},
+	}
+
+	err = r.Close()
+	require.ErrorIs(t, err, chunkerErr, "the failing step's error must surface")
+
+	require.True(t, repl1.closed.Load(), "repl client 1 must be closed despite the chunker error")
+	require.True(t, repl2.closed.Load(), "repl client 2 must be closed despite the chunker error")
+	require.ErrorContains(t, db1.PingContext(t.Context()), "database is closed",
+		"target DB 1 must be closed despite the chunker error")
+	require.ErrorContains(t, db2.PingContext(t.Context()), "database is closed",
+		"target DB 2 must be closed despite the chunker error")
+}

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
@@ -839,4 +841,137 @@ func varcharPKWriteOne(ctx context.Context, db *sql.DB, srcDB string) error {
 		}
 	}
 	return nil
+}
+
+// TestResumeFromCheckpointTooOld verifies that resume refuses a checkpoint
+// whose created_at exceeds CheckpointMaxAge. Unlike the migrate equivalent
+// (TestResumeFromCheckpointTooOld in pkg/migration), the move cannot fall
+// back to a fresh copy — the target tables already contain rows, which is
+// the very reason setup() chose the resume path — so the move must fail
+// loudly with status.ErrCheckpointTooOld and leave the next step to the
+// operator (raise --checkpoint-max-age, or wipe the targets and restart).
+func TestResumeFromCheckpointTooOld(t *testing.T) {
+	srcDB := "source_chkpt_age"
+	dstDB := "dest_chkpt_age"
+	sourceDSN := testutils.DSNForDatabase(srcDB)
+	targetDSN := testutils.DSNForDatabase(dstDB)
+
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+srcDB)
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+dstDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+srcDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+dstDB)
+
+	// Enough rows for several chunks so the copier watermark is ready when
+	// checkpointAndStop dumps the checkpoint. Same shape/size as
+	// TestResumeFromCheckpointMultiTableE2E's t1 (~1010 rows).
+	testutils.RunSQL(t, "CREATE TABLE "+srcDB+".t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, val VARBINARY(64))")
+	testutils.RunSQL(t, "INSERT INTO "+srcDB+".t1 (val) SELECT RANDOM_BYTES(64)")
+	for range 3 { // 1 -> 2 -> 10 -> 1010 rows
+		testutils.RunSQL(t, "INSERT INTO "+srcDB+".t1 (val) SELECT RANDOM_BYTES(64) FROM "+srcDB+".t1 a JOIN "+srcDB+".t1 b JOIN "+srcDB+".t1 c LIMIT 5000")
+	}
+
+	move := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         1,
+		WriteThreads:    1,
+	}
+	checkpointAndStop(t, move)
+
+	// Backdate the checkpoint's created_at to simulate a checkpoint older
+	// than the 7-day default (8 days ago).
+	testutils.RunSQL(t, "UPDATE "+dstDB+"."+checkpointTableName+" SET created_at = DATE_SUB(NOW(), INTERVAL 8 DAY)")
+
+	// Resume must refuse with the sentinel error and not touch the targets.
+	r, err := NewRunner(move)
+	require.NoError(t, err)
+	err = r.Run(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, status.ErrCheckpointTooOld)
+	require.ErrorContains(t, err, "wipe the target tables")
+	require.False(t, r.usedResumeFromCheckpoint)
+	require.NoError(t, r.Close())
+}
+
+// TestResumeFromCheckpointNotTooOld verifies that a fresh checkpoint (well
+// within CheckpointMaxAge) still resumes — i.e. the new age check does not
+// reject valid checkpoints. The resume itself is the same path covered by
+// TestResumeFromCheckpointMultiTableE2E; this variant exists to bracket the
+// age check from both sides.
+func TestResumeFromCheckpointNotTooOld(t *testing.T) {
+	srcDB := "source_chkpt_fresh"
+	dstDB := "dest_chkpt_fresh"
+	sourceDSN := testutils.DSNForDatabase(srcDB)
+	targetDSN := testutils.DSNForDatabase(dstDB)
+
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+srcDB)
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+dstDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+srcDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+dstDB)
+
+	testutils.RunSQL(t, "CREATE TABLE "+srcDB+".t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, val VARBINARY(64))")
+	testutils.RunSQL(t, "INSERT INTO "+srcDB+".t1 (val) SELECT RANDOM_BYTES(64)")
+	for range 3 { // 1 -> 2 -> 10 -> 1010 rows
+		testutils.RunSQL(t, "INSERT INTO "+srcDB+".t1 (val) SELECT RANDOM_BYTES(64) FROM "+srcDB+".t1 a JOIN "+srcDB+".t1 b JOIN "+srcDB+".t1 c LIMIT 5000")
+	}
+
+	move := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         1,
+		WriteThreads:    1,
+	}
+	checkpointAndStop(t, move)
+
+	// Do NOT backdate the checkpoint — it was just created, so it's fresh.
+	move.TargetChunkTime = 5 * time.Second
+	r, err := NewRunner(move)
+	require.NoError(t, err)
+	require.NoError(t, r.Run(t.Context()))
+	require.True(t, r.usedResumeFromCheckpoint, "a fresh checkpoint must still resume")
+	require.NoError(t, r.Close())
+}
+
+// TestCreateSentinelTableIdempotent verifies that createSentinelTable
+// adopts an existing sentinel rather than DROP+CREATE-ing it. The sentinel
+// name is shared with concurrent spirit processes polling it every
+// sentinelCheckInterval, so a DROP+CREATE pair opens a window in which a
+// concurrent --defer-cutover migration observes the sentinel as missing and
+// cuts over without operator approval. We prove no DROP happens by seeding
+// a marker row and asserting it survives both calls.
+func TestCreateSentinelTableIdempotent(t *testing.T) {
+	srcDB := "source_sentinel_idem"
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+srcDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+srcDB)
+
+	db, err := dbconn.New(testutils.DSNForDatabase(srcDB), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	cfg, err := mysql.ParseDSN(testutils.DSNForDatabase(srcDB))
+	require.NoError(t, err)
+
+	r := &Runner{
+		logger:  slog.Default(),
+		sources: []sourceInfo{{db: db, config: cfg}},
+	}
+
+	// Pre-create the sentinel with a marker row, as if another spirit
+	// process (or an earlier run) had already created it.
+	testutils.RunSQL(t, "CREATE TABLE "+srcDB+"."+sentinelTableName+" (id int NOT NULL PRIMARY KEY)")
+	testutils.RunSQL(t, "INSERT INTO "+srcDB+"."+sentinelTableName+" VALUES (1)")
+
+	// Both calls must succeed and adopt the existing table.
+	require.NoError(t, r.createSentinelTable(t.Context()))
+	require.NoError(t, r.createSentinelTable(t.Context()))
+
+	exists, err := r.sentinelTableExists(t.Context())
+	require.NoError(t, err)
+	require.True(t, exists, "sentinel must exist after createSentinelTable")
+
+	var markerCount int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM "+srcDB+"."+sentinelTableName).Scan(&markerCount))
+	require.Equal(t, 1, markerCount, "the pre-existing sentinel must be adopted, not dropped and recreated")
 }


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #925** (`fix-move-resume-watermarks`) — the diff includes its commits until it merges. Review only the last commit, or the diff against that branch.

## Summary

The move runner forked from the migration runner and missed three safety fixes that landed only on the migrate side. This ports all three.

### 1. Checkpoint max-age guard (migrate: 0f921be6, 04b86909, 996f5797)

Move's checkpoint table had no `created_at` column and resume did no age validation — a move would resume from an arbitrarily old checkpoint and replay weeks of binlogs (or fail midway once they'd been purged).

- `created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP` added to the checkpoint DDL.
- New `--checkpoint-max-age` flag on `Move` (default `168h`, same as migrate), normalized in `NewRunner` (zero → default, negative → error) so programmatic callers that bypass Kong get the default too.
- Resume rejects with the shared `status.ErrCheckpointTooOld`, checked **before** the destructive `deleteAboveWatermark` step.

**Operator UX (deliberate difference from migrate):** move does *not* fall back to a fresh copy — the targets are non-empty (that's exactly why the resume path was selected), so it fails loudly and tells the operator to either raise `--checkpoint-max-age` or wipe the targets (including `_spirit_checkpoint`) and restart. Documented in docs/move.md.

### 2. Sentinel DROP+CREATE race (migrate: 9ce0a43b)

`createSentinelTable` still did DROP-then-CREATE. Both tools share the `_spirit_sentinel` name, and a concurrent `--defer-cutover` process polls its sentinel wait every second — the DROP opens a window where that poll observes the sentinel missing and **cuts over without operator approval**. Now a single idempotent `CREATE TABLE IF NOT EXISTS`, with the migrate-side rationale comment adapted.

### 3. fatalError/Close hardening (migrate: ea9c076a)

- `fatalError` now routes through `sync.Once` — move wires N repl clients (one per source) to the same callback, so a concurrent burst is realistic — and nil-checks `cancelFunc`/`targets[0].DB` for early-setup invocations.
- `Close()` runs every cleanup step and `errors.Join`s the results. Previously the first failing step short-circuited the rest, leaking the remaining repl clients' binlog reader goroutines and all target DB handles.

## Testing

- `TestResumeFromCheckpointTooOld` / `TestResumeFromCheckpointNotTooOld` — real checkpoint, backdated via SQL; asserts `errors.Is(err, status.ErrCheckpointTooOld)` and that a fresh checkpoint still resumes.
- `TestCreateSentinelTableIdempotent` — pre-existing sentinel is adopted, never dropped.
- `pkg/move/runner_close_test.go` — mirrors migrate's contract tests: idempotency, 32-goroutine concurrent fatalError burst under `-race` (cancelFunc fires exactly once), past-cutover no-op, nil-cancelFunc safety.
- `TestCloseRunsAllClosersOnError` — rigged chunker close failure; both repl clients and both target DBs still closed, error surfaced via `errors.Is`.
- `go test -race ./pkg/move/ -run 'Sentinel|Checkpoint|Resume|Fatal|Close'` — 16 tests pass; `TestBasicMove`/`TestMoveWithNewTableCreation` pass under `-race`; golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
