### PR TITLE
fix(dbconn): guarantee non-zero retry backoff

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -277,10 +277,20 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 	return rowsAffected, err
 }
 
-// backoff sleeps a few milliseconds before retrying.
-func backoff(i int) {
-	randFactor := i * rand.IntN(10) * int(time.Millisecond)
-	time.Sleep(time.Duration(randFactor))
+// backoffDuration returns the delay before a retry for the given 0-based
+// attempt: a short, jittered interval that grows with the attempt. The
+// (attempt+1) factor and the +1 on the jitter guarantee that every retry —
+// including the first (attempt 0) — backs off for a non-zero time. The
+// previous formula (i * rand.IntN(10) * ms) slept 0ns on the first retry and
+// whenever the jitter rolled 0, so the retry-storm protection did not actually
+// apply when it was first needed.
+func backoffDuration(attempt int) time.Duration {
+	return time.Duration((attempt+1)*(rand.IntN(10)+1)) * time.Millisecond
+}
+
+// backoff sleeps for backoffDuration(attempt) before retrying.
+func backoff(attempt int) {
+	time.Sleep(backoffDuration(attempt))
 }
 
 // ForceExec is like Exec but it has some added logic to force kill

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -37,7 +37,8 @@ func TestBackoffDuration(t *testing.T) {
 	// Every retry — including the first (attempt 0) — must back off for a
 	// non-zero duration. The previous formula slept 0ns on attempt 0 and
 	// whenever the jitter rolled 0, so the retry-storm protection silently did
-	// not apply. 200 samples per attempt exercise the full jitter range.
+	// not apply. We take multiple samples per attempt to cover a variety of
+	// jitter values without sleeping.
 	for attempt := range 6 {
 		upper := time.Duration((attempt+1)*10) * time.Millisecond
 		for range 200 {

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -33,6 +33,21 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
+func TestBackoffDuration(t *testing.T) {
+	// Every retry — including the first (attempt 0) — must back off for a
+	// non-zero duration. The previous formula slept 0ns on attempt 0 and
+	// whenever the jitter rolled 0, so the retry-storm protection silently did
+	// not apply. 200 samples per attempt exercise the full jitter range.
+	for attempt := range 6 {
+		upper := time.Duration((attempt+1)*10) * time.Millisecond
+		for range 200 {
+			d := backoffDuration(attempt)
+			require.Positivef(t, d, "attempt %d backed off for 0ns", attempt)
+			require.LessOrEqualf(t, d, upper, "attempt %d exceeded its max of %s", attempt, upper)
+		}
+	}
+}
+
 func getVariable(trx *sql.Tx, name string, sessionScope bool) (string, error) {
 	var value string
 	scope := "GLOBAL"


### PR DESCRIPTION
## What

The transaction-retry backoff in `pkg/dbconn` could sleep for **0ns**, defeating its own retry-storm protection.

## The bug

`RetryableTransaction` loops with a 0-based attempt index and calls `backoff(i)` between attempts:

```go
func backoff(i int) {
	randFactor := i * rand.IntN(10) * int(time.Millisecond)
	time.Sleep(time.Duration(randFactor))
}
```

- On the **first retry** (`i == 0`), `0 * anything == 0` → no delay at all.
- `rand.IntN(10)` returns `[0,10)`, so **any** retry sleeps 0ns whenever the jitter rolls 0.

So the first retry (and a fraction of later ones) re-hit the server with no backoff — the opposite of the intent.

## The fix

```go
func backoffDuration(attempt int) time.Duration {
	return time.Duration((attempt+1)*(rand.IntN(10)+1)) * time.Millisecond
}
```

`(attempt+1)` and `(jitter+1)` guarantee every retry backs off for a non-zero, jittered interval that grows with the attempt (1–10ms, 2–20ms, 3–30ms, …). It's otherwise the same small, linear, jittered backoff as before. The calculation is split into a pure `backoffDuration` so it's unit-testable without sleeping.

## Testing

- New `TestBackoffDuration` asserts every attempt (including 0) is non-zero and within its bound, across 200 samples per attempt to exercise the jitter range — deterministic, no sleeps.
- `go build ./...`, `go vet ./...`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
