### PR TITLE
test: drop disabled linter tests/dead code and de-flake throttler tests

### DIFF
--- a/pkg/lint/lint_primary_key_type.go
+++ b/pkg/lint/lint_primary_key_type.go
@@ -156,23 +156,10 @@ func (l *PrimaryKeyLinter) checkColumnType(tableName string, column *statement.C
 	columnType := strings.ToUpper(column.Type)
 
 	if _, ok := l.allowedTypes[columnType]; ok {
-		// If the PK column uses a signed integer type, return a warning that it should be unsigned instead
-		// disabling this functionality for now to avoid overly verbose linter output
-		/*
-			if isSignedIntType(column) {
-				return &Violation{
-					Linter:   l,
-					Severity: SeverityWarning,
-					Message:  fmt.Sprintf("Primary key column %q uses signed %s; UNSIGNED is preferred", column.Name, columnType),
-					Location: &Location{
-						Table:  tableName,
-						Column: &column.Name,
-					},
-					Suggestion: new(fmt.Sprintf("Consider using BIGINT UNSIGNED for column '%s' to avoid negative values and increase range", column.Name)),
-				}
-			}
-
-		*/
+		// A PK on an allowed type passes. We deliberately do NOT emit a
+		// "prefer UNSIGNED" warning for signed integer PKs — it was judged
+		// too noisy for real-world schemas. isSignedIntType (with its unit
+		// tests) is retained should that policy be revisited.
 		return nil
 	}
 

--- a/pkg/lint/lint_primary_key_type_test.go
+++ b/pkg/lint/lint_primary_key_type_test.go
@@ -1,10 +1,9 @@
 package lint
 
-// NOTE: Many tests in this file are temporarily disabled because the signed integer
-// warning functionality has been commented out in PrimaryKeyLinter (lint_primary_key_type.go lines 137-156).
-// The linter no longer warns about signed integer types (e.g., BIGINT without UNSIGNED).
-// Tests that are disabled use t.Skip() at the beginning with an explanation.
-// To re-enable these tests, uncomment the signed integer warning code in PrimaryKeyLinter.
+// NOTE: PrimaryKeyLinter deliberately does not warn about signed-integer
+// primary keys (e.g. BIGINT without UNSIGNED) — that check was judged too
+// noisy for real-world schemas. The isSignedIntType helper and its unit tests
+// (TestIsSignedIntType_*) are retained should the policy be revisited.
 
 import (
 	"fmt"
@@ -28,31 +27,6 @@ func TestPrimaryKeyLinter_BigIntUnsigned(t *testing.T) {
 
 	// BIGINT UNSIGNED is ideal - no violations
 	require.Empty(t, violations)
-}
-
-func TestPrimaryKeyLinter_BigIntSigned(t *testing.T) {
-	t.Skip("DISABLED: Signed integer warnings commented out in lint_primary_key_type.go lines 137-156")
-	sql := `CREATE TABLE users (
-		id BIGINT PRIMARY KEY,
-		name VARCHAR(255)
-	)`
-	ct, err := statement.ParseCreateTable(sql)
-	require.NoError(t, err)
-
-	linter := &PrimaryKeyLinter{}
-	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
-
-	// BIGINT without UNSIGNED should be a warning
-	require.Len(t, violations, 1)
-	require.Equal(t, "primary_key", violations[0].Linter.Name())
-	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "signed BIGINT")
-	require.Contains(t, violations[0].Message, "UNSIGNED is preferred")
-	require.Equal(t, "users", violations[0].Location.Table)
-	require.NotNil(t, violations[0].Location.Column)
-	require.Equal(t, "id", *violations[0].Location.Column)
-	require.NotNil(t, violations[0].Suggestion)
-	require.Contains(t, *violations[0].Suggestion, "BIGINT UNSIGNED")
 }
 
 func TestPrimaryKeyLinter_Binary(t *testing.T) {
@@ -162,26 +136,6 @@ func TestPrimaryKeyLinter_CompositePrimaryKeyAllGood(t *testing.T) {
 
 	// Both columns are BIGINT UNSIGNED - no violations
 	require.Empty(t, violations)
-}
-
-func TestPrimaryKeyLinter_CompositePrimaryKeyMixed(t *testing.T) {
-	t.Skip("DISABLED: Signed integer warnings commented out in lint_primary_key_type.go lines 137-156")
-	sql := `CREATE TABLE user_roles (
-		user_id BIGINT,
-		role_id BIGINT UNSIGNED,
-		PRIMARY KEY (user_id, role_id)
-	)`
-	ct, err := statement.ParseCreateTable(sql)
-	require.NoError(t, err)
-
-	linter := &PrimaryKeyLinter{}
-	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
-
-	// user_id is signed BIGINT (warning)
-	require.Len(t, violations, 1)
-	require.Equal(t, "primary_key", violations[0].Linter.Name())
-	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Equal(t, "user_id", *violations[0].Location.Column)
 }
 
 func TestPrimaryKeyLinter_NoPrimaryKey(t *testing.T) {
@@ -426,30 +380,6 @@ func TestPrimaryKeyLinter_ConfigureAllowInt(t *testing.T) {
 
 	// INT should be allowed with custom config - no violations
 	require.Empty(t, violations)
-}
-
-func TestPrimaryKeyLinter_ConfigureAllowIntSigned(t *testing.T) {
-	t.Skip("DISABLED: Signed integer warnings commented out in lint_primary_key_type.go lines 137-156")
-	sql := `CREATE TABLE users (
-		id INT PRIMARY KEY,
-		name VARCHAR(255)
-	)`
-	ct, err := statement.ParseCreateTable(sql)
-	require.NoError(t, err)
-
-	linter := &PrimaryKeyLinter{}
-	err = linter.Configure(map[string]string{
-		"allowedTypes": "bigint,int",
-	})
-	require.NoError(t, err)
-
-	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
-
-	// Signed INT should still give warning about signedness
-	require.Len(t, violations, 1)
-	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "signed INT")
-	require.Contains(t, violations[0].Message, "UNSIGNED is preferred")
 }
 
 func TestPrimaryKeyLinter_ConfigureAllowVarchar(t *testing.T) {
@@ -870,29 +800,6 @@ func TestPrimaryKeyLinter_ConfigureVarbinaryStillWorks(t *testing.T) {
 
 	// VARBINARY should still work correctly with parser quirk
 	require.Empty(t, violations)
-}
-
-func TestPrimaryKeyLinter_ConfigureSignedWarningStillWorks(t *testing.T) {
-	t.Skip("DISABLED: Signed integer warnings commented out in lint_primary_key_type.go lines 137-156")
-	sql := `CREATE TABLE users (
-		id INT PRIMARY KEY,
-		name VARCHAR(255)
-	)`
-	ct, err := statement.ParseCreateTable(sql)
-	require.NoError(t, err)
-
-	linter := &PrimaryKeyLinter{}
-	err = linter.Configure(map[string]string{
-		"allowedTypes": "int,bigint",
-	})
-	require.NoError(t, err)
-
-	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
-
-	// Should still warn about signed INT
-	require.Len(t, violations, 1)
-	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "signed INT")
 }
 
 func TestPrimaryKeyLinter_IntegrationWithConfig(t *testing.T) {

--- a/pkg/lint/lint_unsafe.go
+++ b/pkg/lint/lint_unsafe.go
@@ -102,21 +102,6 @@ func (l *UnsafeLinter) Lint(_ []*statement.CreateTable, changes []*statement.Abs
 					//
 					// I do not believe that PlanetScale has this detection, so we may decide to
 					// implement it here in future.
-					/*
-						v := Violation{
-							Linter:   l,
-							Location: &Location{Table: change.Table},
-							Message:  "Changing column type could lead to data loss by truncation",
-							Severity: SeverityWarning,
-						}
-						if spec.OldColumnName != nil {
-							v.Location.Column = &spec.OldColumnName.Name.O
-						} else if len(spec.NewColumns) > 0 {
-							v.Location.Column = &spec.NewColumns[0].Name.Name.O
-						}
-						violations = append(violations, v)
-
-					*/
 				case ast.AlterTableDropForeignKey, ast.AlterTableRenameColumn,
 					ast.AlterTableRenameTable, ast.AlterTableDropIndex, ast.AlterTableDropCheck,
 					ast.AlterTableOption:

--- a/pkg/lint/lint_unsafe_test.go
+++ b/pkg/lint/lint_unsafe_test.go
@@ -164,52 +164,6 @@ func TestUnsafeLinter_AlterTableDropForeignKey(t *testing.T) {
 	require.Empty(t, violations)
 }
 
-// DISABLED: This test is disabled because the MODIFY COLUMN warning functionality
-// has been commented out in UnsafeLinter (lint_unsafe.go lines 101-117).
-// The linter no longer warns about MODIFY COLUMN operations.
-// To re-enable this test, uncomment the MODIFY COLUMN warning code in UnsafeLinter.
-/*
-func TestUnsafeLinter_AlterTableModifyColumn(t *testing.T) {
-	sql := `ALTER TABLE users MODIFY COLUMN name VARCHAR(500)`
-	stmts, err := statement.New(sql)
-	require.NoError(t, err)
-
-	linter := &UnsafeLinter{}
-	violations := linter.Lint(nil, stmts)
-
-	// MODIFY COLUMN is considered safe (lossy changes detected at runtime)
-	require.Len(t, violations, 1)
-	require.Equal(t, "unsafe", violations[0].Linter.Name())
-	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "Changing column type could lead to data loss by truncation")
-	require.Equal(t, "users", violations[0].Location.Table)
-	require.Equal(t, "name", *violations[0].Location.Column)
-}
-*/
-
-// DISABLED: This test is disabled because the MODIFY/CHANGE COLUMN warning functionality
-// has been commented out in UnsafeLinter (lint_unsafe.go lines 101-117).
-// The linter no longer warns about CHANGE COLUMN operations.
-// To re-enable this test, uncomment the MODIFY/CHANGE COLUMN warning code in UnsafeLinter.
-/*
-func TestUnsafeLinter_AlterTableChangeColumn(t *testing.T) {
-	sql := `ALTER TABLE users CHANGE COLUMN name full_name VARCHAR(255)`
-	stmts, err := statement.New(sql)
-	require.NoError(t, err)
-
-	linter := &UnsafeLinter{}
-	violations := linter.Lint(nil, stmts)
-
-	// CHANGE COLUMN is considered safe (lossy changes detected at runtime)
-	require.Len(t, violations, 1)
-	require.Equal(t, "unsafe", violations[0].Linter.Name())
-	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "Changing column type could lead to data loss by truncation")
-	require.Equal(t, "users", violations[0].Location.Table)
-	require.Equal(t, "name", *violations[0].Location.Column)
-}
-*/
-
 func TestUnsafeLinter_AlterTableRenameColumn(t *testing.T) {
 	sql := `ALTER TABLE users RENAME COLUMN name TO full_name`
 	stmts, err := statement.New(sql)

--- a/pkg/throttler/mock.go
+++ b/pkg/throttler/mock.go
@@ -9,9 +9,20 @@ import (
 // GradualThrottler): tests that exercise the autoscaler's continuous signal
 // use their own GradualThrottler stub instead.
 type Mock struct {
+	// blockDuration is how long BlockWait blocks for. The zero value means
+	// the default of 1s, so &Mock{} keeps its historical behaviour; tests can
+	// set it explicitly to keep fast or to make cancellation unambiguous.
+	blockDuration time.Duration
 }
 
 var _ Throttler = &Mock{}
+
+func (t *Mock) blockFor() time.Duration {
+	if t.blockDuration == 0 {
+		return time.Second
+	}
+	return t.blockDuration
+}
 
 func (t *Mock) Open(_ context.Context) error {
 	return nil
@@ -27,7 +38,7 @@ func (t *Mock) IsThrottled() bool {
 
 func (t *Mock) BlockWait(ctx context.Context) {
 	// Use a timer with context cancellation for interruptible sleep
-	timer := time.NewTimer(time.Second)
+	timer := time.NewTimer(t.blockFor())
 	defer timer.Stop()
 
 	select {

--- a/pkg/throttler/throttler_test.go
+++ b/pkg/throttler/throttler_test.go
@@ -33,9 +33,13 @@ func TestThrottlerInterface(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, throttler.Open(t.Context()))
 
-	time.Sleep(50 * time.Millisecond)         // make sure the throttler loop can calculate.
-	throttler.BlockWait(t.Context())          // wait for catch up (there's no activity)
-	require.False(t, throttler.IsThrottled()) // there's a race, but its unlikely to be throttled
+	throttler.BlockWait(t.Context()) // wait for catch up (there's no activity)
+	// The throttler computes lag asynchronously on its loop, so poll rather
+	// than asserting against a fixed settle time. With no write activity the
+	// replica should quickly report not-throttled.
+	require.Eventually(t, func() bool {
+		return !throttler.IsThrottled()
+	}, 5*time.Second, 10*time.Millisecond)
 
 	require.NoError(t, throttler.Close())
 
@@ -82,18 +86,21 @@ func TestMockThrottler(t *testing.T) {
 	// Test UpdateLag returns no error
 	require.NoError(t, throttler.UpdateLag(t.Context()))
 
-	// Test BlockWait sleeps for approximately 1 second
+	// BlockWait blocks for its configured duration. Use a short duration to
+	// keep the test fast and assert only the lower bound: a tight upper bound
+	// on a sleep is inherently flaky under CI scheduling pressure.
+	blocking := &Mock{blockDuration: 100 * time.Millisecond}
 	start := time.Now()
-	throttler.BlockWait(t.Context())
-	elapsed := time.Since(start)
-	require.GreaterOrEqual(t, elapsed, 1*time.Second)
-	require.Less(t, elapsed, 1500*time.Millisecond) // allow 500ms tolerance for CI scheduling delays
+	blocking.BlockWait(t.Context())
+	require.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond)
 
-	// Test BlockWait respects context cancellation
+	// BlockWait must return promptly when the context is cancelled, well
+	// before its (deliberately huge) block duration would elapse. Comparing
+	// against an hour makes the assertion robust regardless of scheduler delay.
+	interruptible := &Mock{blockDuration: time.Hour}
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 	start = time.Now()
-	throttler.BlockWait(ctx)
-	elapsed = time.Since(start)
-	require.Less(t, elapsed, 100*time.Millisecond) // should return almost immediately
+	interruptible.BlockWait(ctx)
+	require.Less(t, time.Since(start), time.Second)
 }


### PR DESCRIPTION
## What

Two small cleanups surfaced by a codebase review: removing disabled-test / dead-code rot in `pkg/lint`, and de-flaking the throttler tests.

## Dead code & disabled tests (`pkg/lint`)

`pkg/lint` carried two deliberately-disabled warning features as commented-out code, each shadowed by tests that were permanently skipped or commented out:
- `PrimaryKeyLinter` — the signed-integer-PK "prefer UNSIGNED" warning.
- `UnsafeLinter` — the MODIFY/CHANGE COLUMN truncation warning.

Both were intentionally off (judged too noisy / lossy changes are detected at runtime via checksum). This removes the dead code and the dead tests, and rewrites the stale "these tests are disabled" header comments. The `isSignedIntType` helper is kept — it still has direct unit tests and documents the (currently-off) policy should it be revisited.

## Flaky throttler tests (`pkg/throttler`)

- `TestMockThrottler` asserted `BlockWait` elapsed within a `[1s, 1.5s)` window; the upper bound is inherently flaky under CI scheduling pressure. `Mock` now takes a configurable block duration (zero value still defaults to 1s, so existing callers are unchanged), so the test asserts a lower bound on a short block and verifies cancellation interrupts an *hour-long* block — robust regardless of scheduler delay, and faster.
- `TestThrottlerInterface` replaces a fixed `time.Sleep` + a self-described racy assertion with `require.Eventually`.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` all clean.
- `pkg/lint` and `pkg/throttler` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
