### PR TITLE
dbconn: replace RetryableTransaction dup-key bool with a named enum

### DIFF
--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -514,7 +514,7 @@ func (a *ShardedApplier) writeChunklet(ctx context.Context, shard *shardTarget, 
 		"rowCount", len(chunkletData.rows), "table", chunkletData.chunk.ColumnMapping.TargetTable().TableName)
 
 	// Execute the batch insert on this shard's database
-	result, err := dbconn.RetryableTransaction(ctx, shard.writeDB, true, shard.dbConfig, query)
+	result, err := dbconn.RetryableTransaction(ctx, shard.writeDB, dbconn.IgnoreDupKeyWarnings, shard.dbConfig, query)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute chunklet insert on shard %d: %w", shard.shardID, err)
 	}
@@ -731,7 +731,7 @@ func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.T
 				}
 			} else {
 				// Execute as a retryable transaction
-				affected, err = dbconn.RetryableTransaction(ctx, shard.writeDB, false, shard.dbConfig, deleteStmt)
+				affected, err = dbconn.RetryableTransaction(ctx, shard.writeDB, dbconn.ErrorOnDupKey, shard.dbConfig, deleteStmt)
 				if err != nil {
 					err = fmt.Errorf("failed to execute delete on shard %d: %w", shard.shardID, err)
 				}
@@ -926,7 +926,7 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 				}
 			} else {
 				// Execute as a retryable transaction
-				affected, err = dbconn.RetryableTransaction(ctx, a.shards[sid].writeDB, false, a.shards[sid].dbConfig, upsertStmt)
+				affected, err = dbconn.RetryableTransaction(ctx, a.shards[sid].writeDB, dbconn.ErrorOnDupKey, a.shards[sid].dbConfig, upsertStmt)
 				if err != nil {
 					err = fmt.Errorf("failed to execute upsert on shard %d: %w", sid, err)
 				}

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -489,7 +489,7 @@ func (a *SingleTargetApplier) writeChunklet(ctx context.Context, chunkletData ch
 	a.logger.Debug("writing chunklet", "rowCount", len(chunkletData.rows), "table", chunkletData.chunk.ColumnMapping.TargetTable().TableName)
 
 	// Execute the batch insert
-	result, err := dbconn.RetryableTransaction(ctx, a.target.DB, true, a.dbConfig, query)
+	result, err := dbconn.RetryableTransaction(ctx, a.target.DB, dbconn.IgnoreDupKeyWarnings, a.dbConfig, query)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute chunklet insert: %w", err)
 	}
@@ -643,7 +643,7 @@ func (a *SingleTargetApplier) DeleteKeys(ctx context.Context, sourceTable, targe
 	}
 
 	// Execute as a retryable transaction
-	affectedRows, err := dbconn.RetryableTransaction(ctx, a.target.DB, false, a.dbConfig, deleteStmt)
+	affectedRows, err := dbconn.RetryableTransaction(ctx, a.target.DB, dbconn.ErrorOnDupKey, a.dbConfig, deleteStmt)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute delete: %w", err)
 	}
@@ -763,7 +763,7 @@ func (a *SingleTargetApplier) UpsertRows(ctx context.Context, mapping *table.Col
 	}
 
 	// Execute as a retryable transaction
-	affectedRows, err := dbconn.RetryableTransaction(ctx, a.target.DB, false, a.dbConfig, upsertStmt)
+	affectedRows, err := dbconn.RetryableTransaction(ctx, a.target.DB, dbconn.ErrorOnDupKey, a.dbConfig, upsertStmt)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute upsert: %w", err)
 	}

--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -196,7 +196,7 @@ func (c *DistributedChecker) replaceChunk(ctx context.Context, chunk *table.Chun
 	targets := c.applier.GetTargets()
 	for i, target := range targets {
 		c.logger.Debug("deleting chunk range from target", "targetID", i, "chunk", chunk.String(), "table", chunk.Table.TableName)
-		_, err := dbconn.RetryableTransaction(fixCtx, target.DB, false, c.dbConfig, deleteStmt)
+		_, err := dbconn.RetryableTransaction(fixCtx, target.DB, dbconn.ErrorOnDupKey, c.dbConfig, deleteStmt)
 		if err != nil {
 			return fmt.Errorf("failed to delete chunk from target %d: %w", i, err)
 		}

--- a/pkg/checksum/recopier.go
+++ b/pkg/checksum/recopier.go
@@ -100,7 +100,7 @@ func (r *MySQLRecopier) Recopy(ctx context.Context, chunk *table.Chunk) error {
 	// NewTable holds the target-side table info; for sync (same logical
 	// table on both sides) NewTable.QuotedTableName == Table.QuotedTableName.
 	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE %s", chunk.NewTable.QuotedTableName, chunk.String())
-	if _, err := dbconn.RetryableTransaction(fixCtx, r.targetDB, false, r.dbConfig, deleteStmt); err != nil {
+	if _, err := dbconn.RetryableTransaction(fixCtx, r.targetDB, dbconn.ErrorOnDupKey, r.dbConfig, deleteStmt); err != nil {
 		return fmt.Errorf("delete target chunk range: %w", err)
 	}
 

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -283,10 +283,10 @@ func (c *SingleChecker) replaceChunk(ctx context.Context, chunk *table.Chunk) er
 	// against a hung transaction.
 	fixCtx, fixCancel := context.WithTimeout(context.WithoutCancel(ctx), fixChunkTimeout)
 	defer fixCancel()
-	if _, err := dbconn.RetryableTransaction(fixCtx, c.db, false, c.dbConfig, deleteStmt); err != nil {
+	if _, err := dbconn.RetryableTransaction(fixCtx, c.db, dbconn.ErrorOnDupKey, c.dbConfig, deleteStmt); err != nil {
 		return fmt.Errorf("failed to delete existing rows: %w", err)
 	}
-	if _, err := dbconn.RetryableTransaction(fixCtx, c.db, false, c.dbConfig, replaceStmt); err != nil {
+	if _, err := dbconn.RetryableTransaction(fixCtx, c.db, dbconn.ErrorOnDupKey, c.dbConfig, replaceStmt); err != nil {
 		return fmt.Errorf("failed to replace chunk data: %w", err)
 	}
 	return nil

--- a/pkg/copier/unbuffered.go
+++ b/pkg/copier/unbuffered.go
@@ -68,7 +68,7 @@ func (c *Unbuffered) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 	c.logger.Debug("running chunk", "chunk", chunk.String(), "query", query)
 	var affectedRows int64
 	var err error
-	if affectedRows, err = dbconn.RetryableTransaction(ctx, c.db, true, c.dbConfig, query); err != nil {
+	if affectedRows, err = dbconn.RetryableTransaction(ctx, c.db, dbconn.IgnoreDupKeyWarnings, c.dbConfig, query); err != nil {
 		return err
 	}
 	c.logger.Debug("CopyChunk completed",

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -149,9 +149,29 @@ func canRetryError(err error) bool {
 	}
 }
 
+// DupKeyHandling selects how RetryableTransaction treats duplicate-key (1062)
+// warnings. Copy / INSERT IGNORE paths legitimately expect dup-key warnings
+// (e.g. resume re-inserts); checksum-fix DELETE/REPLACE/UPSERT paths do not and
+// want them surfaced. Using a named int enum (rather than a bool) keeps call
+// sites self-documenting and stops a bare positional bool (true/false) from
+// compiling.
+type DupKeyHandling int
+
+const (
+	// ErrorOnDupKey surfaces duplicate-key warnings as errors.
+	ErrorOnDupKey DupKeyHandling = iota
+	// IgnoreDupKeyWarnings tolerates duplicate-key warnings.
+	IgnoreDupKeyWarnings
+)
+
 // RetryableTransaction retries all statements in a transaction, retrying if a statement
 // errors, or there is a deadlock. It will retry up to maxRetries times.
-func RetryableTransaction(ctx context.Context, db *sql.DB, ignoreDupKeyWarnings bool, config *DBConfig, stmts ...string) (int64, error) {
+func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKeyHandling, config *DBConfig, stmts ...string) (int64, error) {
+	switch dupKeyHandling {
+	case ErrorOnDupKey, IgnoreDupKeyWarnings:
+	default:
+		return 0, fmt.Errorf("RetryableTransaction: invalid DupKeyHandling value %d", dupKeyHandling)
+	}
 	var (
 		err          error
 		trx          *sql.Tx
@@ -207,7 +227,7 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, ignoreDupKeyWarnings 
 					// because a historical value like 0000-00-00 00:00:00
 					// might exist in the table and needs to be copied.
 					switch {
-					case code == errFoundDuppKey && ignoreDupKeyWarnings:
+					case code == errFoundDuppKey && dupKeyHandling == IgnoreDupKeyWarnings:
 						continue // ignore duplicate key warnings
 					case code == errCapacityExceeded:
 						// "Memory capacity of 8388608 bytes for 'range_optimizer_max_mem_size' exceeded.

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -77,18 +77,18 @@ func TestRetryableTrx(t *testing.T) {
 		"", // test empty
 		"INSERT INTO test.dbexec (id, colb) VALUES (2, 2)",
 	}
-	_, err = RetryableTransaction(t.Context(), db, true, NewDBConfig(), stmts...)
+	_, err = RetryableTransaction(t.Context(), db, IgnoreDupKeyWarnings, NewDBConfig(), stmts...)
 	require.NoError(t, err)
 
-	_, err = RetryableTransaction(t.Context(), db, true, NewDBConfig(), "INSERT INTO test.dbexec (id, colb) VALUES (2, 2)") // duplicate
+	_, err = RetryableTransaction(t.Context(), db, IgnoreDupKeyWarnings, NewDBConfig(), "INSERT INTO test.dbexec (id, colb) VALUES (2, 2)") // duplicate
 	require.Error(t, err)
 
-	// duplicate, but creates a warning. Ignore duplicate warnings set to true.
-	_, err = RetryableTransaction(t.Context(), db, true, NewDBConfig(), "INSERT IGNORE INTO test.dbexec (id, colb) VALUES (2, 2)")
+	// duplicate, but creates a warning; IgnoreDupKeyWarnings tolerates the dup-key warning.
+	_, err = RetryableTransaction(t.Context(), db, IgnoreDupKeyWarnings, NewDBConfig(), "INSERT IGNORE INTO test.dbexec (id, colb) VALUES (2, 2)")
 	require.NoError(t, err)
 
 	// duplicate, but warning not ignored
-	_, err = RetryableTransaction(t.Context(), db, false, NewDBConfig(), "INSERT IGNORE INTO test.dbexec (id, colb) VALUES (2, 2)")
+	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, NewDBConfig(), "INSERT IGNORE INTO test.dbexec (id, colb) VALUES (2, 2)")
 	require.Error(t, err)
 
 	// start a transaction, acquire a lock for long enough that the first attempt times out
@@ -107,7 +107,7 @@ func TestRetryableTrx(t *testing.T) {
 		err2 := trx.Rollback()
 		require.NoError(t, err2)
 	}()
-	_, err = RetryableTransaction(t.Context(), db, false, config, "UPDATE test.dbexec SET colb=123 WHERE id = 1")
+	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, config, "UPDATE test.dbexec SET colb=123 WHERE id = 1")
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
@@ -122,7 +122,7 @@ func TestRetryableTrx(t *testing.T) {
 	require.NoError(t, err)
 	_, err = trx.ExecContext(t.Context(), "SELECT * FROM test.dbexec WHERE id = 2 FOR UPDATE")
 	require.NoError(t, err)
-	_, err = RetryableTransaction(t.Context(), db, false, config, "UPDATE test.dbexec SET colb=123 WHERE id = 2") // this will fail, since it times out and exhausts retries.
+	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, config, "UPDATE test.dbexec SET colb=123 WHERE id = 2") // this will fail, since it times out and exhausts retries.
 	require.Error(t, err)
 	err = trx.Rollback() // now we can rollback.
 	require.NoError(t, err)
@@ -233,7 +233,7 @@ func testRetryableTrxSurvivesKill(t *testing.T, tableName, killStmtFmt string) {
 
 	// The first attempt is killed mid-statement. RetryableTransaction must
 	// classify the failure as retryable and succeed on a later attempt.
-	_, err = RetryableTransaction(t.Context(), db, false, config, updateStmt)
+	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, config, updateStmt)
 	<-killDone
 	require.NoError(t, err)
 

--- a/pkg/dbconn/trxpool_test.go
+++ b/pkg/dbconn/trxpool_test.go
@@ -31,7 +31,7 @@ func TestTrxPool(t *testing.T) {
 		"INSERT INTO test.trxpool (id, colb) VALUES (1, 1)",
 		"INSERT INTO test.trxpool (id, colb) VALUES (2, 2)",
 	}
-	_, err = RetryableTransaction(t.Context(), db, true, config, stmts...)
+	_, err = RetryableTransaction(t.Context(), db, IgnoreDupKeyWarnings, config, stmts...)
 	require.NoError(t, err)
 
 	// Test that the transaction pool is working.
@@ -40,7 +40,7 @@ func TestTrxPool(t *testing.T) {
 
 	// The pool is all repeatable-read transactions, so if I insert new rows
 	// They can't be visible.
-	_, err = RetryableTransaction(t.Context(), db, true, config, "INSERT INTO test.trxpool (id, colb) VALUES (3, 3)")
+	_, err = RetryableTransaction(t.Context(), db, IgnoreDupKeyWarnings, config, "INSERT INTO test.trxpool (id, colb) VALUES (3, 3)")
 	require.NoError(t, err)
 
 	trx1, err := pool.Get()


### PR DESCRIPTION
## What
`dbconn.RetryableTransaction`'s 3rd parameter was a bare positional `ignoreDupKeyWarnings bool`. Replaced it with a named `DupKeyHandling` enum (`ErrorOnDupKey` / `IgnoreDupKeyWarnings`).

## Why
A positional `bool` mid-signature is easy to transpose, and this one is a correctness lever: the copy / `INSERT IGNORE` paths legitimately tolerate duplicate-key (1062) warnings (e.g. resume re-inserts), while the checksum-fix `DELETE`/`REPLACE`/`UPSERT` paths must surface them. The enum makes every call site self-documenting and a raw bool literal no longer compiles.

## Change
Updated the signature and all call sites — 3 `IgnoreDupKeyWarnings` (was `true`) and 8 `ErrorOnDupKey` (was `false`) in production (`applier`, `checksum`, `copier`), plus the `dbconn` test call sites. Behavior is unchanged; only the parameter's type/spelling changes.

⚠️ Touches a core helper across 4 packages — please run the full MySQL CI suite before merge.

Verified locally: `go build ./...`, `go vet ./...`, `golangci-lint run` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
