### PR TITLE
ci: add Dependabot config for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      # Wait 7 days after a release before opening an update PR, giving a
+      # compromised or broken version time to be caught and yanked before
+      # automation pulls it in.
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       # Batch minor/patch bumps into a single PR to reduce noise. Major bumps
@@ -21,6 +26,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       actions-minor-patch:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Go module dependencies.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # Batch minor/patch bumps into a single PR to reduce noise. Major bumps
+      # are excluded from the group so each gets its own PR for careful review.
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in .github/workflows/.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` enabling weekly Dependabot version updates for two ecosystems:

- **`gomod`** — the Go dependency tree
- **`github-actions`** — actions used in the workflows (e.g. this will flag the deprecated `actions/setup-go@v3` in `linter.yml`)

## Why

Pairs with the govulncheck gate (#1002): govulncheck tells you when a dependency has a *known vulnerability*; Dependabot keeps deps current so you're less likely to be sitting on one in the first place.

## Noise control

- Minor/patch bumps are **grouped into a single PR per ecosystem**, so a routine week is one PR, not ten.
- Major bumps are excluded from the group and get their own PR for individual review.
- `open-pull-requests-limit: 5` per ecosystem.
- Nothing auto-merges — every bump is a reviewable PR.

If the pinned forks (`go-mysql`, `pingcap/*`) turn out to generate noisy bumps, an `ignore:` entry per module is a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)