### PR TITLE
refactor: unify MySQL identifier quoting into sqlescape.EscapeIdentifier

### DIFF
--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/spirit/pkg/checksum"
 	"github.com/block/spirit/pkg/copier"
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/status"
@@ -763,7 +764,7 @@ func (r *Runner) checkTargetEmpty(ctx context.Context) error {
 	for _, t := range r.sourceTables {
 		var dummy int
 		err := r.target.DB.QueryRowContext(ctx,
-			fmt.Sprintf("SELECT 1 FROM `%s`.`%s` LIMIT 1", r.target.Config.DBName, t.TableName)).Scan(&dummy)
+			fmt.Sprintf("SELECT 1 FROM %s.%s LIMIT 1", sqlescape.EscapeIdentifier(r.target.Config.DBName), sqlescape.EscapeIdentifier(t.TableName))).Scan(&dummy)
 		if errors.Is(err, sql.ErrNoRows) {
 			continue // table exists but is empty
 		}

--- a/pkg/dbconn/sqlescape/utils.go
+++ b/pkg/dbconn/sqlescape/utils.go
@@ -88,6 +88,16 @@ func EscapeString(s string) string {
 	return string(escapeStringBackslash(buf, s))
 }
 
+// EscapeIdentifier quotes a MySQL identifier (table, column, index name, ...)
+// by wrapping it in backticks and doubling any embedded backtick, per MySQL's
+// identifier-quoting rules. It is the standalone form of the %n verb used by
+// EscapeSQL, and the single source of truth for identifier quoting across
+// spirit — prefer it over open-coding "`"+s+"`", which produces broken SQL
+// (or allows a quoting break-out) when s contains a backtick.
+func EscapeIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+}
+
 // escapeStringBackslash will escape string into the buffer, with backslash.
 func escapeStringBackslash(buf []byte, v string) []byte {
 	return escapeBytesBackslash(buf, []byte(v))
@@ -122,9 +132,7 @@ func escapeSQL(sql string, args ...any) ([]byte, error) {
 			if !ok {
 				return nil, errors.Errorf("expect a string identifier, got %v", arg)
 			}
-			buf = append(buf, '`')
-			buf = append(buf, strings.ReplaceAll(v, "`", "``")...)
-			buf = append(buf, '`')
+			buf = append(buf, EscapeIdentifier(v)...)
 			i++ // skip specifier
 		case '?':
 			if argPos >= len(args) {

--- a/pkg/dbconn/sqlescape/utils.go
+++ b/pkg/dbconn/sqlescape/utils.go
@@ -95,7 +95,19 @@ func EscapeString(s string) string {
 // spirit — prefer it over open-coding "`"+s+"`", which produces broken SQL
 // (or allows a quoting break-out) when s contains a backtick.
 func EscapeIdentifier(identifier string) string {
-	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+	return string(appendEscapedIdentifier(make([]byte, 0, len(identifier)+2), identifier))
+}
+
+// appendEscapedIdentifier appends identifier to buf as a backtick-quoted MySQL
+// identifier, doubling any embedded backtick. It is the single implementation
+// of identifier quoting — both EscapeIdentifier and the EscapeSQL %n verb use
+// it. strings.ReplaceAll returns its input unchanged when there is no backtick,
+// so the common case appends straight to buf with no extra allocation, keeping
+// the %n verb on its zero-allocation hot path.
+func appendEscapedIdentifier(buf []byte, identifier string) []byte {
+	buf = append(buf, '`')
+	buf = append(buf, strings.ReplaceAll(identifier, "`", "``")...)
+	return append(buf, '`')
 }
 
 // escapeStringBackslash will escape string into the buffer, with backslash.
@@ -132,7 +144,7 @@ func escapeSQL(sql string, args ...any) ([]byte, error) {
 			if !ok {
 				return nil, errors.Errorf("expect a string identifier, got %v", arg)
 			}
-			buf = append(buf, EscapeIdentifier(v)...)
+			buf = appendEscapedIdentifier(buf, v)
 			i++ // skip specifier
 		case '?':
 			if argPos >= len(args) {

--- a/pkg/dbconn/sqlescape/utils_test.go
+++ b/pkg/dbconn/sqlescape/utils_test.go
@@ -463,6 +463,25 @@ func TestEscapeString(t *testing.T) {
 	}
 }
 
+func TestEscapeIdentifier(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"foo", "`foo`"},
+		{"", "``"},
+		{"foo`bar", "`foo``bar`"},
+		{"`", "````"}, // open + doubled backtick + close = 4 backticks
+		{"a`b`c", "`a``b``c`"},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, EscapeIdentifier(tc.in), "input=%q", tc.in)
+	}
+	// EscapeIdentifier must agree with the %n verb, which now delegates to it.
+	out, err := EscapeSQL("use %n", "foo`bar")
+	require.NoError(t, err)
+	require.Equal(t, "use "+EscapeIdentifier("foo`bar"), out)
+}
+
 func BenchmarkEscapeString(b *testing.B) {
 	for b.Loop() {
 		escapeSQL("select %?", "3") //nolint:errcheck

--- a/pkg/dbconn/tablelock.go
+++ b/pkg/dbconn/tablelock.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/table"
 )
 
@@ -38,7 +39,7 @@ func NewTableLock(ctx context.Context, db *sql.DB, tables []*table.TableInfo, co
 		if idx > 0 {
 			builder.WriteString(", ")
 		}
-		builder.WriteString("`" + tbl.TableName + "` WRITE")
+		builder.WriteString(sqlescape.EscapeIdentifier(tbl.TableName) + " WRITE")
 	}
 	lockStmt := builder.String()
 

--- a/pkg/fmt/fmt.go
+++ b/pkg/fmt/fmt.go
@@ -72,7 +72,7 @@ func (cmd *FmtCmd) Run() error {
 	}
 
 	// Ensure the working database exists.
-	if _, err := bootstrapDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", cmd.Database)); err != nil {
+	if _, err := bootstrapDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", sqlescape.EscapeIdentifier(cmd.Database))); err != nil {
 		return fmt.Errorf("failed to create database %s: %w", cmd.Database, err)
 	}
 

--- a/pkg/lint/lint_unsafe.go
+++ b/pkg/lint/lint_unsafe.go
@@ -2,8 +2,8 @@ package lint
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 )
@@ -136,7 +136,7 @@ func unsafeDropColumnViolation(l *UnsafeLinter, tableName string, spec *ast.Alte
 	if spec.OldColumnName != nil {
 		columnName := spec.OldColumnName.Name.O
 		location.Column = &columnName
-		message += " " + quoteUnsafeIdentifier(columnName)
+		message += " " + sqlescape.EscapeIdentifier(columnName)
 	}
 
 	return Violation{
@@ -145,8 +145,4 @@ func unsafeDropColumnViolation(l *UnsafeLinter, tableName string, spec *ast.Alte
 		Message:  message,
 		Severity: SeverityError,
 	}
-}
-
-func quoteUnsafeIdentifier(identifier string) string {
-	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
 }

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/block/spirit/pkg/change"
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 )
@@ -255,7 +256,7 @@ func (c *CutOver) algorithmRenameUnderLock(ctx context.Context) error {
 	renameFragments := []string{}
 	for _, cfg := range c.config {
 		tablesToLock = append(tablesToLock, cfg.table, cfg.newTable)
-		oldQuotedName := fmt.Sprintf("`%s`", cfg.oldTableName)
+		oldQuotedName := sqlescape.EscapeIdentifier(cfg.oldTableName)
 		renameFragments = append(renameFragments,
 			fmt.Sprintf("%s TO %s", cfg.table.QuotedTableName, oldQuotedName),
 			fmt.Sprintf("%s TO %s", cfg.newTable.QuotedTableName, cfg.table.QuotedTableName),
@@ -320,7 +321,7 @@ func (c *CutOver) partialRenameForTest(ctx context.Context) error {
 	// but only include the first rename (original -> _old)
 	for _, cfg := range c.config {
 		tablesToLock = append(tablesToLock, cfg.table, cfg.newTable)
-		oldQuotedName := fmt.Sprintf("`%s`", cfg.oldTableName)
+		oldQuotedName := sqlescape.EscapeIdentifier(cfg.oldTableName)
 		// Only add the first rename: original table -> _old
 		// Intentionally skip the second rename: _new -> original
 		renameFragments = append(renameFragments,

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/checksum"
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/migration/check"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
@@ -185,7 +186,7 @@ func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, er
 		// Trim whitespace and remove trailing semicolon. Without this, the attemptInstantDDL and attemptInplaceDDL functions will fail.
 		m.Alter = strings.TrimSpace(m.Alter)
 		m.Alter = strings.TrimSuffix(m.Alter, ";")
-		fullStatement := fmt.Sprintf("ALTER TABLE `%s` %s", m.Table, m.Alter)
+		fullStatement := fmt.Sprintf("ALTER TABLE %s %s", sqlescape.EscapeIdentifier(m.Table), m.Alter)
 		m.Statement = fullStatement // used in resume from checkpoint
 		p := parser.New()
 		stmtNodes, _, err := p.Parse(fullStatement, "", "")

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/block/spirit/pkg/checksum"
 	"github.com/block/spirit/pkg/copier"
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/lint"
 	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/migration/check"
@@ -603,10 +603,7 @@ func (r *Runner) lint(ctx context.Context) error {
 }
 
 func (r *Runner) getCreateTable(ctx context.Context, db string, tbl string) (*statement.CreateTable, error) {
-	// Escape backticks in db and tbl names to be extra pedantic
-	db = strings.ReplaceAll(db, "`", "``")
-	tbl = strings.ReplaceAll(tbl, "`", "``")
-	sql := fmt.Sprintf("show create table `%s`.`%s`", db, tbl)
+	sql := fmt.Sprintf("show create table %s.%s", sqlescape.EscapeIdentifier(db), sqlescape.EscapeIdentifier(tbl))
 
 	row := r.db.QueryRowContext(ctx, sql)
 	var createTable string

--- a/pkg/move/check/target_state.go
+++ b/pkg/move/check/target_state.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 )
@@ -75,7 +76,7 @@ func validateExistingTargetTable(ctx context.Context, target applier.Target, tab
 	// Check 1: Table must have zero rows
 	// Use LIMIT 1 instead of COUNT(*) for performance - we only need to know if there's at least one row
 	var hasRows int
-	err := target.DB.QueryRowContext(ctx, fmt.Sprintf("SELECT 1 FROM `%s`.`%s` LIMIT 1", target.Config.DBName, tableName)).Scan(&hasRows)
+	err := target.DB.QueryRowContext(ctx, fmt.Sprintf("SELECT 1 FROM %s.%s LIMIT 1", sqlescape.EscapeIdentifier(target.Config.DBName), sqlescape.EscapeIdentifier(tableName))).Scan(&hasRows)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("failed to check if table '%s' on target %d is empty: %w", tableName, targetIndex, err)
 	}

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/block/spirit/pkg/change"
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/move/check"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
@@ -212,7 +213,7 @@ func (c *CutOver) renameAllSources(ctx context.Context, sourceLocks []*dbconn.Ta
 	for i, src := range c.sources {
 		renameFragments := make([]string, 0, len(src.Tables))
 		for _, tbl := range src.Tables {
-			oldQuotedName := fmt.Sprintf("`%s`", check.CutoverOldName(tbl.TableName))
+			oldQuotedName := sqlescape.EscapeIdentifier(check.CutoverOldName(tbl.TableName))
 			renameFragments = append(renameFragments,
 				fmt.Sprintf("%s TO %s", tbl.QuotedTableName, oldQuotedName),
 			)
@@ -225,7 +226,7 @@ func (c *CutOver) renameAllSources(ctx context.Context, sourceLocks []*dbconn.Ta
 			for _, j := range completedRenames {
 				undoFragments := make([]string, 0, len(c.sources[j].Tables))
 				for _, tbl := range c.sources[j].Tables {
-					oldQuotedName := fmt.Sprintf("`%s`", check.CutoverOldName(tbl.TableName))
+					oldQuotedName := sqlescape.EscapeIdentifier(check.CutoverOldName(tbl.TableName))
 					undoFragments = append(undoFragments,
 						fmt.Sprintf("%s TO %s", oldQuotedName, tbl.QuotedTableName),
 					)

--- a/pkg/statement/declarative.go
+++ b/pkg/statement/declarative.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/table"
 	"github.com/pingcap/tidb/pkg/parser/format"
 )
@@ -75,7 +76,7 @@ func DeclarativeToImperative(current, desired []table.TableSchema, opts *DiffOpt
 	slices.Sort(dropNames)
 
 	for _, name := range dropNames {
-		stmts, err := New(fmt.Sprintf("DROP TABLE `%s`", name))
+		stmts, err := New(fmt.Sprintf("DROP TABLE %s", sqlescape.EscapeIdentifier(name)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse DROP TABLE for %q: %w", name, err)
 		}

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -139,7 +139,7 @@ func (ct *CreateTable) Diff(target *CreateTable, opts *DiffOptions) ([]*Abstract
 // buildAlterStatement constructs and parses an ALTER TABLE statement from clauses.
 func (ct *CreateTable) buildAlterStatement(clauses []string) (*AbstractStatement, error) {
 	alter := strings.Join(clauses, ", ")
-	alterStmt := fmt.Sprintf("ALTER TABLE %s %s", quoteIdent(ct.TableName), alter)
+	alterStmt := fmt.Sprintf("ALTER TABLE %s %s", sqlescape.EscapeIdentifier(ct.TableName), alter)
 
 	p := parser.New()
 	stmtNodes, _, err := p.Parse(alterStmt, "", "")
@@ -186,7 +186,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []str
 	var dropClauses []string
 	for _, sourceCol := range ct.Columns {
 		if _, exists := targetColumns[strings.ToLower(sourceCol.Name)]; !exists {
-			dropClauses = append(dropClauses, fmt.Sprintf("DROP COLUMN %s", quoteIdent(sourceCol.Name)))
+			dropClauses = append(dropClauses, fmt.Sprintf("DROP COLUMN %s", sqlescape.EscapeIdentifier(sourceCol.Name)))
 		}
 	}
 	slices.Sort(dropClauses)
@@ -211,7 +211,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []str
 			if prevColumn == "" {
 				clause += " FIRST"
 			} else if !isLastColumn {
-				clause += fmt.Sprintf(" AFTER %s", quoteIdent(prevColumn))
+				clause += fmt.Sprintf(" AFTER %s", sqlescape.EscapeIdentifier(prevColumn))
 			}
 			// If it's the last column, omit AFTER clause (implicit)
 			clauses = append(clauses, clause)
@@ -244,7 +244,7 @@ func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []str
 					if prevColumn == "" {
 						clause += " FIRST"
 					} else {
-						clause += fmt.Sprintf(" AFTER %s", quoteIdent(prevColumn))
+						clause += fmt.Sprintf(" AFTER %s", sqlescape.EscapeIdentifier(prevColumn))
 					}
 				}
 				clauses = append(clauses, clause)
@@ -373,7 +373,7 @@ func (ct *CreateTable) diffPrimaryKey(target *CreateTable, sourceColumns, target
 			// 2. Source has table-level PK and target has inline PK (table-level -> inline transition)
 			if sourcePKIndex == nil || (sourcePKIndex != nil && targetPKIndex == nil) {
 				pkColumn = targetCol.Name
-				addClause = fmt.Sprintf("ADD PRIMARY KEY (%s)", quoteIdent(pkColumn))
+				addClause = fmt.Sprintf("ADD PRIMARY KEY (%s)", sqlescape.EscapeIdentifier(pkColumn))
 				break
 			}
 		}
@@ -492,7 +492,7 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 					pkDropAdded = true
 				}
 			} else {
-				dropClauses = append(dropClauses, fmt.Sprintf("DROP INDEX %s", quoteIdent(sourceIdx.Name)))
+				dropClauses = append(dropClauses, fmt.Sprintf("DROP INDEX %s", sqlescape.EscapeIdentifier(sourceIdx.Name)))
 			}
 		} else if !indexesEqual(sourceIdx, targetIdx) && !indexesEqualIgnoreVisibility(sourceIdx, targetIdx) {
 			// Index exists but changed (and not just visibility) - need to drop and re-add
@@ -510,11 +510,11 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 				// MySQL will actually apply.
 				optionOnlyChanged[sourceIdx.Name] = true
 				separateStatements = append(separateStatements,
-					[]string{fmt.Sprintf("DROP INDEX %s", quoteIdent(sourceIdx.Name))},
+					[]string{fmt.Sprintf("DROP INDEX %s", sqlescape.EscapeIdentifier(sourceIdx.Name))},
 					[]string{formatAddIndex(targetIdx)},
 				)
 			default:
-				dropClauses = append(dropClauses, fmt.Sprintf("DROP INDEX %s", quoteIdent(sourceIdx.Name)))
+				dropClauses = append(dropClauses, fmt.Sprintf("DROP INDEX %s", sqlescape.EscapeIdentifier(sourceIdx.Name)))
 			}
 		}
 	}
@@ -559,9 +559,9 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 			// Only visibility changed
 			targetVisible := targetIdx.Invisible == nil || !*targetIdx.Invisible
 			if targetVisible {
-				alterClauses = append(alterClauses, fmt.Sprintf("ALTER INDEX %s VISIBLE", quoteIdent(targetIdx.Name)))
+				alterClauses = append(alterClauses, fmt.Sprintf("ALTER INDEX %s VISIBLE", sqlescape.EscapeIdentifier(targetIdx.Name)))
 			} else {
-				alterClauses = append(alterClauses, fmt.Sprintf("ALTER INDEX %s INVISIBLE", quoteIdent(targetIdx.Name)))
+				alterClauses = append(alterClauses, fmt.Sprintf("ALTER INDEX %s INVISIBLE", sqlescape.EscapeIdentifier(targetIdx.Name)))
 			}
 		}
 	}
@@ -629,9 +629,9 @@ func (ct *CreateTable) diffConstraints(target *CreateTable) []string {
 		if !exists || !constraintsEqual(sourceConstr, targetConstr) {
 			switch sourceConstr.Type {
 			case "FOREIGN KEY":
-				dropClauses = append(dropClauses, fmt.Sprintf("DROP FOREIGN KEY %s", quoteIdent(sourceConstr.Name)))
+				dropClauses = append(dropClauses, fmt.Sprintf("DROP FOREIGN KEY %s", sqlescape.EscapeIdentifier(sourceConstr.Name)))
 			case "CHECK":
-				dropClauses = append(dropClauses, fmt.Sprintf("DROP CHECK %s", quoteIdent(sourceConstr.Name)))
+				dropClauses = append(dropClauses, fmt.Sprintf("DROP CHECK %s", sqlescape.EscapeIdentifier(sourceConstr.Name)))
 			}
 		}
 	}
@@ -1204,7 +1204,7 @@ func formatColumnDefinition(col *Column) string {
 		typeDef += " unsigned"
 	}
 
-	parts = append(parts, fmt.Sprintf("%s %s", quoteIdent(col.Name), typeDef))
+	parts = append(parts, fmt.Sprintf("%s %s", sqlescape.EscapeIdentifier(col.Name), typeDef))
 
 	// Charset and collation (skip for binary types and JSON)
 	isBinaryType := col.Type == "varbinary" || col.Type == "binary" ||
@@ -1314,7 +1314,7 @@ func formatAddIndex(idx *Index) string {
 		keyword = "ADD INDEX"
 	}
 	if idx.Type != "PRIMARY KEY" && idx.Name != "" {
-		keyword += " " + quoteIdent(idx.Name)
+		keyword += " " + sqlescape.EscapeIdentifier(idx.Name)
 	}
 	parts = append(parts, keyword)
 
@@ -1327,7 +1327,7 @@ func formatAddIndex(idx *Index) string {
 				columns = append(columns, fmt.Sprintf("(%s)", *col.Expression))
 			} else {
 				// Regular column reference
-				colStr := quoteIdent(col.Name)
+				colStr := sqlescape.EscapeIdentifier(col.Name)
 				if col.Length != nil {
 					colStr += fmt.Sprintf("(%d)", *col.Length)
 				}
@@ -1337,7 +1337,7 @@ func formatAddIndex(idx *Index) string {
 	} else {
 		// Fall back to simple column names
 		for _, col := range idx.Columns {
-			columns = append(columns, quoteIdent(col))
+			columns = append(columns, sqlescape.EscapeIdentifier(col))
 		}
 	}
 	parts = append(parts, fmt.Sprintf("(%s)", strings.Join(columns, ", ")))
@@ -1377,31 +1377,31 @@ func formatAddConstraint(constr *Constraint) string {
 	switch constr.Type {
 	case "CHECK":
 		if constr.Name != "" {
-			parts = append(parts, fmt.Sprintf("ADD CONSTRAINT %s CHECK (%s)", quoteIdent(constr.Name), *constr.Expression))
+			parts = append(parts, fmt.Sprintf("ADD CONSTRAINT %s CHECK (%s)", sqlescape.EscapeIdentifier(constr.Name), *constr.Expression))
 		} else {
 			parts = append(parts, fmt.Sprintf("ADD CHECK (%s)", *constr.Expression))
 		}
 	case "FOREIGN KEY":
 		var columns []string
 		for _, col := range constr.Columns {
-			columns = append(columns, quoteIdent(col))
+			columns = append(columns, sqlescape.EscapeIdentifier(col))
 		}
 		var refColumns []string
 		for _, col := range constr.References.Columns {
-			refColumns = append(refColumns, quoteIdent(col))
+			refColumns = append(refColumns, sqlescape.EscapeIdentifier(col))
 		}
 
 		var fkClause string
 		if constr.Name != "" {
 			fkClause = fmt.Sprintf("ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)",
-				quoteIdent(constr.Name),
+				sqlescape.EscapeIdentifier(constr.Name),
 				strings.Join(columns, ", "),
-				quoteIdent(constr.References.Table),
+				sqlescape.EscapeIdentifier(constr.References.Table),
 				strings.Join(refColumns, ", "))
 		} else {
 			fkClause = fmt.Sprintf("ADD FOREIGN KEY (%s) REFERENCES %s (%s)",
 				strings.Join(columns, ", "),
-				quoteIdent(constr.References.Table),
+				sqlescape.EscapeIdentifier(constr.References.Table),
 				strings.Join(refColumns, ", "))
 		}
 
@@ -1727,7 +1727,7 @@ func formatPartitionDefinition(def *PartitionDefinition) string {
 	var parts []string
 
 	// Partition name
-	parts = append(parts, "PARTITION "+quoteIdent(def.Name))
+	parts = append(parts, "PARTITION "+sqlescape.EscapeIdentifier(def.Name))
 
 	// Values clause
 	if def.Values != nil {

--- a/pkg/statement/literal_roundtrip_test.go
+++ b/pkg/statement/literal_roundtrip_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/testutils"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
@@ -33,7 +34,7 @@ func openScratch(t *testing.T) *sql.DB {
 func showCreate(t *testing.T, db *sql.DB, table string) string {
 	t.Helper()
 	var name, createSQL string
-	err := db.QueryRowContext(t.Context(), "SHOW CREATE TABLE "+quoteIdent(table)).Scan(&name, &createSQL)
+	err := db.QueryRowContext(t.Context(), "SHOW CREATE TABLE "+sqlescape.EscapeIdentifier(table)).Scan(&name, &createSQL)
 	require.NoError(t, err)
 	return createSQL
 }
@@ -71,12 +72,12 @@ func applyAndConverge(t *testing.T, db *sql.DB, table, createSQL, targetSQL stri
 	t.Helper()
 
 	// Start from a clean slate.
-	_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+quoteIdent(table))
+	_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))
 	require.NoError(t, err)
 	_, err = db.ExecContext(t.Context(), createSQL)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+quoteIdent(table))
+		_, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))
 	})
 
 	source, err := ParseCreateTable(showCreate(t, db, table))

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -1591,5 +1591,5 @@ func GetMissingSecondaryIndexes(sourceCreateTable, targetCreateTable, tableName 
 		alterClauses = append(alterClauses, sb.String())
 	}
 	// Combine all ADD INDEX clauses into a single ALTER TABLE statement
-	return fmt.Sprintf("ALTER TABLE `%s` %s", tableName, strings.Join(alterClauses, ", ")), nil
+	return fmt.Sprintf("ALTER TABLE %s %s", sqlescape.EscapeIdentifier(tableName), strings.Join(alterClauses, ", ")), nil
 }

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
@@ -363,10 +364,10 @@ func convertCreateIndexToAlterTable(stmt ast.StmtNode) (*AbstractStatement, erro
 	default:
 		keyType = "INDEX"
 	}
-	alterStmt := fmt.Sprintf("ADD %s `%s` (%s)", keyType, ciStmt.IndexName, strings.Join(parts, ", "))
+	alterStmt := fmt.Sprintf("ADD %s %s (%s)", keyType, sqlescape.EscapeIdentifier(ciStmt.IndexName), strings.Join(parts, ", "))
 	// We hint in the statement that it's been rewritten
 	// and in the stmtNode we reparse from the alterStmt.
-	statement := fmt.Sprintf("/* rewritten from CREATE INDEX */ ALTER TABLE `%s` %s", ciStmt.Table.Name, alterStmt)
+	statement := fmt.Sprintf("/* rewritten from CREATE INDEX */ ALTER TABLE %s %s", sqlescape.EscapeIdentifier(ciStmt.Table.Name.String()), alterStmt)
 	p := parser.New()
 	stmtNodes, _, err := p.Parse(statement, "", "")
 	if err != nil {
@@ -389,10 +390,10 @@ func convertDropIndexToAlterTable(stmt ast.StmtNode) (*AbstractStatement, error)
 	if !isDropIndexStmt {
 		return nil, errors.New("not a DROP INDEX statement")
 	}
-	alterStmt := fmt.Sprintf("DROP INDEX `%s`", diStmt.IndexName)
+	alterStmt := fmt.Sprintf("DROP INDEX %s", sqlescape.EscapeIdentifier(diStmt.IndexName))
 	// We hint in the statement that it's been rewritten
 	// and in the stmtNode we reparse from the alterStmt.
-	statement := fmt.Sprintf("/* rewritten from DROP INDEX */ ALTER TABLE `%s` %s", diStmt.Table.Name, alterStmt)
+	statement := fmt.Sprintf("/* rewritten from DROP INDEX */ ALTER TABLE %s %s", sqlescape.EscapeIdentifier(diStmt.Table.Name.String()), alterStmt)
 	p := parser.New()
 	stmtNodes, _, err := p.Parse(statement, "", "")
 	if err != nil {

--- a/pkg/statement/utils.go
+++ b/pkg/statement/utils.go
@@ -9,22 +9,13 @@ import (
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
 )
 
-// quoteIdent wraps a MySQL identifier in backticks, doubling any embedded
-// backtick to escape it per MySQL's identifier-quoting rules. The
-// previous open-coded form (a Go format string with %s inside backticks)
-// produced broken SQL when an identifier contained a backtick — caught
-// only at re-parse time as a confusing parse error rather than at
-// emission. See TestQuoteIdent for the doubled-backtick edge cases.
-func quoteIdent(s string) string {
-	return "`" + strings.ReplaceAll(s, "`", "``") + "`"
-}
-
-// quoteIdentList applies quoteIdent to each element and joins them with
-// the given separator. Helps the common "column list" rendering pattern.
+// quoteIdentList quotes each identifier via sqlescape.EscapeIdentifier (the
+// single source of truth for MySQL identifier quoting) and joins them with the
+// given separator. Helps the common "column list" rendering pattern.
 func quoteIdentList(idents []string, sep string) string {
 	quoted := make([]string, len(idents))
 	for i, s := range idents {
-		quoted[i] = quoteIdent(s)
+		quoted[i] = sqlescape.EscapeIdentifier(s)
 	}
 	return strings.Join(quoted, sep)
 }

--- a/pkg/statement/utils_test.go
+++ b/pkg/statement/utils_test.go
@@ -6,25 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestQuoteIdent verifies that quoteIdent doubles embedded backticks so
-// an identifier containing one renders as valid MySQL SQL. Without this,
-// a column or index name with a backtick produced broken SQL that only
-// surfaced at re-parse time as a confusing parse error.
-func TestQuoteIdent(t *testing.T) {
-	cases := []struct {
-		in, want string
-	}{
-		{"foo", "`foo`"},
-		{"", "``"},
-		{"foo`bar", "`foo``bar`"},
-		{"`", "````"}, // open + doubled-backtick + close = 4
-		{"a`b`c", "`a``b``c`"},
-	}
-	for _, tc := range cases {
-		require.Equal(t, tc.want, quoteIdent(tc.in), "input=%q", tc.in)
-	}
-}
-
 // TestFormatPartitionValue verifies that string partition values are
 // quoted and escaped, while integer/float literals (which the parser
 // flattens into Go strings during Restore) are rendered unquoted. The

--- a/pkg/table/column_mapping.go
+++ b/pkg/table/column_mapping.go
@@ -2,6 +2,8 @@ package table
 
 import (
 	"strings"
+
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 )
 
 // ColumnMapping represents the column relationship between a source and target table,
@@ -91,8 +93,8 @@ func (m *ColumnMapping) Columns() (source, target string) {
 	srcQuoted := make([]string, len(m.sourceColumns))
 	tgtQuoted := make([]string, len(m.targetColumns))
 	for i := range m.sourceColumns {
-		srcQuoted[i] = "`" + m.sourceColumns[i] + "`"
-		tgtQuoted[i] = "`" + m.targetColumns[i] + "`"
+		srcQuoted[i] = sqlescape.EscapeIdentifier(m.sourceColumns[i])
+		tgtQuoted[i] = sqlescape.EscapeIdentifier(m.targetColumns[i])
 	}
 	return strings.Join(srcQuoted, ", "), strings.Join(tgtQuoted, ", ")
 }

--- a/pkg/table/table_schema.go
+++ b/pkg/table/table_schema.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 )
 
 // TableSchema represents a table's name and its raw CREATE TABLE DDL statement.
@@ -91,7 +93,7 @@ func LoadSchemaFromDB(ctx context.Context, db *sql.DB, opts ...FilterOption) ([]
 			continue
 		}
 		var tbl, createStmt string
-		err := db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE `%s`", name)).Scan(&tbl, &createStmt)
+		err := db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s", sqlescape.EscapeIdentifier(name))).Scan(&tbl, &createStmt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get CREATE TABLE for %s: %w", name, err)
 		}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 )
 
 const (
@@ -100,7 +102,7 @@ func NewTableInfo(db *sql.DB, schema, table string) *TableInfo {
 		db:              db,
 		SchemaName:      schema,
 		TableName:       table,
-		QuotedTableName: fmt.Sprintf("`%s`", table),
+		QuotedTableName: sqlescape.EscapeIdentifier(table),
 	}
 }
 
@@ -483,7 +485,7 @@ func (t *TableInfo) wrapCastType(col string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("column %q not found in table %s", col, t.TableName)
 	}
-	return fmt.Sprintf("CAST(`%s` AS %s)", col, castableTp(tp)), nil
+	return fmt.Sprintf("CAST(%s AS %s)", sqlescape.EscapeIdentifier(col), castableTp(tp)), nil
 }
 
 // wrapCastTypeAs generates a CAST expression using sqlCol as the column reference
@@ -496,7 +498,7 @@ func (t *TableInfo) wrapCastTypeAs(sqlCol, typeCol string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("column %q not found for type lookup in table %s", typeCol, t.TableName)
 	}
-	return fmt.Sprintf("CAST(`%s` AS %s)", sqlCol, castableTp(tp)), nil
+	return fmt.Sprintf("CAST(%s AS %s)", sqlescape.EscapeIdentifier(sqlCol), castableTp(tp)), nil
 }
 
 func (t *TableInfo) datumTp(col string) (datumTp, error) {

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 )
 
 // LazyFindP90 finds the second to last value in a slice.
@@ -92,7 +94,7 @@ func removeZerofill(s string) string {
 func QuoteColumns(cols []string) string {
 	q := make([]string, len(cols))
 	for i, col := range cols {
-		q[i] = "`" + col + "`"
+		q[i] = sqlescape.EscapeIdentifier(col)
 	}
 	return strings.Join(q, ", ")
 }
@@ -105,14 +107,14 @@ func QuoteColumns(cols []string) string {
 // vals[i].String() is inlined directly into the SQL fragment because
 // Datum.String() returns a pre-escaped self-contained SQL literal
 // (see its doc comment for the contract). Don't change the format
-// strings below to add quoting or escaping — the values already carry
-// it.
+// strings below to add quoting or escaping for the values — they already
+// carry it. Column identifiers are escaped via sqlescape.EscapeIdentifier.
 func expandRowConstructorComparison(cols []string, operator Operator, vals []Datum) string {
 	if len(cols) != len(vals) {
 		panic("cols should be same size as values")
 	}
 	if len(cols) == 1 {
-		return fmt.Sprintf("`%s` %s %s", cols[0], operator, vals[0].String())
+		return fmt.Sprintf("%s %s %s", sqlescape.EscapeIdentifier(cols[0]), operator, vals[0].String())
 	}
 	// Unless we are in the "final" position
 	// we need to use a different intermediate operator
@@ -128,8 +130,8 @@ func expandRowConstructorComparison(cols []string, operator Operator, vals []Dat
 	buffer := []string{}
 	for i, col := range cols {
 		if i == 0 {
-			conds = append(conds, fmt.Sprintf("(`%s` %s %s)", col, intermediateOperator, vals[i].String()))
-			buffer = append(buffer, fmt.Sprintf("`%s` %s %s", col, "=", vals[i].String()))
+			conds = append(conds, fmt.Sprintf("(%s %s %s)", sqlescape.EscapeIdentifier(col), intermediateOperator, vals[i].String()))
+			buffer = append(buffer, fmt.Sprintf("%s %s %s", sqlescape.EscapeIdentifier(col), "=", vals[i].String()))
 			continue
 		}
 		// If we are in the final position we can
@@ -138,8 +140,8 @@ func expandRowConstructorComparison(cols []string, operator Operator, vals []Dat
 		if i == len(cols)-1 {
 			intermediateOperator = operator
 		}
-		conds = append(conds, fmt.Sprintf("(%s AND `%s` %s %s)", strings.Join(buffer, " AND "), col, intermediateOperator, vals[i].String()))
-		buffer = append(buffer, fmt.Sprintf("`%s` %s %s", col, "=", vals[i].String()))
+		conds = append(conds, fmt.Sprintf("(%s AND %s %s %s)", strings.Join(buffer, " AND "), sqlescape.EscapeIdentifier(col), intermediateOperator, vals[i].String()))
+		buffer = append(buffer, fmt.Sprintf("%s %s %s", sqlescape.EscapeIdentifier(col), "=", vals[i].String()))
 	}
 	return "(" + strings.Join(conds, "\n OR ") + ")"
 }

--- a/pkg/table/utils_test.go
+++ b/pkg/table/utils_test.go
@@ -84,6 +84,11 @@ func TestQuoteCols(t *testing.T) {
 
 	cols = []string{"a"}
 	require.Equal(t, "`a`", QuoteColumns(cols))
+
+	// Identifiers containing a backtick must have it doubled, otherwise the
+	// quoting breaks out and produces invalid SQL.
+	require.Equal(t, "`a``b`", QuoteColumns([]string{"a`b"}))
+	require.Equal(t, "`a``b`, `c`", QuoteColumns([]string{"a`b", "c"}))
 }
 
 func TestExpandRowConstructorComparison(t *testing.T) {

--- a/pkg/testutils/table.go
+++ b/pkg/testutils/table.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
@@ -74,7 +75,7 @@ func (tt *TestTable) dropArtifacts(ctx context.Context) {
 		fmt.Sprintf("_%s_chkpnt", tt.Name),
 	}
 	for _, tbl := range tables {
-		_, err := tt.DB.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", tbl))
+		_, err := tt.DB.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", sqlescape.EscapeIdentifier(tbl)))
 		if err != nil && !isIdentifierTooLongError(err) {
 			// Log but don't fail — cleanup is best-effort and the test
 			// may already be finished (e.g., context canceled race).
@@ -111,13 +112,13 @@ func (tt *TestTable) SeedRows(t *testing.T, insertSelectSQL string, targetRows i
 
 	// Count initial rows (may be >1 if the SELECT produces multiple rows).
 	var count int
-	err = tt.DB.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM `%s`", tt.Name)).Scan(&count)
+	err = tt.DB.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", sqlescape.EscapeIdentifier(tt.Name))).Scan(&count)
 	require.NoError(t, err)
 
 	// Double rows until we reach the target.
 	for count < targetRows {
 		_, err = tt.DB.ExecContext(t.Context(),
-			fmt.Sprintf("%s FROM `%s`", insertSelectSQL, tt.Name))
+			fmt.Sprintf("%s FROM %s", insertSelectSQL, sqlescape.EscapeIdentifier(tt.Name)))
 		require.NoError(t, err)
 		count *= 2
 	}


### PR DESCRIPTION
## What

Unifies MySQL identifier quoting into one helper, `sqlescape.EscapeIdentifier`, and routes every identifier-quoting call site through it.

## Why

There were **four** copies of the same backtick-doubling logic:
- `statement.quoteIdent`
- `lint.quoteUnsafeIdentifier`
- an open-coded `"` + "`" + `s` + "`"` form in `pkg/table`
- the inline body of the `%n` verb in `sqlescape`

Separately, many call sites open-coded ``fmt.Sprintf("`%s`", x)`` for table / column / index / database names. None of those double an embedded backtick, so an identifier containing one produces broken SQL (or, in principle, a quoting break-out) — the exact class of bug the `%n` verb already guards against.

## What changed

- Add `sqlescape.EscapeIdentifier(id string) string` — wraps in backticks and doubles any embedded backtick (MySQL's identifier-quoting rule).
- The `%n` verb now delegates to it, so there is a single implementation.
- Replace the three duplicate helpers and the remaining open-coded sites across `statement`, `table`, `lint`, `migration`, `move`, `datasync`, `fmt`, `dbconn` and `testutils`.
- The list helpers (`statement.quoteIdentList`, `table.QuoteColumns`) are kept and now build on `EscapeIdentifier`.

## Behaviour

Output is **byte-identical** for backtick-free identifiers (the common case), so no existing SQL changes. The only behavioural difference is for identifiers that literally contain a backtick, which previously produced invalid SQL and now quote correctly.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` all clean.
- New `TestEscapeIdentifier` covers the edge cases (incl. asserting `%n` and `EscapeIdentifier` agree).
- DB-free suites pass locally: `sqlescape`, `statement`, `table`, `lint`. The MySQL-backed packages (`migration`, `move`, `datasync`, `dbconn`, `fmt`, `testutils`) are build/vet-verified locally and exercised by the CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
