### PR TITLE
test: add invariant tripwires for State ordinals and columnsEqual fields

### DIFF
--- a/pkg/statement/columns_equal_guard_test.go
+++ b/pkg/statement/columns_equal_guard_test.go
@@ -1,0 +1,245 @@
+package statement
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// columnsEqualWithContext and columnsEqualIgnorePK (both in diff.go)
+// field-by-field compare the parsed Column struct to decide
+// whether a column differs between the source and target schema. If a newly
+// added Column field is NOT wired into these comparisons, two columns that
+// differ only in that field are silently treated as EQUAL — a real ALTER gets
+// dropped and Spirit applies the wrong schema diff. The tests below are the
+// safety net for that class of mistake.
+
+// columnFieldsCompared lists the exported Column fields that the equality logic
+// (columnsEqualWithContext + columnsEqualIgnorePK + the shared
+// columnExtendedAttributesEqual helper) compares. PrimaryKey counts as compared:
+// it IS compared by columnsEqualWithContext and is only skipped by the dedicated
+// *IgnorePK* variant.
+var columnFieldsCompared = map[string]struct{}{
+	"Name":            {},
+	"Type":            {},
+	"Length":          {},
+	"Precision":       {},
+	"Scale":           {},
+	"Unsigned":        {},
+	"EnumValues":      {},
+	"SetValues":       {},
+	"Nullable":        {},
+	"Default":         {},
+	"DefaultIsExpr":   {},
+	"DefaultIsString": {},
+	"OnUpdate":        {},
+	"GeneratedExpr":   {},
+	"GeneratedStored": {},
+	"SRID":            {},
+	"AutoInc":         {},
+	"PrimaryKey":      {},
+	"Unique":          {},
+	"Comment":         {},
+	"Charset":         {},
+	"Collation":       {},
+}
+
+// columnFieldsNotCompared lists exported Column fields that are deliberately
+// excluded from the column equality logic, with the reason.
+var columnFieldsNotCompared = map[string]string{
+	// Raw is the underlying *ast.ColumnDef pointer; it is parser-internal state,
+	// not part of the column's logical definition, so comparing it is meaningless.
+	"Raw": "raw parser AST pointer, not part of logical column definition",
+	// Column-level CHECK is hoisted into table-level CreateTable.Constraints by
+	// the parser (normalizeColumnChecks) and diffed by diffConstraints instead —
+	// see the comment on columnExtendedAttributesEqual. So it is intentionally not
+	// part of per-column equality.
+	"Check": "hoisted to table-level Constraints; diffed by diffConstraints, not here",
+	// Options is a catch-all map for column options the parser did not model
+	// explicitly. It is currently NOT compared by either columnsEqual function.
+	// If you start populating Options with semantically meaningful data, it must
+	// be added to both comparisons and removed from this list.
+	"Options": "catch-all map for unmodeled options; currently not compared by diff.go",
+}
+
+// TestColumnsEqualAllFieldsAccounted is the primary tripwire: it enumerates the
+// exported fields of Column via reflection and asserts that EVERY one is
+// accounted for — either in columnFieldsCompared or in columnFieldsNotCompared,
+// and never both. Adding a field to Column breaks this test until a human
+// decides how the comparison logic should treat it.
+//
+// IF THIS FAILS BECAUSE A FIELD WAS ADDED TO Column:
+// update BOTH columnsEqual functions in diff.go (columnsEqualWithContext AND
+// columnsEqualIgnorePK, plus columnExtendedAttributesEqual for extended
+// attributes) to compare the new field, then add it to columnFieldsCompared. If
+// the new field is intentionally NOT part of column equality (like Raw / Check /
+// Options), add it to columnFieldsNotCompared with a justifying comment instead.
+func TestColumnsEqualAllFieldsAccounted(t *testing.T) {
+	typ := reflect.TypeFor[Column]()
+
+	var exported []string
+	for f := range typ.Fields() {
+		if f.IsExported() {
+			exported = append(exported, f.Name)
+		}
+	}
+
+	for _, name := range exported {
+		_, compared := columnFieldsCompared[name]
+		_, notCompared := columnFieldsNotCompared[name]
+		require.False(t, compared && notCompared,
+			"Column field %q is listed as both compared and not-compared; fix this guard", name)
+		require.True(t, compared || notCompared,
+			"Column field %q is not accounted for. Wire it into BOTH columnsEqual functions "+
+				"in diff.go and add it to columnFieldsCompared, or add it to "+
+				"columnFieldsNotCompared with a reason.", name)
+	}
+
+	// Lock the total so removing a field (or renaming one out of both maps) is
+	// also caught, not just additions.
+	require.Len(t, exported, len(columnFieldsCompared)+len(columnFieldsNotCompared),
+		"Column exported field count changed. Reconcile columnFieldsCompared / "+
+			"columnFieldsNotCompared with the struct. Fields: %v", exported)
+
+	// Guard against the maps rotting: every listed name must be a real field.
+	for name := range columnFieldsCompared {
+		_, ok := typ.FieldByName(name)
+		require.True(t, ok, "columnFieldsCompared lists %q but Column has no such field", name)
+	}
+	for name := range columnFieldsNotCompared {
+		_, ok := typ.FieldByName(name)
+		require.True(t, ok, "columnFieldsNotCompared lists %q but Column has no such field", name)
+	}
+}
+
+// baseColumn returns a Column with every comparable field set to a non-zero,
+// non-nil value so that flipping any single attribute is a detectable change.
+// GeneratedExpr is non-nil so that GeneratedStored is meaningful (it is only
+// compared when a generation expression is present). Type is a non-numeric type
+// so that DefaultIsString participates in the comparison.
+func baseColumn() Column {
+	return Column{
+		Name:            "c",
+		Type:            "varchar",
+		Length:          new(255),
+		Precision:       new(10),
+		Scale:           new(2),
+		Unsigned:        new(true),
+		EnumValues:      []string{"a", "b"},
+		SetValues:       []string{"x", "y"},
+		Nullable:        false,
+		Default:         new("foo"),
+		DefaultIsExpr:   true,
+		DefaultIsString: true,
+		OnUpdate:        new("current_timestamp"),
+		GeneratedExpr:   new("(1 + 1)"),
+		GeneratedStored: true,
+		SRID:            new(uint32(4326)),
+		AutoInc:         true,
+		PrimaryKey:      true,
+		Unique:          true,
+		Comment:         new("hi"),
+		Charset:         new("utf8mb4"),
+		Collation:       new("utf8mb4_bin"),
+	}
+}
+
+// everyComparedFieldMutation returns one mutation per comparable field that, when
+// applied to a baseColumn(), must make it differ. Used by both behavioral tests
+// below. The mutations cover the same field set as columnFieldsCompared.
+func everyComparedFieldMutation() []struct {
+	name   string
+	mutate func(c *Column)
+} {
+	return []struct {
+		name   string
+		mutate func(c *Column)
+	}{
+		{"Name", func(c *Column) { c.Name = "different" }},
+		{"Type", func(c *Column) { c.Type = "char" }},
+		{"Length", func(c *Column) { c.Length = new(100) }},
+		{"Precision", func(c *Column) { c.Precision = new(20) }},
+		{"Scale", func(c *Column) { c.Scale = new(4) }},
+		{"Unsigned", func(c *Column) { c.Unsigned = new(false) }},
+		{"EnumValues", func(c *Column) { c.EnumValues = []string{"a", "c"} }},
+		{"SetValues", func(c *Column) { c.SetValues = []string{"x", "z"} }},
+		{"Nullable", func(c *Column) { c.Nullable = true }},
+		{"Default", func(c *Column) { c.Default = new("bar") }},
+		{"DefaultIsExpr", func(c *Column) { c.DefaultIsExpr = false }},
+		{"DefaultIsString", func(c *Column) { c.DefaultIsString = false }},
+		{"OnUpdate", func(c *Column) { c.OnUpdate = new("now()") }},
+		{"GeneratedExpr", func(c *Column) { c.GeneratedExpr = new("(2 + 2)") }},
+		{"GeneratedStored", func(c *Column) { c.GeneratedStored = false }},
+		{"SRID", func(c *Column) { c.SRID = new(uint32(3857)) }},
+		{"AutoInc", func(c *Column) { c.AutoInc = false }},
+		{"PrimaryKey", func(c *Column) { c.PrimaryKey = false }},
+		{"Unique", func(c *Column) { c.Unique = false }},
+		{"Comment", func(c *Column) { c.Comment = new("bye") }},
+		{"Charset", func(c *Column) { c.Charset = new("latin1") }},
+		{"Collation", func(c *Column) { c.Collation = new("latin1_swedish_ci") }},
+	}
+}
+
+// TestColumnsEqualWithContextDetectsEveryField is behavioral coverage backing
+// the reflection guard: columnsEqualWithContext must return false when ANY single
+// comparable field differs. If a field is added to Column and wired into
+// baseColumn/the mutation list but NOT into columnsEqualWithContext, the matching
+// case fails (the mutated column is still reported equal).
+func TestColumnsEqualWithContextDetectsEveryField(t *testing.T) {
+	// Empty table context (nil TableOptions): the charset/collation
+	// normalization is skipped, so those comparisons behave like plain pointer
+	// equality — exactly what this test wants.
+	ct := &CreateTable{TableName: "t"}
+	target := &CreateTable{TableName: "t"}
+	opts := &DiffOptions{}
+
+	a := baseColumn()
+	b := baseColumn()
+	require.True(t, ct.columnsEqualWithContext(&a, &b, target, opts),
+		"identical columns must compare equal")
+
+	for _, m := range everyComparedFieldMutation() {
+		t.Run(m.name, func(t *testing.T) {
+			src := baseColumn()
+			tgt := baseColumn()
+			m.mutate(&tgt)
+			require.False(t, ct.columnsEqualWithContext(&src, &tgt, target, opts),
+				"columnsEqualWithContext must return false when %s differs; "+
+					"if you added field %s, make sure diff.go compares it", m.name, m.name)
+		})
+	}
+}
+
+// TestColumnsEqualIgnorePKDetectsEveryField mirrors the above for
+// columnsEqualIgnorePK, which compares the same fields EXCEPT PrimaryKey. Every
+// other comparable field, when flipped, must cause it to return false; flipping
+// PrimaryKey alone must NOT (that is the whole point of the IgnorePK variant).
+func TestColumnsEqualIgnorePKDetectsEveryField(t *testing.T) {
+	opts := &DiffOptions{}
+
+	a := baseColumn()
+	b := baseColumn()
+	require.True(t, columnsEqualIgnorePK(&a, &b, opts),
+		"identical columns must compare equal under columnsEqualIgnorePK")
+
+	// PrimaryKey is deliberately ignored by this function.
+	pkOnly := baseColumn()
+	pkOnly.PrimaryKey = !pkOnly.PrimaryKey
+	require.True(t, columnsEqualIgnorePK(&a, &pkOnly, opts),
+		"columnsEqualIgnorePK must ignore a PrimaryKey-only difference")
+
+	for _, m := range everyComparedFieldMutation() {
+		if m.name == "PrimaryKey" {
+			continue // ignored by this function by design
+		}
+		t.Run(m.name, func(t *testing.T) {
+			src := baseColumn()
+			tgt := baseColumn()
+			m.mutate(&tgt)
+			require.False(t, columnsEqualIgnorePK(&src, &tgt, opts),
+				"columnsEqualIgnorePK must return false when %s differs; "+
+					"if you added field %s, make sure diff.go compares it", m.name, m.name)
+		})
+	}
+}

--- a/pkg/status/state_order_test.go
+++ b/pkg/status/state_order_test.go
@@ -1,0 +1,95 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateOrder is a safety-net tripwire for the ordinal values of the State
+// iota block in state.go. The integer ORDER of these constants is load-bearing:
+// code elsewhere gates safety behavior on the ordinal via >= / > comparisons
+// rather than equality. A future reorder or insertion into the const block would
+// silently change which states satisfy those gates and invert the safety logic.
+//
+// Known ordinal-comparison sites that depend on this order (non-exhaustive):
+//   - pkg/migration/runner.go: `state >= Checksum` gates persisting the
+//     checkpoint's checksum_watermark; `state >= CutOver` makes fatalError()
+//     a no-op (errors after cutover are expected and must not cancel/invalidate).
+//   - pkg/move/runner.go: `state >= Checksum` and `state >= CutOver` gate the
+//     continuous-checksum loop and post-cutover error handling.
+//   - pkg/status/task.go: `state > CutOver` / `state >= CutOver` gate progress
+//     reporting and terminal-state handling.
+//   - state.go itself documents that WaitingOnSentinelTable must sort AFTER
+//     Checksum so that `state >= Checksum` stays true while the sentinel wait
+//     blocks the cutover.
+//
+// If you INTENTIONALLY reorder or insert a State, update the expected values
+// below AND audit every `>=` / `>` / `<` comparison against a State constant to
+// confirm the safety gates still hold.
+func TestStateOrder(t *testing.T) {
+	// (a) Lock the exact integer value of EACH State constant. Any insertion or
+	// reorder of the iota block shifts at least one value and fails here.
+	tests := []struct {
+		name  string
+		state State
+		want  int32
+	}{
+		{"Initial", Initial, 0},
+		{"CopyRows", CopyRows, 1},
+		{"ApplyChangeset", ApplyChangeset, 2},
+		{"RestoreSecondaryIndexes", RestoreSecondaryIndexes, 3},
+		{"AnalyzeTable", AnalyzeTable, 4},
+		{"Checksum", Checksum, 5},
+		{"PostChecksum", PostChecksum, 6},
+		{"WaitingOnSentinelTable", WaitingOnSentinelTable, 7},
+		{"CutOver", CutOver, 8},
+		{"Close", Close, 9},
+		{"ErrCleanup", ErrCleanup, 10},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, int32(tc.state),
+				"State %q has unexpected ordinal; the iota block in state.go changed. "+
+					"Audit all >= / > comparisons against State constants before updating this test.",
+				tc.name)
+		})
+	}
+
+	// (b) Assert the key inequalities that gate safety logic explicitly, so the
+	// intent survives even if someone "fixes" the literal values above to match a
+	// reorder without thinking about the comparison sites.
+	require.Greater(t, int32(WaitingOnSentinelTable), int32(Checksum),
+		"WaitingOnSentinelTable must sort strictly after Checksum, so the `state >= Checksum` gate stays true during the sentinel wait")
+	require.Greater(t, int32(CutOver), int32(Checksum),
+		"CutOver must sort strictly after Checksum")
+	require.Greater(t, int32(CutOver), int32(WaitingOnSentinelTable),
+		"CutOver must sort strictly after WaitingOnSentinelTable (the sentinel wait precedes cutover)")
+	require.Greater(t, int32(CutOver), int32(PostChecksum),
+		"CutOver must sort strictly after PostChecksum")
+
+	// (b cont.) Assert the FULL monotonic ordering of the declared states. The
+	// slice is written in the intended logical order; each entry must have a
+	// strictly greater ordinal than the previous one.
+	monotonic := []struct {
+		name  string
+		state State
+	}{
+		{"Initial", Initial},
+		{"CopyRows", CopyRows},
+		{"ApplyChangeset", ApplyChangeset},
+		{"RestoreSecondaryIndexes", RestoreSecondaryIndexes},
+		{"AnalyzeTable", AnalyzeTable},
+		{"Checksum", Checksum},
+		{"PostChecksum", PostChecksum},
+		{"WaitingOnSentinelTable", WaitingOnSentinelTable},
+		{"CutOver", CutOver},
+		{"Close", Close},
+		{"ErrCleanup", ErrCleanup},
+	}
+	for i := 1; i < len(monotonic); i++ {
+		require.Greater(t, int32(monotonic[i].state), int32(monotonic[i-1].state),
+			"State %q must have a strictly greater ordinal than %q",
+			monotonic[i].name, monotonic[i-1].name)
+	}
+}


### PR DESCRIPTION
## What
Two test-only invariant tripwires (no production code changes):

1. **`pkg/status/state_order_test.go`** — locks the `State` iota ordinals and the key inequalities (`WaitingOnSentinelTable >= Checksum`, `CutOver > Checksum`, full monotonic order). Several sites compare these *ordinals* to gate safety behavior — e.g. `state >= Checksum` gates checkpoint `checksum_watermark` persistence, `state >= CutOver` makes `fatalError()` a no-op. Reordering the const block (a natural-looking cleanup) would silently invert those gates with nothing else catching it.

2. **`pkg/statement/columns_equal_guard_test.go`** — asserts via reflection that every exported `Column` field is accounted for in the column-equality logic: 22 compared + 3 documented exclusions (`Raw` = parser AST pointer, `Check` = hoisted to table-level constraints, `Options` = unmodeled catch-all map). Plus behavioral tests that flip each compared field individually. Forgetting to compare a newly-added `Column` field silently treats differing columns as equal — a missed `ALTER`.

## Why
Both encode load-bearing invariants that currently rely solely on human discipline. They are cheap, deterministic (no DB), and fail with an actionable message.

Verified locally: both tests pass; confirmed the column guard actually fires when a compared field is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
