### PR TITLE
Quiet expected context-cancel log noise on shutdown

### DIFF
--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -193,7 +193,7 @@ func (a *ShardedApplier) Start(ctx context.Context) error {
 
 	// Start a single feedback coordinator for all shards
 	a.wg.Add(1)
-	go a.feedbackCoordinator()
+	go a.feedbackCoordinator(workerCtx)
 
 	return nil
 }
@@ -522,8 +522,10 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 	return result, nil
 }
 
-// feedbackCoordinator tracks chunklet completions from all shards and invokes callbacks when work is done
-func (a *ShardedApplier) feedbackCoordinator() {
+// feedbackCoordinator tracks chunklet completions from all shards and invokes callbacks when work is done.
+// ctx is the worker context; once it is cancelled, completions for already-cleaned-up
+// work are an expected part of shutdown rather than a bug (see Apply's ctx-cancel cleanup).
+func (a *ShardedApplier) feedbackCoordinator(ctx context.Context) {
 	defer a.wg.Done()
 	a.logger.Debug("feedbackCoordinator started")
 
@@ -537,7 +539,15 @@ func (a *ShardedApplier) feedbackCoordinator() {
 		pending, exists := a.pendingWork[completion.workID]
 		if !exists {
 			a.pendingMutex.Unlock()
-			a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
+			// On shutdown, Apply's ctx-cancel cleanup deletes pendingWork while
+			// chunklets are still in flight; their completions then arrive here
+			// for work that no longer exists. That is expected teardown, not a
+			// bug, so log it quietly. Outside cancellation it is a real anomaly.
+			if ctx.Err() != nil || errors.Is(completion.err, context.Canceled) {
+				a.logger.Debug("feedbackCoordinator received completion for unknown work during shutdown", "workID", completion.workID)
+			} else {
+				a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
+			}
 			return
 		}
 

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -2,6 +2,7 @@ package applier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -154,7 +155,7 @@ func (a *SingleTargetApplier) Start(ctx context.Context) error {
 	// Start feedback coordinator before workers so completions are always
 	// drained.
 	a.wg.Add(1)
-	go a.feedbackCoordinator()
+	go a.feedbackCoordinator(workerCtx)
 
 	// Spawn the initial worker pool. SetWriteWorkers only takes scaleMu, so
 	// calling it while holding the main lock is safe (no lock nesting on the
@@ -496,8 +497,10 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 	return result, nil
 }
 
-// feedbackCoordinator tracks chunklet completions and invokes callbacks when work is done
-func (a *SingleTargetApplier) feedbackCoordinator() {
+// feedbackCoordinator tracks chunklet completions and invokes callbacks when work is done.
+// ctx is the worker context; once it is cancelled, completions for already-cleaned-up
+// work are an expected part of shutdown rather than a bug (see Apply's ctx-cancel cleanup).
+func (a *SingleTargetApplier) feedbackCoordinator(ctx context.Context) {
 	defer a.wg.Done()
 	a.logger.Debug("feedbackCoordinator started")
 
@@ -510,7 +513,15 @@ func (a *SingleTargetApplier) feedbackCoordinator() {
 		pending, exists := a.pendingWork[completion.workID]
 		if !exists {
 			a.pendingMutex.Unlock()
-			a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
+			// On shutdown, Apply's ctx-cancel cleanup deletes pendingWork while
+			// chunklets are still in flight; their completions then arrive here
+			// for work that no longer exists. That is expected teardown, not a
+			// bug, so log it quietly. Outside cancellation it is a real anomaly.
+			if ctx.Err() != nil || errors.Is(completion.err, context.Canceled) {
+				a.logger.Debug("feedbackCoordinator received completion for unknown work during shutdown", "workID", completion.workID)
+			} else {
+				a.logger.Error("feedbackCoordinator received completion for unknown work", "workID", completion.workID)
+			}
 			return
 		}
 

--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -253,7 +253,16 @@ func (c *buffered) readWorker(ctx context.Context) error {
 		capturedStartTime := chunkStartTime
 		callback := func(affectedRows int64, err error) {
 			if err != nil {
-				c.logger.Error("applier callback received error", "chunk", capturedChunk.String(), "error", err)
+				// A context cancellation (Ctrl+C / graceful shutdown) tears down
+				// in-flight chunklets deliberately — it is not a copy failure, so
+				// log it quietly rather than alarming the user with an ERROR. We
+				// still setInvalid to unwind Run; higher layers filter context
+				// cancellation when deciding the command's exit status.
+				if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+					c.logger.Debug("applier callback cancelled", "chunk", capturedChunk.String(), "error", err)
+				} else {
+					c.logger.Error("applier callback received error", "chunk", capturedChunk.String(), "error", err)
+				}
 				c.setInvalid(err)
 				return
 			}


### PR DESCRIPTION
## Problem

When a `sync` command is interrupted with Ctrl+C, the log can fill with `ERROR` lines that look alarming but are entirely benign:

```
ERROR applier callback received error chunk="`id` >= 6890073 AND `id` < 6902596" error="context canceled"
ERROR applier callback received error chunk="..." error="failed to execute chunklet insert: context canceled"
ERROR feedbackCoordinator received completion for unknown work workID=581
ERROR feedbackCoordinator received completion for unknown work workID=581
...
```

Both come from the deliberate context-cancel teardown:

1. **`applier callback received error`** — `Apply`'s ctx-cancel cleanup invokes the copier callback with `context.Canceled`. The callback logged every non-nil error at `ERROR`.
2. **`feedbackCoordinator received completion for unknown work`** — that cleanup deletes the `pendingWork` entry while chunklets are still in flight; their completions then arrive for work that no longer exists (already documented as expected in `Apply`'s cleanup comment). Logged once per in-flight chunklet → the `workID` spam.

## Fix

Make all three sites context-cancel-aware: log at `DEBUG` when the context is cancelled, but keep `ERROR` otherwise so a genuine anomaly (an unknown-work completion that *isn't* a shutdown) still surfaces loudly.

- `pkg/copier/buffered.go` — apply callback gates on `errors.Is(err, context.Canceled) || ctx.Err() != nil`. Still calls `setInvalid` so `Run` unwinds exactly as before.
- `pkg/applier/single_target.go` and `pkg/applier/sharded.go` — `feedbackCoordinator` now takes the worker context (passed at its single launch site in each `Start`); the unknown-work branch gates on `ctx.Err() != nil || errors.Is(completion.err, context.Canceled)`.

Logging-only behavior change — control flow and error propagation are untouched. `go build` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)