### PR TITLE
test: replace sleep-based waits with require.Eventually (easy cases)

### DIFF
--- a/pkg/migration/helpers_test.go
+++ b/pkg/migration/helpers_test.go
@@ -42,15 +42,10 @@ func mkIniFile(t *testing.T, content string) string {
 // tighter budget produces spurious timeouts (see issue #946).
 func waitForStatus(t *testing.T, m *Runner, target status.State) {
 	t.Helper()
-	timeout := time.After(60 * time.Second)
-	for m.status.Get() < target {
-		select {
-		case <-timeout:
-			t.Fatalf("timeout waiting for status >= %s, current status: %s", target, m.status.Get())
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
+	require.Eventually(t, func() bool {
+		return m.status.Get() >= target
+	}, 60*time.Second, 10*time.Millisecond,
+		"timeout waiting for status >= %s, last status: %s", target, m.status.Get())
 }
 
 // RunnerOption is a functional option for configuring a test Runner.

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,16 +30,12 @@ import (
 // successful checkpoint.
 func waitForCheckpoint(t *testing.T, runner *Runner) {
 	t.Helper()
-	for runner.status.Get() < status.CopyRows {
-		time.Sleep(time.Millisecond)
-	}
-	for {
-		err := runner.DumpCheckpoint(t.Context())
-		if err == nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	require.Eventually(t, func() bool {
+		return runner.status.Get() >= status.CopyRows
+	}, 60*time.Second, time.Millisecond, "timeout waiting for status >= copyRows")
+	require.Eventually(t, func() bool {
+		return runner.DumpCheckpoint(t.Context()) == nil
+	}, 30*time.Second, 10*time.Millisecond, "timeout waiting for first successful checkpoint")
 }
 
 // Test int to bigint primary key while resuming from checkpoint.
@@ -188,8 +185,11 @@ func TestCheckpoint(t *testing.T) {
 	require.NoError(t, ccopier.CopyChunk(t.Context(), chunk1))
 	require.NoError(t, ccopier.CopyChunk(t.Context(), chunk3))
 
-	time.Sleep(time.Second) // wait for status to be updated.
-	require.Contains(t, r.Status(), `migration status: state=copyRows copy-progress=3000/11040 27.17% binlog-deltas=0`)
+	// The status update is asynchronous (the applier phones home after each
+	// chunk completes), so poll until it reflects all three copied chunks.
+	require.Eventually(t, func() bool {
+		return strings.Contains(r.Status(), `migration status: state=copyRows copy-progress=3000/11040 27.17% binlog-deltas=0`)
+	}, 10*time.Second, 50*time.Millisecond, "status never reached expected copy progress; last status: %s", r.Status())
 
 	// The watermark should exist now, because migrateChunk()
 	// gives feedback back to table.


### PR DESCRIPTION
## What

The first pass at moving the test suite off fixed `time.Sleep` waits and onto `require.Eventually`. Scoped deliberately to the **easy, low-risk cases**: a sleep that exists only to wait for an observable condition that is then asserted. Three sites, two of them shared helpers:

| Site | Before | After |
|------|--------|-------|
| `waitForStatus` (helpers_test.go) | `time.After` + `for { select … time.Sleep(10ms) }` | `require.Eventually(status >= target, 60s, 10ms)` |
| `waitForCheckpoint` (resume_test.go) | **two unbounded** `for { … time.Sleep }` loops (no timeout) | two bounded `require.Eventually` |
| `TestCheckpoint` (resume_test.go) | `time.Sleep(1s)` then assert status string | poll the status string until it matches |

`waitForStatus` and `waitForCheckpoint` each back many tests, so this is a broad behavioural improvement from a small diff.

## Why

- **Adds missing timeouts.** `waitForCheckpoint` previously had two `for { … }` loops with *no* timeout — if status never advanced or `DumpCheckpoint` never succeeded, the test hung until the suite-level deadline. `require.Eventually` gives each loop an explicit bound and a clear failure message.
- **Faster + less flaky.** Polling returns as soon as the condition holds instead of always paying a fixed sleep; the bound is generous so it doesn't trade away robustness under CI load.
- **Clearer intent.** The wait condition is now stated directly rather than implied by a magic duration.

`TestCheckpoint` only copies three chunks manually (no background copier is running), so the progress value is fixed at `3000/11040` — the poll converges and cannot overshoot the asserted string.

## Deliberately left alone

These `time.Sleep` calls are **not** condition-waits and were intentionally skipped — they encode real timing semantics that `require.Eventually` cannot express:

- **Load-generation pacing** — `for … { write; time.Sleep(1ms) }` writer loops (datatype, subscription, move write threads).
- **Hold-then-release** — acquire a `FOR UPDATE` lock, sleep, roll back to exercise retry-on-lock-wait (copier, dbconn).
- **Precise inter-event timing** — e.g. move/cutover sleeps `1.5 × renameRetryWait` to land a DROP *between* two rename attempts.
- **Flip-a-flag-then-measure** — throttler/sentinel set a value after a delay and measure the reaction latency.
- **Stay-valid-over-time sampling** — metadatalock asserts a lock is *never* dropped across a window (that's `require.Never`-shaped, not `Eventually`).
- **"Give X a moment to start" coordination** — no single observable condition to key on.

## Possible follow-up

The single most common remaining pattern is the in-goroutine `for m.status.Get() < status.CopyRows { time.Sleep(1ms) }` guard (~12 occurrences) used by concurrent-DML load generators. Converting those isn't a drop-in `require.Eventually`: testify assertions in a non-test goroutine are flagged by `testifylint` (go-require), so they'd need a small non-asserting `waitForCopyRows(ctx, …)` helper instead. Left for a separate change.

## Test plan

- `go vet ./pkg/migration/` and `go vet -tags singleversion ./pkg/migration/` — clean under both build tags.
- `go test -tags singleversion -run 'TestCheckpoint$|TestChangeIntToBigIntPKResumeFromChkPt$'` — pass (validates the `TestCheckpoint` poll + `waitForCheckpoint`).
- `go test -run 'TestDeferCutOver$|TestContinuousChecksumDivergenceClearsCheckpointWatermark$|TestMultiTableMigrationBlockedPerSchema$'` — pass (validates `waitForStatus`).