### PR TITLE
Fix preflight lock-check false positives in move/migration

### DIFF
--- a/pkg/dbconn/kill.go
+++ b/pkg/dbconn/kill.go
@@ -95,6 +95,19 @@ WHERE t.processlist_id IS NOT NULL
 	queryTableClause = " AND (ml.object_schema, ml.object_name) IN (%s) "
 	rdsKillStatement = "CALL mysql.rds_kill(%d)" // not needed in MySQL 8.0 with the CONNECTION_ADMIN privilege
 	killStatement    = "KILL %d"
+
+	// forceKillPrivilegeProbe verifies the connection can read every
+	// performance_schema / information_schema table the force-kill queries
+	// (TableLockQuery and LongRunningEventQuery) depend on. It selects zero rows
+	// (LIMIT 0) so it neither scans nor logs, but MySQL still enforces
+	// table-level SELECT privileges at prepare time, so a missing grant surfaces
+	// as an error.
+	forceKillPrivilegeProbe = `SELECT 1
+FROM performance_schema.metadata_locks ml
+    JOIN performance_schema.threads t ON ml.owner_thread_id = t.thread_id
+    LEFT JOIN performance_schema.events_transactions_current etc ON etc.thread_id = ml.owner_thread_id
+    LEFT JOIN information_schema.innodb_trx trx ON t.processlist_id = trx.trx_mysql_thread_id
+LIMIT 0`
 )
 
 type LockDetail struct {
@@ -165,15 +178,20 @@ func GetLockingTransactions(ctx context.Context, db *sql.DB, tables []*table.Tab
 	query := LongRunningEventQuery
 
 	params := []any{}
-	if len(ignorePIDs) > 0 {
-		// If there are PIDs to ignore, we need to add them to the query
-		inList, inParams := sliceToInList(ignorePIDs)
-		if len(inList) > 0 {
-			inList = ", " + inList // Add a comma for formatting
-		}
-		query += fmt.Sprintf(processIDClause, inList)
-		params = append(params, inParams...)
+	// Always exclude our own connection (CONNECTION_ID()). Reading the
+	// performance_schema tables in this query causes the running connection to
+	// hold SHARED_READ metadata locks on them; without this exclusion the query
+	// observes its own locks and reports them as locking transactions. This is
+	// especially visible in the privileges preflight probe, where the table
+	// filter below is empty (SourceTables aren't populated yet) and the query
+	// would otherwise return every granted table lock on the server, including
+	// its own. Any caller-supplied PIDs are appended to the same NOT IN list.
+	inList, inParams := sliceToInList(ignorePIDs)
+	if len(inList) > 0 {
+		inList = ", " + inList // Add a comma for formatting
 	}
+	query += fmt.Sprintf(processIDClause, inList)
+	params = append(params, inParams...)
 	if len(tables) > 0 {
 		inList, inParams := tablesToInList(tables, logger)
 		query += fmt.Sprintf(queryTableClause, inList)
@@ -253,15 +271,15 @@ func GetTableLocks(ctx context.Context, db *sql.DB, tables []*table.TableInfo, l
 	defer tx.Rollback() //nolint:errcheck
 	query := TableLockQuery
 	params := make([]any, 0, len(tables)*2)
-	if len(ignorePIDs) > 0 {
-		// If there are PIDs to ignore, we need to add them to the query
-		inList, inParams := sliceToInList(ignorePIDs)
-		if len(inList) > 0 {
-			inList = ", " + inList // Add a comma for formatting
-		}
-		query += fmt.Sprintf(processIDClause, inList)
-		params = append(params, inParams...)
+	// Always exclude our own connection (CONNECTION_ID()); see the matching
+	// note in GetLockingTransactions. Any caller-supplied PIDs are appended to
+	// the same NOT IN list.
+	inList, inParams := sliceToInList(ignorePIDs)
+	if len(inList) > 0 {
+		inList = ", " + inList // Add a comma for formatting
 	}
+	query += fmt.Sprintf(processIDClause, inList)
+	params = append(params, inParams...)
 	if len(tables) > 0 {
 		if len(tables) > 0 {
 			inList, inParams := tablesToInList(tables, logger)
@@ -304,6 +322,23 @@ func GetTableLocks(ctx context.Context, db *sql.DB, tables []*table.TableInfo, l
 	}
 
 	return locks, nil
+}
+
+// CheckForceKillPrivileges verifies that the connection can read the
+// performance_schema and information_schema tables required by the force-kill
+// queries used during cutover (see GetTableLocks and GetLockingTransactions).
+// It returns an error when any of those tables is inaccessible — for example,
+// when the user lacks SELECT on performance_schema.*.
+//
+// It is intended for preflight privilege checks: the probe selects zero rows
+// and logs nothing, so unlike GetTableLocks / GetLockingTransactions it neither
+// scans server-wide locks nor emits "found locking transaction" log lines.
+func CheckForceKillPrivileges(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx, forceKillPrivilegeProbe)
+	if err != nil {
+		return err
+	}
+	return rows.Close()
 }
 
 // KillTransaction kills the MySQL session identified by pid (as observed

--- a/pkg/dbconn/kill_test.go
+++ b/pkg/dbconn/kill_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -121,6 +122,53 @@ func TestKillLongRunningTransactions(t *testing.T) {
 		err = tx.Rollback()
 		require.Error(t, err, "expected rollback to fail because transaction was killed")
 	}
+}
+
+// TestCheckForceKillPrivileges verifies the preflight privilege probe used by
+// the move and migration checks: it must error when the connection lacks SELECT
+// on performance_schema.* and succeed once it is granted. Because the probe
+// selects zero rows it never emits "found locking transaction" log lines during
+// preflight. A root connection is required to create the restricted user and
+// grant privileges (the default test user lacks GRANT OPTION).
+func TestCheckForceKillPrivileges(t *testing.T) {
+	config, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	config.User = "root" // needs grant privilege
+	rootDB, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s", config.User, config.Passwd, config.Addr, config.DBName))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rootDB)
+
+	_, err = rootDB.ExecContext(t.Context(), "DROP USER IF EXISTS testforcekillprobeuser")
+	require.NoError(t, err)
+	_, err = rootDB.ExecContext(t.Context(), "CREATE USER testforcekillprobeuser")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = rootDB.ExecContext(t.Context(), "DROP USER IF EXISTS testforcekillprobeuser")
+	})
+	// Grant SELECT on the test schema only, so the user can connect but cannot
+	// read performance_schema.
+	_, err = rootDB.ExecContext(t.Context(), "GRANT SELECT ON test.* TO testforcekillprobeuser")
+	require.NoError(t, err)
+
+	connect := func() *sql.DB {
+		db, err := sql.Open("mysql", fmt.Sprintf("testforcekillprobeuser:@tcp(%s)/%s", config.Addr, config.DBName))
+		require.NoError(t, err)
+		return db
+	}
+
+	lowPrivDB := connect()
+	require.Error(t, CheckForceKillPrivileges(t.Context(), lowPrivDB),
+		"probe must fail without SELECT on performance_schema.*")
+	require.NoError(t, lowPrivDB.Close())
+
+	_, err = rootDB.ExecContext(t.Context(), "GRANT SELECT ON `performance_schema`.* TO testforcekillprobeuser")
+	require.NoError(t, err)
+
+	// Reconnect so the new grant is picked up.
+	grantedDB := connect()
+	defer utils.CloseAndLog(grantedDB)
+	require.NoError(t, CheckForceKillPrivileges(t.Context(), grantedDB),
+		"probe must succeed once SELECT on performance_schema.* is granted")
 }
 
 func TestForceKillGracePeriod(t *testing.T) {

--- a/pkg/migration/check/privileges.go
+++ b/pkg/migration/check/privileges.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/block/spirit/pkg/dbconn"
-	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 )
 
@@ -94,11 +93,11 @@ func privilegesCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 
 	if r.ForceKill {
 		var errs []error
-		// Parsing performance_schema grants seems really hard, so we just try to execute the queries and see if they succeed.
-		if _, err := dbconn.GetTableLocks(ctx, r.DB, []*table.TableInfo{r.Table}, logger, nil); err != nil {
-			errs = append(errs, err)
-		}
-		if _, err := dbconn.GetLockingTransactions(ctx, r.DB, []*table.TableInfo{r.Table}, nil, logger, nil); err != nil {
+		// Parsing performance_schema grants seems really hard, so we just probe
+		// the tables the force-kill queries read and see if it succeeds. This is
+		// a privilege probe only: it selects zero rows and logs nothing. The
+		// actual lock detection (which does log) runs during cutover.
+		if err := dbconn.CheckForceKillPrivileges(ctx, r.DB); err != nil {
 			errs = append(errs, err)
 		}
 		if !skipRolePrivilegeCheck {

--- a/pkg/move/check/privileges.go
+++ b/pkg/move/check/privileges.go
@@ -122,11 +122,10 @@ func checkSourcePrivileges(ctx context.Context, src SourceResource, r Resources,
 	var errs []error
 
 	// Verify SELECT access on performance_schema.*, which is required for the
-	// queries used by force-kill during cutover.
-	if _, err := dbconn.GetTableLocks(ctx, src.DB, r.SourceTables, logger, nil); err != nil {
-		errs = append(errs, err)
-	}
-	if _, err := dbconn.GetLockingTransactions(ctx, src.DB, r.SourceTables, nil, logger, nil); err != nil {
+	// queries used by force-kill during cutover. This is a privilege probe only:
+	// it selects zero rows and logs nothing. The actual lock detection (which
+	// does log) runs during cutover, not preflight.
+	if err := dbconn.CheckForceKillPrivileges(ctx, src.DB); err != nil {
 		errs = append(errs, err)
 	}
 	if !skipRolePrivilegeCheck {


### PR DESCRIPTION
## Problem

Running a `move` (and likewise a migration with force-kill) logs spurious lock warnings at the very start, on an otherwise idle database:

```
INFO found locking transaction pid=116626 lockType=SHARED_READ lockStatus=GRANTED objectSchema=performance_schema
INFO found locking transaction pid=116626 lockType=SHARED_READ lockStatus=GRANTED objectSchema=performance_schema
INFO found locking transaction pid=116626 lockType=SHARED_READ lockStatus=GRANTED objectSchema=performance_schema
INFO found locking transactions count=1 pids=[116626]
```

These are false positives. The preflight privileges check probes the force-kill lock queries only to verify `SELECT` access on `performance_schema.*`, but:

1. At preflight time `SourceTables` isn't populated yet, so the probe ran with an **empty table filter** — the query scanned every granted table lock server-wide.
2. The `CONNECTION_ID()` self-exclusion was only applied when `ignorePIDs` was non-empty (it was `nil` here), so the current connection wasn't excluded.

The result: the probe query observed the `SHARED_READ` metadata locks it holds on the `performance_schema` tables it reads (`metadata_locks`, `threads`, `events_transactions_current`) — three tables, three rows, all spirit's own connection id. The apparent "one row per table being moved" was a coincidence.

It was harmless (the probe discards its result), but the logging is misleading. The real cutover kill path always passes real tables and a non-nil `ignorePIDs`, so it was never affected.

## Fix

1. **Always exclude `CONNECTION_ID()`** in `GetLockingTransactions` and `GetTableLocks`, regardless of `ignorePIDs`. Spirit should never report or kill its own connection. Caller-supplied PIDs still append to the same `NOT IN` list.

2. **Don't log during preflight.** Replace the kill-path probe calls in the move and migration preflight checks with a dedicated `CheckForceKillPrivileges` — a `LIMIT 0` probe that verifies `SELECT` access on the required `performance_schema`/`information_schema` tables without scanning server-wide locks or emitting any log lines. (`LIMIT 0` still enforces table-level privileges at prepare time, verified against MySQL.)

## Testing

- `go build`, `go vet`, `gofmt`, `golangci-lint` — clean.
- Existing `TestKillLongRunningTransactions` passes (real locks still detected; only the self-connection is excluded).
- New `TestCheckForceKillPrivileges` isolates the probe: errors without `SELECT ON performance_schema.*`, succeeds once granted.
- Verified live against MySQL: with the `CONNECTION_ID()` exclusion the unfiltered query returns nothing (self-locks gone); a restricted user is denied by the `LIMIT 0` probe (`SELECT command denied ... for table 'metadata_locks'`) while an authorized user gets zero rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)