### PR TITLE
move: --force wipe-and-restart recovery; datasync checkpoint-wrapper cleanup

### DIFF
--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -412,7 +412,7 @@ func (r *Runner) runCopyOnlyChecksum(ctx context.Context) error {
 func (r *Runner) runContinuous(ctx context.Context) error {
 	// status moves off CopyRows so the status goroutine logs the continuous
 	// phase. The checkpoint table and the periodic checkpoint loop were already
-	// set up before the copy (createCheckpointTable in startFresh/startResume,
+	// set up before the copy (checkpointTbl().Create in startFresh/startResume,
 	// the loop in startBackgroundRoutines), so a restart at any point — copy or
 	// continuous — resumes from the last checkpoint.
 	r.status.Set(status.ApplyChangeset)
@@ -1484,7 +1484,7 @@ func (r *Runner) DumpCheckpoint(ctx context.Context) error {
 	if chunker == nil {
 		return nil // copy pipeline not built yet; nothing to checkpoint
 	}
-	// Idempotent: createCheckpointTable uses CREATE TABLE IF NOT EXISTS, so
+	// Idempotent: Persistent-mode Create uses CREATE TABLE IF NOT EXISTS, so
 	// this is safe even in the brief window before startFresh/startResume has
 	// created the table.
 	err := r.checkpointTbl().Create(ctx)

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -1111,7 +1111,7 @@ func (r *Runner) startFresh(ctx context.Context) error {
 			return fmt.Errorf("failed to start change source: %w", err)
 		}
 	}
-	return r.createCheckpointTable(ctx)
+	return r.checkpointTbl().Create(ctx)
 }
 
 // startResume rebuilds the copy pipeline and opens the chunker at the
@@ -1158,7 +1158,7 @@ func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
 			return fmt.Errorf("failed to start change source: %w", err)
 		}
 	}
-	return r.createCheckpointTable(ctx)
+	return r.checkpointTbl().Create(ctx)
 }
 
 // checkpointTbl returns a handle to datasync's checkpoint table on the target.
@@ -1167,17 +1167,6 @@ func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
 // It always lives on the target because the source may be read-only.
 func (r *Runner) checkpointTbl() *checkpoint.Table {
 	return checkpoint.NewTable(r.target.DB, syncCheckpointTableName, checkpoint.Persistent)
-}
-
-// createCheckpointTable creates the checkpoint table on the target (always
-// the target, since the source may be read-only). It records the copier's low
-// watermark (resume point for a partial copy) and the change-feed position
-// (resume point for continuous sync).
-func (r *Runner) createCheckpointTable(ctx context.Context) error {
-	if err := r.checkpointTbl().Create(ctx); err != nil {
-		return fmt.Errorf("failed to create checkpoint table on target: %w", err)
-	}
-	return nil
 }
 
 // dumpCheckpoint records the copier's low watermark (so a partial copy can
@@ -1498,8 +1487,8 @@ func (r *Runner) DumpCheckpoint(ctx context.Context) error {
 	// Idempotent: createCheckpointTable uses CREATE TABLE IF NOT EXISTS, so
 	// this is safe even in the brief window before startFresh/startResume has
 	// created the table.
-	err := r.createCheckpointTable(ctx)
-	if err == nil {
+	err := r.checkpointTbl().Create(ctx)
+	if err == nil { // success
 		err = r.dumpCheckpoint(ctx)
 	}
 	// status.WatchTask treats a non-nil return here as fatal and cancels the

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -19,6 +19,11 @@ type Move struct {
 	CreateSentinel        bool          `name:"create-sentinel" help:"Create a sentinel table on the source database to block after table copy" default:"false"`
 	DeferSecondaryIndexes bool          `name:"defer-secondary-indexes" help:"Create target tables without secondary indexes, add them before cutover" default:"false"`
 	CheckpointMaxAge      time.Duration `name:"checkpoint-max-age" help:"Maximum age of a checkpoint before refusing to resume from it" optional:"" default:"168h"`
+	// Force makes the runner wipe the target tables and start the copy fresh when
+	// it cannot resume from a checkpoint (e.g. the checkpoint is from an
+	// incompatible spirit version, or the target is in a state resume can't
+	// validate). Without it, an unresumable non-empty target is a hard error.
+	Force bool `name:"force" help:"When the target cannot resume from a checkpoint, wipe the target tables and start the copy fresh instead of failing." default:"false"`
 
 	// EnableExperimentalGTID switches the change source from binlog file+position to MySQL GTIDs.
 	// EXPERIMENTAL — see pkg/change/gtid.go. Requires gtid_mode=ON and

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -573,6 +573,16 @@ func (r *Runner) setup(ctx context.Context) error {
 		if werr := r.wipeTargets(ctx); werr != nil {
 			return fmt.Errorf("force: failed to wipe target before a fresh copy: %w", werr)
 		}
+		// --force only overrides the target-not-empty decision — it must not
+		// bypass the other post-setup safety checks (rename_safety,
+		// source_schema_consistency, ...). Re-run them against the now-wiped
+		// target (target_state passes for the absent tables, exactly as a fresh
+		// move); abort if anything still fails rather than copying into a state
+		// that would only fail at cutover. RunChecks iterates a map, so the
+		// original failure was not necessarily target_state.
+		if err := r.runChecks(ctx, check.ScopePostSetup); err != nil {
+			return fmt.Errorf("force: target still fails post-setup checks after wiping: %w", err)
+		}
 		return r.newCopy(ctx)
 	}
 	// The post-setup checks returned no errors so we can proceed with new copy

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -552,21 +552,65 @@ func (r *Runner) setup(ctx context.Context) error {
 
 	// Run post-setup checks
 	if err = r.runChecks(ctx, check.ScopePostSetup); err != nil {
-		// The checks returned an error, which could just mean that tables exist
-		// on the target. So we can switch tactics and check if these artifacts
-		// pass the tests to resume from checkpoint instead.
-		if resumeErr := r.runChecks(ctx, check.ScopeResume); resumeErr != nil {
-			return fmt.Errorf("target state is invalid for both new copy and resume: new_copy_error=%w, resume_error=%w", err, resumeErr)
+		// New-copy checks failed — usually because tables already exist on the
+		// target. Resume if we can; otherwise --force wipes the target and starts
+		// fresh, and without it this is a hard error.
+		resumable, probeErr := r.canResumeFromCheckpoint(ctx)
+		if probeErr != nil {
+			return probeErr // the probe itself failed transiently — don't wipe on a blip
 		}
-		// We pass the pre-check for resume, so attempt it
-		if err := r.resumeFromCheckpoint(ctx); err != nil {
-			return fmt.Errorf("resume validation passed but checkpoint resume failed: %w", err)
+		if resumable {
+			if resumeErr := r.resumeFromCheckpoint(ctx); resumeErr != nil {
+				return fmt.Errorf("resume validation passed but checkpoint resume failed: %w", resumeErr)
+			}
+			r.logger.Info("Successfully resumed move from existing checkpoint")
+			return nil
 		}
-		r.logger.Info("Successfully resumed move from existing checkpoint")
-		return nil
+		if !r.move.Force {
+			return fmt.Errorf("target state is invalid for both new copy and resume (re-run with --force to wipe the target and start fresh): %w", err)
+		}
+		r.logger.Warn("force set and the target cannot resume; wiping target tables and starting fresh")
+		if werr := r.wipeTargets(ctx); werr != nil {
+			return fmt.Errorf("force: failed to wipe target before a fresh copy: %w", werr)
+		}
+		return r.newCopy(ctx)
 	}
 	// The post-setup checks returned no errors so we can proceed with new copy
 	return r.newCopy(ctx)
+}
+
+// canResumeFromCheckpoint reports whether the move can resume from the target's
+// existing checkpoint: the resume pre-checks pass and the checkpoint is readable
+// with this version's schema. A non-nil error means the probe itself failed
+// transiently (don't act on it). (false, nil) means "not resumable" — the caller
+// decides whether that is fatal or, under --force, a cue to wipe and start fresh.
+func (r *Runner) canResumeFromCheckpoint(ctx context.Context) (bool, error) {
+	if err := r.runChecks(ctx, check.ScopeResume); err != nil {
+		r.logger.Info("resume pre-checks failed", "reason", err)
+		return false, nil
+	}
+	if _, err := r.checkpointTbl().ReadLatest(ctx); err != nil {
+		// No usable checkpoint (missing row, or a layout this version can't read).
+		if errors.Is(err, checkpoint.ErrNotFound) || checkpoint.IsIncompatible(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not read checkpoint to decide resume: %w", err)
+	}
+	return true, nil
+}
+
+// wipeTargets drops the move's target tables (on every target) and the
+// checkpoint table, so a fresh copy can proceed. Used by --force when the target
+// cannot resume. The source — including any sentinel — is left untouched.
+func (r *Runner) wipeTargets(ctx context.Context) error {
+	for i := range r.targets {
+		for _, t := range r.sourceTables {
+			if err := dbconn.Exec(ctx, r.targets[i].DB, "DROP TABLE IF EXISTS %n", t.TableName); err != nil {
+				return fmt.Errorf("drop target table %q on target %d: %w", t.TableName, i, err)
+			}
+		}
+	}
+	return r.checkpointTbl().Drop(ctx) // Transient → DROP TABLE IF EXISTS
 }
 
 func (r *Runner) newCopy(ctx context.Context) error {

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -471,7 +471,10 @@ func TestMoveForceWipesUnresumableTarget(t *testing.T) {
 	// checkpoint table from an incompatible version (old binlog_positions column,
 	// which this version's read can't find).
 	testutils.RunSQL(t, "CREATE TABLE "+dstDB+".t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50) NOT NULL)")
-	testutils.RunSQL(t, "INSERT INTO "+dstDB+".t1 (name) VALUES ('stale')")
+	// id 999 is outside the source's 1..5: a mere overlay (upsert) of the source
+	// rows would leave this row behind, so its absence after --force proves the
+	// table was actually dropped and recreated.
+	testutils.RunSQL(t, "INSERT INTO "+dstDB+".t1 (id, name) VALUES (999, 'stale')")
 	testutils.RunSQL(t, "CREATE TABLE "+dstDB+"._spirit_checkpoint (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, copier_watermark TEXT, checksum_watermark TEXT, binlog_positions TEXT, statement TEXT, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)")
 	testutils.RunSQL(t, "INSERT INTO "+dstDB+"._spirit_checkpoint (copier_watermark, binlog_positions) VALUES ('stale-wm', '{}')")
 
@@ -501,6 +504,11 @@ func TestMoveForceWipesUnresumableTarget(t *testing.T) {
 	var count int
 	require.NoError(t, targetDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM t1").Scan(&count))
 	require.Equal(t, 5, count, "force must wipe the stale data and re-copy the source")
+	// The out-of-range stale row must be gone — proving a drop+recreate, not an
+	// overlay of the source onto the existing table.
+	var stale int
+	require.NoError(t, targetDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM t1 WHERE id = 999 OR name = 'stale'").Scan(&stale))
+	require.Zero(t, stale, "force must drop+recreate the target, not overlay the source onto stale rows")
 }
 
 // TestMoveWithVarcharPK verifies a move on a table with a non-memory-comparable

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -449,6 +449,60 @@ func TestMoveResumeDeletesAboveWatermark(t *testing.T) {
 	require.Equal(t, 5, count)
 }
 
+// TestMoveForceWipesUnresumableTarget verifies --force recovery: when the target
+// is non-empty but cannot be resumed (here a checkpoint table from an
+// incompatible spirit version — the old binlog_positions column), a normal run
+// fails and points at --force, and --force wipes the target tables + checkpoint
+// and copies fresh.
+func TestMoveForceWipesUnresumableTarget(t *testing.T) {
+	srcDB := "source_force_wipe"
+	dstDB := "dest_force_wipe"
+	sourceDSN := testutils.DSNForDatabase(srcDB)
+	targetDSN := testutils.DSNForDatabase(dstDB)
+
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+srcDB)
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+dstDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+srcDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+dstDB)
+	testutils.RunSQL(t, "CREATE TABLE "+srcDB+".t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50) NOT NULL)")
+	testutils.RunSQL(t, "INSERT INTO "+srcDB+".t1 (name) VALUES ('a'),('b'),('c'),('d'),('e')")
+
+	// Target already holds the table with stale data (a prior partial run) plus a
+	// checkpoint table from an incompatible version (old binlog_positions column,
+	// which this version's read can't find).
+	testutils.RunSQL(t, "CREATE TABLE "+dstDB+".t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50) NOT NULL)")
+	testutils.RunSQL(t, "INSERT INTO "+dstDB+".t1 (name) VALUES ('stale')")
+	testutils.RunSQL(t, "CREATE TABLE "+dstDB+"._spirit_checkpoint (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, copier_watermark TEXT, checksum_watermark TEXT, binlog_positions TEXT, statement TEXT, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)")
+	testutils.RunSQL(t, "INSERT INTO "+dstDB+"._spirit_checkpoint (copier_watermark, binlog_positions) VALUES ('stale-wm', '{}')")
+
+	newMove := func(force bool) *Move {
+		return &Move{
+			SourceDSN:       sourceDSN,
+			TargetDSN:       targetDSN,
+			TargetChunkTime: 100 * time.Millisecond,
+			Threads:         2,
+			WriteThreads:    2,
+			Force:           force,
+		}
+	}
+
+	// Without --force: an unresumable non-empty target is a hard error that
+	// points the operator at --force.
+	err := newMove(false).Run()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--force")
+
+	// With --force: wipe the stale target + checkpoint and copy the source fresh.
+	require.NoError(t, newMove(true).Run())
+
+	targetDB, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+	var count int
+	require.NoError(t, targetDB.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM t1").Scan(&count))
+	require.Equal(t, 5, count, "force must wipe the stale data and re-copy the source")
+}
+
 // TestMoveWithVarcharPK verifies a move on a table with a non-memory-comparable
 // primary key (VARCHAR with a CI collation) — the case from issue #607. The
 // move runs under concurrent writes to exercise the binlog replay path.


### PR DESCRIPTION
## What

Two follow-ups on top of the `pkg/checkpoint` extraction (#999):

1. **move `--force` recovery** — wipe-and-restart when the target can't resume.
2. **datasync cleanup** — drop the thin `createCheckpointTable` wrapper.


## move `--force` recovery

When move can't resume from a checkpoint — the resume pre-checks fail, or the checkpoint is missing/unreadable (e.g. written by an incompatible spirit version after the format change) — `--force` wipes the target tables + checkpoint and copies fresh. Without it, an unresumable non-empty target stays a hard error that now names `--force`.

The decision is made **before** `resumeFromCheckpoint` mutates anything, and only on a genuinely-unusable checkpoint: `checkpoint.IsIncompatible` distinguishes an incompatible checkpoint from a transient read error, so a blip never triggers a destructive wipe. Mirrors datasync's `--force` — datasync drops the whole target database; move drops only its own target tables + checkpoint, since the target DB may hold unrelated tables.

## datasync cleanup

Removes the one-line `createCheckpointTable` wrapper, calling `r.checkpointTbl().Create(ctx)` directly at its three call sites (matching how migration and move already do it), and updates the comments that referenced the old function name.

## Testing

All under `-race`: `TestMoveForceWipesUnresumableTarget` (a no-force run errors and names `--force`; `--force` wipes the stale target + checkpoint and re-copies), move resume E2E, and the full datasync suite (resume, no-watermark-row, force, incompatible-checkpoint recovery, copy-only). Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
