### PR TITLE
migration: verify server state when cutover RENAME fails with connection loss

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -7,6 +7,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/rand"
 	"sync"
@@ -83,25 +84,25 @@ func NewDBConfig() *DBConfig {
 	}
 }
 
-// canRetryError looks at the MySQL error and decides if it is considered
-// a permanent failure or not. For simplicity a "retryable" error means
-// rollback the transaction and start the transaction again.
-// This is because it gets complicated in cases where the statement could
-// succeed but then there is a deadlock later on.
-func canRetryError(err error) bool {
-	// Connection-level failures never surface as a *mysql.MySQLError:
-	// go-sql-driver returns driver.ErrBadConn when it is safe to retry on a
-	// new connection (nothing was written yet), and mysql.ErrInvalidConn when
-	// the connection died mid-statement (e.g. a network blip, the connection
-	// was killed, or an Aurora failover with RejectReadOnly enabled — the
-	// driver converts read-only errors 1290/1792/1836 into driver.ErrBadConn
-	// and discards the connection). Retrying is safe because each retry starts
-	// a fresh transaction — database/sql hands BeginTx a new connection if the
-	// old one is dead. Note this function does not itself enforce idempotency;
-	// callers are responsible for routing only idempotent statements through
-	// RetryableTransaction. Spirit's own callers do so (INSERT IGNORE /
-	// REPLACE / DELETE by PK), but the function does not verify it.
-	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) {
+// IsConnectionLossError reports whether err indicates that the connection to
+// MySQL failed or was lost, meaning the client cannot know whether the last
+// statement it sent was executed by the server. Connection-level failures
+// never surface as a *mysql.MySQLError: go-sql-driver returns
+// driver.ErrBadConn when the failure was detected before anything was
+// written, and mysql.ErrInvalidConn when the connection died mid-statement —
+// possibly *after* the server executed the statement but before the client
+// read the result. Raw io.EOF is included for paths that surface the
+// TCP-level error directly, and the client-library codes CR_CONN_HOST_ERROR
+// (2003) / CR_SERVER_LOST (2013) are included because proxies (e.g. ProxySQL,
+// RDS Proxy) can relay them inside real server error packets.
+//
+// In contrast to deterministic SQL errors (lock wait timeout, deadlock, ...),
+// where the server has positively reported that the statement did NOT take
+// effect, these errors are ambiguous. Callers retrying a non-idempotent
+// statement (e.g. the cutover RENAME TABLE) must verify server-side state
+// before deciding whether the statement was applied.
+func IsConnectionLossError(err error) bool {
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) || errors.Is(err, io.EOF) {
 		return true
 	}
 	var val *mysql.MySQLError
@@ -109,9 +110,39 @@ func canRetryError(err error) bool {
 		return false
 	}
 	switch val.Number {
-	case errLockWaitTimeout, errDeadlock, errCannotConnect,
-		errConnLost, errReadOnly, errReadOnlyTransaction, errReadOnlyMode,
-		errQueryInterrupted:
+	case errCannotConnect, errConnLost:
+		return true
+	default:
+		return false
+	}
+}
+
+// canRetryError looks at the MySQL error and decides if it is considered
+// a permanent failure or not. For simplicity a "retryable" error means
+// rollback the transaction and start the transaction again.
+// This is because it gets complicated in cases where the statement could
+// succeed but then there is a deadlock later on.
+func canRetryError(err error) bool {
+	// Connection-loss errors (driver.ErrBadConn, mysql.ErrInvalidConn, ...)
+	// are retryable: a network blip, a killed connection, or an Aurora
+	// failover with RejectReadOnly enabled (the driver converts read-only
+	// errors 1290/1792/1836 into driver.ErrBadConn and discards the
+	// connection) all qualify. Retrying is safe because each retry starts
+	// a fresh transaction — database/sql hands BeginTx a new connection if the
+	// old one is dead. Note this function does not itself enforce idempotency;
+	// callers are responsible for routing only idempotent statements through
+	// RetryableTransaction. Spirit's own callers do so (INSERT IGNORE /
+	// REPLACE / DELETE by PK), but the function does not verify it.
+	if IsConnectionLossError(err) {
+		return true
+	}
+	var val *mysql.MySQLError
+	if !errors.As(err, &val) {
+		return false
+	}
+	switch val.Number {
+	case errLockWaitTimeout, errDeadlock, errReadOnly,
+		errReadOnlyTransaction, errReadOnlyMode, errQueryInterrupted:
 		return true
 	default:
 		return false

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -153,6 +154,31 @@ func TestCanRetryError(t *testing.T) {
 	require.False(t, canRetryError(errors.New("not a mysql error")))
 	require.False(t, canRetryError(&mysql.MySQLError{Number: 1064})) // syntax error
 	require.False(t, canRetryError(&mysql.MySQLError{Number: 1062})) // duplicate key
+}
+
+func TestIsConnectionLossError(t *testing.T) {
+	// Connection-loss errors: the client cannot know whether the statement
+	// it sent was executed by the server.
+	require.True(t, IsConnectionLossError(driver.ErrBadConn))
+	require.True(t, IsConnectionLossError(mysql.ErrInvalidConn))
+	require.True(t, IsConnectionLossError(io.EOF))
+	require.True(t, IsConnectionLossError(&mysql.MySQLError{Number: 2003})) // CR_CONN_HOST_ERROR relayed by a proxy
+	require.True(t, IsConnectionLossError(&mysql.MySQLError{Number: 2013})) // CR_SERVER_LOST relayed by a proxy
+
+	// Wrapped variants must also be detected.
+	require.True(t, IsConnectionLossError(fmt.Errorf("rename failed: %w", driver.ErrBadConn)))
+	require.True(t, IsConnectionLossError(fmt.Errorf("rename failed: %w", mysql.ErrInvalidConn)))
+	require.True(t, IsConnectionLossError(fmt.Errorf("rename failed: %w", io.EOF)))
+
+	// Deterministic SQL errors are not connection loss: the server has
+	// positively reported that the statement failed.
+	require.False(t, IsConnectionLossError(nil))
+	require.False(t, IsConnectionLossError(errors.New("not a mysql error")))
+	require.False(t, IsConnectionLossError(&mysql.MySQLError{Number: 1205})) // lock wait timeout
+	require.False(t, IsConnectionLossError(&mysql.MySQLError{Number: 1213})) // deadlock
+	require.False(t, IsConnectionLossError(&mysql.MySQLError{Number: 1146})) // no such table
+	require.False(t, IsConnectionLossError(context.DeadlineExceeded))
+	require.False(t, IsConnectionLossError(context.Canceled))
 }
 
 // testRetryableTrxSurvivesKill blocks an UPDATE behind a row lock, kills it

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -37,6 +37,11 @@ type CutOver struct {
 	config   []*cutoverConfig
 	dbConfig *dbconn.DBConfig
 	logger   *slog.Logger
+	// testInjectRenameError is a test-only seam: when non-nil it is returned
+	// in place of a successful rename's nil result, simulating a connection
+	// that died after the server committed the RENAME TABLE but before the
+	// client read the OK packet.
+	testInjectRenameError error
 }
 
 type cutoverConfig struct {
@@ -87,6 +92,13 @@ func (c *CutOver) Run(ctx context.Context) error {
 	// than just whatever happened on the last try.
 	var attemptErrs []error
 	backoff := cutoverInitialBackoff
+	// renameMayHaveCommitted is set when an attempt fails with a
+	// connection-loss error. RENAME TABLE is atomic server-side, but if the
+	// connection dies after the server commits the rename and before the
+	// client reads the OK packet, the client observes a connection error for
+	// a rename that actually succeeded. Once set, every subsequent decision
+	// point first verifies the server state instead of blindly retrying.
+	renameMayHaveCommitted := false
 	for i := range max(1, c.dbConfig.MaxRetries) {
 		if ctx.Err() != nil {
 			return errors.Join(append(attemptErrs, ctx.Err())...)
@@ -107,6 +119,14 @@ func (c *CutOver) Run(ctx context.Context) error {
 			if backoff > cutoverMaxBackoff {
 				backoff = cutoverMaxBackoff
 			}
+		}
+		// If a previous attempt failed ambiguously, re-check the server state
+		// before doing anything else — in particular before feed.Flush below,
+		// which would otherwise fail with ER_NO_SUCH_TABLE applying buffered
+		// changes to the renamed-away _new table and abort the whole retry
+		// loop ("cutover failed" after a cutover that actually succeeded).
+		if renameMayHaveCommitted && c.confirmRenameCompleted(ctx) {
+			return nil
 		}
 		// Try and catch up before we attempt the cutover.
 		// since we will need to catch up again with the lock held
@@ -130,6 +150,20 @@ func (c *CutOver) Run(ctx context.Context) error {
 		}
 		if err != nil {
 			attemptErrs = append(attemptErrs, fmt.Errorf("attempt %d: %w", i+1, err))
+			if dbconn.IsConnectionLossError(err) {
+				// Ambiguous failure: the connection died, so the client
+				// cannot know whether the server committed the rename before
+				// the OK packet was lost. Verify the actual server state on a
+				// fresh connection before treating this as a failure.
+				// Deterministic SQL errors (lock wait timeout, deadlock, ...)
+				// deliberately skip this: for those the server positively
+				// reported the statement failed, so the normal retry path is
+				// correct.
+				renameMayHaveCommitted = true
+				if c.confirmRenameCompleted(ctx) {
+					return nil
+				}
+			}
 			c.logger.Warn("cutover failed",
 				"error", err.Error(),
 				"next_backoff", backoff,
@@ -139,8 +173,78 @@ func (c *CutOver) Run(ctx context.Context) error {
 		c.logger.Warn("final cut over operation complete")
 		return nil
 	}
+	// Retries are exhausted. If any attempt failed ambiguously, give the
+	// state check one final chance before declaring failure: the server may
+	// have committed the rename only after the last in-loop verification ran
+	// (e.g. the dying rename was still waiting on metadata locks).
+	if renameMayHaveCommitted && c.confirmRenameCompleted(ctx) {
+		return nil
+	}
 	c.logger.Error("cutover failed, and retries exhausted")
 	return errors.Join(attemptErrs...)
+}
+
+// confirmRenameCompleted wraps renameCompleted with logging for use in the
+// retry loop after an ambiguous connection-loss failure. It returns true only
+// if the server-side state proves the cutover rename was committed.
+func (c *CutOver) confirmRenameCompleted(ctx context.Context) bool {
+	completed, err := c.renameCompleted(ctx)
+	if err != nil {
+		c.logger.Warn("could not verify whether the cutover rename was committed after a connection failure; continuing to retry",
+			"error", err.Error())
+		return false
+	}
+	if !completed {
+		return false
+	}
+	c.logger.Warn("cutover rename was committed by the server even though the client connection failed; treating cutover as successful")
+	return true
+}
+
+// renameCompleted reports whether the cutover RENAME TABLE has been committed
+// on the server, by inspecting information_schema on a fresh connection from
+// the pool. It is used when a cutover attempt fails with a connection-loss
+// error and the outcome of the rename is therefore unknown to the client.
+//
+// The signature checked is, for every table in the cutover:
+//   - `<table>` exists, and
+//   - `_<table>_new` is gone, and
+//   - `_<table>_old` exists.
+//
+// This combination is unambiguous evidence that the rename committed:
+// `_<table>_old` is dropped immediately before the cutover starts (see
+// (*Runner).run) and the cutover's atomic RENAME TABLE is the only statement
+// spirit issues that re-creates it, while that same statement is the only
+// thing that removes `_<table>_new`. We deliberately do not compare
+// `<table>`'s schema against the expected post-ALTER schema: for
+// idempotent-shaped ALTERs (e.g. ENGINE=InnoDB, MODIFY to the same type) the
+// pre- and post-cutover schemas are identical, so a schema comparison cannot
+// distinguish the two states, whereas table existence can. Concurrent
+// operators renaming or dropping tables out from under a running migration
+// are not a supported scenario.
+func (c *CutOver) renameCompleted(ctx context.Context) (bool, error) {
+	for _, cfg := range c.config {
+		// The RENAME TABLE statement uses schema-unqualified names, resolved
+		// against the connection's default database — the schema the
+		// migration runs in (cfg.table.SchemaName). A single query keeps the
+		// three existence checks in one consistent snapshot.
+		var origExists, newExists, oldExists bool
+		err := c.db.QueryRowContext(ctx, `SELECT
+			COUNT(CASE WHEN table_name = ? THEN 1 END) > 0,
+			COUNT(CASE WHEN table_name = ? THEN 1 END) > 0,
+			COUNT(CASE WHEN table_name = ? THEN 1 END) > 0
+			FROM information_schema.tables WHERE table_schema = ?`,
+			cfg.table.TableName, cfg.newTable.TableName, cfg.oldTableName,
+			cfg.table.SchemaName,
+		).Scan(&origExists, &newExists, &oldExists)
+		if err != nil {
+			return false, err
+		}
+		if !origExists || newExists || !oldExists {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // algorithmRenameUnderLock is the preferred cutover algorithm.
@@ -195,7 +299,15 @@ func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*ta
 	}
 
 	renameStatement := "RENAME TABLE " + strings.Join(renameFragments, ", ")
-	return tableLock.ExecUnderLock(ctx, renameStatement)
+	if err := tableLock.ExecUnderLock(ctx, renameStatement); err != nil {
+		return err
+	}
+	if c.testInjectRenameError != nil {
+		// Test-only seam: the rename was committed by the server, but we
+		// pretend the client never read the OK packet.
+		return c.testInjectRenameError
+	}
+	return nil
 }
 
 // partialRenameForTest performs a partial cutover (only renames original table to _old)

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -81,6 +81,206 @@ func TestCutOver(t *testing.T) {
 	require.Equal(t, 2, count)
 }
 
+// TestCutoverRenameCompletedDetection unit-tests the renameCompleted helper
+// against real server state: it must detect a committed cutover rename
+// (original exists, _new gone, _old exists — for every table in the config)
+// and must not claim success in any other state.
+func TestCutoverRenameCompletedDetection(t *testing.T) {
+	t.Parallel()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	// NewTestTable registers cleanup for the table and its _new/_old artifacts.
+	testutils.NewTestTable(t, "renamecheck_a", `CREATE TABLE renamecheck_a (
+		id int NOT NULL AUTO_INCREMENT PRIMARY KEY
+	)`)
+	testutils.NewTestTable(t, "renamecheck_b", `CREATE TABLE renamecheck_b (
+		id int NOT NULL AUTO_INCREMENT PRIMARY KEY
+	)`)
+	testutils.RunSQL(t, `CREATE TABLE _renamecheck_a_new (id int NOT NULL AUTO_INCREMENT PRIMARY KEY)`)
+	testutils.RunSQL(t, `CREATE TABLE _renamecheck_b_new (id int NOT NULL AUTO_INCREMENT PRIMARY KEY)`)
+
+	// renameCompleted only reads db and config, so the CutOver can be
+	// constructed directly without a change feed.
+	cutover := &CutOver{
+		db:     db,
+		logger: slog.Default(),
+		config: []*cutoverConfig{
+			{
+				table:        table.NewTableInfo(db, cfg.DBName, "renamecheck_a"),
+				newTable:     table.NewTableInfo(db, cfg.DBName, "_renamecheck_a_new"),
+				oldTableName: "_renamecheck_a_old",
+			},
+			{
+				table:        table.NewTableInfo(db, cfg.DBName, "renamecheck_b"),
+				newTable:     table.NewTableInfo(db, cfg.DBName, "_renamecheck_b_new"),
+				oldTableName: "_renamecheck_b_old",
+			},
+		},
+	}
+
+	// State 1: nothing renamed yet (_new exists, _old absent) — not completed.
+	completed, err := cutover.renameCompleted(t.Context())
+	require.NoError(t, err)
+	require.False(t, completed, "must not report success before the rename has run")
+
+	// State 2: partial-cutover-shaped state on table a (original renamed away,
+	// _new still present) — not completed. This is the state the test-only
+	// partialRenameForTest seam produces; it must never be mistaken for a
+	// committed cutover.
+	testutils.RunSQL(t, "RENAME TABLE renamecheck_a TO _renamecheck_a_old")
+	completed, err = cutover.renameCompleted(t.Context())
+	require.NoError(t, err)
+	require.False(t, completed, "must not report success for a partial rename state")
+	testutils.RunSQL(t, "RENAME TABLE _renamecheck_a_old TO renamecheck_a") // undo
+
+	// State 3: full cutover rename committed on table a only — not completed,
+	// because every table in the config must show the post-rename signature.
+	testutils.RunSQL(t, "RENAME TABLE renamecheck_a TO _renamecheck_a_old, _renamecheck_a_new TO renamecheck_a")
+	completed, err = cutover.renameCompleted(t.Context())
+	require.NoError(t, err)
+	require.False(t, completed, "must not report success while another table's rename is missing")
+
+	// State 4: full cutover rename committed on both tables — completed.
+	testutils.RunSQL(t, "RENAME TABLE renamecheck_b TO _renamecheck_b_old, _renamecheck_b_new TO renamecheck_b")
+	completed, err = cutover.renameCompleted(t.Context())
+	require.NoError(t, err)
+	require.True(t, completed, "must detect a committed cutover rename")
+}
+
+// TestCutoverConnectionLossAfterRenameCommitted exercises the ambiguous
+// failure path end to end: the server commits the cutover RENAME TABLE but
+// the client sees a connection-loss error instead of the OK packet (injected
+// via the testInjectRenameError seam). Run must detect from server state that
+// the rename was committed and report the cutover as successful instead of
+// retrying into ER_NO_SUCH_TABLE failures.
+func TestCutoverConnectionLossAfterRenameCommitted(t *testing.T) {
+	t.Parallel()
+	testutils.NewTestTable(t, "cutoverconnloss", `CREATE TABLE cutoverconnloss (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	testutils.RunSQL(t, `CREATE TABLE _cutoverconnloss_new (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	testutils.RunSQL(t, `CREATE TABLE _cutoverconnloss_chkpnt (a int)`) // for binlog advancement
+	// Two rows in the original table so post-cutover state is distinguishable.
+	testutils.RunSQL(t, `INSERT INTO cutoverconnloss VALUES (1, 2), (2, 2)`)
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, cfg.DBName, "cutoverconnloss")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t1new := table.NewTableInfo(db, cfg.DBName, "_cutoverconnloss_new")
+	logger := slog.Default()
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t1new, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+
+	cutover, err := NewCutOver(db, []*cutoverConfig{
+		{
+			table:        t1,
+			newTable:     t1new,
+			oldTableName: "_cutoverconnloss_old",
+		},
+	}, feed, dbconn.NewDBConfig(), logger)
+	require.NoError(t, err)
+	// Simulate the server committing the rename while the client's
+	// connection dies before the OK packet is read. mysql.ErrInvalidConn is
+	// exactly what go-sql-driver returns when a connection dies mid-statement.
+	cutover.testInjectRenameError = mysql.ErrInvalidConn
+
+	require.NoError(t, cutover.Run(t.Context()),
+		"a rename committed by the server must be reported as success despite the connection loss")
+
+	// Verify the cutover actually happened exactly once: the original name
+	// now points at the (empty) new table, _old holds the 2 original rows,
+	// and _new is gone.
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM cutoverconnloss").Scan(&count))
+	require.Equal(t, 0, count)
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM _cutoverconnloss_old").Scan(&count))
+	require.Equal(t, 2, count)
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = '_cutoverconnloss_new'",
+		cfg.DBName).Scan(&count))
+	require.Equal(t, 0, count)
+}
+
+// TestCutoverDeterministicErrorDoesNotVerify is the negative counterpart of
+// TestCutoverConnectionLossAfterRenameCommitted: when an attempt fails with a
+// deterministic (non-connection) error, the state verification must NOT kick
+// in — the server positively reported a failure, so the existing retry
+// behavior is preserved and Run returns an error.
+func TestCutoverDeterministicErrorDoesNotVerify(t *testing.T) {
+	t.Parallel()
+	testutils.NewTestTable(t, "cutoverdeterr", `CREATE TABLE cutoverdeterr (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	testutils.RunSQL(t, `CREATE TABLE _cutoverdeterr_new (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	testutils.RunSQL(t, `CREATE TABLE _cutoverdeterr_chkpnt (a int)`) // for binlog advancement
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	config := dbconn.NewDBConfig()
+	config.MaxRetries = 2
+	config.LockWaitTimeout = 1
+
+	db, err := dbconn.New(testutils.DSN(), config)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, cfg.DBName, "cutoverdeterr")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t1new := table.NewTableInfo(db, cfg.DBName, "_cutoverdeterr_new")
+	logger := slog.Default()
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t1new, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+
+	cutover, err := NewCutOver(db, []*cutoverConfig{
+		{
+			table:        t1,
+			newTable:     t1new,
+			oldTableName: "_cutoverdeterr_old",
+		},
+	}, feed, config, logger)
+	require.NoError(t, err)
+	// A deterministic error: the rename is committed underneath, but the
+	// reported error is not connection-class, so verification must not run
+	// and Run must fail (attempt 2 then fails on the missing _new table).
+	cutover.testInjectRenameError = &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+
+	err = cutover.Run(t.Context())
+	require.Error(t, err, "a deterministic error must keep the existing retry-then-fail behavior")
+	require.Contains(t, err.Error(), "attempt 1:")
+}
+
 func TestMDLLockFails(t *testing.T) {
 	t.Parallel()
 	testutils.NewTestTable(t, "mdllocks", `CREATE TABLE mdllocks (


### PR DESCRIPTION
## Summary

Fixes an ambiguous-failure mode at migrate cutover: `RENAME TABLE` is atomic server-side, but if the connection dies after the server commits it and before the client reads the OK, the client sees a connection-loss error for a rename that **succeeded**.

### The retry failure mode (traced)

Post-rename, `t` still exists (it's the new table); what's gone is `_t_new`. The retry in `CutOver.Run` then fails on `_t_new`, not `t`:

1. `feed.Flush(ctx)` at the top of the retry applies buffered events to `_t_new` → `ER_NO_SUCH_TABLE` (1146), and that error path returned immediately, aborting all remaining retries; or
2. if the flush is a no-op, `LOCK TABLES ... `_t_new` WRITE` hits 1146.

Either way `Run` reports "cutover failed" after a committed cutover. The next run can't resume (`_t_new` missing), starts a *new* migration that clones the already-altered `t`, and re-applies the ALTER — a loud dup-column error for `ADD COLUMN`, but a **silent full second migration** for idempotent-shaped ALTERs (`ENGINE=InnoDB`, `MODIFY` to the same type). Failure-retrying automation can loop or double-migrate.

### The fix

A sticky `renameMayHaveCommitted` flag plus a `renameCompleted` helper; the retry loop is otherwise untouched:

- `renameCompleted` checks information_schema on a fresh pool connection, per cutover table, in one consistent query: original exists AND `_new` gone AND `_old` exists. That signature is unambiguous because `_old` is dropped immediately before `cutover.Run` and the atomic rename is the only spirit statement that re-creates `_old`/removes `_new`. ("Original has the new schema" is undecidable for exactly the silent cases.)
- Verification runs (a) right after a connection-loss-classified attempt, (b) on entry to each subsequent retry — before `feed.Flush`, which would otherwise abort the loop — and (c) once after retries are exhausted, covering a rename the server commits late (e.g. it was still waiting on MDL when the client died). On confirmation, `Run` logs and returns success; normal post-cutover cleanup proceeds.
- New `dbconn.IsConnectionLossError`, factored out of `canRetryError` so both share one list (`driver.ErrBadConn`, `mysql.ErrInvalidConn`, `io.EOF` wrappers, CR 2003/2013). Deterministic SQL errors (lock-wait timeout, deadlock, killed, read-only) deliberately do **not** trigger verification — the server positively reported failure, so existing retry behavior is preserved. Side effect: `canRetryError` now also retries raw `io.EOF` (strict, safe broadening; callers route only idempotent statements through it per its contract).

## Testing

- `TestCutoverRenameCompletedDetection` — helper against real MySQL state: not-renamed / partial / one-of-two / fully-renamed.
- `TestCutoverConnectionLossAfterRenameCommitted` — full integration through `CutOver.Run` via a small injection seam (modeled on the existing `useTestCutover` seam): rename commits, client sees `mysql.ErrInvalidConn`, `Run` returns success, swap happened exactly once.
- `TestCutoverDeterministicErrorDoesNotVerify` — injected deadlock keeps retry-then-fail behavior.
- `TestIsConnectionLossError` in dbconn.
- `go test -race ./pkg/migration/ -run 'Cutover|CutOver'` all pass (incl. all 4 `TestCutoverAtomicityWithConcurrentWrites` variants); full `./pkg/dbconn/` suite passes; golangci-lint clean.

### Caveat

A residual race remains if the server commits the dying rename *after* the final post-exhaustion check — the window is one information_schema query wide and requires the rename to outlive every retry's backoff; the pre-existing failure behavior applies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
