### PR TITLE
throttler/copier: hold autoscaling steady on stale or reset Aurora signals

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -413,6 +413,8 @@ With this flag, [write-threads](#write-threads) becomes the *starting* value; th
 
 The signal comes from the Aurora throttlers — active-threads and commit-latency (see [max-commit-latency](#max-commit-latency)) — which are auto-enabled on Aurora. Replica lag ([replica-dsn](#replica-dsn)) deliberately contributes **no** continuous signal: lag is a budget, not a load gauge, and steering on it would park replicas well behind. Replicas remain protected by the hard-stop throttle only. If no continuous signal is available at all (for example a non-Aurora target), autoscaling does not engage: a warning is logged and write threads stay fixed at the starting value.
 
+If a signal stops updating mid-migration (for example the monitoring connection is partitioned, or grants are revoked), the controller does not keep scaling on the frozen value: after ~15 seconds without a successful sample the signal reports a neutral utilization inside the hold band, freezing the write-thread count in place (a warning is logged). Scaling resumes automatically when sampling recovers.
+
 This flag only applies to the default buffered copier; with [unbuffered](#unbuffered) it is ignored (with a warning). Autoscaling is not yet supported by `spirit move`.
 
 ### tls-ca

--- a/pkg/copier/autoscaler.go
+++ b/pkg/copier/autoscaler.go
@@ -15,10 +15,6 @@ import (
 // halvings then wait out the cooldown so the signal can catch up). See
 // issue #831.
 const (
-	// acTick is how often the controller re-evaluates. Aligned with the
-	// throttler poll interval (5s) — sampling faster than the signal updates
-	// just adds noise.
-	acTick = 5 * time.Second
 	// acLowWatermark: below this utilization there is headroom on every signal,
 	// so we may add a thread (subject to cooldown). acHighWatermark: at or above
 	// this we back off immediately. The band between them is the dead-zone where
@@ -32,6 +28,12 @@ const (
 	// first. Increases and decreases hold independent cooldowns — see tick().
 	acCooldownTicks = 2
 )
+
+// acTick is how often the controller re-evaluates. Aligned with the
+// throttler poll interval (5s) — sampling faster than the signal updates
+// just adds noise. Var (not const) so tests can shorten it; production
+// never mutates it.
+var acTick = 5 * time.Second
 
 // writeScaler is the optional capability the autoscaler drives. The
 // SingleTargetApplier implements it; the ShardedApplier does not (yet), so the

--- a/pkg/copier/autoscaler_test.go
+++ b/pkg/copier/autoscaler_test.go
@@ -4,11 +4,19 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"math"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/metrics"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/throttler"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,15 +29,17 @@ func (f *fakeScaler) SetWriteWorkers(n int) { f.n = n }
 
 // utilThrottler is a GradualThrottler stub whose Utilization is scripted by
 // the test. Only Utilization is exercised by the autoscaler; the rest satisfy
-// the interface.
-type utilThrottler struct{ util float64 }
+// the interface. The value is stored atomically so the integration test can
+// move it while the autoscaler goroutine reads it concurrently (-race).
+type utilThrottler struct{ utilBits atomic.Uint64 }
 
 var _ throttler.GradualThrottler = &utilThrottler{}
 
+func (u *utilThrottler) setUtil(v float64)               { u.utilBits.Store(math.Float64bits(v)) }
 func (u *utilThrottler) Open(context.Context) error      { return nil }
 func (u *utilThrottler) Close() error                    { return nil }
-func (u *utilThrottler) IsThrottled() bool               { return u.util >= 1.0 }
-func (u *utilThrottler) Utilization() float64            { return u.util }
+func (u *utilThrottler) IsThrottled() bool               { return u.Utilization() >= 1.0 }
+func (u *utilThrottler) Utilization() float64            { return math.Float64frombits(u.utilBits.Load()) }
 func (u *utilThrottler) BlockWait(context.Context)       {}
 func (u *utilThrottler) UpdateLag(context.Context) error { return nil }
 
@@ -50,7 +60,7 @@ func newTestScaler(start, max int) (*autoScaler, *fakeScaler, *utilThrottler) {
 
 func TestAutoScaler_IncreasesBelowLowWatermarkAfterCooldown(t *testing.T) {
 	as, fs, ut := newTestScaler(2, 8)
-	ut.util = 0.2 // well below low watermark
+	ut.setUtil(0.2) // well below low watermark
 
 	// First sub-low tick increases immediately (cooldown starts at 0).
 	as.tick(t.Context())
@@ -70,7 +80,7 @@ func TestAutoScaler_IncreasesBelowLowWatermarkAfterCooldown(t *testing.T) {
 
 func TestAutoScaler_DecreasesImmediatelyAtHighWatermark(t *testing.T) {
 	as, fs, ut := newTestScaler(8, 16)
-	ut.util = 0.95 // at/above high watermark
+	ut.setUtil(0.95) // at/above high watermark
 
 	as.tick(t.Context())
 	require.Equal(t, 4, as.current, "8 should halve to 4 immediately")
@@ -92,18 +102,18 @@ func TestAutoScaler_DecreaseNotBlockedByIncreaseCooldown(t *testing.T) {
 	// An increase's cooldown must not delay a backoff: if the increase tipped
 	// the server over the high watermark, the very next tick halves.
 	as, _, ut := newTestScaler(4, 8)
-	ut.util = 0.2
+	ut.setUtil(0.2)
 	as.tick(t.Context())
 	require.Equal(t, 5, as.current, "increase under low watermark")
 
-	ut.util = 0.95
+	ut.setUtil(0.95)
 	as.tick(t.Context())
 	require.Equal(t, 3, as.current, "halve immediately despite increase cooldown: ceil(5/2)=3")
 }
 
 func TestAutoScaler_HoldsInDeadBand(t *testing.T) {
 	as, _, ut := newTestScaler(4, 16)
-	ut.util = 0.7 // between low (0.5) and high (0.9)
+	ut.setUtil(0.7) // between low (0.5) and high (0.9)
 
 	for range 5 {
 		as.tick(t.Context())
@@ -113,7 +123,7 @@ func TestAutoScaler_HoldsInDeadBand(t *testing.T) {
 
 func TestAutoScaler_ClampsAtMax(t *testing.T) {
 	as, _, ut := newTestScaler(3, 4)
-	ut.util = 0.0 // maximum headroom, always wants to increase
+	ut.setUtil(0.0) // maximum headroom, always wants to increase
 
 	// Drive many ticks; should climb to the cap and stop.
 	for range 30 {
@@ -124,7 +134,7 @@ func TestAutoScaler_ClampsAtMax(t *testing.T) {
 
 func TestAutoScaler_ClampsAtMinOne(t *testing.T) {
 	as, _, ut := newTestScaler(2, 8)
-	ut.util = 1.5 // way over
+	ut.setUtil(1.5) // way over
 
 	for range 10 {
 		as.tick(t.Context())
@@ -137,6 +147,53 @@ func TestAutoScaler_MaxFlooredAtStart(t *testing.T) {
 	// we never scale below where we began except via the >high backoff path.
 	as, _, _ := newTestScaler(6, 2)
 	require.Equal(t, 6, as.max)
+}
+
+// TestAutoScaler_DeadBandBoundaries pins the documented [low, high) edge
+// semantics of the dead band: tick() uses `util < low` for increases and
+// `util >= high` for decreases, so exactly-low must HOLD and exactly-high
+// must HALVE. The epsilon cases guard against either comparison being
+// accidentally flipped to <= / >.
+func TestAutoScaler_DeadBandBoundaries(t *testing.T) {
+	const eps = 1e-9
+	tests := []struct {
+		name string
+		util float64
+		want int // expected current after one tick, starting from 4
+	}{
+		{"just below low increases", acLowWatermark - eps, 5},
+		{"exactly low holds", acLowWatermark, 4},
+		{"just below high holds", acHighWatermark - eps, 4},
+		{"exactly high halves", acHighWatermark, 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			as, _, ut := newTestScaler(4, 16)
+			ut.setUtil(tc.util)
+			as.tick(t.Context())
+			require.Equal(t, tc.want, as.current)
+		})
+	}
+}
+
+// TestAutoScaler_StaleHoldValueParksInDeadBand pins the cross-package
+// invariant the staleness guard depends on: the utilization a stale throttler
+// reports (throttler.StaleUtilizationHold) must sit inside this controller's
+// dead band [low, high), so a dead signal freezes the thread count rather
+// than ramping it to the cap or shrinking it to 1. If either side moves and
+// breaks the relationship, this fails loudly.
+func TestAutoScaler_StaleHoldValueParksInDeadBand(t *testing.T) {
+	require.GreaterOrEqual(t, throttler.StaleUtilizationHold, acLowWatermark,
+		"stale hold below the low watermark would scale up blind on a dead signal")
+	require.Less(t, throttler.StaleUtilizationHold, acHighWatermark,
+		"stale hold at/above the high watermark would halve on a dead signal")
+
+	as, _, ut := newTestScaler(4, 16)
+	ut.setUtil(throttler.StaleUtilizationHold)
+	for range 5 {
+		as.tick(t.Context())
+	}
+	require.Equal(t, 4, as.current, "stale hold utilization must freeze the thread count")
 }
 
 func TestCeilDiv(t *testing.T) {
@@ -177,4 +234,125 @@ func TestAutoscalerIfEnabled_Gating(t *testing.T) {
 	c.throttler = gradual
 	c.applier = nil
 	require.Nil(t, c.autoscalerIfEnabled())
+}
+
+// gatedUtilThrottler extends utilThrottler with a BlockWait that parks the
+// copier's read workers until the test closes the gate. That keeps the copy
+// alive (without burning rows) while the autoscaler — which ticks
+// independently of chunk flow — makes its scaling decisions, so the test can
+// observe them deterministically before letting the copy finish.
+type gatedUtilThrottler struct {
+	utilThrottler
+	gate chan struct{}
+}
+
+func (g *gatedUtilThrottler) BlockWait(ctx context.Context) {
+	select {
+	case <-g.gate:
+	case <-ctx.Done():
+	}
+}
+
+// TestAutoScalerIntegrationEngaged runs the autoscaler for real: a buffered
+// copy of a real table through a real SingleTargetApplier, with the
+// autoscaler goroutine (run/tick on a ticker) driving SetWriteWorkers from a
+// test-controlled utilization signal. It asserts the live worker pool grows
+// under low utilization, halves at the high watermark, and that the copy then
+// completes correctly. goleak in TestMain verifies nothing leaks.
+func TestAutoScalerIntegrationEngaged(t *testing.T) {
+	// Shorten the control-loop tick (production default 5s) so scaling
+	// happens in milliseconds. Copier tests do not run in parallel, so
+	// mutating the package var with a restore is safe.
+	prevTick := acTick
+	acTick = 20 * time.Millisecond
+	t.Cleanup(func() { acTick = prevTick })
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS autoscale_src, autoscale_dst")
+	testutils.RunSQL(t, "CREATE TABLE autoscale_src (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, val VARCHAR(64) NOT NULL)")
+	testutils.RunSQL(t, "CREATE TABLE autoscale_dst (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, val VARCHAR(64) NOT NULL)")
+	// Seed a few thousand small rows by doubling: 2^12 = 4096.
+	testutils.RunSQL(t, "INSERT INTO autoscale_src (val) VALUES ('seed')")
+	for range 12 {
+		testutils.RunSQL(t, "INSERT INTO autoscale_src (val) SELECT val FROM autoscale_src")
+	}
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	// Resolve the schema from the DSN rather than hardcoding it, so the test
+	// works against any test database.
+	dsnCfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	t1 := table.NewTableInfo(db, dsnCfg.DBName, "autoscale_src")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, dsnCfg.DBName, "autoscale_dst")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	const start, maxThreads = 2, 4 // mirrors ResolveMaxWriteThreads: cap = 2x start
+
+	applierCfg := applier.NewApplierDefaultConfig()
+	applierCfg.Threads = start
+	app, err := applier.NewSingleTargetApplier(applier.Target{DB: db, KeyRange: "0"}, applierCfg)
+	require.NoError(t, err)
+
+	gated := &gatedUtilThrottler{gate: make(chan struct{})}
+	gated.setUtil(0.2) // below the low watermark: the controller wants to grow
+
+	cfg := NewCopierDefaultConfig()
+	cfg.Applier = app
+	cfg.Throttler = gated
+	cfg.Concurrency = 2
+	cfg.Autoscale = AutoscaleConfig{Enabled: true, StartThreads: start, MaxThreads: maxThreads}
+
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: cfg.TargetChunkTime, Logger: cfg.Logger})
+	require.NoError(t, err)
+	require.NoError(t, chunker.Open())
+	copier, err := NewCopier(db, chunker, cfg)
+	require.NoError(t, err)
+
+	copyDone := make(chan error, 1)
+	go func() { copyDone <- copier.Run(t.Context()) }()
+
+	// Phase 1: sustained low utilization → additive +1 per cooldown until the
+	// live worker pool reaches the cap. ActiveWriteWorkers observes the real
+	// goroutine pool, so this proves run() drove SetWriteWorkers on the
+	// applier (not just controller-internal state).
+	require.Eventually(t, func() bool { return app.ActiveWriteWorkers() == maxThreads },
+		10*time.Second, 5*time.Millisecond,
+		"autoscaler should grow the live worker pool to the cap under low utilization")
+
+	// Phase 2: utilization at/above the high watermark → multiplicative
+	// backoff. Parked workers exit asynchronously, so wait for convergence.
+	// (Sustained overload may halve again, cooldown-spaced, hence <=.)
+	gated.setUtil(0.95)
+	require.Eventually(t, func() bool { return app.ActiveWriteWorkers() <= maxThreads/2 },
+		10*time.Second, 5*time.Millisecond,
+		"autoscaler should halve the live worker pool at the high watermark")
+
+	// Park the signal in the dead band and release the gate: the copy now
+	// proceeds to completion with the scaled-down pool.
+	gated.setUtil(0.7)
+	close(gated.gate)
+	select {
+	case err := <-copyDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Minute):
+		t.Fatal("copy did not complete after releasing the throttler gate")
+	}
+
+	// The copy must be complete and correct despite the mid-copy rescaling.
+	var srcRows, dstRows int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM autoscale_src").Scan(&srcRows))
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM autoscale_dst").Scan(&dstRows))
+	require.Equal(t, 4096, srcRows)
+	require.Equal(t, srcRows, dstRows, "destination row count must match source after autoscaled copy")
+
+	var checksumSrc, checksumDst string
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT BIT_XOR(CRC32(CONCAT(id, val))) FROM autoscale_src").Scan(&checksumSrc))
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT BIT_XOR(CRC32(CONCAT(id, val))) FROM autoscale_dst").Scan(&checksumDst))
+	require.Equal(t, checksumSrc, checksumDst, "checksum mismatch between source and destination")
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS autoscale_src, autoscale_dst")
 }

--- a/pkg/throttler/aurora_activethreads.go
+++ b/pkg/throttler/aurora_activethreads.go
@@ -159,6 +159,10 @@ type ActiveThreads struct {
 
 	// lastActiveThreads holds the most recent observation for logging.
 	lastActiveThreads atomic.Int64
+
+	// stale guards Utilization() against the cached value freezing when
+	// sampling fails persistently. See stale.go.
+	stale staleGuard
 }
 
 var _ GradualThrottler = (*ActiveThreads)(nil)
@@ -220,7 +224,20 @@ func (a *ActiveThreads) IsThrottled() bool {
 // Utilization reports the most recent active-CPU-thread count as a fraction of
 // the instance vCPU count. 1.0 means active threads equal vCPUs (the point at
 // which one more thread trips IsThrottled). Returns 0 if vCPUs is not yet known.
+//
+// When sampling has failed for longer than staleSignalThreshold the cached
+// count is no longer trustworthy, so this reports StaleUtilizationHold
+// instead — parking the autoscaler in its dead band rather than letting a
+// frozen value drive scaling. IsThrottled/BlockWait are unaffected.
 func (a *ActiveThreads) Utilization() float64 {
+	if stale, entering := a.stale.check(staleSignalThreshold); stale {
+		if entering {
+			a.logger.Warn("active-threads signal is stale; holding autoscaler utilization steady until sampling recovers",
+				"last_successful_sample_age", a.stale.age(),
+				"hold_utilization", StaleUtilizationHold)
+		}
+		return StaleUtilizationHold
+	}
 	if a.vCPUs <= 0 {
 		return 0
 	}
@@ -262,7 +279,15 @@ func (a *ActiveThreads) UpdateLag(ctx context.Context) error {
 
 // applySample updates state from a single observation. Split out so tests can
 // drive the calculation without a real Aurora.
+//
+// Unlike the commit-latency throttler there is no counter-reset case to
+// handle here: the active-thread count is an instantaneous gauge (the query
+// clamps at >= 0), not a delta of cumulative counters, so a failover cannot
+// produce a bogus value — only an error, which the staleness guard covers.
 func (a *ActiveThreads) applySample(active int64) {
+	if a.stale.markFresh() {
+		a.logger.Info("active-threads sampling recovered; resuming live utilization signal")
+	}
 	a.lastActiveThreads.Store(active)
 	throttled := active > a.vCPUs
 	prev := a.isThrottled.Swap(throttled)

--- a/pkg/throttler/aurora_activethreads_test.go
+++ b/pkg/throttler/aurora_activethreads_test.go
@@ -69,6 +69,40 @@ func TestActiveThreads_UtilizationZeroVCPUs(t *testing.T) {
 	require.Zero(t, a.Utilization())
 }
 
+func TestActiveThreads_StaleSignalReportsHold(t *testing.T) {
+	a := newTestActiveThreads(t, 8)
+
+	a.applySample(2) // util 0.25
+	require.InDelta(t, 0.25, a.Utilization(), 1e-9)
+
+	// Persistent sampling failure: the cached count freezes at 2 while the
+	// last successful sample ages out. Utilization must hold in the dead
+	// band; the binary hard-stop state is unchanged.
+	ageLastSample(&a.stale, staleSignalThreshold+time.Second)
+	require.InDelta(t, StaleUtilizationHold, a.Utilization(), 1e-9)
+	require.False(t, a.IsThrottled())
+
+	// A fresh sample recovers the live signal.
+	a.applySample(2)
+	require.InDelta(t, 0.25, a.Utilization(), 1e-9)
+}
+
+func TestActiveThreads_StaleSignalKeepsThrottledHardStop(t *testing.T) {
+	a := newTestActiveThreads(t, 8)
+
+	a.applySample(20) // over vCPUs → throttled
+	require.True(t, a.IsThrottled())
+
+	ageLastSample(&a.stale, staleSignalThreshold+time.Second)
+	require.True(t, a.IsThrottled(), "staleness must not clear the hard-stop")
+	require.InDelta(t, StaleUtilizationHold, a.Utilization(), 1e-9)
+}
+
+func TestActiveThreads_NeverSampledIsNotStale(t *testing.T) {
+	a := newTestActiveThreads(t, 8)
+	require.Zero(t, a.Utilization(), "pre-Open must read as idle, not as a stale hold")
+}
+
 func TestActiveThreads_BlockWaitReturnsImmediatelyWhenUnthrottled(t *testing.T) {
 	a := newTestActiveThreads(t, 8)
 	start := time.Now()

--- a/pkg/throttler/aurora_commitlatency.go
+++ b/pkg/throttler/aurora_commitlatency.go
@@ -85,6 +85,10 @@ type CommitLatency struct {
 	// avgLatencyUs holds the most recent window-averaged latency in
 	// microseconds, exposed for logging/debugging.
 	avgLatencyUs atomic.Int64
+
+	// stale guards Utilization() against the cached value freezing when
+	// sampling fails persistently. See stale.go.
+	stale staleGuard
 }
 
 var _ GradualThrottler = (*CommitLatency)(nil)
@@ -147,7 +151,20 @@ func (c *CommitLatency) IsThrottled() bool {
 // fraction of the configured threshold. 1.0 means latency equals the threshold
 // (the point at which IsThrottled trips). Returns 0 if the threshold is
 // non-positive (which NewCommitLatencyThrottler already rejects).
+//
+// When sampling has failed for longer than staleSignalThreshold the cached
+// average is no longer trustworthy, so this reports StaleUtilizationHold
+// instead — parking the autoscaler in its dead band rather than letting a
+// frozen value drive scaling. IsThrottled/BlockWait are unaffected.
 func (c *CommitLatency) Utilization() float64 {
+	if stale, entering := c.stale.check(staleSignalThreshold); stale {
+		if entering {
+			c.logger.Warn("commit-latency signal is stale; holding autoscaler utilization steady until sampling recovers",
+				"last_successful_sample_age", c.stale.age(),
+				"hold_utilization", StaleUtilizationHold)
+		}
+		return StaleUtilizationHold
+	}
 	thresholdUs := c.threshold.Microseconds()
 	if thresholdUs <= 0 {
 		return 0
@@ -196,6 +213,13 @@ func (c *CommitLatency) UpdateLag(ctx context.Context) error {
 // applySample updates state from a single observation. Split out so tests can
 // drive the calculation without standing up a real Aurora.
 func (c *CommitLatency) applySample(commits, latency int64) {
+	// Any successfully scanned sample refreshes the signal, even one we end
+	// up discarding below (reset, idle window): the monitor connection is
+	// alive and the next window will produce a usable delta.
+	if c.stale.markFresh() {
+		c.logger.Info("commit-latency sampling recovered; resuming live utilization signal")
+	}
+
 	c.sampleMu.Lock()
 	prevCommits := c.prevCommits
 	prevLatency := c.prevLatency
@@ -215,7 +239,19 @@ func (c *CommitLatency) applySample(commits, latency int64) {
 
 	// Counter resets (server restart, failover) produce a negative delta;
 	// drop the sample rather than report a bogus huge or negative latency.
-	if deltaCommits <= 0 || deltaLatency < 0 {
+	// Carry the previous average and throttle state forward unchanged: the
+	// new baseline is already stored, so the next window computes a real
+	// delta. Storing 0 here would report Utilization()==0 for a full window
+	// and hand the autoscaler a spurious scale-up right after a failover —
+	// the worst possible moment.
+	if deltaCommits < 0 || deltaLatency < 0 {
+		return
+	}
+
+	// Idle window: no new commits means no signal, not zero latency from a
+	// loaded server. Treat the workload as quiet — clear the throttle rather
+	// than carry a stale "throttled" forward.
+	if deltaCommits == 0 {
 		c.isThrottled.Store(false)
 		c.avgLatencyUs.Store(0)
 		return

--- a/pkg/throttler/aurora_commitlatency_test.go
+++ b/pkg/throttler/aurora_commitlatency_test.go
@@ -87,18 +87,43 @@ func TestCommitLatency_NoNewCommitsClearsThrottle(t *testing.T) {
 	require.False(t, c.IsThrottled())
 }
 
-func TestCommitLatency_CounterResetClearsThrottle(t *testing.T) {
+func TestCommitLatency_CounterResetRetainsPreviousSignal(t *testing.T) {
 	c := newTestCommitLatency(t, 100*time.Millisecond)
 
 	c.applySample(1_000_000, 2_000_000_000)
-	c.applySample(1_000_100, 2_020_000_000) // throttled
+	c.applySample(1_000_100, 2_020_000_000) // 200ms avg → throttled
 	require.True(t, c.IsThrottled())
+	require.Equal(t, int64(200_000), c.avgLatencyUs.Load())
 
-	// Server restart / failover: counters go backwards. Don't report a
-	// nonsense huge negative latency — just drop the sample.
+	// Server restart / failover: counters go backwards. The sample is
+	// dropped, but the previous average and throttle state carry forward —
+	// storing 0 would report Utilization()==0 for a full window and hand
+	// the autoscaler a spurious scale-up right after the failover.
 	c.applySample(50, 1_000)
+	require.True(t, c.IsThrottled(), "reset window must not clear the previous throttle state")
+	require.Equal(t, int64(200_000), c.avgLatencyUs.Load(), "reset window must retain the previous average")
+	require.InDelta(t, 2.0, c.Utilization(), 1e-9)
+
+	// The reset sample established a new baseline, so the next window
+	// computes a real delta: 1000 commits at 5ms avg → recovered.
+	c.applySample(1_050, 5_001_000)
 	require.False(t, c.IsThrottled())
-	require.Equal(t, int64(0), c.avgLatencyUs.Load())
+	require.Equal(t, int64(5_000), c.avgLatencyUs.Load())
+}
+
+func TestCommitLatency_LatencyCounterResetRetainsPreviousSignal(t *testing.T) {
+	c := newTestCommitLatency(t, 100*time.Millisecond)
+
+	c.applySample(1_000_000, 2_000_000_000)
+	c.applySample(1_001_000, 2_002_000_000) // 2ms avg, not throttled
+	require.Equal(t, int64(2_000), c.avgLatencyUs.Load())
+
+	// Latency counter reset while the commit counter happens to still be
+	// ahead (partial reset): negative latency delta must also be treated
+	// as a reset, not as zero latency.
+	c.applySample(1_002_000, 1_000)
+	require.Equal(t, int64(2_000), c.avgLatencyUs.Load(), "negative latency delta must retain the previous average")
+	require.False(t, c.IsThrottled())
 }
 
 func TestCommitLatency_Utilization(t *testing.T) {
@@ -114,6 +139,55 @@ func TestCommitLatency_Utilization(t *testing.T) {
 	// 1000 commits, +200_000_000us latency → 200ms avg → 2.0 of threshold.
 	c.applySample(1_002_000, 2_250_000_000)
 	require.InDelta(t, 2.0, c.Utilization(), 1e-9)
+}
+
+// ageLastSample backdates a stale guard's last successful sample so tests can
+// simulate a sampling outage without sleeping through the real threshold.
+func ageLastSample(g *staleGuard, by time.Duration) {
+	g.lastSampleAt.Store(time.Now().Add(-by).UnixNano())
+}
+
+func TestCommitLatency_StaleSignalReportsHold(t *testing.T) {
+	c := newTestCommitLatency(t, 100*time.Millisecond)
+
+	c.applySample(1_000_000, 2_000_000_000)
+	c.applySample(1_001_000, 2_020_000_000) // 20ms avg → util 0.2
+	require.InDelta(t, 0.2, c.Utilization(), 1e-9)
+
+	// Simulate persistent sampling failure: the last successful sample ages
+	// past the threshold while the cached value stays frozen at 0.2. The
+	// autoscaler must see the hold value, not the frozen one — otherwise it
+	// would ramp +1 thread per cooldown to the cap on a dead signal.
+	ageLastSample(&c.stale, staleSignalThreshold+time.Second)
+	require.InDelta(t, StaleUtilizationHold, c.Utilization(), 1e-9)
+	// The binary hard-stop semantics are unchanged by staleness.
+	require.False(t, c.IsThrottled())
+
+	// A fresh sample recovers the live signal: another 20ms-avg window.
+	c.applySample(1_002_000, 2_040_000_000)
+	require.InDelta(t, 0.2, c.Utilization(), 1e-9)
+}
+
+func TestCommitLatency_StaleSignalKeepsThrottledHardStop(t *testing.T) {
+	c := newTestCommitLatency(t, 100*time.Millisecond)
+
+	c.applySample(1_000_000, 2_000_000_000)
+	c.applySample(1_000_100, 2_020_000_000) // 200ms avg → throttled, util 2.0
+	require.True(t, c.IsThrottled())
+
+	// Staleness only affects Utilization(): the frozen IsThrottled state
+	// stays exactly as it was (BlockWait semantics unchanged), while the
+	// utilization parks in the dead band.
+	ageLastSample(&c.stale, staleSignalThreshold+time.Second)
+	require.True(t, c.IsThrottled())
+	require.InDelta(t, StaleUtilizationHold, c.Utilization(), 1e-9)
+}
+
+func TestCommitLatency_NeverSampledIsNotStale(t *testing.T) {
+	// Pre-Open there is no sample at all; that must read as "not yet
+	// running" (utilization 0), not as a stale signal holding at 0.7.
+	c := newTestCommitLatency(t, 100*time.Millisecond)
+	require.Zero(t, c.Utilization())
 }
 
 func TestCommitLatency_BlockWaitReturnsImmediatelyWhenUnthrottled(t *testing.T) {

--- a/pkg/throttler/stale.go
+++ b/pkg/throttler/stale.go
@@ -1,0 +1,83 @@
+package throttler
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Staleness guard for polled gradual signals.
+//
+// The Aurora throttlers sample on a background loop and cache the result;
+// Utilization() only reads the cache. If sampling fails persistently (monitor
+// connections partitioned, grants revoked mid-migration, a failover the pool
+// won't reconnect from), the poll loop logs and continues — and the cached
+// value freezes. A value frozen below the autoscaler's low watermark would add
+// a write thread every cooldown until the 2x cap, ramping blind on a dead
+// signal, with the binary IsThrottled hard-stop equally frozen. The guard
+// breaks that failure mode: once the last successful sample is older than
+// staleSignalThreshold, Utilization() reports StaleUtilizationHold — a value
+// inside the autoscaler's dead band — so the controller freezes scaling in
+// place (no growth, no shrink) until sampling recovers.
+//
+// IsThrottled()/BlockWait() are deliberately NOT touched by the guard: they
+// keep reporting the last computed state exactly as before, so the binary
+// throttle semantics are unchanged whether the signal is fresh or stale.
+const (
+	// staleSignalThreshold is how old the last successful sample may be
+	// before Utilization() stops trusting the cached value. Three poll
+	// intervals (commitLatencyPollInterval and activeThreadsPollInterval are
+	// both 5s): one or two failed or slow polls — a brief failover blip, one
+	// stalled perf-schema query — don't flap the guard, but the signal is
+	// declared stale before the autoscaler can take more than one blind step,
+	// since its increases are spaced (acCooldownTicks+1)*acTick = 15s apart.
+	staleSignalThreshold = 15 * time.Second
+
+	// StaleUtilizationHold is the utilization reported while the signal is
+	// stale. It must sit inside the autoscaler's dead band [low, high) —
+	// currently [0.5, 0.9) — so a stale signal holds the write-thread count
+	// steady rather than ramping it or shrinking it. 0.7 is the midpoint,
+	// keeping maximum distance from both watermarks if they ever move.
+	// Exported so the autoscaler tests can pin this invariant.
+	StaleUtilizationHold = 0.7
+)
+
+// staleGuard tracks the freshness of a polled signal. It is embedded by the
+// gradual throttlers (CommitLatency, ActiveThreads): applySample marks the
+// signal fresh, Utilization checks it. All methods are safe for concurrent
+// use.
+type staleGuard struct {
+	lastSampleAt atomic.Int64 // unixnano of the last successful sample; 0 = never sampled
+	warned       atomic.Bool  // true once the current stale period has been logged
+}
+
+// markFresh records a successful sample at the current time. It returns true
+// when the signal was previously declared stale — i.e. this sample is a
+// recovery — so the caller can log the transition exactly once.
+func (s *staleGuard) markFresh() (recovered bool) {
+	s.lastSampleAt.Store(time.Now().UnixNano())
+	return s.warned.Swap(false)
+}
+
+// check reports whether the signal is stale (no successful sample within
+// threshold). entering is true only for the first check that finds the signal
+// stale, so callers can log a warning once per stale period rather than on
+// every call.
+//
+// A guard that has never seen a sample is not stale: the throttlers fail
+// Open() if their very first sample fails, so "no sample yet" means the
+// throttler isn't open, not that a working signal died.
+func (s *staleGuard) check(threshold time.Duration) (stale, entering bool) {
+	last := s.lastSampleAt.Load()
+	if last == 0 {
+		return false, false
+	}
+	if time.Since(time.Unix(0, last)) < threshold {
+		return false, false
+	}
+	return true, s.warned.CompareAndSwap(false, true)
+}
+
+// age returns the time since the last successful sample, for logging.
+func (s *staleGuard) age() time.Duration {
+	return time.Since(time.Unix(0, s.lastSampleAt.Load()))
+}

--- a/pkg/throttler/stale_test.go
+++ b/pkg/throttler/stale_test.go
@@ -1,0 +1,75 @@
+package throttler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaleGuard_NeverSampledIsNotStale(t *testing.T) {
+	var g staleGuard
+	stale, entering := g.check(time.Second)
+	require.False(t, stale)
+	require.False(t, entering)
+}
+
+func TestStaleGuard_FreshSampleIsNotStale(t *testing.T) {
+	var g staleGuard
+	require.False(t, g.markFresh(), "first sample is not a recovery")
+	stale, entering := g.check(time.Second)
+	require.False(t, stale)
+	require.False(t, entering)
+}
+
+func TestStaleGuard_EnteringReportedOncePerStalePeriod(t *testing.T) {
+	var g staleGuard
+	g.markFresh()
+	ageLastSample(&g, 2*time.Second)
+
+	// First check that observes staleness reports entering=true so the
+	// caller logs exactly one warning...
+	stale, entering := g.check(time.Second)
+	require.True(t, stale)
+	require.True(t, entering)
+
+	// ...and every subsequent check during the same stale period does not
+	// (the warning is rate-limited to the transition, not per-call).
+	for range 3 {
+		stale, entering = g.check(time.Second)
+		require.True(t, stale)
+		require.False(t, entering)
+	}
+}
+
+func TestStaleGuard_RecoveryReportedOnce(t *testing.T) {
+	var g staleGuard
+	g.markFresh()
+	ageLastSample(&g, 2*time.Second)
+	_, entering := g.check(time.Second)
+	require.True(t, entering)
+
+	// The first fresh sample after a stale period is a recovery (logged
+	// once); subsequent samples are routine.
+	require.True(t, g.markFresh())
+	require.False(t, g.markFresh())
+
+	stale, _ := g.check(time.Second)
+	require.False(t, stale)
+}
+
+func TestStaleGuard_NewStalePeriodWarnsAgain(t *testing.T) {
+	var g staleGuard
+	g.markFresh()
+	ageLastSample(&g, 2*time.Second)
+	_, entering := g.check(time.Second)
+	require.True(t, entering)
+
+	// Recover, then go stale a second time: the new period must produce a
+	// new warning rather than staying silenced forever.
+	require.True(t, g.markFresh())
+	ageLastSample(&g, 2*time.Second)
+	stale, entering := g.check(time.Second)
+	require.True(t, stale)
+	require.True(t, entering)
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #953** (`831-autoscale-write-threads`) — the diff includes its commits until it merges. Review only the last commit, or the diff against that branch.

## Summary

Hardens the experimental write-thread autoscaler against stale and reset Aurora signals, and closes its engaged-path coverage gap (the autoscaler `run()` loop previously executed in zero tests across the suite — the E2E only covers the no-signal downgrade path).

### 1. Stale-signal guard

Both Aurora throttlers sample on a 5s poll loop and cache the result; `Utilization()` only reads the cache. If sampling fails persistently (monitor pool partition, revoked grants, a failover the pool won't reconnect from), the cached value freezes — and a value frozen below 0.5 made the autoscaler add +1 thread per cooldown to the 2× cap, with the binary hard-stop equally frozen. Pre-autoscaling, a frozen signal meant "stop throttling"; with autoscaling it meant "actively add load."

New `staleGuard` (`pkg/throttler/stale.go`) embedded in `CommitLatency` and `ActiveThreads`: `applySample` marks the signal fresh; once the last successful sample is older than **15s (3 poll intervals)**, `Utilization()` reports `StaleUtilizationHold = 0.7` — the midpoint of the autoscaler's dead band — parking the controller (no growth, no shrink) until sampling recovers.

Design choices:
- **Guard lives in the throttlers, not the autoscaler** — only the throttler knows whether sampling succeeds; the autoscaler sees a float and can't distinguish "frozen" from "stable". The experimental `GradualThrottler` interface is unchanged, and the guard composes through `gradualMultiThrottler`'s max(): a stale child holds while a fresh child can still force a halve.
- **`IsThrottled()`/`BlockWait()` untouched** — binary hard-stop semantics identical whether fresh or stale (both pinned by tests).
- **Transition-based logging** — one warning on entering stale, one info on recovery; never per-call.
- "Never sampled" is deliberately *not* stale: the throttlers fail `Open()` if the first sample errors, so no-sample means not-running.

### 2. Counter-reset scale-up blip

`CommitLatency.applySample` stored `avgLatencyUs=0` on a negative delta (counter reset at failover), so `Utilization()==0` for up to one window → one spurious +1 at the worst possible moment. Reset windows now carry the previous average and throttle state forward unchanged (the reset sample still re-baselines, so the next window computes a real delta). The idle-window case (`deltaCommits == 0`, no reset) keeps its existing clear-the-throttle behavior as an explicit branch. `ActiveThreads` has no analogous case (instantaneous gauge, clamped ≥ 0) — documented with a comment.

### 3. Dead-band boundary tests

`TestAutoScaler_DeadBandBoundaries`: 0.5−ε grows, **0.5 holds**, 0.9−ε holds, **0.9 halves** — pinning the documented `[low, high)` edges, previously untested. Plus a test asserting `low <= StaleUtilizationHold < high`.

### 4. Engaged-path integration test

`TestAutoScalerIntegrationEngaged` runs `autoscaler.run()` for real: a buffered copy of 4096 rows through a real `SingleTargetApplier` (start=2, cap=4), driven by a test-controlled `GradualThrottler` whose `BlockWait` gates the read workers so scaling is observed deterministically mid-copy. Asserts via `ActiveWriteWorkers()` that the pool grows to the cap at util 0.2 and halves at 0.95, then that the copy completes with matching row counts and `BIT_XOR(CRC32(...))` checksums; goleak verifies no leaks. Test seam: `acTick` const → package var (production default 5s unchanged), matching the established `commitLatencyPollInterval` pattern. Runs in ~0.3s.

## Testing

All with `-race` against MySQL 8.0.43: `./pkg/throttler/` ok, `./pkg/copier/` full suite ok (incl. new integration test), `./pkg/migration/ -run Autoscal` ok; build/gofmt/golangci-lint clean.

Behavior-change note: `TestCommitLatency_CounterResetClearsThrottle` → `TestCommitLatency_CounterResetRetainsPreviousSignal` — the old expectation (zero the average on reset) is precisely the bug fixed in (2). A partial-reset variant (negative latency delta, positive commit delta) is also covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
