### PR TITLE
tests: cover never-executed repair/recovery paths (Recopy, status, gtid recreate, flush-under-lock)

### DIFF
--- a/pkg/change/flush_under_lock_test.go
+++ b/pkg/change/flush_under_lock_test.go
@@ -1,0 +1,98 @@
+package change
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// newStartedClientForFlushTest builds a Source of the requested kind
+// (binlog or gtid) subscribed to srcName -> dstName tables, starts it,
+// and registers cleanup. Used to exercise the FlushUnderTableLock error
+// branches identically for both implementations.
+func newStartedClientForFlushTest(t *testing.T, useGTID bool, srcName, dstName string) (Source, *table.TableInfo, *table.TableInfo) {
+	t.Helper()
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	testutils.RunSQL(t, fmt.Sprintf("DROP TABLE IF EXISTS %s, %s", srcName, dstName))
+	testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE %s (a INT NOT NULL, b INT, PRIMARY KEY (a))", srcName))
+	testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE %s (a INT NOT NULL, b INT, PRIMARY KEY (a))", dstName))
+
+	t1 := table.NewTableInfo(db, cfg.DBName, srcName)
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, cfg.DBName, dstName)
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	var client Source
+	if useGTID {
+		client = NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
+	} else {
+		client = NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
+	}
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	t.Cleanup(client.Close)
+	return client, t1, t2
+}
+
+// runFlushUnderTableLockErrorBranches covers the two uncovered error
+// branches of FlushUnderTableLock, which are identical in shape for the
+// binlog and GTID clients:
+//
+//  1. zero locks -> refused outright (flushing "under lock" without a
+//     lock would silently run outside the caller's critical section)
+//  2. the under-lock flush itself fails -> the error must propagate.
+//     The failure is forced by buffering a change and then dropping the
+//     target table before flushing, so the subscription's REPLACE fails.
+func runFlushUnderTableLockErrorBranches(t *testing.T, useGTID bool, srcName, dstName string) {
+	t.Helper()
+	client, t1, _ := newStartedClientForFlushTest(t, useGTID, srcName, dstName)
+
+	// Branch 1: no locks supplied.
+	err := client.FlushUnderTableLock(t.Context(), nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "requires at least one table lock")
+
+	// Buffer one change, then make the target unwritable.
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (a, b) VALUES (1, 1)", srcName))
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen())
+	testutils.RunSQL(t, "DROP TABLE "+dstName)
+
+	// Lock only the source table (locking the now-dropped target would
+	// fail), as a stand-in for the cutover's table locks. The under-lock
+	// flush REPLACEs into the dropped target table and must error.
+	lockDB, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(lockDB) })
+	lock, err := dbconn.NewTableLock(t.Context(), lockDB, []*table.TableInfo{t1}, dbconn.NewDBConfig(), slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLogWithContext(t.Context(), lock) })
+
+	err = client.FlushUnderTableLock(t.Context(), []*dbconn.TableLock{lock})
+	require.Error(t, err)
+	require.ErrorContains(t, err, dstName)
+}
+
+func TestBinlogFlushUnderTableLockErrors(t *testing.T) {
+	runFlushUnderTableLockErrorBranches(t, false, "flushlockerrt1", "flushlockerrt2")
+}
+
+func TestGTIDFlushUnderTableLockErrors(t *testing.T) {
+	runFlushUnderTableLockErrorBranches(t, true, "gtidflushlockerrt1", "gtidflushlockerrt2")
+}

--- a/pkg/change/flush_under_lock_test.go
+++ b/pkg/change/flush_under_lock_test.go
@@ -82,7 +82,9 @@ func runFlushUnderTableLockErrorBranches(t *testing.T, useGTID bool, srcName, ds
 	t.Cleanup(func() { utils.CloseAndLog(lockDB) })
 	lock, err := dbconn.NewTableLock(t.Context(), lockDB, []*table.TableInfo{t1}, dbconn.NewDBConfig(), slog.Default())
 	require.NoError(t, err)
-	t.Cleanup(func() { utils.CloseAndLogWithContext(t.Context(), lock) })
+	// defer, not t.Cleanup: t.Context() is canceled before Cleanup callbacks
+	// run, which would fail the UNLOCK and leave the lock held into teardown.
+	defer utils.CloseAndLogWithContext(t.Context(), lock)
 
 	err = client.FlushUnderTableLock(t.Context(), []*dbconn.TableLock{lock})
 	require.Error(t, err)

--- a/pkg/change/gtid_recreate_test.go
+++ b/pkg/change/gtid_recreate_test.go
@@ -1,0 +1,151 @@
+package change
+
+import (
+	"context"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// killGTIDSyncer closes the syncer out from under the gtidClient's
+// readStream. GetEvent then fails until maxConsecutiveErrors accumulate
+// (~500ms), at which point readStream calls recreateStreamer and the
+// dump resumes from bufferedGTID.
+func killGTIDSyncer(t *testing.T, client *gtidClient) {
+	t.Helper()
+	client.mu.Lock()
+	syncer := client.syncer
+	client.mu.Unlock()
+	require.NotNil(t, syncer)
+	syncer.Close()
+}
+
+// TestGTIDRecreateStreamerRecovers drives the gtidClient's real
+// consecutive-error path (readStream -> recreateStreamer), the GTID
+// analog of TestRecreateStreamerSkipsFlushedReplay:
+//
+//  1. Stream and flush one row so the client has a non-trivial
+//     bufferedGTID/flushedGTID.
+//  2. Kill the syncer so GetEvent fails repeatedly and readStream
+//     recreates the streamer at bufferedGTID.
+//  3. Write another row. Its transaction can only be observed through
+//     the recreated stream, so BlockWait returning proves the recovery
+//     completed (BlockWait targets the server's executed GTID set,
+//     which includes the new transaction).
+//  4. Flush and assert both rows landed on the target table.
+func TestGTIDRecreateStreamerRecovers(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS gtidrecreatet1, gtidrecreatet2")
+	testutils.RunSQL(t, "CREATE TABLE gtidrecreatet1 (a INT NOT NULL, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE gtidrecreatet2 (a INT NOT NULL, b INT, PRIMARY KEY (a))")
+
+	t1 := table.NewTableInfo(db, cfg.DBName, "gtidrecreatet1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, cfg.DBName, "gtidrecreatet2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*gtidClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	// Establish a healthy stream: one row buffered and flushed.
+	testutils.RunSQL(t, "INSERT INTO gtidrecreatet1 (a, b) VALUES (1, 1)")
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen())
+	require.NoError(t, client.Flush(t.Context()))
+	positionBeforeKill := client.Position()
+	require.NotEmpty(t, positionBeforeKill)
+
+	killGTIDSyncer(t, client)
+
+	// This transaction is only observable through the recreated stream.
+	testutils.RunSQL(t, "INSERT INTO gtidrecreatet1 (a, b) VALUES (2, 5)")
+
+	// BlockWait targets the server's current executed GTID set (which
+	// contains the post-kill INSERT), so returning without error means
+	// readStream went through recreateStreamer and caught back up.
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen(),
+		"the post-kill INSERT must be buffered after the streamer recreation")
+
+	require.NoError(t, client.Flush(t.Context()))
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM gtidrecreatet2").Scan(&count))
+	require.Equal(t, 2, count, "both rows must reach the target across the recreation")
+
+	// The resume coordinate must have advanced past the pre-kill flush.
+	require.NotEqual(t, positionBeforeKill, client.Position(),
+		"flushed GTID set must advance after the recreated stream catches up")
+}
+
+// TestGTIDMaxRecreateAttemptsError is the GTID analog of
+// TestMaxRecreateAttemptsError: when recreateStreamer keeps failing
+// (the server address is unreachable), readStream must exhaust
+// maxRecreateAttempts (lowered to 3 in TestMain), signal a fatal error
+// through the caller's CancelFunc, and exit cleanly.
+func TestGTIDMaxRecreateAttemptsError(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS gtidrecreateerrt1, gtidrecreateerrt2")
+	testutils.RunSQL(t, "CREATE TABLE gtidrecreateerrt1 (a INT NOT NULL PRIMARY KEY)")
+	testutils.RunSQL(t, "CREATE TABLE gtidrecreateerrt2 (a INT NOT NULL PRIMARY KEY)")
+
+	t1 := table.NewTableInfo(db, cfg.DBName, "gtidrecreateerrt1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, cfg.DBName, "gtidrecreateerrt2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	// The repl client calls CancelFunc on fatal stream errors, which
+	// cancels the context (mimicking what the migration runner does).
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	clientConfig := NewClientDefaultConfig()
+	clientConfig.CancelFunc = func() bool { cancel(); return true }
+	client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), clientConfig).(*gtidClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(ctx))
+
+	// Point the syncer config at a dead address (closed port for an
+	// instant connection-refused, no DNS involved) and kill the live
+	// syncer. Every recreateStreamer attempt now fails. Mutate cfg under
+	// client.mu because recreateStreamer reads it under the same lock.
+	client.mu.Lock()
+	client.cfg.Host = "127.0.0.1"
+	client.cfg.Port = 1
+	syncer := client.syncer
+	client.mu.Unlock()
+	require.NotNil(t, syncer)
+	syncer.Close()
+
+	// Wait for the readStream goroutine to exit after exhausting the
+	// recreation attempts (3 in TestMain; failures are immediate, the
+	// dominant cost is the 2s backoff between attempts).
+	client.streamWG.Wait()
+
+	require.Error(t, ctx.Err(), "caller context should be cancelled via CancelFunc on fatal stream error")
+
+	client.Close()
+}

--- a/pkg/checksum/recopier_test.go
+++ b/pkg/checksum/recopier_test.go
@@ -1,0 +1,257 @@
+package checksum
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// recopierHarness wires up everything MySQLRecopier needs against real
+// MySQL: a source table in the DSN database, an identical target table in
+// a unique throwaway database, TableInfos for both sides, and a started
+// SingleTargetApplier pointed at the target. This mirrors the production
+// wiring in datasync.Runner.runContinuousChecksum.
+type recopierHarness struct {
+	srcDB        *sql.DB
+	dstDB        *sql.DB
+	srcTable     *table.TableInfo
+	dstTable     *table.TableInfo
+	targetDBName string
+	tableName    string
+	recopier     *MySQLRecopier
+}
+
+// newRecopierHarness creates source + target copies of tableName and a
+// recopier between them. Source rows are ids 1..20 with id 8 skipped (the
+// gap lets tests plant a "row that exists only on the target" inside a
+// chunk range).
+func newRecopierHarness(t *testing.T, tableName string) *recopierHarness {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	targetDBName, _ := testutils.CreateUniqueTestDatabase(t)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS "+tableName)
+	testutils.RunSQL(t, fmt.Sprintf(
+		"CREATE TABLE %s (id INT NOT NULL, b INT NOT NULL, c VARCHAR(32) NOT NULL, PRIMARY KEY (id))", tableName))
+	t.Cleanup(func() {
+		testutils.RunSQL(t, "DROP TABLE IF EXISTS "+tableName)
+	})
+	var values []string
+	for i := 1; i <= 20; i++ {
+		if i == 8 {
+			continue // deliberate gap, see doc comment
+		}
+		values = append(values, fmt.Sprintf("(%d, %d, 'row-%d')", i, i*10, i))
+	}
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s VALUES %s", tableName, strings.Join(values, ",")))
+
+	// Target is an exact copy in the throwaway database.
+	testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE %s.%s LIKE %s", targetDBName, tableName, tableName))
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s.%s SELECT * FROM %s", targetDBName, tableName, tableName))
+
+	srcDB, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(srcDB) })
+
+	dstCfg := cfg.Clone()
+	dstCfg.DBName = targetDBName
+	dstDB, err := dbconn.New(dstCfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(dstDB) })
+
+	srcTable := table.NewTableInfo(srcDB, cfg.DBName, tableName)
+	require.NoError(t, srcTable.SetInfo(t.Context()))
+	dstTable := table.NewTableInfo(dstDB, targetDBName, tableName)
+	require.NoError(t, dstTable.SetInfo(t.Context()))
+
+	app, err := applier.NewSingleTargetApplier(applier.Target{
+		DB:       dstDB,
+		Config:   dstCfg,
+		KeyRange: "0",
+	}, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, app.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, app.Stop()) })
+
+	recopier, err := NewMySQLRecopier(srcDB, dstDB, app, dbconn.NewDBConfig(), nil)
+	require.NoError(t, err)
+
+	return &recopierHarness{
+		srcDB:        srcDB,
+		dstDB:        dstDB,
+		srcTable:     srcTable,
+		dstTable:     dstTable,
+		targetDBName: targetDBName,
+		tableName:    tableName,
+		recopier:     recopier,
+	}
+}
+
+// chunk builds a [lo, hi) chunk over the harness tables, the same shape
+// the continuous-checksum chunker hands to the Recopier.
+func (h *recopierHarness) chunk(t *testing.T, lo, hi int) *table.Chunk {
+	t.Helper()
+	loDatum, err := table.NewDatumFromValue(lo, "int")
+	require.NoError(t, err)
+	hiDatum, err := table.NewDatumFromValue(hi, "int")
+	require.NoError(t, err)
+	return &table.Chunk{
+		Key:           []string{"id"},
+		ChunkSize:     uint64(hi - lo), //nolint:gosec // test values are small and positive
+		LowerBound:    &table.Boundary{Value: []table.Datum{loDatum}, Inclusive: true},
+		UpperBound:    &table.Boundary{Value: []table.Datum{hiDatum}, Inclusive: false},
+		Table:         h.srcTable,
+		NewTable:      h.dstTable,
+		ColumnMapping: table.NewColumnMapping(h.srcTable, h.dstTable, nil),
+	}
+}
+
+// rows returns every row of the given table as "id#b#c" strings, ordered
+// by id, for whole-table equality assertions.
+func (h *recopierHarness) rows(t *testing.T, quotedTableName string) []string {
+	t.Helper()
+	rows, err := h.srcDB.QueryContext(t.Context(),
+		"SELECT CONCAT_WS('#', id, b, c) FROM "+quotedTableName+" ORDER BY id")
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+	var result []string
+	for rows.Next() {
+		var s string
+		require.NoError(t, rows.Scan(&s))
+		result = append(result, s)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+func (h *recopierHarness) requireTargetMatchesSource(t *testing.T) {
+	t.Helper()
+	require.Equal(t,
+		h.rows(t, h.srcTable.QuotedTableName),
+		h.rows(t, h.dstTable.QuotedTableName),
+		"target table must match source table after recopy")
+}
+
+func TestMySQLRecopierRepairsDivergedChunk(t *testing.T) {
+	h := newRecopierHarness(t, "recopier_repair_t1")
+
+	// Diverge the target inside chunk [1, 11): two modified rows, one
+	// deleted row, and one extra row (id 8 — the gap in the source).
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("UPDATE %s SET b = 999 WHERE id IN (2, 5)", h.tableName))
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("DELETE FROM %s WHERE id = 7", h.tableName))
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("INSERT INTO %s VALUES (8, 888, 'phantom')", h.tableName))
+
+	require.NoError(t, h.recopier.Recopy(t.Context(), h.chunk(t, 1, 11)))
+	h.requireTargetMatchesSource(t)
+}
+
+// TestMySQLRecopierEmptySourceRange covers the DELETE-only path: the
+// source has no rows in the chunk range, so a recopy must remove the
+// target's stray rows and return without invoking the applier.
+func TestMySQLRecopierEmptySourceRange(t *testing.T) {
+	h := newRecopierHarness(t, "recopier_empty_t1")
+
+	// Source ids stop at 20; plant a target-only row at id 55.
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("INSERT INTO %s VALUES (55, 5550, 'stray')", h.tableName))
+
+	require.NoError(t, h.recopier.Recopy(t.Context(), h.chunk(t, 50, 60)))
+	h.requireTargetMatchesSource(t)
+}
+
+// TestMySQLRecopierConcurrent locks in the Recopier interface contract
+// from continuous.go: "Recopy must be safe to call concurrently from
+// multiple worker goroutines". Two goroutines recopy adjacent diverged
+// chunks; the internal mutex serializes them and both must succeed.
+// Run with -race.
+func TestMySQLRecopierConcurrent(t *testing.T) {
+	h := newRecopierHarness(t, "recopier_concurrent_t1")
+
+	// Diverge both halves of the table.
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("UPDATE %s SET b = 111 WHERE id IN (3, 9)", h.tableName))
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("UPDATE %s SET b = 222 WHERE id IN (12, 19)", h.tableName))
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("DELETE FROM %s WHERE id IN (4, 15)", h.tableName))
+
+	chunks := []*table.Chunk{h.chunk(t, 1, 11), h.chunk(t, 11, 21)}
+	errs := make([]error, len(chunks))
+	var wg sync.WaitGroup
+	for i, c := range chunks {
+		wg.Go(func() {
+			errs[i] = h.recopier.Recopy(t.Context(), c)
+		})
+	}
+	wg.Wait()
+	for i, err := range errs {
+		require.NoError(t, err, "concurrent Recopy of chunk %d failed", i)
+	}
+	h.requireTargetMatchesSource(t)
+}
+
+// TestMySQLRecopierTargetTableMissing covers the error path: the target
+// table is dropped before Recopy, so the DELETE step fails and the error
+// must propagate (not hang, not panic).
+func TestMySQLRecopierTargetTableMissing(t *testing.T) {
+	h := newRecopierHarness(t, "recopier_missing_t1")
+
+	testutils.RunSQLInDatabase(t, h.targetDBName, "DROP TABLE "+h.tableName)
+
+	err := h.recopier.Recopy(t.Context(), h.chunk(t, 1, 11))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "delete target chunk range")
+}
+
+// TestMySQLRecopierApplierWriteFails covers the applier-error branch: the
+// DELETE succeeds but the rewrite fails (target schema diverged so the
+// INSERT references a column that no longer exists). The applier reports
+// the failure through the Apply callback and Recopy must surface it.
+func TestMySQLRecopierApplierWriteFails(t *testing.T) {
+	h := newRecopierHarness(t, "recopier_applyerr_t1")
+
+	// Mutate the target schema *after* TableInfo was captured, so the
+	// DELETE (by id) still works but the applier's INSERT of column c fails.
+	testutils.RunSQLInDatabase(t, h.targetDBName,
+		fmt.Sprintf("ALTER TABLE %s DROP COLUMN c", h.tableName))
+
+	err := h.recopier.Recopy(t.Context(), h.chunk(t, 1, 11))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "applier write")
+}
+
+func TestNewMySQLRecopierValidation(t *testing.T) {
+	srcDB, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(srcDB)
+
+	app, err := applier.NewSingleTargetApplier(applier.Target{DB: srcDB}, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	_, err = NewMySQLRecopier(nil, srcDB, app, nil, nil)
+	require.ErrorContains(t, err, "sourceDB must be non-nil")
+	_, err = NewMySQLRecopier(srcDB, nil, app, nil, nil)
+	require.ErrorContains(t, err, "targetDB must be non-nil")
+	_, err = NewMySQLRecopier(srcDB, srcDB, nil, nil, nil)
+	require.ErrorContains(t, err, "applier must be non-nil")
+
+	// nil dbConfig and logger are allowed; defaults are applied.
+	r, err := NewMySQLRecopier(srcDB, srcDB, app, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, r.dbConfig)
+	require.NotNil(t, r.logger)
+}

--- a/pkg/status/task_test.go
+++ b/pkg/status/task_test.go
@@ -1,0 +1,256 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeTask is a minimal Task implementation for driving WatchTask and the
+// dump loops. Calls are signalled on buffered channels (non-blocking
+// sends) so tests can wait for "at least N ticks fired" without sleeps.
+type fakeTask struct {
+	state           atomic.Int32 // holds a State
+	statusCh        chan struct{}
+	checkpointCh    chan struct{}
+	dumpErr         func() error // optional; called by DumpCheckpoint
+	cancelOnce      sync.Once
+	cancelCh        chan struct{}
+	statusCount     atomic.Int64
+	checkpointCount atomic.Int64
+}
+
+func newFakeTask(state State) *fakeTask {
+	f := &fakeTask{
+		statusCh:     make(chan struct{}, 64),
+		checkpointCh: make(chan struct{}, 64),
+		cancelCh:     make(chan struct{}),
+	}
+	f.state.Store(int32(state))
+	return f
+}
+
+func (f *fakeTask) setState(state State) { f.state.Store(int32(state)) }
+
+func (f *fakeTask) Progress() Progress {
+	return Progress{CurrentState: State(f.state.Load()), Summary: "fake"}
+}
+
+func (f *fakeTask) Status() string {
+	f.statusCount.Add(1)
+	select {
+	case f.statusCh <- struct{}{}:
+	default:
+	}
+	return "fake status"
+}
+
+func (f *fakeTask) DumpCheckpoint(_ context.Context) error {
+	f.checkpointCount.Add(1)
+	select {
+	case f.checkpointCh <- struct{}{}:
+	default:
+	}
+	if f.dumpErr != nil {
+		return f.dumpErr()
+	}
+	return nil
+}
+
+func (f *fakeTask) Cancel() {
+	f.cancelOnce.Do(func() { close(f.cancelCh) })
+}
+
+func (f *fakeTask) cancelled() bool {
+	select {
+	case <-f.cancelCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// setTestIntervals shrinks the package-level tickers for the duration of
+// the test and restores them afterwards.
+func setTestIntervals(t *testing.T, status, checkpoint time.Duration) {
+	t.Helper()
+	oldStatus, oldCheckpoint := StatusInterval, CheckpointDumpInterval
+	StatusInterval, CheckpointDumpInterval = status, checkpoint
+	t.Cleanup(func() {
+		StatusInterval, CheckpointDumpInterval = oldStatus, oldCheckpoint
+	})
+}
+
+// waitSignal waits for one signal on ch, failing the test rather than
+// hanging if the loop under test stopped firing.
+func waitSignal(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+// TestWatchTaskFiresAndStopsOnCancel verifies the two WatchTask loops
+// both fire repeatedly on their tickers, and that the returned wait
+// function blocks until both goroutines exit after ctx cancellation.
+// Goroutine leaks are caught by goleak in TestMain.
+func TestWatchTaskFiresAndStopsOnCancel(t *testing.T) {
+	setTestIntervals(t, 2*time.Millisecond, 2*time.Millisecond)
+	task := newFakeTask(CopyRows)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	wait := WatchTask(ctx, task, slog.Default())
+
+	// Two signals each proves the loops keep ticking, not just fire once.
+	waitSignal(t, task.statusCh, "first status dump")
+	waitSignal(t, task.statusCh, "second status dump")
+	waitSignal(t, task.checkpointCh, "first checkpoint dump")
+	waitSignal(t, task.checkpointCh, "second checkpoint dump")
+
+	cancel()
+	wait() // must return; deadlock here = goroutines did not stop on cancel
+
+	if task.cancelled() {
+		t.Fatal("task.Cancel must not be called on a clean ctx cancellation")
+	}
+}
+
+// TestWatchTaskStopsPastCutover verifies both loops exit on their own
+// (no ctx cancellation) once the task reports a state past CutOver:
+// the status loop on state > CutOver, the checkpoint loop on
+// state >= CutOver. Neither dump should do any work.
+func TestWatchTaskStopsPastCutover(t *testing.T) {
+	setTestIntervals(t, 2*time.Millisecond, 2*time.Millisecond)
+	task := newFakeTask(Close) // Close > CutOver
+
+	wait := WatchTask(t.Context(), task, slog.Default())
+	wait() // both loops must exit on their first tick without ctx cancel
+
+	if n := task.statusCount.Load(); n != 0 {
+		t.Fatalf("Status was called %d times; the status loop must not report past CutOver", n)
+	}
+	if n := task.checkpointCount.Load(); n != 0 {
+		t.Fatalf("DumpCheckpoint was called %d times; the checkpoint loop must not dump past CutOver", n)
+	}
+}
+
+// TestContinuallyDumpStatusStopsWhenStateAdvances verifies the status
+// loop runs while the state is at or below CutOver and then exits on its
+// own when the state advances past CutOver mid-run.
+func TestContinuallyDumpStatusStopsWhenStateAdvances(t *testing.T) {
+	setTestIntervals(t, 2*time.Millisecond, time.Hour)
+	task := newFakeTask(CopyRows)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpStatus(t.Context(), task, slog.Default())
+	}()
+
+	waitSignal(t, task.statusCh, "first status dump")
+	waitSignal(t, task.statusCh, "second status dump")
+	task.setState(Close)
+	waitSignal(t, done, "status loop exit after state advanced past CutOver")
+}
+
+// TestContinuallyDumpCheckpointWatermarkNotReady verifies that
+// ErrWatermarkNotReady is non-fatal: the loop logs, continues ticking,
+// and never calls task.Cancel.
+func TestContinuallyDumpCheckpointWatermarkNotReady(t *testing.T) {
+	setTestIntervals(t, time.Hour, 2*time.Millisecond)
+	task := newFakeTask(CopyRows)
+	task.dumpErr = func() error { return ErrWatermarkNotReady }
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(ctx, task, slog.Default())
+	}()
+
+	// Two failed dumps prove the loop continued past the first
+	// watermark-not-ready error instead of returning.
+	waitSignal(t, task.checkpointCh, "first checkpoint attempt")
+	waitSignal(t, task.checkpointCh, "second checkpoint attempt")
+
+	cancel()
+	waitSignal(t, done, "checkpoint loop exit on ctx cancel")
+	if task.cancelled() {
+		t.Fatal("watermark-not-ready must not cancel the task")
+	}
+}
+
+// TestContinuallyDumpCheckpointFatalErrorCancelsTask verifies the fatal
+// path: a checkpoint write error that is not watermark-not-ready and not
+// context.Canceled must call task.Cancel (fast-fail) and stop the loop.
+func TestContinuallyDumpCheckpointFatalErrorCancelsTask(t *testing.T) {
+	setTestIntervals(t, time.Hour, 2*time.Millisecond)
+	task := newFakeTask(CopyRows)
+	task.dumpErr = func() error { return errors.New("cannot write checkpoint: disk full") }
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(t.Context(), task, slog.Default())
+	}()
+
+	waitSignal(t, done, "checkpoint loop exit after fatal error")
+	if !task.cancelled() {
+		t.Fatal("a fatal checkpoint error must cancel the task")
+	}
+	if n := task.checkpointCount.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 checkpoint attempt before the fatal exit, got %d", n)
+	}
+}
+
+// TestContinuallyDumpCheckpointContextCanceledError verifies that a
+// DumpCheckpoint failing with context.Canceled stops the loop quietly:
+// no retry, no task.Cancel.
+func TestContinuallyDumpCheckpointContextCanceledError(t *testing.T) {
+	setTestIntervals(t, time.Hour, 2*time.Millisecond)
+	task := newFakeTask(CopyRows)
+	task.dumpErr = func() error { return context.Canceled }
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(t.Context(), task, slog.Default())
+	}()
+
+	waitSignal(t, done, "checkpoint loop exit on context.Canceled dump error")
+	if task.cancelled() {
+		t.Fatal("a context.Canceled dump error must not cancel the task")
+	}
+}
+
+// TestContinuallyDumpCheckpointErrorDuringCutover verifies the race
+// guard: if the checkpoint write fails but the task has meanwhile moved
+// to >= CutOver (e.g. the checkpoint table was dropped by the cutover),
+// the loop exits without treating it as fatal — no task.Cancel.
+func TestContinuallyDumpCheckpointErrorDuringCutover(t *testing.T) {
+	setTestIntervals(t, time.Hour, 2*time.Millisecond)
+	task := newFakeTask(CopyRows)
+	task.dumpErr = func() error {
+		// Simulate cutover landing while the dump was in flight: the
+		// checkpoint table is gone and the state has advanced.
+		task.setState(CutOver)
+		return errors.New("Table 'test._t1_chkpnt' doesn't exist")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(t.Context(), task, slog.Default())
+	}()
+
+	waitSignal(t, done, "checkpoint loop exit after error during cutover")
+	if task.cancelled() {
+		t.Fatal("a checkpoint error after reaching CutOver must not cancel the task")
+	}
+}


### PR DESCRIPTION
## Summary

Test-only PR covering repair/recovery paths that previously executed in **zero** tests across the entire suite (measured with `-coverpkg=./pkg/...` over a full run). These are exactly the paths that only run when something has already gone wrong, so they were the least-exercised and highest-stakes gaps. No production-code changes; no test seams were needed.

### 1. `MySQLRecopier.Recopy` — 0% → 88.4% (`pkg/checksum/recopier_test.go`)

The continuous-checksum divergence-repair path used by datasync had never once executed. Real-MySQL harness mirroring the production wiring (`datasync.Runner.runContinuousChecksum`): repair of a chunk with modified + deleted + phantom rows; the DELETE-only empty-source-range path; the documented "safe to call concurrently" contract (two goroutines on adjacent diverged chunks under `-race`); error propagation for a missing target table and a schema diverged after TableInfo capture; constructor validation. Uncovered remainder: row-scan error branches and the 10-minute `fixCtx` timeout arm — not deterministically reachable without seams.

### 2. `pkg/status` — package 20% → 89.8%, task.go 0% → 100% (`pkg/status/task_test.go`)

Fake `Task` driven entirely by channels (no synchronization sleeps; goleak via the existing package `TestMain`). Covers both `WatchTask` loops ticking and joining on ctx cancel, self-termination past `CutOver`, and all four `DumpCheckpoint` error branches (`ErrWatermarkNotReady` → continue; fatal → `Cancel()`; `context.Canceled` → quiet exit; error racing cutover → exit without Cancel).

### 3. `gtid.go recreateStreamer` — 0% → 100% (`pkg/change/gtid_recreate_test.go`)

The GTID streamer error-recovery path, modeled on the existing binlog-client recreate tests: kill the syncer mid-stream and prove recovery by observing a transaction written *after* the kill through the recreated stream (resume GTID set advances); plus exhaustion of `maxRecreateAttempts` signaling the caller's `CancelFunc`.

### 4. `FlushUnderTableLock` error branches, both clients (`pkg/change/flush_under_lock_test.go`)

Shared helper run against the binlog and GTID clients: the zero-locks refusal and under-lock flush failure propagation. Deliberately skipped: the `BlockWait`-fails-between-flushes branch — it needs a 30s timeout to elapse mid-call, so covering it would mean a 30s test or an invasive seam.

## Verification

Every test passed `-race -count=3` (per-package and a combined final run). Build/gofmt/golangci-lint clean. Small row counts (≤20), unique table names, no sleep-based synchronization — blocking receives with failure timeouts throughout.

Note: existing `pkg/change` tests hardcode the `test` schema; the new tests derive it from the parsed DSN so they pass on servers with a non-default database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
