### PR TITLE
fix(throttler): stop small-instance throttle flood and size the pool for control-plane queries

### DIFF
--- a/pkg/copier/autoscaler.go
+++ b/pkg/copier/autoscaler.go
@@ -57,11 +57,11 @@ const (
 	// vault across the band and ping-pong with the -1 path.
 	acHighWatermark = 0.7
 	// acPanicThreshold is where back-off turns multiplicative. At 1.0 the
-	// smoothed signal has reached vCPUs — sustained load at or past the point
-	// where the raw per-sample hard-stop trips (it fires on running > vCPUs).
-	// By the time the average climbs here the hard-stop has typically been
-	// firing on the raw samples, so the copy is already being paused; halving
-	// sheds enough that the resume is gentle. This compares the gradual
+	// smoothed signal has reached vCPUs — sustained load just below the point
+	// where the raw per-sample hard-stop trips (it fires on running > vCPUs +
+	// selfMonitoringHeadroom). By the time the average climbs here the hard-stop
+	// is typically firing on the raw samples, so the copy is already being
+	// paused; halving sheds enough that the resume is gentle. This compares the gradual
 	// (smoothed) utilization, NOT IsThrottled() — on a
 	// multi-throttler that would include binary children like replica lag,
 	// and halving on those is unguided (they already pause the copy, which

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -151,6 +151,27 @@ func NewRunner(m *Migration) (*Runner, error) {
 	return runner, nil
 }
 
+// controlPlaneConns is the connection headroom the main pool reserves above
+// the copy hot path (Threads read workers + WriteThreads applier workers) for
+// the periodic control-plane queries that also run on r.db:
+//
+//   - +1 checkpoint INSERT          (every CheckpointDumpInterval)
+//   - +1 replication-flush poll     (every DefaultFlushInterval, reads gtid_executed)
+//   - +len(changes) table-stats     (AutoUpdateStatistics runs one goroutine per change table)
+//
+// A single fixed spare (the historical "+1") could not cover these once the
+// copier + applier saturated the budget: a saturated pool left checkpoint, the
+// flush poll, and the stats updater serializing behind one connection — adding
+// latency to checkpoints and stretching flush durations. The squeeze is worst
+// on non-autoscaling instances, where maxWrite == WriteThreads leaves no
+// incidental slack (an autoscaling pool sized for 2× WriteThreads happens to
+// carry spare connections while the applier runs near its start size).
+// Throttler polls are NOT counted here — they run on the dedicated monitorDB
+// pool (see the monitorDB field).
+func (r *Runner) controlPlaneConns() int {
+	return len(r.changes) + 2
+}
+
 func (r *Runner) SetMetricsSink(sink metrics.Sink) {
 	r.metricsSink = sink
 }
@@ -198,13 +219,15 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Size the connection pool the same way for both the buffered and
 	// unbuffered paths:
 	//
-	//	pool = threads + write-threads + 1
+	//	pool = threads + write-threads + controlPlaneConns()
 	//
-	//	- threads        copier + checksum read concurrency
-	//	- write-threads  replication-applier write concurrency
-	//	- +1             headroom for control-plane queries (feedback,
-	//	                 checkpoints) so they don't wait behind a fully
-	//	                 saturated copier + applier
+	//	- threads             copier + checksum read concurrency
+	//	- write-threads       replication-applier write concurrency
+	//	- controlPlaneConns() headroom for the periodic control-plane queries
+	//	                      that also run on the main pool (checkpoint,
+	//	                      replication-flush poll, per-table stats), so they
+	//	                      don't serialize behind a single spare connection
+	//	                      once the copier + applier saturate the budget.
 	//
 	// WriteThreads may still be 0 here — that's the "auto-size on Aurora"
 	// sentinel, which can only be resolved once we have a connection to probe
@@ -212,7 +235,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// setupCopierCheckerAndReplClient grows it to the final size after
 	// resolving WriteThreads. The pool only ever grows (via SetMaxOpenConns);
 	// later phases (checksum, cutover) ratchet it further but never shrink it.
-	r.dbConfig.MaxOpenConnections = r.migration.Threads + r.migration.WriteThreads + 1
+	r.dbConfig.MaxOpenConnections = r.migration.Threads + r.migration.WriteThreads + r.controlPlaneConns()
 	r.db, err = dbconn.New(r.dsn(), r.dbConfig)
 	if err != nil {
 		return fmt.Errorf("failed to connect to main database (DSN: %s): %w", maskPasswordInDSN(r.dsn()), err)
@@ -558,11 +581,11 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	// start value.
 	maxWrite := throttler.ResolveMaxWriteThreads(r.migration.WriteThreads, autoscale)
 	// Finalize the pool now that WriteThreads (and its autoscale ceiling) is
-	// known: threads + maxWrite + 1 (see the MaxOpenConnections doc in Run).
-	// Sizing for maxWrite ensures a scaled-up applier never starves on
-	// connections. This is a no-op unless WriteThreads was auto-sized up from 0
+	// known: threads + maxWrite + controlPlaneConns() (see the MaxOpenConnections
+	// doc in Run). Sizing for maxWrite ensures a scaled-up applier never starves
+	// on connections. This is a no-op unless WriteThreads was auto-sized up from 0
 	// or autoscaling raised the ceiling; the pool only ever grows.
-	if poolSize := r.migration.Threads + maxWrite + 1; poolSize > r.dbConfig.MaxOpenConnections {
+	if poolSize := r.migration.Threads + maxWrite + r.controlPlaneConns(); poolSize > r.dbConfig.MaxOpenConnections {
 		r.dbConfig.MaxOpenConnections = poolSize
 		r.db.SetMaxOpenConns(poolSize)
 	}

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -1,0 +1,23 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestControlPlaneConns documents the connection headroom the main pool
+// reserves above the copy hot path: a fixed +2 (checkpoint INSERT and the
+// replication-flush poll) plus one per change table (AutoUpdateStatistics runs
+// a goroutine each). A single fixed spare could not cover these once the
+// copier + applier saturated the budget — see controlPlaneConns.
+func TestControlPlaneConns(t *testing.T) {
+	// Single-table: checkpoint + replication poll + one stats updater.
+	single := &Runner{changes: make([]*tableChange, 1)}
+	require.Equal(t, 3, single.controlPlaneConns())
+
+	// Multi-table: the stats-updater term scales with the number of tables, so
+	// a multi-table ALTER does not starve them behind the fixed headroom.
+	multi := &Runner{changes: make([]*tableChange, 3)}
+	require.Equal(t, 5, multi.controlPlaneConns())
+}

--- a/pkg/throttler/aurora_threadsrunning.go
+++ b/pkg/throttler/aurora_threadsrunning.go
@@ -55,11 +55,13 @@ const (
 	// needs no privilege beyond what those already require — there is no
 	// separate grant probe.
 	//
-	// No self-exclusion: the monitor's own polling query counts itself as one
-	// running thread (and the commit-latency poller may add another). On the
-	// 4+ vCPU instances where the autoscaler engages, ±1–2 is in the noise and
-	// the EWMA smooths it, so we accept the small over-count rather than carry
-	// machinery to subtract it.
+	// Self-counting: the monitor's own polling query counts itself as one
+	// running thread (and the commit-latency poller / GTID-changeset flush may
+	// add another). The EWMA Utilization() signal absorbs this small over-count
+	// and the autoscaler only engages at 4+ vCPUs where ±1–2 is in the noise,
+	// so Utilization carries no correction. The binary hard-stop, however, has
+	// no averaging to lean on and must work down to the smallest instances, so
+	// it compensates explicitly — see selfMonitoringHeadroom.
 	threadsRunningQuery = `SELECT CAST(VARIABLE_VALUE AS UNSIGNED)
 	FROM performance_schema.global_status
 	WHERE VARIABLE_NAME = 'Threads_running'`
@@ -176,9 +178,32 @@ var threadsRunningPollInterval = 5 * time.Second
 // within one poll.
 const threadsRunningEWMAAlpha = 0.3
 
+// selfMonitoringHeadroom is added to the vCPU count to form the hard-stop
+// threshold, so the throttle fires on the production workload saturating the
+// box — not on spirit's own baseline.
+//
+// Threads_running is a whole-server gauge, so it includes spirit's own
+// monitoring connections: this throttler's polling query is itself a running
+// thread at the instant it samples (see threadsRunningQuery), and the
+// commit-latency poller and periodic GTID-changeset flush share the monitor
+// pool. That self-count is ~1–2 threads and does not grow with the instance.
+//
+// On 4+ vCPU instances that over-count is in the noise. On small instances it
+// is the entire margin: at vCPUs=2 spirit's own polling alone holds
+// Threads_running at or above a bare vCPU threshold, so the copy throttles
+// against itself with zero production load and creeps forward only via
+// BlockWait's 60s timeout (the "threads-running throttler timed out" warning).
+// This fixed headroom lets the copy run when only spirit is busy while still
+// backing off once the production workload piles real work onto the box. The
+// copy's own read/apply threads are deliberately NOT excluded — those are
+// genuine CPU load that should count toward saturation; only spirit's
+// (instance-size-independent) monitoring footprint is.
+const selfMonitoringHeadroom = 2
+
 // ThreadsRunning throttles when the server's Threads_running count exceeds the
-// instance vCPU count. Aurora-only — depends on @@innodb_buffer_pool_instances
-// matching vCPUs.
+// instance vCPU count plus a small headroom for spirit's own monitoring
+// connections (see selfMonitoringHeadroom). Aurora-only — depends on
+// @@innodb_buffer_pool_instances matching vCPUs.
 type ThreadsRunning struct {
 	db     *sql.DB
 	logger *slog.Logger
@@ -263,9 +288,10 @@ func (a *ThreadsRunning) IsThrottled() bool {
 }
 
 // Utilization reports the smoothed (EWMA) Threads_running count as a fraction
-// of the instance vCPU count. 1.0 means the sustained average equals vCPUs —
-// around where the raw signal trips IsThrottled. Returns 0 if vCPUs is not yet
-// known. The smoothing exists for the autoscaler, this method's only consumer:
+// of the instance vCPU count. 1.0 means the sustained average equals vCPUs;
+// the raw hard-stop trips a little above this, at vCPUs + selfMonitoringHeadroom.
+// Returns 0 if vCPUs is not yet known. The smoothing exists for the autoscaler,
+// this method's only consumer:
 // it must see sustained load, not single-sample spikes (see
 // threadsRunningEWMAAlpha). The binary hard-stop deliberately does not share
 // it.
@@ -289,9 +315,17 @@ func (a *ThreadsRunning) Utilization() float64 {
 	return math.Float64frombits(a.smoothedBits.Load()) / float64(a.vCPUs)
 }
 
-// BlockWait blocks until Threads_running falls to or below vCPUs, or up to
-// 60s. Matches the commit-latency throttler's loop shape so the multi-
-// throttler waits uniformly across signals.
+// throttleThreshold is the Threads_running level the hard-stop trips above: the
+// instance vCPU count plus headroom for spirit's own monitoring connections
+// (see selfMonitoringHeadroom). Single source of truth for applySample's
+// comparison and the log lines, so they can never drift apart.
+func (a *ThreadsRunning) throttleThreshold() int64 {
+	return a.vCPUs + selfMonitoringHeadroom
+}
+
+// BlockWait blocks until Threads_running falls to or below the throttle
+// threshold (vCPUs + headroom), or up to 60s. Matches the commit-latency
+// throttler's loop shape so the multi-throttler waits uniformly across signals.
 func (a *ThreadsRunning) BlockWait(ctx context.Context) {
 	timer := time.NewTimer(blockWaitInterval)
 	defer timer.Stop()
@@ -309,7 +343,8 @@ func (a *ThreadsRunning) BlockWait(ctx context.Context) {
 	}
 	a.logger.Warn("threads-running throttler timed out",
 		"threads_running", a.lastThreadsRunning.Load(),
-		"vCPUs", a.vCPUs)
+		"vCPUs", a.vCPUs,
+		"throttle_threshold", a.throttleThreshold())
 }
 
 // UpdateLag samples Threads_running and updates throttled state.
@@ -347,13 +382,15 @@ func (a *ThreadsRunning) applySample(running int64) {
 		a.smoothedBits.Store(math.Float64bits(prev + threadsRunningEWMAAlpha*(sample-prev)))
 	}
 
-	// The hard-stop compares the raw sample, not the EWMA: it protects the
+	// The hard-stop compares the raw sample (against vCPUs plus headroom for
+	// spirit's own monitoring threads), not the EWMA: it protects the
 	// production workload and must engage within one poll of a load spike.
-	throttled := running > a.vCPUs
+	throttled := running > a.throttleThreshold()
 	prev := a.isThrottled.Swap(throttled)
 	if throttled && !prev {
-		a.logger.Warn("Threads_running exceeds vCPUs, throttling",
+		a.logger.Warn("Threads_running exceeds throttle threshold, throttling",
 			"threads_running", running,
-			"vCPUs", a.vCPUs)
+			"vCPUs", a.vCPUs,
+			"throttle_threshold", a.throttleThreshold())
 	}
 }

--- a/pkg/throttler/aurora_threadsrunning_test.go
+++ b/pkg/throttler/aurora_threadsrunning_test.go
@@ -29,19 +29,38 @@ func TestThreadsRunning_BelowVCPUs(t *testing.T) {
 	require.Equal(t, int64(4), a.lastThreadsRunning.Load())
 }
 
-func TestThreadsRunning_AtVCPUsIsNotThrottled(t *testing.T) {
-	// Threshold is strictly greater than vCPUs — sitting exactly at vCPUs is
-	// not over-subscribed, so we should not throttle.
+func TestThreadsRunning_AtThresholdIsNotThrottled(t *testing.T) {
+	// The hard-stop trips strictly above vCPUs + selfMonitoringHeadroom, so
+	// sitting exactly at the threshold (here 8+2=10) is not over-subscribed and
+	// must not throttle. The headroom absorbs spirit's own monitoring threads.
 	a := newTestThreadsRunning(t, 8)
-	a.applySample(8)
+	a.applySample(a.vCPUs + selfMonitoringHeadroom)
 	require.False(t, a.IsThrottled())
 }
 
-func TestThreadsRunning_AboveVCPUsThrottles(t *testing.T) {
+func TestThreadsRunning_AboveThresholdThrottles(t *testing.T) {
 	a := newTestThreadsRunning(t, 8)
-	a.applySample(9)
+	sample := a.vCPUs + selfMonitoringHeadroom + 1 // one over the threshold
+	a.applySample(sample)
 	require.True(t, a.IsThrottled())
-	require.Equal(t, int64(9), a.lastThreadsRunning.Load())
+	require.Equal(t, sample, a.lastThreadsRunning.Load())
+}
+
+func TestThreadsRunning_HeadroomSparesSmallInstance(t *testing.T) {
+	// Regression for the "threads-running throttler timed out" flood on small
+	// Aurora instances: at vCPUs=2 spirit's own monitoring footprint pushes
+	// Threads_running to ~3-4 with zero production load. The headroom must keep
+	// those samples from tripping the hard-stop (else the copy throttles against
+	// itself and only advances via BlockWait's 60s timeout), while genuine
+	// production load on top still throttles.
+	a := newTestThreadsRunning(t, 2) // threshold = 2 + 2 = 4
+	for _, spiritOnly := range []int64{2, 3, 4} {
+		a.applySample(spiritOnly)
+		require.Falsef(t, a.IsThrottled(),
+			"Threads_running=%d (spirit's own baseline) must not throttle on a 2-vCPU box", spiritOnly)
+	}
+	a.applySample(5) // production work piled on top of spirit's baseline
+	require.True(t, a.IsThrottled(), "real load above the threshold must still throttle")
 }
 
 func TestThreadsRunning_RecoversBelowVCPUs(t *testing.T) {


### PR DESCRIPTION
## What & why

Investigating a flood of `warn threads-running throttler timed out` on a 2-vCPU (r6g.large) Aurora migration surfaced two related undersizing problems on small / non-autoscaling instances. Two independent fixes, one per commit.

### 1. Threads-running throttle trips on spirit's own baseline

The hard-stop throttled when `Threads_running > vCPUs`. On a 2-vCPU box that threshold is so low it's tripped by spirit's *own* monitoring footprint — the throttler's polling query counts itself as a running thread, and the commit-latency poller / periodic GTID-changeset flush share the monitor pool. With zero production load `Threads_running` already sits at/above the bare threshold, so the copy throttles against itself and advances only through `BlockWait`'s 60s timeout (the warning flood; copy crawls at ~2 chunks/min).

- Added `selfMonitoringHeadroom = 2`; the hard-stop now trips on `Threads_running > vCPUs + headroom`.
- Headroom covers spirit's own (instance-size-independent) monitoring connections, while still backing off when the production workload piles real work on the box.
- The copy's own read/apply threads are **not** excluded — they're genuine CPU load that should count toward saturation.
- `Utilization()` and the write-thread autoscaler are untouched (separate, smoothed signal).

### 2. Main pool starves control-plane queries under a saturated copy

The main pool was sized `Threads + WriteThreads + 1` — a single spare for *every* periodic control-plane query on `r.db`: the checkpoint INSERT (50s), the replication periodic-flush poll (30s), and one table-stats updater **per table** (5min). When the copier + shared applier saturate the budget, these serialize behind the lone spare, stalling checkpoints and stretching flush durations (observed: a 9.4s GTID flush). Worst on non-autoscaling instances, where `maxWrite == WriteThreads` leaves no incidental slack.

- Replaced the fixed `+1` with `controlPlaneConns() = len(changes) + 2` at both pool-sizing sites.
- Throttler polls are unaffected — they already run on the dedicated `monitorDB` pool.

The two issues interact: throttling currently masks the pool contention (`conns-in-use` 0-1); fixing #1 lets the copy saturate more often and exposes #2.

## Testing

- `go build ./...`, `go vet ./pkg/throttler ./pkg/copier ./pkg/migration` clean.
- Throttler suite passes; added `TestThreadsRunning_HeadroomSparesSmallInstance` (regression for the 2-vCPU flood) and tightened the boundary tests to the new threshold.
- Added `TestControlPlaneConns` documenting the headroom formula (single- and multi-table).

## Notes / out of scope

- Neither fix helps an **in-flight** migration without a restart (resumes from the checkpoint low-watermark).
- The `move` runner has the same class of control-plane consumers with its own fixed `+2`; left untouched here.

Relates to #831. Happy to file a dedicated issue if preferred (per the PR template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)