### PR TITLE
fix(checksum): treat end-of-table yield timeout as a yield, not a spurious failure

### DIFF
--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -642,10 +642,15 @@ func (c *DistributedChecker) runChecksum(ctx context.Context) error {
 	}
 	// Distinguish between the yield timeout expiring and the parent context
 	// being canceled. If the parent context is still valid but the yield context
-	// expired and the chunker hasn't finished, this was a yield, not a failure.
-	// This check must come before inspecting err1, because the yield timeout can
-	// cause context errors from in-flight queries.
-	if ctx.Err() == nil && yieldCtx.Err() != nil && !c.chunker.IsRead() {
+	// expired, this was a yield, not a failure. We resume from the watermark
+	// when either the chunker hasn't finished, or an in-flight chunk query was
+	// cancelled by the deadline (err1 != nil): the latter happens when the
+	// timeout fires on the final chunk after all chunks have been dispatched
+	// (IsRead() is already true), so !IsRead() alone would miss it and surface
+	// the deadline as a spurious failure. This check must come before inspecting
+	// err1, because the yield timeout can cause context errors from in-flight
+	// queries.
+	if ctx.Err() == nil && yieldCtx.Err() != nil && (!c.chunker.IsRead() || err1 != nil) {
 		return ErrYieldTimeout
 	}
 	if err1 != nil {

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -83,6 +83,82 @@ func TestDistributedCheckerHonorsYieldTimeoutConfig(t *testing.T) {
 	require.Equal(t, config.YieldTimeout, distributedChecker.yieldTimeout)
 }
 
+// TestDistributedCheckerYieldTimeout drives the distributed checker through
+// real yield/resume cycles. With a short YieldTimeout and a table wide enough
+// that one pass exceeds the timeout window, runChecksumWithYield must release
+// its source/target transaction pools, resume from the low watermark, and
+// still pass — and yieldsPerformed records that at least one yield actually
+// happened. This is the distributed analog of TestYieldTimeout (single
+// checker); TestDistributedCheckerHonorsYieldTimeoutConfig above only checks
+// the config plumbing, not the runtime behavior.
+func TestDistributedCheckerYieldTimeout(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	newDBName, _ := testutils.CreateUniqueTestDatabase(t)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS yield_dist_t1")
+	testutils.RunSQL(t, "CREATE TABLE yield_dist_t1 (a INT NOT NULL AUTO_INCREMENT, b VARCHAR(255), c VARCHAR(255), PRIMARY KEY (a))")
+	// Wide rows so a single checksum pass takes longer than the yield window
+	// and forces at least one yield/resume cycle. Same technique as
+	// TestYieldTimeout (single checker); the row count is sized so the pass
+	// still overruns the window on CI hardware faster than a dev laptop,
+	// keeping the yield deterministic rather than flaky.
+	testutils.RunSQL(t, "INSERT INTO yield_dist_t1 (b, c) SELECT REPEAT('x', 200), REPEAT('y', 200) FROM information_schema.columns a, information_schema.columns b LIMIT 150000")
+
+	// The target holds an identical copy, so the checksum passes despite
+	// yielding repeatedly.
+	testutils.RunSQL(t, "CREATE TABLE "+newDBName+".yield_dist_t1 LIKE yield_dist_t1")
+	testutils.RunSQL(t, "INSERT INTO "+newDBName+".yield_dist_t1 SELECT * FROM yield_dist_t1")
+
+	destCfg := cfg.Clone()
+	destCfg.DBName = newDBName
+
+	src, err := dbconn.New(cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(src)
+	dest, err := dbconn.New(destCfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(dest)
+
+	t1 := table.NewTableInfo(src, "test", "yield_dist_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(dest, newDBName, "yield_dist_t1")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	target := applier.Target{DB: dest, KeyRange: "0", Config: destCfg}
+	app, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	feed := change.NewBinlogClient(src, cfg.Addr, cfg.User, cfg.Passwd, app, change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.Applier = app
+	// Concurrency 1 so the first chunk completes in order and sets the low
+	// watermark; a short timeout so a pass yields mid-table before the table is
+	// fully read. The lock-acquisition phase runs under the parent context, not
+	// the yield context, so this short window only bounds the chunk loop — the
+	// first 1000-row chunk still completes well within it. See TestYieldTimeout.
+	config.Concurrency = 1
+	config.YieldTimeout = 50 * time.Millisecond
+
+	checker, err := NewChecker([]*sql.DB{src}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+
+	// The checksum must still pass — it resumes from the watermark after each yield.
+	require.NoError(t, checker.Run(t.Context()))
+
+	distributedChecker, ok := checker.(*DistributedChecker)
+	require.True(t, ok)
+	require.Positive(t, distributedChecker.yieldsPerformed.Load(), "expected at least one yield to occur")
+	t.Logf("yields performed: %d", distributedChecker.yieldsPerformed.Load())
+}
+
 func TestFixCorruptWithApplier(t *testing.T) {
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -534,11 +534,15 @@ func (c *SingleChecker) runChecksum(ctx context.Context) error {
 	closeErr := c.trxPool.Close()
 	// Distinguish between the yield timeout expiring and the parent context
 	// being canceled. If the parent context is still valid but the yield context
-	// expired and the chunker hasn't finished, this was a yield — not a failure.
+	// expired, this was a yield — not a failure. We resume from the watermark
+	// when either the chunker hasn't finished, or an in-flight query/rollback
+	// was cancelled by the deadline (err1/closeErr != nil): the latter happens
+	// when the timeout fires on the final chunk after all chunks have been
+	// dispatched (IsRead() is already true), so !IsRead() alone would miss it.
 	// This check must come before inspecting closeErr or err1, because the yield
 	// timeout can cause both transaction rollback errors and context errors from
 	// in-flight queries.
-	if ctx.Err() == nil && yieldCtx.Err() != nil && !c.chunker.IsRead() {
+	if ctx.Err() == nil && yieldCtx.Err() != nil && (!c.chunker.IsRead() || err1 != nil || closeErr != nil) {
 		return ErrYieldTimeout
 	}
 	if closeErr != nil {


### PR DESCRIPTION
Follow-up to #1022 (which added yield/resume to the distributed checksum and closed #993).

## The bug

The yield/resume detection in `runChecksum` decides "was this a yield or a real failure?" with:

```go
if ctx.Err() == nil && yieldCtx.Err() != nil && !c.chunker.IsRead() {
    return ErrYieldTimeout
}
```

`!c.chunker.IsRead()` misses the case where the yield timeout fires on the **final** chunk. Once every chunk has been dispatched `IsRead()` is already `true`, so when the deadline then cancels the in-flight chunk query, the resulting `context deadline exceeded` is **not** recognized as a yield. It falls through to the error path and surfaces as a spurious:

```
checksum failed: ... context deadline exceeded
```

This is **fatal for the `DistributedChecker`**, whose `Run()` returns on the first `runChecksumWithYield` error. The `SingleChecker` has the same flawed detection but happens to mask it: its `Run()` retries up to `maxRetries`, so the bad attempt is only a wasted retry. Both are wrong.

In production this is low-probability (the final pass normally completes within the window, so the 24h timeout never fires on it) but non-deterministic — exactly the kind of thing a multi-day distributed checksum, which is what the yield feature exists for, can hit right at the finish line.

## The fix

Also treat a deadline-induced in-flight error as a yield when the yield context expired and the parent context is still healthy:

- distributed: `(!c.chunker.IsRead() || err1 != nil)`
- single: `(!c.chunker.IsRead() || err1 != nil || closeErr != nil)` — the single checker also propagates a trx-pool rollback error.

The common mid-table yield path (`!IsRead()`) is unchanged; this only adds the previously-missed end-of-table case.

## Test

Adds `TestDistributedCheckerYieldTimeout`, the distributed analog of `TestYieldTimeout`. It drives real yield/resume cycles (short `YieldTimeout`, a table large enough to overrun the window) and asserts the run passes and `yieldsPerformed > 0`. This exercises the actual resume path — which `TestDistributedCheckerHonorsYieldTimeoutConfig` did not (it only checked config plumbing) — and gives the distributed `yieldsPerformed` counter its first reader.

Before this fix the new test failed ~2/3 of runs; after it, 8/8 (and the full `pkg/checksum` suite stays green).

## Tests run
- `go test ./pkg/checksum -run 'TestYieldTimeout$|TestDistributedCheckerYieldTimeout$' -count=5` — green
- `go test ./pkg/checksum -count=1` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
