### PR TITLE
test: use waitForStatus for the resume-during-checksum sentinel wait

### DIFF
--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -381,10 +381,8 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 	go func() {
 		c <- r.Run(ctx)
 	}()
-	for r.status.Get() < status.WaitingOnSentinelTable {
-		// Wait for the sentinel table.
-		time.Sleep(time.Millisecond)
-	}
+	// Wait for the migration to block on the sentinel table.
+	waitForStatus(t, r, status.WaitingOnSentinelTable)
 
 	require.NoError(t, r.checksum(t.Context()))       // run the checksum, the original Run is blocked on sentinel.
 	require.NoError(t, r.DumpCheckpoint(t.Context())) // dump a checkpoint with the watermark.


### PR DESCRIPTION
## What

`TestCheckpointResumeDuringChecksum` hand-rolled an **unbounded** status poll to wait for the migration to block on the sentinel table:

```go
for r.status.Get() < status.WaitingOnSentinelTable {
    // Wait for the sentinel table.
    time.Sleep(time.Millisecond)
}
```

Replaced with the existing helper:

```go
waitForStatus(t, r, status.WaitingOnSentinelTable)
```

## Why

This runs on the test goroutine and polls an observable status — exactly what `waitForStatus` (itself `require.Eventually`-based since #1001) is for. The helper also **bounds** the wait at 60s instead of spinning forever if the status never advances.

It's a straggler from the earlier sweep (#1001 / #1004 / #1012): the goroutine-guard pass only matched `status.CopyRows`, so this `WaitingOnSentinelTable` wait was missed.

## Test plan

- `go vet -tags singleversion ./pkg/migration/` — clean.
- `golangci-lint run ./pkg/migration/` — 0 issues.
- `go test -tags singleversion -run TestCheckpointResumeDuringChecksum` — pass (13s).