### PR TITLE
fix(statement): escape index and column identifiers in GetMissingSecondaryIndexes

### DIFF
--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -1526,7 +1526,7 @@ func GetMissingSecondaryIndexes(sourceCreateTable, targetCreateTable, tableName 
 
 		// Add index name if present
 		if constraint.Name != "" {
-			fmt.Fprintf(&sb, " `%s`", constraint.Name)
+			fmt.Fprintf(&sb, " %s", sqlescape.EscapeIdentifier(constraint.Name))
 		}
 
 		// Add columns
@@ -1538,7 +1538,7 @@ func GetMissingSecondaryIndexes(sourceCreateTable, targetCreateTable, tableName 
 			switch {
 			case key.Column != nil:
 				// Regular column reference
-				fmt.Fprintf(&sb, "`%s`", key.Column.Name.String())
+				sb.WriteString(sqlescape.EscapeIdentifier(key.Column.Name.String()))
 				// Add length if specified
 				if key.Length > 0 {
 					fmt.Fprintf(&sb, "(%d)", key.Length)

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -1741,6 +1741,21 @@ func TestGetMissingSecondaryIndexes(t *testing.T) {
 			tableName:     "users",
 			expectedAlter: "ALTER TABLE `users` ADD INDEX `idx_name` (`name`) COMMENT 'Test: apostrophe\\' and \\\"quotes\\\" and backslash\\\\'",
 		},
+		{
+			// A backtick inside an index or column name must be doubled,
+			// the same way the table name already is, or the generated
+			// ALTER TABLE breaks out of the identifier quoting.
+			name: "Index and column names containing a backtick are escaped",
+			sourceCreateTable: "CREATE TABLE t (\n" +
+				"  `c``1` INT,\n" +
+				"  INDEX `i``x` (`c``1`)\n" +
+				")",
+			targetCreateTable: "CREATE TABLE t (\n" +
+				"  `c``1` INT\n" +
+				")",
+			tableName:     "t",
+			expectedAlter: "ALTER TABLE `t` ADD INDEX `i``x` (`c``1`)",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Follow-up to #1014 / 6429c3c, which unified identifier quoting through `sqlescape.EscapeIdentifier`. That sweep escaped the table name in `GetMissingSecondaryIndexes`, but the index name and the index column names in the same function were left wrapping the raw value in backticks:

```go
fmt.Fprintf(&sb, " `%s`", constraint.Name)
fmt.Fprintf(&sb, "`%s`", key.Column.Name.String())
```

When an index or column name contains a backtick, the output breaks out of the identifier quoting and is invalid SQL, which is the case #1014 set out to fix. For a source index ``i`x`` on column ``c`1`` the generated statement was:

```
ALTER TABLE `t` ADD INDEX `i`x` (`c`1`)
```

and is now:

```
ALTER TABLE `t` ADD INDEX `i``x` (`c``1`)
```

Both sites now go through `sqlescape.EscapeIdentifier`, matching the table name and the already-escaped index `COMMENT` in the same function. Output is unchanged for backtick-free identifiers, so the existing expectations are untouched. Added a backtick case to `TestGetMissingSecondaryIndexes`; the package unit tests and `go vet` pass (the live-MySQL cases need a running database).

Closes #1019
