### PR TITLE
table: don't treat dispatched-but-uncommitted chunks as below the low watermark

### DIFF
--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -63,9 +63,22 @@ func (t *chunkerComposite) additionalConditionsSQL(whereSent bool) string {
 // boundary of this chunk. This method is slower, but works better when the
 // table can not predictably be chunked by just dividing the range between min and max values.
 // as with auto_increment PRIMARY KEYs. This is the same method used by gh-ost.
+// It wraps next() so that every successfully dispatched chunk is counted as
+// in-flight until the consumer returns it via Feedback() (see
+// watermarkTracker.inflightChunks).
 func (t *chunkerComposite) Next() (*Chunk, error) {
 	t.Lock()
 	defer t.Unlock()
+	chunk, err := t.next()
+	if err != nil {
+		return nil, err
+	}
+	t.chunkDispatched()
+	return chunk, nil
+}
+
+// next computes the next chunk. Caller must hold t.Mutex.
+func (t *chunkerComposite) next() (*Chunk, error) {
 	if t.finalChunkSent {
 		return nil, ErrTableIsRead
 	}
@@ -300,6 +313,7 @@ func (t *chunkerComposite) Reset() error {
 	t.chunkSize = StartingChunkSize
 	t.watermark = nil
 	t.lowerBoundWatermarkMap = make(map[string]*Chunk, 0)
+	t.inflightChunks = 0
 	t.chunkTimingInfo = []time.Duration{}
 
 	// Reset progress tracking
@@ -315,6 +329,7 @@ func (t *chunkerComposite) Reset() error {
 func (t *chunkerComposite) Feedback(chunk *Chunk, d time.Duration, actualRows uint64) {
 	t.Lock()
 	defer t.Unlock()
+	t.chunkFedBack()
 	t.bumpWatermark(chunk, t.logger)
 
 	// Update progress tracking - add the actual rows processed
@@ -400,6 +415,7 @@ func (t *chunkerComposite) open() (err error) {
 	}
 	t.finalChunkSent = false
 	t.chunkSize = StartingChunkSize
+	t.inflightChunks = 0
 	t.checkpointHighPtr = Datum{} // reset checkpoint high pointer
 
 	// Initialize progress tracking
@@ -534,8 +550,22 @@ func (t *chunkerComposite) KeyBelowLowWatermark(key0 any) bool {
 	t.Lock()
 	defer t.Unlock()
 
-	// If we've sent the final chunk, everything is below
-	if t.finalChunkSent {
+	// Once the final chunk has been dispatched AND every dispatched chunk
+	// has been returned via Feedback(), the entire key space has been
+	// copied and committed, so everything is below the low watermark.
+	//
+	// finalChunkSent alone is NOT sufficient: dispatch (Next) and commit
+	// (Feedback) are decoupled — with the buffered copier a chunk's writes
+	// can still be in flight when another worker draws the final chunk.
+	// Returning true for a key inside such an in-flight chunk would let a
+	// binlog DELETE for that key flush to the target as a no-op before the
+	// chunk's INSERT lands, resurrecting a stale copy of the row. While
+	// chunks remain in flight we fall through to the watermark comparison
+	// below, which only admits keys below the contiguously-committed range.
+	// A false return merely defers the key to a later flush; the cutover
+	// flush bypasses this filter entirely (see
+	// change.bufferedMap.flushMapLocked).
+	if t.finalChunkSent && t.allDispatchedChunksFedBack() {
 		return true
 	}
 

--- a/pkg/table/chunker_composite_test.go
+++ b/pkg/table/chunker_composite_test.go
@@ -938,6 +938,96 @@ func TestCompositeChunkerWatermarkOptimizations(t *testing.T) {
 	require.NoError(t, comp.Close())
 }
 
+// TestCompositeChunkerKeyBelowLowWatermarkInflightFinalChunk is a regression
+// test: KeyBelowLowWatermark used to return true for ALL keys as soon as the
+// final chunk had been dispatched via Next(), even though earlier chunks could
+// still be in flight (dispatched but not yet committed and fed back). With the
+// buffered copier, dispatch and commit are decoupled, so a binlog DELETE for a
+// key inside an in-flight chunk could flush to the target as a no-op before
+// the chunk's INSERT landed, resurrecting a stale copy of the row. The
+// shortcut must only fire once every dispatched chunk has been returned via
+// Feedback(). See also the optimistic chunker variant in
+// chunker_optimistic_test.go.
+func TestCompositeChunkerKeyBelowLowWatermarkInflightFinalChunk(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS composite_inflight_t1")
+	testutils.RunSQL(t, `CREATE TABLE composite_inflight_t1 (
+		a int NOT NULL,
+		b int NOT NULL,
+		PRIMARY KEY (a)
+	)`)
+	// Non-auto-inc PK so NewChunker selects the composite chunker.
+	// Seed 3000 rows with a=1..3000 (split into 3 inserts to stay below
+	// the default cte_max_recursion_depth of 1000).
+	for i := range 3 {
+		testutils.RunSQL(t, fmt.Sprintf(`INSERT INTO composite_inflight_t1 (a, b)
+			WITH RECURSIVE seq AS (
+				SELECT 1 AS n UNION ALL SELECT n + 1 FROM seq WHERE n < 1000
+			)
+			SELECT n + %d, 1 FROM seq`, i*1000))
+	}
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Logf("failed to close db: %v", err)
+		}
+	}()
+
+	tbl := NewTableInfo(db, "test", "composite_inflight_t1")
+	require.NoError(t, tbl.SetInfo(t.Context()))
+
+	chunker, err := NewChunker(tbl, ChunkerConfig{})
+	require.NoError(t, err)
+	comp := chunker.(*chunkerComposite)
+	comp.SetDynamicChunking(false)
+	require.NoError(t, comp.Open())
+
+	// With 3000 rows and StartingChunkSize=1000 we get three chunks:
+	// c1 = (-inf, 1001), c2 = [1001, ~2002), c3 = [~2002, +inf) (final).
+	c1, err := comp.Next()
+	require.NoError(t, err)
+	require.NotNil(t, c1.UpperBound)
+	c2, err := comp.Next()
+	require.NoError(t, err)
+	require.NotNil(t, c2.UpperBound)
+	c3, err := comp.Next()
+	require.NoError(t, err)
+	require.Nil(t, c3.UpperBound)  // final chunk is open-ended
+	require.True(t, comp.IsRead()) // the final chunk has been dispatched
+
+	// Commit only c1: the contiguous low watermark advances to c1's upper
+	// bound (1001).
+	comp.Feedback(c1, 100*time.Millisecond, 1000)
+
+	// The final chunk has been dispatched, but c2 and c3 are still in
+	// flight. A key inside c2's range must NOT be reported below the low
+	// watermark — the old shortcut returned true for it as soon as
+	// finalChunkSent was set.
+	require.False(t, comp.KeyBelowLowWatermark(1500), "key inside in-flight c2 must not be below the low watermark")
+	// Keys in the contiguously-committed range still flush normally.
+	require.True(t, comp.KeyBelowLowWatermark(500))
+
+	// Committing the final chunk doesn't change anything while c2 remains
+	// in flight.
+	comp.Feedback(c3, 100*time.Millisecond, 1000)
+	require.False(t, comp.KeyBelowLowWatermark(1500))
+
+	// Commit c2: every dispatched chunk has now been fed back, so the
+	// post-copy steady state applies — everything is below.
+	comp.Feedback(c2, 100*time.Millisecond, 1000)
+	require.True(t, comp.KeyBelowLowWatermark(1500))
+	require.True(t, comp.KeyBelowLowWatermark(2500))
+	require.True(t, comp.KeyBelowLowWatermark(999999))
+
+	// Reset() clears the in-flight bookkeeping along with the rest of the
+	// chunker state.
+	require.NoError(t, comp.Reset())
+	require.False(t, comp.KeyBelowLowWatermark(500))
+
+	require.NoError(t, comp.Close())
+}
+
 // TestCompositeChunkerKeyAboveHighWatermarkMultiColumn is a regression test:
 // KeyAboveHighWatermark only sees key[0], so for a multi-column chunk key,
 // equality on the first column is ambiguous. With chunkPtrs = (5, 101), the

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -116,9 +116,22 @@ func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
 	}, nil
 }
 
+// Next returns the next chunk to process. It wraps next() so that every
+// successfully dispatched chunk is counted as in-flight until the consumer
+// returns it via Feedback() (see watermarkTracker.inflightChunks).
 func (t *chunkerOptimistic) Next() (*Chunk, error) {
 	t.Lock()
 	defer t.Unlock()
+	chunk, err := t.next()
+	if err != nil {
+		return nil, err
+	}
+	t.chunkDispatched()
+	return chunk, nil
+}
+
+// next computes the next chunk. Caller must hold t.Mutex.
+func (t *chunkerOptimistic) next() (*Chunk, error) {
 	if t.finalChunkSent {
 		return nil, ErrTableIsRead
 	}
@@ -316,6 +329,7 @@ func (t *chunkerOptimistic) Reset() error {
 	t.chunkSize = StartingChunkSize
 	t.watermark = nil
 	t.lowerBoundWatermarkMap = make(map[string]*Chunk, 0)
+	t.inflightChunks = 0
 	t.chunkTimingInfo = []time.Duration{}
 	t.chunkPrefetchingEnabled = false
 
@@ -336,6 +350,7 @@ func (t *chunkerOptimistic) Reset() error {
 func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, _ uint64) {
 	t.Lock()
 	defer t.Unlock()
+	t.chunkFedBack()
 	t.bumpWatermark(chunk, t.logger)
 
 	// It is up to the chunker implementation to decide how to track "rows copied"
@@ -427,6 +442,7 @@ func (t *chunkerOptimistic) open() (err error) {
 	t.chunkPtr = NewNilDatum(t.Ti.keyDatums[0])
 	t.finalChunkSent = false
 	t.chunkSize = StartingChunkSize
+	t.inflightChunks = 0
 
 	// Initialize progress tracking
 	atomic.StoreUint64(&t.rowsCopied, 0)
@@ -525,11 +541,24 @@ func (t *chunkerOptimistic) KeyAboveHighWatermark(key0 any) bool {
 func (t *chunkerOptimistic) KeyBelowLowWatermark(key0 any) bool {
 	t.Lock()
 	defer t.Unlock()
-	if t.finalChunkSent {
+	// Once the final chunk has been dispatched AND every dispatched chunk
+	// has been returned via Feedback(), the entire key space has been
+	// copied and committed, so everything is below the low watermark.
+	//
+	// finalChunkSent alone is NOT sufficient: dispatch (Next) and commit
+	// (Feedback) are decoupled — with the buffered copier a chunk's writes
+	// can still be in flight when another worker draws the final chunk.
+	// Returning true for a key inside such an in-flight chunk would let a
+	// binlog DELETE for that key flush to the target as a no-op before the
+	// chunk's INSERT lands, resurrecting a stale copy of the row. While
+	// chunks remain in flight we fall through to the watermark comparison
+	// below, which only admits keys below the contiguously-committed range.
+	// A false return merely defers the key to a later flush; the cutover
+	// flush bypasses this filter entirely (see
+	// change.bufferedMap.flushMapLocked).
+	if t.finalChunkSent && t.allDispatchedChunksFedBack() {
 		return true // we're done, so everything is below.
 	}
-	// There should be no race where there is no upperBound, but final chunk is not sent,
-	// but we check for nil on upper bound anyway.
 	if t.watermark == nil || t.watermark.LowerBound == nil || t.watermark.UpperBound == nil {
 		return false // watermark is probably not ready.
 	}

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -187,6 +187,87 @@ func TestLowWatermark(t *testing.T) {
 	require.Empty(t, chunker.lowerBoundWatermarkMap)
 }
 
+// TestOptimisticChunkerKeyBelowLowWatermarkInflightFinalChunk is a regression
+// test: KeyBelowLowWatermark used to return true for ALL keys as soon as the
+// final chunk had been dispatched via Next(), even though earlier chunks could
+// still be in flight (dispatched but not yet committed and fed back). With the
+// buffered copier, dispatch and commit are decoupled, so a binlog DELETE for a
+// key inside an in-flight chunk could flush to the target as a no-op before
+// the chunk's INSERT landed, resurrecting a stale copy of the row. The
+// shortcut must only fire once every dispatched chunk has been returned via
+// Feedback().
+func TestOptimisticChunkerKeyBelowLowWatermarkInflightFinalChunk(t *testing.T) {
+	t1 := newTableInfo4Test("test", "t1")
+	t1.minValue = Datum{Val: int64(1), Tp: signedType}
+	t1.maxValue = Datum{Val: int64(4000), Tp: signedType}
+	t1.EstimatedRows = 4000
+	t1.KeyColumns = []string{"id"}
+	t1.keyColumnsMySQLTp = []string{"bigint"}
+	t1.keyDatums = []datumTp{signedType}
+	t1.KeyIsAutoInc = true
+	t1.Columns = []string{"id", "name"}
+	// Prevent Next() from synchronously refreshing statistics (which needs a
+	// real DB connection) when it reaches the end of the table.
+	t1.statisticsLastUpdated = time.Now()
+
+	chunker := &chunkerOptimistic{
+		Ti:                t1,
+		dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: ChunkerDefaultTarget},
+		watermarkTracker:  watermarkTracker{lowerBoundWatermarkMap: make(map[string]*Chunk)},
+		logger:            slog.Default(),
+	}
+	chunker.SetDynamicChunking(false)
+	require.NoError(t, chunker.Open())
+
+	// Dispatch every chunk up front, simulating parallel read workers that
+	// race ahead of the async write workers.
+	chunk0, err := chunker.Next() // `id` < 1
+	require.NoError(t, err)
+	chunk1, err := chunker.Next() // [1, 1001)
+	require.NoError(t, err)
+	chunk2, err := chunker.Next() // [1001, 2001)
+	require.NoError(t, err)
+	chunk3, err := chunker.Next() // [2001, 3001) — held in flight below
+	require.NoError(t, err)
+	require.Equal(t, "`id` >= 2001 AND `id` < 3001", chunk3.String())
+	chunk4, err := chunker.Next() // [3001, 4001) — held in flight below
+	require.NoError(t, err)
+	finalChunk, err := chunker.Next() // `id` >= 4001 (final, open-ended)
+	require.NoError(t, err)
+	require.Nil(t, finalChunk.UpperBound)
+	require.True(t, chunker.IsRead()) // the final chunk has been dispatched
+
+	// Commit chunk0..chunk2: the contiguous low watermark advances to 2001.
+	chunker.Feedback(chunk0, time.Second, 1)
+	chunker.Feedback(chunk1, time.Second, 1000)
+	chunker.Feedback(chunk2, time.Second, 1000)
+
+	// The final chunk has been dispatched, but chunk3, chunk4 and the final
+	// chunk itself are still in flight. Keys inside the in-flight ranges
+	// must NOT be reported below the low watermark — the old shortcut
+	// returned true for them as soon as finalChunkSent was set.
+	require.False(t, chunker.KeyBelowLowWatermark(2500), "key inside in-flight chunk3 must not be below the low watermark")
+	require.False(t, chunker.KeyBelowLowWatermark(3500), "key inside in-flight chunk4 must not be below the low watermark")
+	// Keys in the contiguously-committed range still flush normally.
+	require.True(t, chunker.KeyBelowLowWatermark(1500))
+
+	// Committing the final chunk doesn't change anything while chunk3 and
+	// chunk4 remain in flight.
+	chunker.Feedback(finalChunk, time.Second, 1)
+	require.False(t, chunker.KeyBelowLowWatermark(2500))
+
+	// Commit chunk4 out of order: chunk3 is still in flight.
+	chunker.Feedback(chunk4, time.Second, 1000)
+	require.False(t, chunker.KeyBelowLowWatermark(2500))
+
+	// Commit chunk3: every dispatched chunk has now been fed back, so the
+	// post-copy steady state applies — everything is below.
+	chunker.Feedback(chunk3, time.Second, 1000)
+	require.True(t, chunker.KeyBelowLowWatermark(2500))
+	require.True(t, chunker.KeyBelowLowWatermark(3500))
+	require.True(t, chunker.KeyBelowLowWatermark(999999))
+}
+
 func TestOptimisticDynamicChunking(t *testing.T) {
 	t1 := newTableInfo4Test("test", "t1")
 	t1.minValue = Datum{Val: int64(1), Tp: signedType}

--- a/pkg/table/watermark_tracker.go
+++ b/pkg/table/watermark_tracker.go
@@ -19,6 +19,38 @@ type watermarkTracker struct {
 	watermark              *Chunk
 	lowerBoundWatermarkMap map[string]*Chunk
 	checkpointHighPtr      Datum
+
+	// inflightChunks counts chunks that have been dispatched via Next()
+	// but not yet returned via Feedback(). Dispatch and commit are
+	// decoupled (e.g. the buffered copier queues chunklets that async
+	// write workers commit later), so "the final chunk has been
+	// dispatched" does NOT imply "everything has been copied". Only when
+	// the final chunk has been dispatched AND inflightChunks is zero has
+	// every dispatched chunk been committed and fed back.
+	inflightChunks uint64
+}
+
+// chunkDispatched records that Next() handed out a chunk.
+// Caller must hold the chunker's mutex.
+func (w *watermarkTracker) chunkDispatched() {
+	w.inflightChunks++
+}
+
+// chunkFedBack records that a previously-dispatched chunk completed and
+// was returned via Feedback(). Guarded against underflow in case a
+// caller feeds back a chunk that was never dispatched (some tests do).
+// Caller must hold the chunker's mutex.
+func (w *watermarkTracker) chunkFedBack() {
+	if w.inflightChunks > 0 {
+		w.inflightChunks--
+	}
+}
+
+// allDispatchedChunksFedBack reports whether every chunk handed out by
+// Next() has been returned via Feedback(). Caller must hold the
+// chunker's mutex.
+func (w *watermarkTracker) allDispatchedChunksFedBack() bool {
+	return w.inflightChunks == 0
 }
 
 // isSpecialRestoredChunk reports whether `chunk` is the first chunk


### PR DESCRIPTION
## The bug

`KeyBelowLowWatermark` returned true for **every** key as soon as the final chunk was *dispatched* by `Next()`:

```go
if t.finalChunkSent {
    return true // we're done, so everything is below.
}
```

But dispatch and commit are decoupled: with the buffered copier, a chunk's chunklets can still be queued behind async write workers when another read worker draws the final chunk. The interleaving:

1. Read worker A reads chunk C (containing row K); its chunklets sit in the applier queue.
2. Read worker B draws the final chunk → `finalChunkSent = true`.
3. Source commits `DELETE K`; the event is buffered.
4. The periodic flush filter consults `KeyBelowLowWatermark(K)` → shortcut says true → the DELETE applies to the target as a no-op (K not inserted yet).
5. The applier commits chunk C → `INSERT IGNORE` resurrects the stale image of K.

In migrate the mandatory checksum repairs it — silently burning one of three retries and violating the stated invariant that the low watermark only covers durably-copied ranges. In `sync` there is no blocking checksum and the divergence persists until the continuous checker repairs it. The watermark `Feedback()` path was always correct; only the shortcut bypassed it.

## The fix

Track dispatched-but-not-fed-back chunks in the shared `watermarkTracker` (embedded by both leaf chunkers, so `multiChunker` inherits the fix): incremented in `Next()`, decremented in `Feedback()` (underflow-guarded for tests that feed back undispatched chunks), zeroed in `open()`/`Reset()`. The shortcut now requires `finalChunkSent && allDispatchedChunksFedBack()`.

**No stall is possible**: a false return merely defers the key to a later flush — the flush filter only applies when not under lock and not bypassed, and the cutover-time flush (`bypassWatermark`/under-lock) skips the filter entirely. Once the last chunk is fed back, the steady-state true is restored.

## Tests

New unit tests in both `chunker_optimistic_test.go` and `chunker_composite_test.go`: construct the "final chunk dispatched but chunks still in flight" state and assert `KeyBelowLowWatermark` returns false for keys in the in-flight range, then `Feedback()` the outstanding chunks and assert it flips to true.

## Results

`go test -race -count=1` against MySQL 8.0.43: `./pkg/table/` ok (9.9s), `./pkg/copier/` ok (15.0s), full `./pkg/change/` ok (108.6s). Build/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
