### PR TITLE
fix(statement): treat bare and quoted numeric column defaults as equal

### DIFF
--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -802,10 +802,13 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	if !columnExtendedAttributesEqual(a, b) {
 		return false
 	}
-	// A quoted string literal default ('TRUE') is a different value than the
-	// same text as a keyword/number default (TRUE), even when the stored
-	// strings match — so quotedness is part of column identity.
-	if a.DefaultIsString != b.DefaultIsString {
+	// On a string column a quoted string literal default ('TRUE') is a
+	// different value than the same text as a keyword/number default (TRUE),
+	// so quotedness is part of column identity. On a numeric column it is not:
+	// MySQL always renders the default quoted, so `DEFAULT 0` (bare) and
+	// `DEFAULT '0'` (the SHOW CREATE TABLE form) are the same default and must
+	// compare equal — the value itself is already compared above.
+	if a.DefaultIsString != b.DefaultIsString && !isNumericColumnType(a.Type) {
 		return false
 	}
 	if a.AutoInc != b.AutoInc {
@@ -911,7 +914,10 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 	if !columnExtendedAttributesEqual(a, b) {
 		return false
 	}
-	if a.DefaultIsString != b.DefaultIsString {
+	// Numeric defaults are always rendered quoted by MySQL, so quotedness is
+	// not meaningful for them; for string columns it is. See the equivalent
+	// guard in columnsEqualWithContext.
+	if a.DefaultIsString != b.DefaultIsString && !isNumericColumnType(a.Type) {
 		return false
 	}
 	if a.AutoInc != b.AutoInc {

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -1038,6 +1038,76 @@ func TestDiff(t *testing.T) {
 	}
 }
 
+// TestDiff_NumericDefaultQuoting verifies that on a numeric column a bare
+// default (DEFAULT 0, as a user typically writes it) and a quoted default
+// (DEFAULT '0', the form MySQL's SHOW CREATE TABLE always renders) are treated
+// as the same default, so a diff between the two converges to no change. The
+// quotedness still matters on string columns, where 'NULL' is a real default
+// distinct from no default — that case must still produce a change.
+func TestDiff_NumericDefaultQuoting(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		target      string
+		expectEmpty bool
+	}{
+		{
+			name:        "bigint_quoted_source_bare_target",
+			source:      "CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, amount BIGINT NOT NULL DEFAULT '0', PRIMARY KEY (id))",
+			target:      "CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, amount BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (id))",
+			expectEmpty: true,
+		},
+		{
+			name:        "bigint_bare_source_quoted_target",
+			source:      "CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, amount BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (id))",
+			target:      "CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, amount BIGINT NOT NULL DEFAULT '0', PRIMARY KEY (id))",
+			expectEmpty: true,
+		},
+		{
+			name:        "int_quoted_vs_bare",
+			source:      "CREATE TABLE t1 (id INT PRIMARY KEY, n INT NOT NULL DEFAULT '42')",
+			target:      "CREATE TABLE t1 (id INT PRIMARY KEY, n INT NOT NULL DEFAULT 42)",
+			expectEmpty: true,
+		},
+		{
+			name:        "decimal_quoted_vs_bare_same_value",
+			source:      "CREATE TABLE t1 (id INT PRIMARY KEY, price DECIMAL(10,2) NOT NULL DEFAULT '0.00')",
+			target:      "CREATE TABLE t1 (id INT PRIMARY KEY, price DECIMAL(10,2) NOT NULL DEFAULT 0.00)",
+			expectEmpty: true,
+		},
+		{
+			name:        "numeric_value_change_still_diffs",
+			source:      "CREATE TABLE t1 (id INT PRIMARY KEY, n INT NOT NULL DEFAULT '0')",
+			target:      "CREATE TABLE t1 (id INT PRIMARY KEY, n INT NOT NULL DEFAULT 5)",
+			expectEmpty: false,
+		},
+		{
+			name:        "string_literal_null_default_still_diffs",
+			source:      "CREATE TABLE t1 (id INT PRIMARY KEY, c VARCHAR(20))",
+			target:      "CREATE TABLE t1 (id INT PRIMARY KEY, c VARCHAR(20) DEFAULT 'NULL')",
+			expectEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source, err := ParseCreateTable(tt.source)
+			require.NoError(t, err)
+			target, err := ParseCreateTable(tt.target)
+			require.NoError(t, err)
+
+			stmts, err := source.Diff(target, nil)
+			require.NoError(t, err)
+
+			if tt.expectEmpty {
+				require.Nil(t, stmts, "numeric default quoting must not produce a diff")
+			} else {
+				require.Len(t, stmts, 1)
+			}
+		})
+	}
+}
+
 func TestDiff_DifferentTableNames(t *testing.T) {
 	ct1, err := ParseCreateTable("CREATE TABLE t1 (id INT PRIMARY KEY)")
 	require.NoError(t, err)

--- a/pkg/statement/literal_roundtrip_test.go
+++ b/pkg/statement/literal_roundtrip_test.go
@@ -239,6 +239,51 @@ func TestRoundTrip_StringNullDefaultProducesDiff(t *testing.T) {
 	require.Equal(t, "NULL", stored)
 }
 
+// TestRoundTrip_NumericDefaultConverges verifies that a numeric column whose
+// default is written bare in the desired DDL (DEFAULT 0) converges against the
+// table MySQL actually creates, whose SHOW CREATE TABLE renders the default
+// quoted (DEFAULT '0'). Without treating the two forms as equal, every diff
+// would emit a phantom MODIFY COLUMN that never converges.
+func TestRoundTrip_NumericDefaultConverges(t *testing.T) {
+	db := openScratch(t)
+
+	cases := []struct {
+		name      string
+		targetSQL string
+	}{
+		{
+			name:      "bigint",
+			targetSQL: "CREATE TABLE rt (id BIGINT UNSIGNED NOT NULL, amount BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (id))",
+		},
+		{
+			name:      "int_nonzero",
+			targetSQL: "CREATE TABLE rt (id INT PRIMARY KEY, n INT NOT NULL DEFAULT 42)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS rt")
+			require.NoError(t, err)
+			_, err = db.ExecContext(t.Context(), tc.targetSQL)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS rt")
+			})
+
+			// MySQL renders the numeric default quoted; the desired DDL has it
+			// bare. Diffing the live table against the desired DDL must converge.
+			live, err := ParseCreateTable(showCreate(t, db, "rt"))
+			require.NoError(t, err)
+			target, err := ParseCreateTable(tc.targetSQL)
+			require.NoError(t, err)
+
+			stmts, err := live.Diff(target, nil)
+			require.NoError(t, err)
+			require.Nil(t, stmts, "bare and quoted numeric defaults must converge; got: %+v", stmts)
+		})
+	}
+}
+
 // TestRoundTrip_PartitionStringValuesWithQuotes verifies that LIST COLUMNS
 // partition values on a string column round-trip, including a value that
 // looks numeric ('2020') and one whose value contains an apostrophe (o'hare,

--- a/pkg/statement/utils.go
+++ b/pkg/statement/utils.go
@@ -98,6 +98,32 @@ func getPreviousColumn(columns []Column, name string) string {
 	return ""
 }
 
+// numericColumnTypes are the column types whose DEFAULT value is a number.
+// MySQL's SHOW CREATE TABLE always renders a numeric default in quoted form
+// (e.g. `bigint DEFAULT '0'`, `tinyint(1) DEFAULT '1'`) regardless of whether
+// the user wrote it quoted or bare, so for these types the quotedness of the
+// default carries no meaning — `DEFAULT 0` and `DEFAULT '0'` are the same
+// default. Type names come from the parser's canonical form (types.TypeStr),
+// so only those spellings appear here.
+var numericColumnTypes = map[string]bool{
+	"tinyint":   true,
+	"smallint":  true,
+	"mediumint": true,
+	"int":       true,
+	"bigint":    true,
+	"decimal":   true,
+	"float":     true,
+	"double":    true,
+	"year":      true,
+}
+
+// isNumericColumnType reports whether a column type holds a numeric default,
+// for which a quoted (`'0'`) and bare (`0`) default of the same value are
+// equivalent. See numericColumnTypes.
+func isNumericColumnType(typeName string) bool {
+	return numericColumnTypes[strings.ToLower(typeName)]
+}
+
 // needsQuotes decides whether a column DEFAULT value needs to be wrapped
 // in single quotes when emitted. SQL functions / boolean / NULL
 // literals and parseable numerics are emitted bare; everything else is


### PR DESCRIPTION
## Summary

Numeric column defaults written bare in a schema (`DEFAULT 0`) never matched the table MySQL actually creates, whose `SHOW CREATE TABLE` always renders the default quoted (`bigint DEFAULT '0'`, `tinyint(1) DEFAULT '1'`). The column-equality check treats the default's quotedness (`DefaultIsString`) as part of column identity, so the diff emitted a phantom `MODIFY COLUMN ... DEFAULT 0` that never converged.

The quotedness distinction is correct for **string** columns — a string literal `'TRUE'`/`'NULL'` is genuinely different from the keyword/number form — but meaningless for **numeric** columns, where MySQL canonicalizes every default to the quoted form.

The fix skips the `DefaultIsString` comparison for numeric column types in both column-equality paths (`columnsEqualWithContext`, `columnsEqualIgnorePK`). The default **value** is still compared, so:

- `DEFAULT 0` ⇔ `DEFAULT '0'` on a numeric column → no diff (converges)
- a real value change (`DEFAULT 0` → `DEFAULT 5`) → still diffs
- a string literal `'NULL'` on a string column → still differs from no default

```
desired DDL:        amount BIGINT NOT NULL DEFAULT 0      (DefaultIsString=false)
SHOW CREATE TABLE:  amount bigint NOT NULL DEFAULT '0'    (DefaultIsString=true)
before: MODIFY COLUMN `amount` bigint(20) NOT NULL DEFAULT 0   (never converges)
after:  no change
```

## Tests

- `TestDiff_NumericDefaultQuoting` — pure-parse cases: quoted⇔bare convergence (bigint/int/decimal, both directions), value-change still diffs, string-literal `'NULL'` still diffs.
- `TestRoundTrip_NumericDefaultConverges` — DB-backed: create with a bare numeric default, then diff the live table (which MySQL stores quoted) against the desired DDL and assert convergence.

Existing `literal_roundtrip` string/keyword/NULL cases continue to pass, confirming the string-column behavior is unchanged.