### PR TITLE
migration/move: stop persisting checksum_watermark once the continuous checksum finds differences

### DIFF
--- a/pkg/migration/checksum_invalidation_test.go
+++ b/pkg/migration/checksum_invalidation_test.go
@@ -135,24 +135,7 @@ func TestChecksumErrorPreservesCheckpoint(t *testing.T) {
 func TestDumpCheckpointSuppressesWatermarkWithDifferences(t *testing.T) {
 	t.Parallel()
 	r := setupRunnerForChecksumTest(t, "chkpt_invariant")
-
-	// Seed the table with enough rows that the chunker can carve out
-	// multiple chunks. The composite chunker won't report a low-watermark
-	// until at least one fully-processed chunk has had Feedback, which in
-	// practice requires more than one chunk on the runway.
-	seedRows(t, r.db, r.migration.Table, 4096)
-	require.NoError(t, r.changes[0].table.SetInfo(t.Context()))
-	require.NoError(t, r.initChunkers())
-	require.NoError(t, r.copyChunker.Open())
-	require.NoError(t, r.checksumChunker.Open())
-	disableDynamicChunking(t, r.copyChunker)
-	disableDynamicChunking(t, r.checksumChunker)
-	require.NoError(t, r.setupCopierCheckerAndReplClient(t.Context()))
-	require.NoError(t, r.replClient.Start(t.Context()))
-	t.Cleanup(func() { r.replClient.Close() })
-
-	advanceUntilWatermark(t, r.copyChunker)
-	advanceUntilWatermark(t, r.checksumChunker)
+	advanceRunnerToChecksumWatermarks(t, r)
 
 	// Swap in a mock checker whose DifferencesFound() we control. The
 	// invariant only looks at this value (and the chunker's watermark);
@@ -176,6 +159,199 @@ func TestDumpCheckpointSuppressesWatermarkWithDifferences(t *testing.T) {
 	require.NotEmpty(t, copierWM)
 	require.NotEmpty(t, checksumWM,
 		"checksum_watermark must be persisted again once DifferencesFound clears")
+}
+
+// TestDumpCheckpointSuppressesWatermarkWithContinuousDifferences pins the
+// sentinel-wait half of the invariant: the continuous checker is a separate
+// object from r.checker, so DumpCheckpoint must consult it too. Once it has
+// repaired any chunk, checkpoints must stop carrying a checksum_watermark —
+// even though the initial checker is still clean — or the operator's re-run
+// would resume the checksum at the end-of-initial-pass watermark and never
+// re-verify the repaired range.
+func TestDumpCheckpointSuppressesWatermarkWithContinuousDifferences(t *testing.T) {
+	t.Parallel()
+	r := setupRunnerForChecksumTest(t, "chkpt_cont_invariant")
+	advanceRunnerToChecksumWatermarks(t, r)
+
+	// The initial checksum completed clean; the runner is now blocked in
+	// the sentinel wait (which is >= Checksum, so watermarks are dumped).
+	r.checker = &mockChecker{}
+	r.status.Set(status.WaitingOnSentinelTable)
+
+	// --- Case 1: no continuous checker yet (just entered the wait). ---
+	require.NoError(t, r.DumpCheckpoint(t.Context()))
+	copierWM, checksumWM := latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, copierWM, "copier_watermark should always be persisted")
+	require.NotEmpty(t, checksumWM,
+		"checksum_watermark must be persisted while no continuous checker exists")
+
+	// --- Case 2: continuous checker exists and is clean. ---
+	cont := &mockChecker{}
+	r.continuousChecker = cont
+	require.NoError(t, r.DumpCheckpoint(t.Context()))
+	_, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM,
+		"checksum_watermark must be persisted while the continuous checker is clean")
+
+	// --- Case 3: continuous checker has repaired a chunk. ---
+	cont.differencesFound.Store(1)
+	require.NoError(t, r.DumpCheckpoint(t.Context()))
+	copierWM, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, copierWM)
+	require.Empty(t, checksumWM,
+		"checksum_watermark must be empty once the continuous checker found differences, even with a clean initial checker")
+}
+
+// TestInvalidateChecksumWatermarkAfterContinuousDivergence pins the
+// race-closing half of the sentinel-wait fix: a checkpoint row that was
+// persisted WITH a watermark before the continuous checker recorded its
+// difference must be blanked by invalidateChecksumWatermark on the abort
+// path, because resume reads the latest row.
+func TestInvalidateChecksumWatermarkAfterContinuousDivergence(t *testing.T) {
+	t.Parallel()
+	r := setupRunnerForChecksumTest(t, "chkpt_cont_invalidate")
+	advanceRunnerToChecksumWatermarks(t, r)
+
+	r.checker = &mockChecker{}
+	r.status.Set(status.WaitingOnSentinelTable)
+
+	// Persist a checkpoint while everything is believed clean — this is the
+	// "last periodic dump before the difference was recorded" row that the
+	// abort path must neutralize.
+	require.NoError(t, r.DumpCheckpoint(t.Context()))
+	_, checksumWM := latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM)
+
+	// No continuous checker, or a clean one: invalidate must be a no-op.
+	require.NoError(t, r.invalidateChecksumWatermark(t.Context()))
+	_, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM,
+		"invalidate must not touch the watermark when no continuous checker exists")
+	cont := &mockChecker{}
+	r.continuousChecker = cont
+	require.NoError(t, r.invalidateChecksumWatermark(t.Context()))
+	_, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM,
+		"invalidate must not touch the watermark while the continuous checker is clean")
+
+	// Continuous checker found (and repaired) a difference: the
+	// already-persisted watermark row must be rewritten to empty.
+	cont.differencesFound.Store(1)
+	require.NoError(t, r.invalidateChecksumWatermark(t.Context()))
+	copierWM, checksumWM := latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, copierWM, "copier_watermark must survive invalidation")
+	require.Empty(t, checksumWM,
+		"the previously-persisted checksum_watermark must be blanked after continuous divergence")
+	var stale int
+	require.NoError(t, r.db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s` WHERE checksum_watermark <> ''",
+			r.checkpointTable.SchemaName, r.checkpointTable.TableName)).Scan(&stale))
+	require.Zero(t, stale, "no checkpoint row may carry a checksum_watermark after invalidation")
+}
+
+// TestContinuousChecksumDivergenceClearsCheckpointWatermark is the E2E
+// version: a defer-cutover migration reaches the sentinel wait, a row in the
+// _new table is corrupted externally, the continuous checksum detects and
+// repairs it and deliberately aborts the run — and the final on-disk
+// checkpoint state must carry NO checksum_watermark anywhere, so the
+// operator's re-run re-verifies the whole table instead of silently
+// resuming past the repaired chunk.
+//
+// Not parallel: it shortens the package-global continuousChecksumMinInterval
+// so the first continuous pass starts promptly.
+func TestContinuousChecksumDivergenceClearsCheckpointWatermark(t *testing.T) {
+	origInterval := continuousChecksumMinInterval
+	continuousChecksumMinInterval = 2 * time.Second
+	t.Cleanup(func() { continuousChecksumMinInterval = origInterval })
+
+	tableName := "cont_chk_clear"
+	tt := testutils.NewTestTable(t, tableName, `CREATE TABLE cont_chk_clear (
+		id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		val VARCHAR(64) NOT NULL
+	)`)
+	tt.SeedRows(t, "INSERT INTO cont_chk_clear (val) SELECT 'a'", 1000)
+
+	m := NewTestRunner(t, tableName, "ENGINE=InnoDB",
+		WithThreads(1),
+		WithDeferCutOver(),
+		WithRespectSentinel())
+	defer utils.CloseAndLog(m)
+
+	var runErr error
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		runErr = m.Run(t.Context())
+	}()
+
+	waitForStatus(t, m, status.WaitingOnSentinelTable)
+
+	// The test-suite checkpoint dumper runs every 100ms (see TestMain).
+	// Wait until a checkpoint row carrying the end-of-initial-checksum
+	// watermark is on disk: that is exactly the stale row the fix must
+	// neutralize.
+	checkpointTable := utils.CheckpointTableName(tableName)
+	require.Eventually(t, func() bool {
+		var checksumWM string
+		err := tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(
+			"SELECT checksum_watermark FROM `%s` ORDER BY id DESC LIMIT 1", checkpointTable)).Scan(&checksumWM)
+		return err == nil && checksumWM != ""
+	}, 30*time.Second, 50*time.Millisecond,
+		"expected a checkpoint row with a checksum_watermark during the sentinel wait")
+
+	// Corrupt a row in the new table behind spirit's back. The continuous
+	// checksum (first pass starts after the shortened min-interval) detects
+	// the divergence, repairs it, and aborts the run rather than allowing
+	// cutover.
+	testutils.RunSQL(t, fmt.Sprintf("UPDATE `%s` SET val = 'corrupted' WHERE id = 1", utils.NewTableName(tableName)))
+
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Minute):
+		t.Fatal("timed out waiting for the continuous checksum to abort the migration")
+	}
+	require.Error(t, runErr)
+	require.ErrorContains(t, runErr, "continuous checksum")
+
+	// The deliberate abort must leave a checkpoint (resume is allowed) ...
+	require.True(t, checkpointTableExists(t, m),
+		"checkpoint must be preserved so the operator can re-run")
+	var copierWM string
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(
+		"SELECT copier_watermark FROM `%s` ORDER BY id DESC LIMIT 1", checkpointTable)).Scan(&copierWM))
+	require.NotEmpty(t, copierWM, "copier_watermark must survive the abort")
+
+	// ... but no row anywhere may still carry a checksum_watermark: both the
+	// rows dumped after the difference was recorded (suppression) and the
+	// rows dumped before it (abort-path UPDATE) must be blank.
+	var stale int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(), fmt.Sprintf(
+		"SELECT COUNT(*) FROM `%s` WHERE checksum_watermark <> ''", checkpointTable)).Scan(&stale))
+	require.Zero(t, stale,
+		"no checkpoint row may carry a checksum_watermark after the continuous-checksum abort")
+}
+
+// advanceRunnerToChecksumWatermarks seeds the runner's table and brings both
+// the copy and checksum chunkers to a state where they report low-watermarks,
+// so DumpCheckpoint will persist them. The seed needs enough rows that the
+// chunker can carve out multiple chunks: the composite chunker won't report a
+// low-watermark until at least one fully-processed chunk has had Feedback,
+// which in practice requires more than one chunk on the runway.
+func advanceRunnerToChecksumWatermarks(t *testing.T, r *Runner) {
+	t.Helper()
+	seedRows(t, r.db, r.migration.Table, 4096)
+	require.NoError(t, r.changes[0].table.SetInfo(t.Context()))
+	require.NoError(t, r.initChunkers())
+	require.NoError(t, r.copyChunker.Open())
+	require.NoError(t, r.checksumChunker.Open())
+	disableDynamicChunking(t, r.copyChunker)
+	disableDynamicChunking(t, r.checksumChunker)
+	require.NoError(t, r.setupCopierCheckerAndReplClient(t.Context()))
+	require.NoError(t, r.replClient.Start(t.Context()))
+	t.Cleanup(func() { r.replClient.Close() })
+
+	advanceUntilWatermark(t, r.copyChunker)
+	advanceUntilWatermark(t, r.checksumChunker)
 }
 
 // seedRows populates the named table by doubling until it has at least

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -1582,9 +1582,12 @@ func (r *Runner) waitOnSentinelTable(ctx context.Context) (retErr error) {
 		// was already cancelled.
 		if err := r.invalidateChecksumWatermark(context.WithoutCancel(ctx)); err != nil {
 			r.logger.Error("failed to clear persisted checksum watermark after continuous checksum divergence", "error", err)
-			if retErr == nil {
-				retErr = fmt.Errorf("failed to clear persisted checksum watermark: %w", err)
-			}
+			// Join rather than suppress, even when the continuous-checksum
+			// abort already set retErr: a failed invalidation means a stale
+			// checksum_watermark may remain on disk, letting a resume skip
+			// the full re-verification this abort exists to force. The
+			// operator must see both failures.
+			retErr = errors.Join(retErr, fmt.Errorf("failed to clear persisted checksum watermark: %w", err))
 		}
 	}()
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -73,6 +73,26 @@ type Runner struct {
 
 	chunkerMu sync.RWMutex // protects copyChunker and checksumChunker from concurrent access
 
+	// continuousChecker is the sentinel-wait re-verification checker built
+	// by runContinuousChecksum. It is deliberately separate from r.checker
+	// (fresh chunker, not wired into resume), but DumpCheckpoint must
+	// consult it: once it has repaired any chunk, the initial checksum's
+	// watermark no longer proves the table clean, so persisting it would
+	// let a resumed run skip re-verifying the repaired range. Written once
+	// by the continuous-checksum goroutine and read by the checkpoint
+	// dumper goroutine — both under checkpointMu.
+	continuousChecker checksum.Checker
+
+	// checkpointMu serializes checkpoint persistence (DumpCheckpoint's
+	// watermark-condition evaluation + INSERT) against the sentinel-abort
+	// path that blanks the persisted checksum_watermark
+	// (invalidateChecksumWatermark). Without it, a periodic dump that
+	// evaluated its conditions just before the continuous checker recorded
+	// a difference could INSERT a stale-watermark row *after* the abort
+	// path's UPDATE, resurrecting the watermark on the latest row — the
+	// row resume reads. It also guards continuousChecker (see above).
+	checkpointMu sync.Mutex
+
 	// Track some key statistics.
 	startTime             time.Time
 	sentinelWaitStartTime time.Time
@@ -1324,6 +1344,12 @@ func (r *Runner) addsUniqueIndex() bool {
 // would always restart at the copier, but it can now also resume at
 // the checksum phase.
 func (r *Runner) DumpCheckpoint(ctx context.Context) error {
+	// Serialize the whole dump (condition evaluation + INSERT) against
+	// invalidateChecksumWatermark, so the sentinel-abort path can never be
+	// overtaken by an in-flight dump that read its conditions before the
+	// continuous checker recorded a difference. See checkpointMu.
+	r.checkpointMu.Lock()
+	defer r.checkpointMu.Unlock()
 	// Check if replication client and copier are initialized (nil if called before setup completes).
 	// We hold chunkerMu to synchronize with initChunkers(), which
 	// may be assigning r.copyChunker concurrently during setup.
@@ -1367,13 +1393,24 @@ func (r *Runner) DumpCheckpoint(ctx context.Context) error {
 	// resumed run to re-verify the table from the start of the checksum
 	// phase. That is the only safe recovery from a not-yet-completed
 	// repair.
+	//
+	// The same invariant applies to the sentinel-wait continuous checker
+	// (a separate object from r.checker — see continuousChecker): once it
+	// has repaired any chunk, the watermark we would persist here is the
+	// end-of-initial-checksum watermark, and resuming from it would let
+	// the operator's re-run "pass" by verifying only the trailing chunks —
+	// silently neutralizing the deliberate abort that the continuous
+	// checksum triggers on divergence. So the watermark is persisted only
+	// while BOTH checkers are clean (or the continuous one doesn't exist
+	// yet).
 	var checksumWatermark string
 	if r.status.Get() >= status.Checksum {
 		wm, wmErr := checksumChunker.GetLowWatermark()
 		if wmErr != nil {
 			return status.ErrWatermarkNotReady
 		}
-		if r.checker != nil && r.checker.DifferencesFound() == 0 {
+		if r.checker != nil && r.checker.DifferencesFound() == 0 &&
+			(r.continuousChecker == nil || r.continuousChecker.DifferencesFound() == 0) {
 			checksumWatermark = wm
 		}
 	}
@@ -1507,11 +1544,27 @@ func (r *Runner) waitOnSentinelTable(ctx context.Context) (retErr error) {
 	defer func() {
 		cancelContinuous()
 		<-continuousDone
-		if retErr != nil {
-			return
-		}
-		if continuousErr != nil && ctx.Err() == nil {
+		if retErr == nil && continuousErr != nil && ctx.Err() == nil {
 			retErr = fmt.Errorf("continuous checksum failed: %w", continuousErr)
+		}
+		// If the continuous checker repaired any chunk, this run is about
+		// to abort (with MaxRetries=1, checker.Run errors whenever
+		// DifferencesFound > 0, and runContinuousChecksum propagates it).
+		// The periodic dumper stops persisting a checksum_watermark the
+		// instant the difference is recorded, but a dump whose conditions
+		// were read just before that instant can still land a stale
+		// watermark row afterwards. Rewrite the persisted rows here —
+		// strictly after any such in-flight INSERT, via checkpointMu — so
+		// the on-disk state after the abort forces full checksum
+		// re-verification on resume. The continuous goroutine has exited
+		// (see <-continuousDone above), so the counter we read is final.
+		// WithoutCancel: this cleanup must run even when the parent ctx
+		// was already cancelled.
+		if err := r.invalidateChecksumWatermark(context.WithoutCancel(ctx)); err != nil {
+			r.logger.Error("failed to clear persisted checksum watermark after continuous checksum divergence", "error", err)
+			if retErr == nil {
+				retErr = fmt.Errorf("failed to clear persisted checksum watermark: %w", err)
+			}
 		}
 	}()
 
@@ -1560,6 +1613,32 @@ func (r *Runner) waitOnSentinelTable(ctx context.Context) (retErr error) {
 	}
 }
 
+// invalidateChecksumWatermark blanks the checksum_watermark on this
+// migration's persisted checkpoint rows if (and only if) the sentinel-wait
+// continuous checker recorded any repaired chunks. Called from the
+// sentinel-abort path: the periodic dumper already refuses to persist a
+// watermark once the difference counter is non-zero, but the difference can
+// be recorded between a dump's condition read and its INSERT — this UPDATE,
+// serialized against the dumper via checkpointMu, runs strictly after any
+// such in-flight INSERT and guarantees resume re-verifies from the start of
+// the checksum phase. Scoped by statement because in multi-table mode the
+// checkpoint table is shared with other concurrently-running migrations in
+// the same schema (resume filters on statement the same way).
+func (r *Runner) invalidateChecksumWatermark(ctx context.Context) error {
+	r.checkpointMu.Lock()
+	defer r.checkpointMu.Unlock()
+	if r.continuousChecker == nil || r.continuousChecker.DifferencesFound() == 0 {
+		return nil
+	}
+	r.logger.Warn("continuous checksum found differences; clearing persisted checksum watermark so the next run re-verifies from the start of the checksum phase")
+	return dbconn.Exec(ctx, r.db, "UPDATE %n.%n SET checksum_watermark = %? WHERE statement = %?",
+		r.checkpointTable.SchemaName,
+		r.checkpointTable.TableName,
+		"",
+		r.migration.Statement,
+	)
+}
+
 // runContinuousChecksum loops calling a fresh checker over the source/new
 // tables for as long as ctx is alive. It is the "continuous" half of the
 // two-checksum model (see docs/migrate.md) and is only called while the
@@ -1600,6 +1679,15 @@ func (r *Runner) runContinuousChecksum(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create continuous checker: %w", err)
 	}
+	// Publish the checker so DumpCheckpoint (on the WatchTask goroutine)
+	// can consult its DifferencesFound() when deciding whether the
+	// persisted checksum_watermark is still trustworthy. Published before
+	// the first pass starts, so there is no window where a difference
+	// could be recorded while the dumper still believes the table clean —
+	// the checker increments its counter atomically *before* repairing.
+	r.checkpointMu.Lock()
+	r.continuousChecker = checker
+	r.checkpointMu.Unlock()
 
 	iteration := 0
 	var lastDuration time.Duration // zero before the first iteration → full interval wait

--- a/pkg/move/checksum_invariant_test.go
+++ b/pkg/move/checksum_invariant_test.go
@@ -207,6 +207,92 @@ func TestDumpCheckpointSuppressesWatermarkWithDifferences(t *testing.T) {
 		"checksum_watermark must be persisted again once DifferencesFound clears")
 }
 
+// TestDumpCheckpointSuppressesWatermarkWithContinuousDifferences pins the
+// sentinel-wait half of the invariant in the move runner: the continuous
+// checker is a separate object from r.checker, so DumpCheckpoint must
+// consult it too. Once it has repaired any chunk, checkpoints must stop
+// carrying a checksum_watermark — even though the initial checker is still
+// clean — or the operator's re-run would resume the checksum at the
+// end-of-initial-pass watermark and never re-verify the repaired range.
+// Mirrors the migration-package test of the same name.
+func TestDumpCheckpointSuppressesWatermarkWithContinuousDifferences(t *testing.T) {
+	r, ctx := setupRunnerForChecksumTest(t, "cont_invariant")
+
+	// The initial checksum completed clean; the move is now blocked in the
+	// sentinel wait (which is >= Checksum, so watermarks are dumped).
+	r.checker = &mockChecker{}
+	r.status.Set(status.WaitingOnSentinelTable)
+
+	// --- Case 1: no continuous checker yet (just entered the wait). ---
+	require.NoError(t, r.DumpCheckpoint(ctx))
+	copierWM, checksumWM := latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, copierWM, "copier_watermark should always be persisted")
+	require.NotEmpty(t, checksumWM,
+		"checksum_watermark must be persisted while no continuous checker exists")
+
+	// --- Case 2: continuous checker exists and is clean. ---
+	cont := &mockChecker{}
+	r.continuousChecker = cont
+	require.NoError(t, r.DumpCheckpoint(ctx))
+	_, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM,
+		"checksum_watermark must be persisted while the continuous checker is clean")
+
+	// --- Case 3: continuous checker has repaired a chunk. ---
+	cont.differencesFound.Store(1)
+	require.NoError(t, r.DumpCheckpoint(ctx))
+	copierWM, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, copierWM)
+	require.Empty(t, checksumWM,
+		"checksum_watermark must be empty once the continuous checker found differences, even with a clean initial checker")
+}
+
+// TestInvalidateChecksumWatermarkAfterContinuousDivergence pins the
+// race-closing half of the sentinel-wait fix in the move runner: a
+// checkpoint row that was persisted WITH a watermark before the continuous
+// checker recorded its difference must be blanked by
+// invalidateChecksumWatermark on the abort path, because resume reads the
+// latest row. Mirrors the migration-package test of the same name.
+func TestInvalidateChecksumWatermarkAfterContinuousDivergence(t *testing.T) {
+	r, ctx := setupRunnerForChecksumTest(t, "cont_invalidate")
+
+	r.checker = &mockChecker{}
+	r.status.Set(status.WaitingOnSentinelTable)
+
+	// Persist a checkpoint while everything is believed clean — this is the
+	// "last periodic dump before the difference was recorded" row that the
+	// abort path must neutralize.
+	require.NoError(t, r.DumpCheckpoint(ctx))
+	_, checksumWM := latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM)
+
+	// No continuous checker, or a clean one: invalidate must be a no-op.
+	require.NoError(t, r.invalidateChecksumWatermark(ctx))
+	_, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM,
+		"invalidate must not touch the watermark when no continuous checker exists")
+	cont := &mockChecker{}
+	r.continuousChecker = cont
+	require.NoError(t, r.invalidateChecksumWatermark(ctx))
+	_, checksumWM = latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, checksumWM,
+		"invalidate must not touch the watermark while the continuous checker is clean")
+
+	// Continuous checker found (and repaired) a difference: the
+	// already-persisted watermark row must be rewritten to empty.
+	cont.differencesFound.Store(1)
+	require.NoError(t, r.invalidateChecksumWatermark(ctx))
+	copierWM, checksumWM := latestCheckpointWatermarks(t, r)
+	require.NotEmpty(t, copierWM, "copier_watermark must survive invalidation")
+	require.Empty(t, checksumWM,
+		"the previously-persisted checksum_watermark must be blanked after continuous divergence")
+	var stale int
+	require.NoError(t, r.targets[0].DB.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s` WHERE checksum_watermark <> ''",
+			r.checkpointTable.SchemaName, r.checkpointTable.TableName)).Scan(&stale))
+	require.Zero(t, stale, "no checkpoint row may carry a checksum_watermark after invalidation")
+}
+
 func checkpointTableExists(t *testing.T, r *Runner) bool {
 	t.Helper()
 	var n int

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
@@ -84,6 +85,26 @@ type Runner struct {
 	copier            copier.Copier
 	checker           checksum.Checker
 	checksumWatermark string
+
+	// continuousChecker is the sentinel-wait re-verification checker built
+	// by runContinuousChecksum. It is deliberately separate from r.checker
+	// (fresh chunker, not wired into resume), but DumpCheckpoint must
+	// consult it: once it has repaired any chunk, the initial checksum's
+	// watermark no longer proves the tables clean, so persisting it would
+	// let a resumed run skip re-verifying the repaired range. Written once
+	// by the continuous-checksum goroutine and read by the checkpoint
+	// dumper goroutine — both under checkpointMu. Mirrors pkg/migration.
+	continuousChecker checksum.Checker
+
+	// checkpointMu serializes checkpoint persistence (DumpCheckpoint's
+	// watermark-condition evaluation + INSERT) against the sentinel-abort
+	// path that blanks the persisted checksum_watermark
+	// (invalidateChecksumWatermark). Without it, a periodic dump that
+	// evaluated its conditions just before the continuous checker recorded
+	// a difference could INSERT a stale-watermark row *after* the abort
+	// path's UPDATE, resurrecting the watermark on the latest row — the
+	// row resume reads. It also guards continuousChecker (see above).
+	checkpointMu sync.Mutex
 
 	// Track some key statistics.
 	startTime                time.Time
@@ -1238,11 +1259,27 @@ func (r *Runner) waitOnSentinelTable(ctx context.Context) (retErr error) {
 	defer func() {
 		cancelContinuous()
 		<-continuousDone
-		if retErr != nil {
-			return
-		}
-		if continuousErr != nil && ctx.Err() == nil {
+		if retErr == nil && continuousErr != nil && ctx.Err() == nil {
 			retErr = fmt.Errorf("continuous checksum failed: %w", continuousErr)
+		}
+		// If the continuous checker repaired any chunk, this run is about
+		// to abort (with MaxRetries=1, checker.Run errors whenever
+		// DifferencesFound > 0, and runContinuousChecksum propagates it).
+		// The periodic dumper stops persisting a checksum_watermark the
+		// instant the difference is recorded, but a dump whose conditions
+		// were read just before that instant can still land a stale
+		// watermark row afterwards. Rewrite the persisted rows here —
+		// strictly after any such in-flight INSERT, via checkpointMu — so
+		// the on-disk state after the abort forces full checksum
+		// re-verification on resume. The continuous goroutine has exited
+		// (see <-continuousDone above), so the counter we read is final.
+		// WithoutCancel: this cleanup must run even when the parent ctx
+		// was already cancelled.
+		if err := r.invalidateChecksumWatermark(context.WithoutCancel(ctx)); err != nil {
+			r.logger.Error("failed to clear persisted checksum watermark after continuous checksum divergence", "error", err)
+			if retErr == nil {
+				retErr = fmt.Errorf("failed to clear persisted checksum watermark: %w", err)
+			}
 		}
 	}()
 
@@ -1287,6 +1324,31 @@ func (r *Runner) waitOnSentinelTable(ctx context.Context) (retErr error) {
 	}
 }
 
+// invalidateChecksumWatermark blanks the checksum_watermark on the persisted
+// checkpoint rows if (and only if) the sentinel-wait continuous checker
+// recorded any repaired chunks. Called from the sentinel-abort path: the
+// periodic dumper already refuses to persist a watermark once the difference
+// counter is non-zero, but the difference can be recorded between a dump's
+// condition read and its INSERT — this UPDATE, serialized against the dumper
+// via checkpointMu, runs strictly after any such in-flight INSERT and
+// guarantees resume re-verifies from the start of the checksum phase.
+// Unlike pkg/migration there is no statement scoping: a move owns its
+// target's checkpoint table outright (resume reads the latest row
+// unfiltered). Mirrors pkg/migration/runner.go.
+func (r *Runner) invalidateChecksumWatermark(ctx context.Context) error {
+	r.checkpointMu.Lock()
+	defer r.checkpointMu.Unlock()
+	if r.continuousChecker == nil || r.continuousChecker.DifferencesFound() == 0 {
+		return nil
+	}
+	r.logger.Warn("continuous checksum found differences; clearing persisted checksum watermark so the next run re-verifies from the start of the checksum phase")
+	return dbconn.Exec(ctx, r.targets[0].DB, "UPDATE %n.%n SET checksum_watermark = %?",
+		r.checkpointTable.SchemaName,
+		r.checkpointTable.TableName,
+		"",
+	)
+}
+
 // runContinuousChecksum loops calling a fresh distributed checker over the
 // source/target tables for as long as ctx is alive. It is the "continuous"
 // half of the two-checksum model (see docs/move.md) and is only called while
@@ -1328,6 +1390,15 @@ func (r *Runner) runContinuousChecksum(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create continuous checker: %w", err)
 	}
+	// Publish the checker so DumpCheckpoint (on the WatchTask goroutine)
+	// can consult its DifferencesFound() when deciding whether the
+	// persisted checksum_watermark is still trustworthy. Published before
+	// the first pass starts, so there is no window where a difference
+	// could be recorded while the dumper still believes the tables clean —
+	// the checker increments its counter atomically *before* repairing.
+	r.checkpointMu.Lock()
+	r.continuousChecker = checker
+	r.checkpointMu.Unlock()
 
 	iteration := 0
 	var lastDuration time.Duration // zero before the first iteration → full interval wait
@@ -1423,6 +1494,12 @@ func (r *Runner) buildContinuousChunker() (table.Chunker, error) {
 // would always restart at the copier, but it can now also resume at
 // the checksum phase.
 func (r *Runner) DumpCheckpoint(ctx context.Context) error {
+	// Serialize the whole dump (condition evaluation + INSERT) against
+	// invalidateChecksumWatermark, so the sentinel-abort path can never be
+	// overtaken by an in-flight dump that read its conditions before the
+	// continuous checker recorded a difference. See checkpointMu.
+	r.checkpointMu.Lock()
+	defer r.checkpointMu.Unlock()
 	// Collect per-source positions (opaque strings owned by the source
 	// implementation), keyed by sourceKey (addr/dbname).
 	positions := make(map[string]string)
@@ -1448,13 +1525,23 @@ func (r *Runner) DumpCheckpoint(ctx context.Context) error {
 	// suppress the watermark so a restart re-validates from the start of
 	// the checksum phase. See pkg/migration/runner.go DumpCheckpoint for
 	// the full rationale.
+	//
+	// The same invariant applies to the sentinel-wait continuous checker
+	// (a separate object from r.checker — see continuousChecker): once it
+	// has repaired any chunk, the watermark here is the stale
+	// end-of-initial-checksum one, and resuming from it would verify only
+	// the trailing chunks — silently neutralizing the deliberate abort the
+	// continuous checksum triggers on divergence. So the watermark is
+	// persisted only while BOTH checkers are clean (or the continuous one
+	// doesn't exist yet).
 	var checksumWatermark string
 	if r.status.Get() >= status.Checksum && r.checker != nil {
 		wm, wmErr := r.checksumChunker.GetLowWatermark()
 		if wmErr != nil {
 			return status.ErrWatermarkNotReady
 		}
-		if r.checker.DifferencesFound() == 0 {
+		if r.checker.DifferencesFound() == 0 &&
+			(r.continuousChecker == nil || r.continuousChecker.DifferencesFound() == 0) {
 			checksumWatermark = wm
 		}
 	}

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1277,9 +1277,12 @@ func (r *Runner) waitOnSentinelTable(ctx context.Context) (retErr error) {
 		// was already cancelled.
 		if err := r.invalidateChecksumWatermark(context.WithoutCancel(ctx)); err != nil {
 			r.logger.Error("failed to clear persisted checksum watermark after continuous checksum divergence", "error", err)
-			if retErr == nil {
-				retErr = fmt.Errorf("failed to clear persisted checksum watermark: %w", err)
-			}
+			// Join rather than suppress, even when the continuous-checksum
+			// abort already set retErr: a failed invalidation means a stale
+			// checksum_watermark may remain on disk, letting a resume skip
+			// the full re-verification this abort exists to force. The
+			// operator must see both failures.
+			retErr = errors.Join(retErr, fmt.Errorf("failed to clear persisted checksum watermark: %w", err))
 		}
 	}()
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #925** (`fix-move-resume-watermarks`) — the diff includes its commits until it merges. Review only the last commit. Touches `DumpCheckpoint`/`runContinuousChecksum` in both runners; merges independently of #954/#957 apart from trivial proximity.

## The bug (both `pkg/migration` and `pkg/move`)

During the sentinel wait (`--defer-cutover`), `runContinuousChecksum` re-verifies the table with `FixDifferences:true, MaxRetries:1`. On divergence it repairs the chunk and the run **deliberately aborts** so the operator's re-run must fully re-verify before cutover. But `DumpCheckpoint` decided whether to persist `checksum_watermark` by consulting only the **initial** checker (`r.checker.DifferencesFound() == 0`). The continuous checker is a separate object, so sentinel-wait checkpoints kept carrying the end-of-initial-checksum watermark — and the re-run resumed the checksum **at** that watermark, "passing" by verifying only the trailing chunks. The repaired chunk was never re-verified: the deliberate abort was silently neutralized, in exactly the situation (unexplained divergence — a spirit bug or external writes to `_new`) where full re-verification matters most.

## The fix (mirrored, deliberately parallel diffs in both runners)

1. **Visibility** — `runContinuousChecksum` publishes its checker on the runner before the first pass. `DumpCheckpoint`'s condition becomes: initial checker clean **and** (no continuous checker yet **or** continuous checker clean). The checker increments its counter atomically *before* repairing, so suppression takes effect the instant divergence is detected.
2. **Last-dump race closed** — a periodic dump can evaluate its conditions just before the difference is recorded and INSERT a stale-watermark row afterwards. On the abort path (in `waitOnSentinelTable`'s defer, after `<-continuousDone` makes the counter final), `invalidateChecksumWatermark` blanks `checksum_watermark` on the persisted rows via UPDATE. UPDATE over "dump once more" because it can't fail with `ErrWatermarkNotReady`, doesn't depend on chunker state, and scrubs every row including the one resume reads. Runs under `context.WithoutCancel`; statement-scoped in `pkg/migration` (multi-table migrations share `_spirit_checkpoint` with concurrent runs — resume filters on statement the same way).
3. **Synchronization** — a new `checkpointMu` serializes the whole dump (condition read + INSERT) against the abort-path UPDATE and guards the `continuousChecker` field. Mutex ordering guarantees any in-flight stale INSERT commits *before* the blank UPDATE, so the final on-disk state after an abort never carries a watermark. Lock order is `checkpointMu` → `chunkerMu` with no reverse acquisition.

## Tests

- `TestDumpCheckpointSuppressesWatermarkWithContinuousDifferences` (both packages) — clean initial + dirty continuous checker ⇒ empty watermark; nil/clean continuous keeps persisting.
- `TestInvalidateChecksumWatermarkAfterContinuousDivergence` (both packages) — the race row (persisted with a watermark before divergence) is blanked; no-op while clean; copier watermark survives.
- `TestContinuousChecksumDivergenceClearsCheckpointWatermark` (migration E2E, real path end-to-end) — defer-cutover migration reaches the sentinel wait, test observes a watermark-bearing checkpoint row, corrupts a row in `_new`; the continuous checksum detects, repairs, and aborts — after which **no** checkpoint row carries a checksum watermark while the copier watermark survives for resume. ~2.6s.

No move-side E2E: that would need new multi-DB sentinel scaffolding; the move unit tests pin both halves of the invariant on the real `DumpCheckpoint`/`invalidateChecksumWatermark` code, and the migration E2E exercises the shared `waitOnSentinelTable` wiring shape.

## Results

`go test -race ./pkg/migration/ -run 'Checkpoint|Checksum|Sentinel'` ok (9 tests); same filter for `./pkg/move/` ok (8 tests); build/gofmt/golangci-lint clean. MySQL 8.0.43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
