### PR TITLE
datasync: don't leak DB pools when a teardown step fails in Close()

### DIFF
--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -1334,22 +1334,28 @@ func (r *Runner) Close() error {
 		r.replClient.StopPeriodicFlush()
 		r.replClient.Close()
 	}
+	// Run every cleanup step unconditionally and collect errors with
+	// errors.Join. Previously the first failing step short-circuited the
+	// rest, leaking the remaining DB pools (the target and source handles).
+	// The individual close calls are independent enough that running them
+	// all does no harm.
+	var errs []error
 	if r.copyChunker != nil {
 		if err := r.copyChunker.Close(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if r.ownsTarget && r.target.DB != nil {
 		if err := r.target.DB.Close(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if r.source.db != nil {
 		if err := r.source.db.Close(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // --- progress-field setters (guard the fields the status.Task accessors read) ---


### PR DESCRIPTION
## What
`datasync.Runner.Close()` short-circuited on the first failing teardown step (`copyChunker.Close()`, then `target.DB.Close()`), so a failure left the remaining DB pools (target, source) open.

## Why
`pkg/migration` and `pkg/move` were already fixed to run every teardown step unconditionally and join errors with `errors.Join` — the migration runner even documents this exact regression in a comment. `datasync` was missed and kept the pre-fix shape.

## Change
Accumulate errors across all teardown steps and return `errors.Join(errs...)`, mirroring `pkg/migration/runner.go`'s `Close()`. Ordering, nil-checks, and the `ownsTarget` guard are preserved.

Verified locally: `go build ./...`, `go vet ./...`, `golangci-lint run` all clean. DB-backed tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
