### PR TITLE
fix(move): ignore column-level AUTO_INCREMENT in target schema check

### DIFF
--- a/pkg/move/check/schema_compare.go
+++ b/pkg/move/check/schema_compare.go
@@ -35,6 +35,10 @@ func showCreateTable(ctx context.Context, db *sql.DB, schema, table string) (str
 // and diffing the structured form via statement.CreateTable.Diff. This canonical
 // comparison:
 //   - ignores AUTO_INCREMENT counter values (instance-specific noise),
+//   - ignores the column-level AUTO_INCREMENT attribute: an unsharded source
+//     legitimately differs from a sharded target that drops AUTO_INCREMENT in
+//     favor of a Vitess sequence; the difference does not affect copy
+//     correctness, so it must not block a move into a pre-created target,
 //   - ignores ENGINE and ROW_FORMAT cosmetic defaults,
 //   - DOES compare column types, nullability, defaults, and per-column /
 //     per-table CHARACTER SET and COLLATE,
@@ -65,7 +69,13 @@ func schemaDiff(table, wantCreate, gotCreate string) (string, error) {
 	// Diff(got -> want): the returned clauses are the ALTER that would morph the
 	// validated schema ("got") into the reference schema ("want"). If nil, the
 	// two schemas are equivalent under the canonicalization rules above.
-	stmts, err := got.Diff(want, statement.NewDiffOptions())
+	// IgnoreColumnAutoIncrement: a sharded target legitimately drops the
+	// column-level AUTO_INCREMENT flag (IDs come from a Vitess sequence), and
+	// that difference is not a copy-correctness concern — so it must not block
+	// the move (see the doc comment above).
+	diffOpts := statement.NewDiffOptions()
+	diffOpts.IgnoreColumnAutoIncrement = true
+	stmts, err := got.Diff(want, diffOpts)
 	if err != nil {
 		return "", fmt.Errorf("failed to diff CREATE TABLE statements: %w", err)
 	}

--- a/pkg/move/check/schema_compare_test.go
+++ b/pkg/move/check/schema_compare_test.go
@@ -1,0 +1,54 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaDiffIgnoresColumnAutoIncrement locks in the behavior that the
+// move-tables schema comparison treats a column-level AUTO_INCREMENT
+// difference as equivalent. This is the unsharded-source → sharded-target
+// case: the source carries AUTO_INCREMENT on its primary key, while the
+// sharded target intentionally drops it in favor of a Vitess sequence. That
+// difference does not affect copy correctness and must not block the move
+// (target_state / resume_state checks), which previously reported a spurious
+// "schema does not match source" mismatch.
+func TestSchemaDiffIgnoresColumnAutoIncrement(t *testing.T) {
+	source := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+		"  `customer_id` bigint DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+	target := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` bigint DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+
+	diff, err := schemaDiff("corder", source, target)
+	require.NoError(t, err)
+	require.Empty(t, diff, "a column-level AUTO_INCREMENT difference must not be reported as a schema mismatch")
+}
+
+// TestSchemaDiffDetectsRealMismatch ensures the AUTO_INCREMENT relaxation is
+// narrow: a genuine column difference (here a type change, the dangerous case
+// the check exists to catch) is still reported even when AUTO_INCREMENT also
+// differs.
+func TestSchemaDiffDetectsRealMismatch(t *testing.T) {
+	source := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+		"  `sku` varbinary(128) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+	target := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `sku` varchar(128) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+
+	diff, err := schemaDiff("corder", source, target)
+	require.NoError(t, err)
+	require.NotEmpty(t, diff, "a genuine column type mismatch must still be reported")
+	require.Contains(t, diff, "sku", "the reported diff should name the mismatched column")
+}

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -13,9 +13,21 @@ import (
 
 // DiffOptions controls the behavior of the Diff operation.
 type DiffOptions struct {
-	// IgnoreAutoIncrement skips diffing the AUTO_INCREMENT table option.
+	// IgnoreAutoIncrement skips diffing the AUTO_INCREMENT table option
+	// (the table-level next-value counter, e.g. `AUTO_INCREMENT=100`).
 	// Default: true (via NewDiffOptions).
 	IgnoreAutoIncrement bool
+
+	// IgnoreColumnAutoIncrement skips diffing the column-level AUTO_INCREMENT
+	// attribute (whether a column carries the AUTO_INCREMENT flag). This is
+	// distinct from IgnoreAutoIncrement, which only covers the table-option
+	// counter. Default: false (via NewDiffOptions) — for general schema diffing
+	// a column gaining or losing AUTO_INCREMENT is a real change. It is enabled
+	// by consumers like the move-tables target-state check, where an unsharded
+	// source legitimately differs from a sharded target that drops
+	// AUTO_INCREMENT in favor of a Vitess sequence: the difference does not
+	// affect copy correctness and must not block the move.
+	IgnoreColumnAutoIncrement bool
 
 	// IgnoreEngine skips diffing the ENGINE table option.
 	// Default: true (via NewDiffOptions).
@@ -40,11 +52,12 @@ type DiffOptions struct {
 // By default, AUTO_INCREMENT, ENGINE, and ROW_FORMAT differences are ignored.
 func NewDiffOptions() *DiffOptions {
 	return &DiffOptions{
-		IgnoreAutoIncrement:    true,
-		IgnoreEngine:           true,
-		IgnoreCharsetCollation: false,
-		IgnorePartitioning:     false,
-		IgnoreRowFormat:        true,
+		IgnoreAutoIncrement:       true,
+		IgnoreColumnAutoIncrement: false,
+		IgnoreEngine:              true,
+		IgnoreCharsetCollation:    false,
+		IgnorePartitioning:        false,
+		IgnoreRowFormat:           true,
 	}
 }
 
@@ -65,7 +78,7 @@ func (ct *CreateTable) Diff(target *CreateTable, opts *DiffOptions) ([]*Abstract
 	var alterClauses []string
 
 	// 1. Diff columns (DROP, ADD, MODIFY)
-	columnClauses := ct.diffColumns(target)
+	columnClauses := ct.diffColumns(target, opts)
 	alterClauses = append(alterClauses, columnClauses...)
 
 	// 2. Diff indexes (DROP, ADD). Option-only index changes (same column
@@ -147,7 +160,7 @@ func (ct *CreateTable) buildAlterStatement(clauses []string) (*AbstractStatement
 }
 
 // diffColumns compares columns and returns ALTER clauses for differences
-func (ct *CreateTable) diffColumns(target *CreateTable) []string {
+func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []string {
 	var clauses []string
 
 	// Build maps for easier lookup. Keys are lowercased so identifier
@@ -206,7 +219,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 			// Skip modification if only PRIMARY KEY changed (already handled in diffIndexes)
 			// When PRIMARY KEY is dropped, nullability change is implicit, so skip it
 			pkOnlyChange := sourceCol.PrimaryKey != targetCol.PrimaryKey &&
-				columnsEqualIgnorePK(sourceCol, &targetCol)
+				columnsEqualIgnorePK(sourceCol, &targetCol, opts)
 
 			// Also check if only nullability changed due to PK drop
 			// (PK columns are NOT NULL, dropping PK makes them NULL)
@@ -222,7 +235,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable) []string {
 			// look up with the same normalization to avoid missing a
 			// position-only change when the target's spelling is in mixed
 			// or upper case.
-			needsModify := (!ct.columnsEqualWithContext(sourceCol, &targetCol, target) && !pkOnlyChange && !pkDroppedNullabilityChange) ||
+			needsModify := (!ct.columnsEqualWithContext(sourceCol, &targetCol, target, opts) && !pkOnlyChange && !pkDroppedNullabilityChange) ||
 				needsExplicitPosition[strings.ToLower(targetCol.Name)]
 
 			if needsModify {
@@ -753,7 +766,7 @@ func (to *TableOptions) getAutoIncrement() *string {
 // columnsEqualWithContext checks if two columns are equal, considering table context for charset/collation
 // If a column's charset is nil, it inherits from the table. If it's explicitly set to the same as the table,
 // it's considered equal to nil (no explicit charset needed).
-func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable) bool {
+func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable, opts *DiffOptions) bool {
 	// Column names are case-insensitive in MySQL, so `id` and `ID` refer
 	// to the same column.
 	if !strings.EqualFold(a.Name, b.Name) {
@@ -808,7 +821,7 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	if a.DefaultIsString != b.DefaultIsString {
 		return false
 	}
-	if a.AutoInc != b.AutoInc {
+	if !opts.IgnoreColumnAutoIncrement && a.AutoInc != b.AutoInc {
 		return false
 	}
 	if a.PrimaryKey != b.PrimaryKey {
@@ -865,7 +878,7 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 }
 
 // columnsEqualIgnorePK checks if two columns are equal, ignoring the PrimaryKey attribute
-func columnsEqualIgnorePK(a, b *Column) bool {
+func columnsEqualIgnorePK(a, b *Column, opts *DiffOptions) bool {
 	// Column names are case-insensitive in MySQL.
 	if !strings.EqualFold(a.Name, b.Name) {
 		return false
@@ -914,7 +927,7 @@ func columnsEqualIgnorePK(a, b *Column) bool {
 	if a.DefaultIsString != b.DefaultIsString {
 		return false
 	}
-	if a.AutoInc != b.AutoInc {
+	if !opts.IgnoreColumnAutoIncrement && a.AutoInc != b.AutoInc {
 		return false
 	}
 	// Skip PrimaryKey comparison

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -1112,6 +1112,43 @@ func TestDiff_DiffOptions(t *testing.T) {
 			expected: "ALTER TABLE `t1` AUTO_INCREMENT=100",
 		},
 
+		// IgnoreColumnAutoIncrement controls the column-level AUTO_INCREMENT
+		// flag, which is distinct from the AUTO_INCREMENT=N table-option
+		// counter (IgnoreAutoIncrement). By default a column gaining or losing
+		// AUTO_INCREMENT is a real change; the move-tables target-state check
+		// sets IgnoreColumnAutoIncrement so an unsharded source can move into a
+		// sharded target that drops AUTO_INCREMENT in favor of a Vitess sequence.
+		{
+			name:     "DefaultDetectsColumnAutoIncrement",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT)",
+			opts:     nil, // nil uses NewDiffOptions(): IgnoreColumnAutoIncrement=false
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int(11) NOT NULL AUTO_INCREMENT",
+		},
+		{
+			name:     "IgnoreColumnAutoIncrement_TargetAdds",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT)",
+			opts:     &DiffOptions{IgnoreColumnAutoIncrement: true},
+			expected: "",
+		},
+		{
+			// The move-tables scenario: the source carries AUTO_INCREMENT, the
+			// sharded target dropped it because IDs come from a Vitess sequence.
+			name:     "IgnoreColumnAutoIncrement_SourceDrops",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			opts:     &DiffOptions{IgnoreColumnAutoIncrement: true},
+			expected: "",
+		},
+		{
+			name:     "IgnoreColumnAutoIncrement_StillDetectsColumnChanges",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT, b INT)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b VARCHAR(100))",
+			opts:     &DiffOptions{IgnoreColumnAutoIncrement: true},
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` varchar(100) NULL",
+		},
+
 		// IgnoreCharsetCollation
 		{
 			name:     "IgnoreCharsetCollation_Charset",
@@ -1256,6 +1293,7 @@ func TestDiff_ChangePartitionType(t *testing.T) {
 func TestNewDiffOptions(t *testing.T) {
 	opts := NewDiffOptions()
 	require.True(t, opts.IgnoreAutoIncrement, "IgnoreAutoIncrement should default to true")
+	require.False(t, opts.IgnoreColumnAutoIncrement, "IgnoreColumnAutoIncrement should default to false")
 	require.True(t, opts.IgnoreEngine, "IgnoreEngine should default to true")
 	require.False(t, opts.IgnoreCharsetCollation, "IgnoreCharsetCollation should default to false")
 	require.False(t, opts.IgnorePartitioning, "IgnorePartitioning should default to false")


### PR DESCRIPTION
## Problem

`move-tables` aborts when moving an **unsharded source into a sharded target** if the target drops `AUTO_INCREMENT` on its primary key in favor of a Vitess sequence — the standard Vitess sharding pattern (MySQL auto-increment can't coordinate across shards, so IDs come from a sequence instead).

The move fails its pre-flight with:

```
target state is invalid for both new copy and resume:
  new_copy_error=table 'corder' exists on target 0 (...) but schema does not match source;
  reconcile the target to the source with: ALTER TABLE `corder` MODIFY COLUMN `order_id` bigint(20) NOT NULL AUTO_INCREMENT ...
```

### Root cause

The `target_state` / `resume_state` checks compare the canonicalized `CREATE TABLE` of source and target via `schemaDiff` → `statement.CreateTable.Diff`. `DiffOptions.IgnoreAutoIncrement` (default true) only suppresses the **table-level** `AUTO_INCREMENT=N` counter; the **column-level** `AUTO_INCREMENT` attribute (`col.AutoInc`) was always diffed, with no way to suppress it. So a source with `order_id ... AUTO_INCREMENT` and a sharded target without it were reported as mismatched, blocking the move.

A column-level `AUTO_INCREMENT` difference is not a copy-correctness concern — unlike column type / charset / collation, which this check exists to guard and still does.

## Fix

- Add `IgnoreColumnAutoIncrement` to `statement.DiffOptions`, threaded through `diffColumns` → `columnsEqualWithContext` / `columnsEqualIgnorePK`. **Default `false`**, so general schema diffing (e.g. declarative schema apply) is unchanged — gaining/losing `AUTO_INCREMENT` is still a real change there.
- Enable it in the move check's `schemaDiff`, which is shared by the `target_state`, `resume_state`, and `source_schema_consistency` checks. Both the new-copy and resume branches need it (the error is "invalid for both"); for source-to-source consistency it's harmless since auto-increment never affects the copy.

## Tests

- `pkg/statement`: new `TestDiff_DiffOptions` cases for `IgnoreColumnAutoIncrement` (target adds / source drops / still detects real column changes) and a `TestNewDiffOptions` assertion for the default.
- `pkg/move/check`: new `schema_compare_test.go` verifying the source-with-auto-increment vs target-without case yields no diff, while a genuine column-type mismatch is still reported.

`go build ./...`, `go test ./pkg/statement/... ./pkg/move/check/...`, and `golangci-lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)