### PR TITLE
move: pin checksum YieldTimeout to the package default

### DIFF
--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1194,6 +1194,13 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 		Logger:          r.logger,
 		Applier:         r.applier,
 		FixDifferences:  true,
+		// Migration exposes this as the --checksum-yield-timeout flag
+		// (default 24h); move intentionally has no equivalent knob
+		// ("decisions, not options"), so pin the package default here.
+		// Setting it explicitly keeps move consistent with migration's
+		// effective behaviour and decouples it from the checksum package's
+		// internal zero-value fallback.
+		YieldTimeout: checksum.DefaultYieldTimeout,
 	})
 	if err != nil {
 		return err
@@ -1480,6 +1487,14 @@ func (r *Runner) runContinuousChecksum(ctx context.Context) error {
 		// loop itself supplies the retry, so we don't nest a second
 		// retry loop inside each iteration.
 		MaxRetries: 1,
+		// A single continuous pass over a large table can run for hours
+		// during the sentinel wait (capped by sentinelWaitLimit). Pin the
+		// package default yield timeout so a long pass periodically
+		// releases its REPEATABLE READ transaction and curbs InnoDB HLL
+		// growth on the source — matching migration's continuous checker,
+		// which derives the same value from --checksum-yield-timeout.
+		// Move has no equivalent flag by design ("decisions, not options").
+		YieldTimeout: checksum.DefaultYieldTimeout,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create continuous checker: %w", err)


### PR DESCRIPTION
## What
Move's initial and continuous checksum checkers never set `YieldTimeout`, so they fell back to the checksum package's internal zero-value default (24h). Migration sets it explicitly (from `--checksum-yield-timeout`, default 24h).

## Why
`git` history shows the continuous-checksum commit wired `YieldTimeout` into migration but omitted move — despite its commit message stating the feature was *"Mirrored across pkg/migration and pkg/move."* Because migration's flag also defaults to 24h, default behavior is identical, so this is an **intent/consistency fix, not a behavior change**. It matters operationally because move's continuous pass can run for hours during the sentinel wait (bounded by `sentinelWaitLimit`), and the yield periodically releases the long-running `REPEATABLE READ` transaction to curb InnoDB history-list growth on the source.

## Change
Pin `YieldTimeout: checksum.DefaultYieldTimeout` on both move checker configs, each with an explanatory comment. No new CLI flag — consistent with move's existing surface and the project's "decisions, not options" philosophy.

Verified locally: `go build ./...`, `go vet ./...`, `golangci-lint run` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
