### PR TITLE
docs: fix drift against current code and document newer features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ pkg/
   checksum/   → Post-copy data verification (CRC32 + BIT_XOR)
   dbconn/     → MySQL connection management, TLS, retries, locking, kill logic
   statement/  → SQL parsing via TiDB parser (ALTER, CREATE, DROP, RENAME)
-  lint/       → Static analysis framework for schemas and DDL (15 built-in linters)
+  lint/       → Static analysis framework for schemas and DDL (17 built-in linters)
   fmt/        → Schema file formatter (canonicalize CREATE TABLE .sql files)
   throttler/  → Rate limiting interface (noop, mock, replica-lag based)
   status/     → State machine and progress reporting
@@ -227,7 +227,7 @@ Three chunker implementations:
 Uses the [TiDB parser](https://github.com/pingcap/tidb/tree/master/pkg/parser) for SQL parsing. If a DDL cannot be parsed by TiDB, Spirit cannot execute it. `parse_create_table.go` provides structured `CREATE TABLE` parsing.
 
 ### `pkg/lint`
-15 built-in linters that auto-register via `init()`. Each linter is in its own file (`lint_<name>.go`). To add a new linter, create a new file following the existing pattern and implement the `Linter` interface from `linter.go`.
+17 built-in linters that auto-register via `init()`. Each linter is in its own file (`lint_<name>.go`). To add a new linter, create a new file following the existing pattern and implement the `Linter` interface from `linter.go`.
 
 ### `pkg/dbconn`
 Handles connection management including:
@@ -260,13 +260,13 @@ How the recently-unified pieces handle per-tool differences, as patterns to copy
 
 - **`sentinel.Wait`** takes the two genuinely runner-specific steps as callbacks (`RunChecksum`, `InvalidateWatermark`) — e.g. migration scopes its watermark `UPDATE` by `statement` (its checkpoint table is shared across multi-table migrations) while move blanks the whole per-move table. The poll/timeout/continuous-checksum-lifecycle orchestration is shared; only the divergent bits are injected.
 - **`status.WatchTask`** is consumed via a small interface (`status.Task`); each runner keeps a `var _ status.Task = (*Runner)(nil)` assertion so a signature drift fails the build. A checkpoint-write failure is **fatal** here (calls `Cancel()`); don't reintroduce a loop that swallows it.
-- **`checksum.ContinuousChecker`** is configured per-tool: migration runs it with **no `Recopier`** (a confirmed divergence must *abort* the cutover via `ErrPermanentDivergence`), datasync runs it **with** a `MySQLRecopier` (self-heal). Both pace passes with `MinPassInterval`.
+- **`checksum.ContinuousChecker`** is configured per-tool, and whether a confirmed stable divergence *aborts* or *self-heals* is an **explicit `ContinuousCheckerConfig.DivergenceIsFatal` policy** (block/spirit#994) — it is no longer *inferred* from `Recopier` presence. **migration**: `DivergenceIsFatal: true` with **no `Recopier`** — replication keeps `_new` in sync, so a confirmed divergence is a real bug and `Run` returns `checksum.ErrPermanentDivergence` to abort the cutover. **datasync**: `DivergenceIsFatal: false` plus a `MySQLRecopier` — it verifies a still-converging target, so divergences are expected and self-heal by recopying the chunk from source. When `DivergenceIsFatal` is false a `Recopier` is mandatory (without one, divergence is treated as fatal); the two knobs are decoupled, so `DivergenceIsFatal: true` aborts **even if** a `Recopier` is supplied (`TestDivergenceIsFatalAbortsDespiteRecopier`). Both pace passes with `MinPassInterval` (`checksum.ContinuousMinPassInterval`).
 - **`pkg/sentinel`** takes the schema from the connection (`DATABASE()` / unqualified DDL), not a passed-in schema name, so it works under Vitess. Prefer this pattern for new helpers — point the `*sql.DB` at the right schema rather than threading a schema string. `pkg/checkpoint` follows it too.
 - **`pkg/checkpoint`** owns the one checkpoint-table schema and its create/drop/exists/write/read, keyed on the connection's selected schema (`DATABASE()` / unqualified, like sentinel). `Write` keeps a **single row** (`REPLACE` on `id=1` — atomic, so a crash never leaves no checkpoint, and bounded). Two `Mode`s differ only in `Create`: `Transient` (DROP+CREATE — a checkpoint for one finite run: single-table & atomic multi-table migration, move) vs `Persistent` (CREATE IF NOT EXISTS, never cleared — a continuous run: datasync, whose existence is its resume signal). Resume *policy* stays per-runner (statement match, collision, max-age, multi-source positions, datasync's three-state `Exists` routing); the package interprets no watermarks. `checkpoint.IsIncompatible` tells an unreadable cross-version checkpoint apart from a transient read error, so recovery never fires on a blip — migration falls back to a fresh run; datasync recovers under `--force` (drops the target DB).
 
 ### Not yet unified (live drift — touch with care)
 
-- **move's continuous checksum** still uses the distributed/sharded `checksum.Checker` (it is multi-source / possibly multi-target); `ContinuousChecker` is single-source/single-target.
+- **move's continuous checksum** still uses the distributed/sharded `checksum.Checker` (it is multi-source / possibly multi-target); `ContinuousChecker` is single-source/single-target. The explicit `DivergenceIsFatal` policy above was introduced partly to keep this future conversion clean: move is replication-backed like migration, so it would set `DivergenceIsFatal: true`. The blocker is multi-source/multi-target support in `ContinuousChecker`, not the abort policy.
 - **`fatalError` / `Close` teardown** are similar but not identical between the three — keep the run-all-steps + `errors.Join` teardown idiom and the `>= CutOver` no-op guard in `fatalError` consistent when you touch them.
 
 When you add a checkpoint field, add it to `pkg/checkpoint`'s schema — it is shared by all three. When you add a teardown step, a new lifecycle phase, or a safety gate, grep all three `runner.go` files and decide explicitly: port, or extract.
@@ -293,7 +293,7 @@ Key principles:
 
 ### Adding a new linter
 1. Create `pkg/lint/lint_<name>.go` implementing the `Linter` interface
-2. Register it in an `init()` function using `RegisterLinter()`
+2. Register it in an `init()` function using `Register()` (defined in `registry.go`)
 3. Create `pkg/lint/lint_<name>_test.go` with comprehensive test cases
 4. Follow the pattern of existing linters (e.g., `lint_has_fk.go`)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,8 +15,8 @@ If the `MYSQL_DSN` is not specified, it currently defaults to `spirit:spirit@tcp
 ### Running tests with docker on specific MySQL version
 ```bash
 cd compose/
-docker compose down --volumes && docker compose up -f compose.yml -f 8.0.28.yml 
-docker compose up mysql test --abort-on-container-exit
+docker compose -f compose.yml -f 8.0.28.yml down --volumes
+docker compose -f compose.yml -f 8.0.28.yml up mysql test --abort-on-container-exit
 ```
 
 ## Running linter
@@ -52,4 +52,4 @@ make setup-hooks
 ./scripts/setup-git-hooks.sh
 ```
 
-This configures a pre-push hook that runs golangci-lint in Docker, catching errors before they reach the remote repository. Commits remain fast and unblocked. See `.githooks/README.md` for more details.
+This configures a pre-push hook that runs golangci-lint in Docker, catching errors before they reach the remote repository. Commits remain fast and unblocked.

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -25,6 +25,7 @@ spirit migrate --host mydb:3306 --username root --password secret \
 - [lint](#lint)
 - [lint-only](#lint-only)
 - [lock-wait-timeout](#lock-wait-timeout)
+- [max-commit-latency](#max-commit-latency)
 - [password](#password)
 - [replica-dsn](#replica-dsn)
   - [Replica TLS Behavior](#replica-tls-behavior)
@@ -212,7 +213,7 @@ spirit migrate --enable-experimental-gtid \
 ### host
 
 - Type: String
-- Default value: `localhost:3306`
+- Default value: `127.0.0.1:3306`
 - Examples: `mydbhost`, `mydbhost:3307`
 
 The host (and optional port) to use when connecting to MySQL. If no port is provided, 3306 is used.
@@ -419,6 +420,15 @@ The signal comes from the Aurora throttlers — threads-running and commit-laten
 If a signal stops updating mid-migration (for example the monitoring connection is partitioned, or grants are revoked), the controller does not keep scaling on the frozen value: after ~15 seconds without a successful sample the signal reports a neutral utilization inside the hold band, freezing the write-thread count in place (a warning is logged). Scaling resumes automatically when sampling recovers.
 
 This flag only applies to the default buffered copier; with [unbuffered](#unbuffered) it is ignored (with a warning). Autoscaling is not yet supported by `spirit move`.
+
+### max-commit-latency
+
+- Type: Duration
+- Default value: `100ms`
+
+Throttles the copy when the server's average commit latency exceeds this threshold, protecting the primary workload's write latency from the migration's own write volume.
+
+It is currently **auto-enabled only on Aurora** (auto-detected); on other servers it has no effect. The default of `100ms` is intentionally a high upper bound, so it trims only the most extreme tail latencies rather than throttling under normal load. See [block/spirit#468](https://github.com/block/spirit/issues/468).
 
 ### tls-ca
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -17,6 +17,7 @@ This will copy all tables from the source database to the target database, verif
 - [create-sentinel](#create-sentinel)
 - [defer-secondary-indexes](#defer-secondary-indexes)
 - [enable-experimental-gtid](#enable-experimental-gtid)
+- [force](#force)
 - [source-dsn](#source-dsn)
 - [target-chunk-time](#target-chunk-time)
 - [target-dsn](#target-dsn)
@@ -65,17 +66,26 @@ Each continuous-checksum pass runs once with no internal retry (the loop itself 
 
 When set to `true`, target tables are created without secondary indexes. The indexes are restored from the source schema just before cutover. This can significantly speed up the initial data load for tables with many secondary indexes.
 
+### force
+
+- Type: Boolean
+- Default value: `false`
+
+When Move cannot resume from an existing checkpoint — for example the checkpoint was written by an incompatible Spirit version, or the target is in a state the resume path cannot validate — it fails rather than risk corrupting a partially-copied target (see [checkpoint-max-age](#checkpoint-max-age)).
+
+Passing `--force` changes that recovery behaviour: instead of failing, Move wipes the target tables and starts the copy fresh, re-running the post-setup safety checks against the cleaned target rather than bypassing them. Use it only when the target's current contents can safely be discarded.
+
 ### enable-experimental-gtid
 
 - Type: Boolean
 - Default value: `false`
 
 > **⚠️ Experimental.** See the full caveats and on-disk-format warning in the
-> [migrate `--enable-experimental-gtid` documentation](migrate.md#gtid).
+> [migrate `--enable-experimental-gtid` documentation](migrate.md#enable-experimental-gtid).
 
 When set to `true`, Move switches each source's replication change feed from
 the default binlog **file + offset** coordinate to a MySQL **GTID set**
-coordinate. Behaviour is identical to [`spirit migrate --enable-experimental-gtid`](migrate.md#gtid)
+coordinate. Behaviour is identical to [`spirit migrate --enable-experimental-gtid`](migrate.md#enable-experimental-gtid)
 in every other respect — the copier, applier, checksum, sentinel wait, cutover,
 and checkpoint contract are unchanged.
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -167,7 +167,7 @@ Intended for testing/iterating.
 - Default value: `false`
 
 > **⚠️ Experimental.** See the full caveats and on-disk-format warning in the
-> [migrate `--gtid` documentation](migrate.md#gtid).
+> [migrate `--enable-experimental-gtid` documentation](migrate.md#enable-experimental-gtid).
 
 When set to `true`, the built-in MySQL binlog source switches from the default
 binlog **file + offset** coordinate to a MySQL **GTID set** coordinate. The

--- a/pkg/checksum/README.md
+++ b/pkg/checksum/README.md
@@ -31,12 +31,15 @@ There are also some known cases where a checksum failure is not a bug. This incl
 
 ## Implementations
 
-The checksum package contains two implementations:
+The checksum package contains three implementations:
 
 1. **SingleChecker** - Compares two tables on the same MySQL server (for schema changes, or 1:1 moves)
 2. **DistributedChecker** - Compares a source table against multiple distributed target databases (for sharded scenarios)
+3. **ContinuousChecker** - A lock-free, *eventually-consistent* verifier that runs indefinitely against a live system where the target lags the source by a small replication delay (used by `spirit sync`, and by `spirit migrate` while waiting on a deferred cutover)
 
-Both implementations use the same underlying checksum algorithm: **CRC32 with XOR aggregation**. This technique computes a checksum for each chunk of rows and can efficiently detect differences without comparing individual rows.
+`SingleChecker` and `DistributedChecker` take a brief table lock to establish a consistent `REPEATABLE READ` snapshot; `ContinuousChecker` deliberately does not (see [Continuous checksum](#continuous-checksum) below).
+
+All three use the same underlying checksum algorithm: **CRC32 with XOR aggregation**. This technique computes a checksum for each chunk of rows and can efficiently detect differences without comparing individual rows.
 
 ## Checksum Algorithm
 
@@ -58,3 +61,16 @@ The actual implementation includes additional handling:
 - **Type casting**: Applies `CAST` operations to convert columns to the target table's type for comparable string representations
 
 The CRC32 + XOR aggregate technique for table checksumming was pioneered by **pt-table-checksum** from Percona Toolkit, which established this as a reliable method for verifying data consistency in MySQL. This same approach has since been adopted by other database tools, including TiDB's data migration and verification utilities, demonstrating its effectiveness for distributed database scenarios.
+
+## Continuous checksum
+
+`ContinuousChecker` verifies a target that is still converging toward the source over a live replication feed, so a first-attempt mismatch is *expected* (the target simply hasn't caught up yet) rather than alarming. It runs in **passes**: each pass walks every chunk once and then drains a delayed-retry queue until empty. A mismatched chunk is re-read after a short delay and passes once the target's CRC matches a source CRC the checker has witnessed. A chunk whose source keeps changing (a "hot chunk") cycles to the back of the queue without blocking the pass.
+
+When a chunk's source CRC is stable across the retry window but the target still disagrees, that is a **stable divergence**. How the checker reacts is governed by two config fields:
+
+- **`Recopier`** — when set, a stable divergence is *repaired* by recopying that chunk from the source: `DELETE` the key range on the target, re-`SELECT` from the source, and re-apply through the same write path the change feed uses. `MySQLRecopier` is the production implementation used by `spirit sync`. Recopies are serialized and run under a cancellation-detached, time-bounded (10 minute) context, so a chunk is never left deleted-but-not-rewritten.
+- **`DivergenceIsFatal`** — selects the policy explicitly, rather than inferring it from `Recopier` presence:
+  - `true` (e.g. `spirit migrate`'s deferred-cutover check): replication keeps the new table in sync, so a confirmed stable divergence is a real bug. `Run` returns `ErrPermanentDivergence` and the caller aborts the cutover. No `Recopier` is configured.
+  - `false` (e.g. `spirit sync`): the target is expected to converge, so divergences self-heal via the `Recopier`. A `Recopier` is **required** in this mode; without one, divergence is treated as fatal.
+
+The two are decoupled: `DivergenceIsFatal: true` aborts even if a `Recopier` is supplied. Passes are paced by `MinPassInterval` so a small table is not re-checksummed back-to-back. `FirstCleanPass` exposes a channel that closes the first time a pass completes with every chunk read-verified equal and zero recopies — the signal that the target is known consistent.

--- a/pkg/copier/README.md
+++ b/pkg/copier/README.md
@@ -104,6 +104,7 @@ type CopierConfig struct {
 - **`DBConfig`**: Database connection configuration including retry settings.
 - **`Applier`**: Used by the buffered copier to write rows to the target. The migration runner shares one applier between the copier and the replication client, so this field may be set even when the copier itself is unbuffered — the unbuffered copier ignores it. Required (non-nil) for the buffered copier (i.e. whenever `Unbuffered` is false).
 - **`Unbuffered`** (default: `false`): Selects between the buffered and unbuffered copier implementations. When `false` (the default), the buffered copier streams rows through `Applier`; when `true`, the legacy unbuffered copier issues `INSERT IGNORE INTO _new ... SELECT FROM original` directly and ignores `Applier`. Both the struct's zero value and `NewCopierDefaultConfig()` leave this `false`, so the buffered copier is the default and a non-nil `Applier` is required. The migration runner sets `Unbuffered` from `--unbuffered`; the move/sync runners always leave it `false`.
+- **`Autoscale`** (`AutoscaleConfig`, default: disabled): configures the experimental write-thread autoscaler, enabled via `--enable-experimental-autoscaling`. When `Enabled`, it scales the applier's live write-worker count between `StartThreads` and `MaxThreads` based on throttler utilization. Only applies to the buffered copier with a dynamically-scalable applier. See [Write-thread autoscaling](#write-thread-autoscaling-experimental) under Core Concepts.
 
 ## Usage
 
@@ -238,6 +239,19 @@ Both copier implementations use goroutines for parallel chunk processing:
 - Each reader goroutine reads chunks and sends rows to the applier
 - The applier has its own internal parallelism for writing
 - Callbacks notify readers when writes complete
+
+### Write-thread autoscaling (experimental)
+
+When `AutoscaleConfig.Enabled` is set (the `--enable-experimental-autoscaling` flag), the buffered copier runs a control loop that adjusts the applier's live write-worker count between `StartThreads` and `MaxThreads`, based on a throttler's continuous **utilization** signal. It only engages when the throttler implements `throttler.GradualThrottler` (the Aurora throttlers do) and the applier implements the dynamic-scaling capability (`SingleTargetApplier` does; `ShardedApplier` does not); otherwise it is skipped.
+
+Each tick (5s, aligned to the throttler poll) it reads utilization — `0` = idle, `1.0` = the point the hard-stop trips — and steers toward a dead band:
+
+- **below 40%**: add one thread (cooldown-gated)
+- **40–70%**: hold
+- **70–100%**: shed one thread (cooldown-gated)
+- **≥100%**: halve (the first breach is immediate)
+
+Steps are ±1 with a ~15s per-direction cooldown; only the panic zone is multiplicative. The shape is deliberately gentle because the signal is largely self-induced — the copy's own write workers move `Threads_running` — so classic AIMD halving would sawtooth. The autoscaler never touches the binary `BlockWait()` hard-stop, which remains the safety net underneath. See `autoscaler.go` and [issue #831](https://github.com/block/spirit/issues/831).
 
 ### Error Handling
 

--- a/pkg/migration/resume-from-checkpoint.md
+++ b/pkg/migration/resume-from-checkpoint.md
@@ -22,6 +22,8 @@ CREATE TABLE _tablename_chkpnt (
 
 The checkpoint captures everything needed to resume: where the copier was, the opaque change-source position to resume streaming from, and the original DDL statement.
 
+**Atomic multi-table migrations** (one `--statement` containing several `ALTER`s) are the exception to the per-table naming above. Rather than a `_<table>_chkpnt` table per table, they share a single fixed-name `_spirit_checkpoint` table per schema, with the `original_table_name` column left empty. Because that name is fixed, only one atomic multi-table migration may run per schema at a time — they coordinate through a schema-scoped lock, so a second one fails fast rather than corrupting the first's checkpoint. Plain single-table migrations are unaffected and continue to use `_<table>_chkpnt`.
+
 ## What happens on resume
 
 When a new Runner starts (`Runner.Run()` → `setup()`), it always attempts `resumeFromCheckpoint()` first. This performs several validation steps before committing to the resume path:

--- a/pkg/throttler/README.md
+++ b/pkg/throttler/README.md
@@ -16,7 +16,7 @@ In practice, throttlers haven't been used as extensively as originally envisione
 
 However, it remains available and maintained for community use, particularly for users running traditional MySQL replication topologies. We are open to contributions to throttler improvements, such as being able to throttle on multiple replicas at once ([issue #220](https://github.com/block/spirit/issues/220)).
 
-Two **Aurora-specific throttlers** — commit-latency and threads-running — were added later ([#468](https://github.com/block/spirit/issues/468), [#831](https://github.com/block/spirit/issues/831)) and are **auto-enabled whenever Spirit detects it is running against Aurora**. These are the throttlers most Block migrations actually run, and they double as the continuous load signal that drives the copier's experimental write-thread autoscaler (see [`GradualThrottler`](#gradualthrottler-optional-extension) below).
+Two **Aurora-specific throttlers** were added later: a threads-running throttler ([#831](https://github.com/block/spirit/issues/831)) and a commit-latency throttler ([#468](https://github.com/block/spirit/issues/468)). On Aurora the threads-running throttler is **always enabled**, while commit-latency is enabled **by default** but gated on a positive `--max-commit-latency` (default `100ms`; set `--max-commit-latency=0` to disable it). These are the throttlers most Block migrations actually run, and they double as the continuous load signal that drives the copier's experimental write-thread autoscaler (see [`GradualThrottler`](#gradualthrottler-optional-extension) below).
 
 ## Interface
 
@@ -100,7 +100,7 @@ throttler, err := throttler.NewThreadsRunningThrottler(db, logger)
 
 Polls the `Threads_running` status variable every 5 seconds and compares it to the instance vCPU count (read from `@@innodb_buffer_pool_instances`, which Aurora pins to the vCPU count). The binary hard-stop trips when the raw count exceeds `vCPUs + 2` — a small headroom for Spirit's own monitoring connections — while `Utilization()` reports an EWMA-smoothed `Threads_running / vCPUs`, so the autoscaler tracks sustained load rather than instantaneous spikes. Aurora-only; see [issue #831](https://github.com/block/spirit/issues/831).
 
-Both Aurora throttlers are gated on an `IsAurora()` probe — which confirms `performance_schema.global_status` is readable and the Aurora status variables are present — and are auto-enabled by the migration runner when it succeeds. They run together, and the highest utilization across them drives the autoscaler.
+Both throttlers require an `IsAurora()` probe — which confirms `performance_schema.global_status` is readable and the Aurora status variables are present. When it succeeds, `throttler.AuroraSetup.Build` assembles them: the threads-running throttler is **always** built, while commit-latency is added only when `CommitLatencyThreshold > 0` (wired from `--max-commit-latency`). Whichever are enabled run together, and the highest utilization across them drives the autoscaler.
 
 ## Usage
 

--- a/pkg/throttler/README.md
+++ b/pkg/throttler/README.md
@@ -16,6 +16,8 @@ In practice, throttlers haven't been used as extensively as originally envisione
 
 However, it remains available and maintained for community use, particularly for users running traditional MySQL replication topologies. We are open to contributions to throttler improvements, such as being able to throttle on multiple replicas at once ([issue #220](https://github.com/block/spirit/issues/220)).
 
+Two **Aurora-specific throttlers** — commit-latency and threads-running — were added later ([#468](https://github.com/block/spirit/issues/468), [#831](https://github.com/block/spirit/issues/831)) and are **auto-enabled whenever Spirit detects it is running against Aurora**. These are the throttlers most Block migrations actually run, and they double as the continuous load signal that drives the copier's experimental write-thread autoscaler (see [`GradualThrottler`](#gradualthrottler-optional-extension) below).
+
 ## Interface
 
 All throttlers implement the `Throttler` interface:
@@ -29,6 +31,21 @@ type Throttler interface {
     UpdateLag(ctx context.Context) error
 }
 ```
+
+### `GradualThrottler` (optional extension)
+
+Throttlers whose underlying signal is continuous — not just a binary stop/go — may additionally implement `GradualThrottler`:
+
+```go
+type GradualThrottler interface {
+    Throttler
+    // Utilization reports current load relative to this throttler's throttle
+    // point: 0 = idle, 1.0 = exactly where IsThrottled() flips true, >1.0 = over.
+    Utilization() float64
+}
+```
+
+The copier's write-thread autoscaler type-asserts for this and only engages when it is present. The two Aurora throttlers implement it; the replication-lag throttler deliberately does **not** — lag is an SLO-style budget, not a load gauge, so steering on it would park replicas behind. Binary-signal throttlers protect only via the `IsThrottled()` / `BlockWait()` hard-stop.
 
 ## Implementations
 
@@ -62,6 +79,28 @@ throttler, err := throttler.NewReplicationThrottler(
 - Automatically detects idle replicas to avoid false positives
 - Checks lag every 5 seconds by default
 - Blocks copy operations when lag exceeds tolerance (default: up to 60 seconds per check)
+
+### Aurora Commit-Latency Throttler
+
+```go
+throttler, err := throttler.NewCommitLatencyThrottler(
+    db,
+    100*time.Millisecond,  // latency threshold
+    logger,
+)
+```
+
+Polls Aurora's cumulative commit counters (`AuroraDb_commits` and `AuroraDb_commit_latency`, from `performance_schema.global_status`) every 5 seconds and throttles when the **window-averaged** commit latency reaches the threshold. Watching commit latency lets it react to storage-layer saturation directly. It implements `GradualThrottler`, reporting `Utilization()` as `avg_latency / threshold`. Aurora-only; see [issue #468](https://github.com/block/spirit/issues/468).
+
+### Aurora Threads-Running Throttler
+
+```go
+throttler, err := throttler.NewThreadsRunningThrottler(db, logger)
+```
+
+Polls the `Threads_running` status variable every 5 seconds and compares it to the instance vCPU count (read from `@@innodb_buffer_pool_instances`, which Aurora pins to the vCPU count). The binary hard-stop trips when the raw count exceeds `vCPUs + 2` — a small headroom for Spirit's own monitoring connections — while `Utilization()` reports an EWMA-smoothed `Threads_running / vCPUs`, so the autoscaler tracks sustained load rather than instantaneous spikes. Aurora-only; see [issue #831](https://github.com/block/spirit/issues/831).
+
+Both Aurora throttlers are gated on an `IsAurora()` probe — which confirms `performance_schema.global_status` is readable and the Aurora status variables are present — and are auto-enabled by the migration runner when it succeeds. They run together, and the highest utilization across them drives the autoscaler.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Documentation-only changes: fix drift that accumulated as the code moved ahead of the docs, and document several features that had no docs. Each change was verified against the current code.

## Drift fixes

- **AGENTS.md**: describe the explicit `ContinuousCheckerConfig.DivergenceIsFatal` policy (the abort-vs-self-heal choice is an explicit field, not inferred from `Recopier` presence); correct the built-in linter count to **17** (was 15); `Register()`, not `RegisterLinter()`.
- **DEVELOPMENT.md**: correct the `docker compose -f … up` invocation (the `-f` flags must precede the subcommand); drop the dead `.githooks/README.md` reference.
- **docs/migrate.md**: document the `--max-commit-latency` flag (it was cross-referenced from the autoscaling section but had no entry — a dead `#max-commit-latency` anchor); correct the `host` default to `127.0.0.1`.
- **docs/move.md**: document the `--force` flag (present in code, undocumented); fix two dead `migrate.md#gtid` anchors → `#enable-experimental-gtid`.
- **docs/sync.md**: fix the dead `migrate.md#gtid` cross-link and its stale `--gtid` label (migrate's flag is `--enable-experimental-gtid`).

## New documentation

- **pkg/throttler**: the two Aurora throttlers (commit-latency, threads-running) and the `GradualThrottler` utilization extension.
- **pkg/copier**: the experimental write-thread autoscaler.
- **pkg/checksum**: `ContinuousChecker` (lock-free, eventually-consistent) and the `DivergenceIsFatal` / `Recopier` divergence policy.
- **pkg/migration**: atomic multi-table migrations share one `_spirit_checkpoint` table per schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
