### PR TITLE
ci: add govulncheck dependency vulnerability scanning

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,29 @@
+name: govulncheck
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  schedule:
+    # Weekly on Monday 08:00 UTC. govulncheck reads from the Go vuln DB at
+    # runtime, so this catches newly-disclosed vulnerabilities in existing
+    # dependencies even when no code has changed.
+    - cron: "0 8 * * 1"
+permissions:
+  contents: read
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...


### PR DESCRIPTION
## What

Adds a `govulncheck` CI workflow that scans the dependency tree for known vulnerabilities.

## Why

The repo has a strong test/version CI matrix and linter setup, but no automated supply-chain / vulnerability scanning. `govulncheck` closes that gap with effectively zero noise: it performs call-graph reachability analysis, so it only reports vulnerabilities in code paths the binary actually calls.

## Details

- Runs on every PR and push to `main`/`master`.
- Weekly scheduled run (Mon 08:00 UTC) catches newly-disclosed vulns in existing deps even when nothing has changed — `govulncheck` reads the Go vuln DB at runtime.
- Uses Go 1.26, matching `go.mod` and the existing lint workflow. (Uses `actions/setup-go@v5` rather than the `@v3` in `linter.yml`, since v3 is deprecated.)

## Verification

Ran locally against the current tree:

```
No vulnerabilities found.
```

So this merges green; it only goes red when a reachable vuln is actually introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)