### PR TITLE
lint: include dropped column names in unsafe violations

### DIFF
--- a/pkg/lint/declarative_test.go
+++ b/pkg/lint/declarative_test.go
@@ -168,6 +168,43 @@ func TestPlanChanges_StructuredViolations(t *testing.T) {
 	require.Empty(t, change.Errors())
 }
 
+func TestPlanChanges_DropColumnsHaveColumnDetails(t *testing.T) {
+	current := []table.TableSchema{
+		{Name: "users", Schema: `CREATE TABLE users (
+			id BIGINT PRIMARY KEY,
+			email VARCHAR(255),
+			phone VARCHAR(255)
+		)`},
+	}
+	desired := []table.TableSchema{
+		{Name: "users", Schema: `CREATE TABLE users (
+			id BIGINT PRIMARY KEY
+		)`},
+	}
+
+	plan, err := PlanChanges(current, desired, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.True(t, plan.HasErrors())
+
+	change := plan.Changes[0]
+	require.Equal(t, "users", change.TableName)
+	require.Len(t, change.Errors(), 2)
+
+	columnMessages := map[string]string{}
+	for _, violation := range change.Errors() {
+		require.Equal(t, "unsafe", violation.Linter.Name())
+		require.NotNil(t, violation.Location)
+		require.Equal(t, "users", violation.Location.Table)
+		require.NotNil(t, violation.Location.Column)
+		columnMessages[*violation.Location.Column] = violation.Message
+	}
+	require.Equal(t, map[string]string{
+		"email": "Unsafe operation detected: DROP COLUMN `email`",
+		"phone": "Unsafe operation detected: DROP COLUMN `phone`",
+	}, columnMessages)
+}
+
 func TestPlanChanges_WithLintConfig(t *testing.T) {
 	// Disable the has_foreign_key linter — FK warnings should not appear.
 	current := []table.TableSchema{

--- a/pkg/lint/lint_unsafe.go
+++ b/pkg/lint/lint_unsafe.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/block/spirit/pkg/statement"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -71,7 +72,9 @@ func (l *UnsafeLinter) Lint(_ []*statement.CreateTable, changes []*statement.Abs
 		case *ast.AlterTableStmt:
 			for _, spec := range node.Specs {
 				switch spec.Tp { //nolint: exhaustive
-				case ast.AlterTableDropColumn, ast.AlterTableDropPrimaryKey, ast.AlterTableDropPartition, ast.AlterTableDiscardPartitionTablespace,
+				case ast.AlterTableDropColumn:
+					violations = append(violations, unsafeDropColumnViolation(l, change.Table, spec))
+				case ast.AlterTableDropPrimaryKey, ast.AlterTableDropPartition, ast.AlterTableDiscardPartitionTablespace,
 					ast.AlterTableDiscardTablespace, ast.AlterTableCoalescePartitions:
 					violations = append(violations, Violation{
 						Linter:   l,
@@ -125,4 +128,25 @@ func (l *UnsafeLinter) Lint(_ []*statement.CreateTable, changes []*statement.Abs
 		}
 	}
 	return violations
+}
+
+func unsafeDropColumnViolation(l *UnsafeLinter, tableName string, spec *ast.AlterTableSpec) Violation {
+	location := &Location{Table: tableName}
+	message := "Unsafe operation detected: DROP COLUMN"
+	if spec.OldColumnName != nil {
+		columnName := spec.OldColumnName.Name.O
+		location.Column = &columnName
+		message += " " + quoteUnsafeIdentifier(columnName)
+	}
+
+	return Violation{
+		Linter:   l,
+		Location: location,
+		Message:  message,
+		Severity: SeverityError,
+	}
+}
+
+func quoteUnsafeIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
 }

--- a/pkg/lint/lint_unsafe_test.go
+++ b/pkg/lint/lint_unsafe_test.go
@@ -66,8 +66,11 @@ func TestUnsafeLinter_AlterTableDropColumn(t *testing.T) {
 	require.Equal(t, "unsafe", violations[0].Linter.Name())
 	require.Equal(t, SeverityError, violations[0].Severity)
 	require.Contains(t, violations[0].Message, "Unsafe operation")
+	require.Equal(t, "Unsafe operation detected: DROP COLUMN `email`", violations[0].Message)
 	t.Log(violations[0].Message)
 	require.Equal(t, "users", violations[0].Location.Table)
+	require.NotNil(t, violations[0].Location.Column)
+	require.Equal(t, "email", *violations[0].Location.Column)
 }
 
 func TestUnsafeLinter_AlterTableDropPrimaryKey(t *testing.T) {
@@ -313,6 +316,9 @@ func TestUnsafeLinter_AlterTableMultipleSpecs(t *testing.T) {
 	require.Equal(t, "unsafe", violations[0].Linter.Name())
 	require.Equal(t, SeverityError, violations[0].Severity)
 	require.Equal(t, "users", violations[0].Location.Table)
+	require.NotNil(t, violations[0].Location.Column)
+	require.Equal(t, "phone", *violations[0].Location.Column)
+	require.Equal(t, "Unsafe operation detected: DROP COLUMN `phone`", violations[0].Message)
 }
 
 func TestUnsafeLinter_AlterTableMultipleUnsafeSpecs(t *testing.T) {
@@ -333,6 +339,16 @@ func TestUnsafeLinter_AlterTableMultipleUnsafeSpecs(t *testing.T) {
 		require.Equal(t, SeverityError, v.Severity)
 		require.Equal(t, "users", v.Location.Table)
 	}
+
+	columnMessages := map[string]string{}
+	for _, v := range violations {
+		require.NotNil(t, v.Location.Column)
+		columnMessages[*v.Location.Column] = v.Message
+	}
+	require.Equal(t, map[string]string{
+		"email": "Unsafe operation detected: DROP COLUMN `email`",
+		"phone": "Unsafe operation detected: DROP COLUMN `phone`",
+	}, columnMessages)
 }
 
 func TestUnsafeLinter_EmptyInput(t *testing.T) {


### PR DESCRIPTION
## Why

Unsafe `DROP COLUMN` lint violations currently identify the table but not the specific dropped column. Consumers that render lint output cannot distinguish multiple dropped columns on the same table without parsing DDL text.

## What

- Populate `Location.Column` for `ALTER TABLE ... DROP COLUMN` unsafe violations
- Include the dropped column name in the unsafe violation message
- Cover direct unsafe linting and declarative `PlanChanges` output for multiple dropped columns

## Risk Assessment

Low — this preserves the existing error severity and unsafe blocking behavior while adding more precise structured location details and messages.

Generated with Amp
