### PR TITLE
fix(throttler): use innodb_buffer_pool_instances as vCPU proxy

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -396,7 +396,7 @@ By default Spirit does not dynamically adjust the number of threads while runnin
 
 Sets the parallelism of the **replication applier** — the number of concurrent write threads used to apply changes (read from the binlog) to the new table. Copier and checksum parallelism are controlled separately by [threads](#threads).
 
-A value of `0` means **auto**: on Aurora, Spirit sets `write-threads` to the instance vCPU count (read from `@@innodb_purge_threads`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+A value of `0` means **auto**: on Aurora, Spirit sets `write-threads` to the instance vCPU count (read from `@@innodb_buffer_pool_instances`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
 
 ### enable-experimental-autoscaling
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -131,6 +131,6 @@ How many chunks to copy in parallel from the source.
 
 How many concurrent write threads to use per target when inserting rows. This controls the fan-out parallelism of the buffered copier's write side.
 
-A value of `0` means **auto**: on Aurora, the value is set to the target instance's vCPU count (read from `@@innodb_purge_threads`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+A value of `0` means **auto**: on Aurora, the value is set to the target instance's vCPU count (read from `@@innodb_buffer_pool_instances`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
 
 Move does not support the experimental write-thread autoscaling available in [`spirit migrate`](migrate.md#enable-experimental-autoscaling).

--- a/pkg/throttler/aurora_activethreads.go
+++ b/pkg/throttler/aurora_activethreads.go
@@ -27,7 +27,7 @@ import (
 //
 // Also different from previous tools use of "threads running" is that we compare
 // the threads to the instance vCPU count, which we can deterministically get on
-// Aurora via @@innodb_purge_threads.
+// Aurora via @@innodb_buffer_pool_instances.
 //
 // This is called *aurora* active threads, but the only thing aurora specific is that
 // the vCPU count is retrievable from a variable. I've tried on MySQL to find a consistent
@@ -39,19 +39,30 @@ const (
 	// where events_waits_current has no row for a thread (e.g., wait
 	// consumer disabled) — that thread is then counted as on-CPU, which is
 	// the safe-conservative behavior.
+	//
+	// The sampling connection excludes itself (CONNECTION_ID()) — without
+	// this the monitor's own query always counts as one active thread,
+	// which on small instances (vCPUs=2) eats half the headroom and can
+	// throttle a migration with no other activity on the server.
 	activeThreadsQuery = `SELECT
 		GREATEST(COUNT(*) - COALESCE(SUM(CASE WHEN ewc.EVENT_NAME = 'wait/io/redo_log_flush' AND ewc.END_EVENT_ID IS NULL THEN 1 ELSE 0 END), 0), 0) AS active_cpu_threads
 	FROM performance_schema.threads pps
 	LEFT JOIN performance_schema.events_waits_current ewc ON pps.THREAD_ID = ewc.THREAD_ID
 	WHERE pps.PROCESSLIST_ID IS NOT NULL
+	  AND pps.PROCESSLIST_ID <> CONNECTION_ID()
 	  AND pps.PROCESSLIST_COMMAND = 'Query'`
 
-	// auroraVCPUsQuery reads the vCPU count from @@innodb_purge_threads.
-	// Aurora pins this to the instance vCPU count (see issue #831). On RDS
-	// MySQL the var also exists but its value tracks Aurora-style sizing
-	// only on Aurora — we gate the throttler on IsAurora, so this query is
+	// auroraVCPUsQuery reads the vCPU count from @@innodb_buffer_pool_instances,
+	// which Aurora pins to the instance vCPU count (see issue #831).
+	//
+	// Do NOT use @@innodb_purge_threads for this: Aurora sizes it by a
+	// stepped formula, not the vCPU count (r7g family: large=1, xlarge=1,
+	// 2xlarge=3, 4xlarge=3, 8xlarge=6, 16xlarge=12), so it badly
+	// under-reads CPU capacity at every size. On community MySQL
+	// innodb_buffer_pool_instances is sized by buffer pool size / CPU
+	// hints instead — we gate the throttler on IsAurora, so this query is
 	// only ever issued there.
-	auroraVCPUsQuery = `SELECT @@innodb_purge_threads`
+	auroraVCPUsQuery = `SELECT @@innodb_buffer_pool_instances`
 )
 
 // DefaultWriteThreads is the fallback apply (write) thread count used when
@@ -62,17 +73,17 @@ const (
 // as not requesting it at all.
 const DefaultWriteThreads = 4
 
-// auroraVCPUs reads the instance vCPU count from @@innodb_purge_threads, which
-// Aurora pins to the vCPU count (issue #831). It returns an error if the value
-// is non-positive. This is only meaningful on Aurora — callers should gate on
-// IsAurora first.
+// auroraVCPUs reads the instance vCPU count from @@innodb_buffer_pool_instances,
+// which Aurora pins to the vCPU count (issue #831). It returns an error if the
+// value is non-positive. This is only meaningful on Aurora — callers should gate
+// on IsAurora first.
 func auroraVCPUs(ctx context.Context, db *sql.DB) (int, error) {
 	var vCPUs int
 	if err := db.QueryRowContext(ctx, auroraVCPUsQuery).Scan(&vCPUs); err != nil {
-		return 0, fmt.Errorf("reading @@innodb_purge_threads for vCPU count: %w", err)
+		return 0, fmt.Errorf("reading @@innodb_buffer_pool_instances for vCPU count: %w", err)
 	}
 	if vCPUs <= 0 {
-		return 0, fmt.Errorf("@@innodb_purge_threads returned non-positive value %d", vCPUs)
+		return 0, fmt.Errorf("@@innodb_buffer_pool_instances returned non-positive value %d", vCPUs)
 	}
 	return vCPUs, nil
 }
@@ -80,8 +91,9 @@ func auroraVCPUs(ctx context.Context, db *sql.DB) (int, error) {
 // ResolveWriteThreads resolves the number of apply (write) threads to use
 // against a target. A positive requested value is returned unchanged. Zero
 // means "auto-size": on Aurora it resolves to the instance vCPU count
-// (@@innodb_purge_threads); on non-Aurora there is no reliable vCPU signal to
-// size from, so it falls back to DefaultWriteThreads (logging that it did so).
+// (@@innodb_buffer_pool_instances); on non-Aurora there is no reliable vCPU
+// signal to size from, so it falls back to DefaultWriteThreads (logging that it
+// did so).
 // A negative value is rejected.
 func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int, logger *slog.Logger) (int, error) {
 	if requested < 0 {
@@ -144,7 +156,7 @@ func CanReadActiveThreads(ctx context.Context, db *sql.DB) error {
 
 // ActiveThreads throttles when the count of query-running threads (excluding
 // those waiting on the redo log) exceeds the instance vCPU count. Aurora-
-// only — depends on @@innodb_purge_threads matching vCPUs.
+// only — depends on @@innodb_buffer_pool_instances matching vCPUs.
 type ActiveThreads struct {
 	db     *sql.DB
 	logger *slog.Logger

--- a/pkg/throttler/aurora_activethreads_test.go
+++ b/pkg/throttler/aurora_activethreads_test.go
@@ -206,8 +206,8 @@ func TestAuroraVCPUs_LocalMySQL(t *testing.T) {
 	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
-	// @@innodb_purge_threads exists on stock MySQL too (it just isn't pinned
-	// to the vCPU count there). The query and positive-value check should
+	// @@innodb_buffer_pool_instances exists on stock MySQL too (it just isn't
+	// pinned to the vCPU count there). The query and positive-value check should
 	// still succeed — this guards the shared helper used by both the
 	// active-threads throttler and write-thread auto-sizing.
 	vCPUs, err := auroraVCPUs(t.Context(), db)


### PR DESCRIPTION
## Problem

Schema changes on small Aurora instances (e.g. `r6g.large`) are getting throttled by the active-threads throttler with no real activity on the server. Two bugs combine to cause this:

1. **Wrong vCPU proxy.** The Aurora active-threads throttler — and write-thread auto-sizing — read the instance vCPU count from `@@innodb_purge_threads`. Aurora does **not** pin that variable to the vCPU count; it sizes it by a stepped formula that under-reads CPU capacity at every instance size:

   | instance (r7g) | vCPUs | `innodb_purge_threads` |
   |---|---|---|
   | large | 2 | 1 |
   | xlarge | 4 | 1 |
   | 2xlarge | 8 | 3 |
   | 4xlarge | 16 | 3 |
   | 8xlarge | 32 | 6 |
   | 16xlarge | 64 | 12 |

   So an `r6g.large` (2 vCPUs) read as `1`, and a `4xlarge` read as `3`.

2. **Observer effect.** The monitor pool's own polling query runs as a `'Query'` thread and counted *itself* in the active-thread total. With the vCPU count mis-read as `1`, a single write worker plus the sampler's own query read as `2 active_threads > 1 vCPU` and throttled a migration that had no other activity.

## Fix

- Switch the vCPU proxy to `@@innodb_buffer_pool_instances`, which Aurora pins to the instance vCPU count. (This was the proxy used in prior tooling; `innodb_purge_threads` was the wrong choice.)
- Exclude the sampling connection (`AND pps.PROCESSLIST_ID <> CONNECTION_ID()`) from the active-threads count so the monitor query no longer counts itself.

## Testing

- `go test ./pkg/throttler/` passes (all active-threads, vCPU, and write-thread resolution tests).
- Validated the new `activeThreadsQuery` and `SELECT @@innodb_buffer_pool_instances` against a live MySQL 8.0 server; with the self-exclusion the sampler reads `0` instead of counting its own query.

Refs #831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)