### PR TITLE
checksum: drain the change feed before a fatal divergence verdict

### DIFF
--- a/pkg/checksum/continuous.go
+++ b/pkg/checksum/continuous.go
@@ -35,8 +35,12 @@
 //       success the chunk counts as resolved for pass-completion purposes
 //       (in the per-pass "recopies" bucket), but the pass is no longer
 //       clean — the repaired rows were never observed equal, so they are
-//       re-verified by the next pass's fresh walk. Without a Recopier the
-//       run returns ErrPermanentDivergence.
+//       re-verified by the next pass's fresh walk. Without a Recopier (or
+//       when DivergenceIsFatal is set) the divergence is fatal — but first,
+//       if a change feed is present, the checker drains it (Flush) and
+//       re-reads: a target merely behind on applying buffered changes (apply
+//       lag) reconciles here and passes, so only a mismatch that survives a
+//       full drain returns ErrPermanentDivergence.
 //
 // Hot chunks slow but do not block pass completion: they cycle to the back
 // of the FIFO while other entries resolve. A genuinely permanently-hot row
@@ -892,6 +896,46 @@ func (c *ContinuousChecker) executeWork(ctx context.Context, item *workItem) *wo
 		res.passed = true
 		res.recopied = true
 		return res
+	}
+
+	// Fatal-divergence path (no Recopier, or DivergenceIsFatal — e.g. the
+	// migration cutover gate). Before declaring a permanent divergence, drain
+	// the change feed and re-read the chunk. A target that is merely behind on
+	// applying buffered changes (apply lag) would otherwise be misclassified as
+	// divergence and abort the cutover — even though the cutover's own
+	// FlushUnderTableLock reconciles exactly that lag moments later. Draining
+	// here performs the same reconciliation before we judge, so only a mismatch
+	// that survives a full drain (with the source still unchanged) is treated as
+	// real. The feed is advisory and may be nil (e.g. copy-only sync has no
+	// feed); with nothing to drain, the mismatch is taken at face value.
+	if c.feed != nil {
+		if flushErr := c.feed.Flush(ctx); flushErr != nil {
+			res.err = fmt.Errorf("drain change feed before divergence verdict for chunk %s: %w", item.chunk.String(), flushErr)
+			return res
+		}
+		srcCRC, tgtCRC, srcCount, tgtCount, err = c.readChunk(ctx, item.chunk)
+		if err != nil {
+			res.err = fmt.Errorf("re-read chunk %s after feed drain: %w", item.chunk.String(), err)
+			return res
+		}
+		newSrc = chunkSig{crc: srcCRC, count: srcCount}
+		newTgt = chunkSig{crc: tgtCRC, count: tgtCount}
+		res.newSrc = newSrc
+		res.newTgt = newTgt
+		if newTgt == newSrc || newTgt == item.originalSrc {
+			// The target caught up once the feed drained: this was apply lag,
+			// not divergence. Counts as a normal verified pass (not a recopy).
+			res.passed = true
+			return res
+		}
+		if newSrc != item.originalSrc {
+			// The source changed again while we drained — treat it as a hot
+			// chunk and re-enqueue (handleResult re-queues a retry result that
+			// is neither passed nor permanent) instead of declaring divergence.
+			return res
+		}
+		// Source still unchanged and target still wrong after a full drain →
+		// genuine divergence. Fall through.
 	}
 	res.permanent = true
 	return res

--- a/pkg/checksum/continuous_test.go
+++ b/pkg/checksum/continuous_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -564,6 +566,103 @@ func TestDivergenceIsFatalAbortsDespiteRecopier(t *testing.T) {
 	require.ErrorIs(t, err, ErrPermanentDivergence,
 		"DivergenceIsFatal must abort with ErrPermanentDivergence even with a Recopier set")
 	require.Equal(t, 0, recopier.callCount(), "the Recopier must not be called when DivergenceIsFatal")
+	require.Positive(t, c.Stats().PermanentFailures)
+}
+
+// fakeFeed is a minimal change.Source double for continuous-checksum tests.
+// Only Flush carries behaviour — it runs flushFn so a test can simulate the
+// target catching up as buffered changes are applied (apply lag draining).
+// Every other method is an inert no-op.
+type fakeFeed struct {
+	flushFn func(ctx context.Context) error
+	flushes atomic.Int64
+}
+
+var _ change.Source = (*fakeFeed)(nil)
+
+func (f *fakeFeed) Flush(ctx context.Context) error {
+	f.flushes.Add(1)
+	if f.flushFn != nil {
+		return f.flushFn(ctx)
+	}
+	return nil
+}
+func (f *fakeFeed) AddSubscription(_, _ *table.TableInfo, _ table.MappedChunker) error { return nil }
+func (f *fakeFeed) Start(context.Context) error                                        { return nil }
+func (f *fakeFeed) StartFromPosition(context.Context, string) error                    { return nil }
+func (f *fakeFeed) Position() string                                                   { return "" }
+func (f *fakeFeed) FlushUnderTableLock(context.Context, []*dbconn.TableLock) error     { return nil }
+func (f *fakeFeed) BlockWait(context.Context) error                                    { return nil }
+func (f *fakeFeed) GetDeltaLen() int                                                   { return 0 }
+func (f *fakeFeed) SetWatermarkOptimization(context.Context, bool) error               { return nil }
+func (f *fakeFeed) StartPeriodicFlush(context.Context, time.Duration)                  {}
+func (f *fakeFeed) StopPeriodicFlush()                                                 {}
+func (f *fakeFeed) AllChangesFlushed() bool                                            { return true }
+func (f *fakeFeed) Close()                                                             {}
+
+// TestDivergenceIsFatalReconcilesApplyLag is the regression test for the
+// false-positive cutover abort: a chunk that is merely behind on applying
+// buffered changes (apply lag) must NOT be reported as a fatal divergence.
+// Before declaring a stable divergence on the fatal path, the checker drains
+// the change feed and re-reads; once the feed flushes, the target catches up
+// and the chunk verifies clean — the same reconciliation the cutover performs
+// under its table lock.
+func TestDivergenceIsFatalReconcilesApplyLag(t *testing.T) {
+	chunker := newTestChunker(1)
+	var drained atomic.Bool
+	feed := &fakeFeed{
+		flushFn: func(context.Context) error { drained.Store(true); return nil },
+	}
+	cfg := fastConfig()
+	cfg.DivergenceIsFatal = true // migration cutover-gate policy; no Recopier
+
+	c := newTestChecker(t, chunker, cfg,
+		func(ctx context.Context, chunk *table.Chunk, attempt int) (int64, int64, uint64, error) {
+			// Source is stable at 100. The target lags at 99 (a buffered change
+			// not yet flushed) until the feed drains, after which it matches.
+			if drained.Load() {
+				return 100, 100, 1000, nil
+			}
+			return 100, 99, 1000, nil
+		},
+	)
+	c.feed = feed // attach a feed so the drain-and-confirm path engages
+
+	stop, _ := runUntil(t, c)
+	select {
+	case <-c.FirstCleanPass():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("FirstCleanPass did not fire — apply lag misclassified as divergence; stats=%+v", c.Stats())
+	}
+	require.Equal(t, uint64(0), c.Stats().PermanentFailures, "apply lag must not count as permanent divergence")
+	require.True(t, drained.Load(), "the checker must drain the feed before judging divergence")
+	require.GreaterOrEqual(t, feed.flushes.Load(), int64(1), "feed.Flush must be called to confirm divergence")
+
+	err := stop()
+	require.True(t, errors.Is(err, context.Canceled) || err == nil)
+}
+
+// TestDivergenceIsFatalStillAbortsAfterDrain guards the fix above: a genuine
+// divergence — one the feed drain does NOT reconcile — must still return
+// ErrPermanentDivergence. The drain rules out apply lag; it must not mask real
+// corruption.
+func TestDivergenceIsFatalStillAbortsAfterDrain(t *testing.T) {
+	chunker := newTestChunker(1)
+	feed := &fakeFeed{} // Flush is a no-op: draining changes nothing
+	cfg := fastConfig()
+	cfg.DivergenceIsFatal = true
+
+	c := newTestChecker(t, chunker, cfg,
+		func(ctx context.Context, chunk *table.Chunk, attempt int) (int64, int64, uint64, error) {
+			return 100, 99, 1000, nil // stable, real divergence; a drain won't fix it
+		},
+	)
+	c.feed = feed
+
+	err := c.Run(t.Context())
+	require.ErrorIs(t, err, ErrPermanentDivergence,
+		"a divergence that survives a feed drain must still be fatal")
+	require.GreaterOrEqual(t, feed.flushes.Load(), int64(1), "the checker must attempt a drain before the fatal verdict")
 	require.Positive(t, c.Stats().PermanentFailures)
 }
 


### PR DESCRIPTION
## Problem

`ContinuousChecker`'s stable-divergence check — source CRC unchanged across the `RetryDelay` window and the target still mismatched — is fundamentally a statement about **apply lag**. The target (`_new` for `migrate`, the target table for `sync`) only catches up as the change feed flushes buffered binlog changes.

With the default 60s `RetryDelay` vs a 30s flush interval there is normally a 2× margin, but under a write burst plus throttling the apply lag can transiently exceed `RetryDelay` while the source is momentarily quiet. A chunk that is merely behind is then misclassified as a **permanent divergence**.

For `migrate` (`DivergenceIsFatal=true`, no `Recopier`) that returns `ErrPermanentDivergence` and **aborts the cutover**. It is most damaging at the sentinel drop: the cutover's own `FlushUnderTableLock` would reconcile exactly that lag moments later, and a verdict that races the cancellation can convert a clean sentinel-drop into a spurious abort (`sentinel.Wait` promotes a non-nil `continuousErr` to a failure whenever the parent ctx is still uncancelled).

It is **safe** — it only ever aborts, never corrupts — but it is a nondeterministic abort of a healthy migration, which undermines cutover predictability.

## Fix

On the fatal-divergence path, before declaring a permanent divergence, drain the feed (`Flush`) and re-read the chunk — the same reconciliation the cutover performs under its lock:

- target has caught up → **apply lag**, passes (a verified read, not a recopy)
- source moved again → **hot chunk**, re-enqueue
- still mismatched with source unchanged → **genuine divergence**, fatal

This also neutralizes the exit race: a verdict that now reaches `permanent` is real, and a cancellation mid-drain surfaces as `context.Canceled` (suppressed as a clean shutdown). The feed is advisory and may be `nil` (copy-only `sync`), in which case the mismatch is taken at face value as before. The `sync` recopy path is unchanged.

**Concurrency:** the checker-initiated `Flush` can run concurrently with `migrate`'s periodic flush, which is safe — `bufferedMap.Flush` holds its lock through the entire drain (a concurrent caller no-ops on an already-drained map) and the flushed-position advance is monotonic-guarded.

## Tests

- `TestDivergenceIsFatalReconcilesApplyLag` — apply lag must not be reported as fatal divergence (fails without the fix).
- `TestDivergenceIsFatalStillAbortsAfterDrain` — a divergence that survives the drain is still fatal, with the drain attempted first.

All existing continuous-checksum tests stay green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
