### PR TITLE
fix(gtid): pin TIMESTAMP decoding to UTC like the binlog client

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -291,28 +291,15 @@ func (c *binlogClient) getCurrentBinlogPosition(ctx context.Context) (mysql.Posi
 	}, nil
 }
 
-// Start initializes the binlog syncer and spawns the binlog reader
-// goroutine. Returns once the reader is running; the stream itself
-// continues until Close is called or ctx is cancelled.
-// Satisfies Source interface.
-func (c *binlogClient) Start(ctx context.Context) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	host, portStr, err := net.SplitHostPort(c.host)
-	if err != nil {
-		return fmt.Errorf("failed to parse host: %w", err)
-	}
-	// convert portStr to a uint16
-	port, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		return fmt.Errorf("failed to parse port: %w", err)
-	}
-	c.cfg = replication.BinlogSyncerConfig{
+// buildSyncerConfig returns the BinlogSyncerConfig used by Start. Split
+// out (mirroring gtidClient.buildSyncerConfig) so tests can assert the
+// decode options below stay in sync between the two clients.
+func (c *binlogClient) buildSyncerConfig(host string, port uint16) replication.BinlogSyncerConfig {
+	return replication.BinlogSyncerConfig{
 		ServerID: c.serverID,
 		Flavor:   "mysql",
 		Host:     host,
-		Port:     uint16(port),
+		Port:     port,
 		User:     c.username,
 		Password: c.password,
 		Logger:   c.logger,
@@ -337,6 +324,26 @@ func (c *binlogClient) Start(ctx context.Context) error {
 		// consistent with the UTC-pinned copier connections.
 		TimestampStringLocation: time.UTC,
 	}
+}
+
+// Start initializes the binlog syncer and spawns the binlog reader
+// goroutine. Returns once the reader is running; the stream itself
+// continues until Close is called or ctx is cancelled.
+// Satisfies Source interface.
+func (c *binlogClient) Start(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	host, portStr, err := net.SplitHostPort(c.host)
+	if err != nil {
+		return fmt.Errorf("failed to parse host: %w", err)
+	}
+	// convert portStr to a uint16
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return fmt.Errorf("failed to parse port: %w", err)
+	}
+	c.cfg = c.buildSyncerConfig(host, uint16(port))
 
 	// Apply TLS configuration using the same infrastructure as main database connections
 	if c.dbConfig != nil {

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -283,6 +283,30 @@ func (c *gtidClient) StartFromPosition(ctx context.Context, pos string) error {
 	return c.Start(ctx)
 }
 
+// buildSyncerConfig returns the BinlogSyncerConfig used by Start. Split
+// out (mirroring binlogClient.buildSyncerConfig) so tests can assert the
+// decode options below stay in sync between the two clients.
+func (c *gtidClient) buildSyncerConfig(host string, port uint16) replication.BinlogSyncerConfig {
+	return replication.BinlogSyncerConfig{
+		ServerID: c.serverID,
+		Flavor:   "mysql",
+		Host:     host,
+		Port:     port,
+		User:     c.username,
+		Password: c.password,
+		Logger:   c.logger,
+		// Render JSON the same way the binlog client does — see the
+		// rationale on NewBinlogClient.
+		RenderJSONAsMySQLText: true,
+		// Decode TIMESTAMP values in UTC the same way the binlog client
+		// does — see the rationale on NewBinlogClient. Without this, the
+		// decoder uses the process's local timezone while the applier
+		// writes over time_zone='+00:00' connections, silently shifting
+		// stored TIMESTAMP values on any non-UTC host.
+		TimestampStringLocation: time.UTC,
+	}
+}
+
 // Start satisfies Source. On a fresh start it reads @@GLOBAL.gtid_executed
 // and begins streaming from there; on a resume (flushedGTID already
 // primed by StartFromPosition) it validates the position covers
@@ -299,18 +323,7 @@ func (c *gtidClient) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse port: %w", err)
 	}
-	c.cfg = replication.BinlogSyncerConfig{
-		ServerID: c.serverID,
-		Flavor:   "mysql",
-		Host:     host,
-		Port:     uint16(port),
-		User:     c.username,
-		Password: c.password,
-		Logger:   c.logger,
-		// Render JSON the same way the binlog client does — see the
-		// rationale on NewBinlogClient.
-		RenderJSONAsMySQLText: true,
-	}
+	c.cfg = c.buildSyncerConfig(host, uint16(port))
 	if c.dbConfig != nil {
 		tlsConfig, err := dbconn.GetTLSConfigForBinlog(c.dbConfig, host)
 		if err != nil {

--- a/pkg/change/gtid_test.go
+++ b/pkg/change/gtid_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
@@ -11,10 +12,30 @@ import (
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
 	mysql2 "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
+
+// TestSyncerConfigDecodeOptions verifies that both change sources pin the
+// row-decode options that keep replayed values byte-identical to what the
+// server stored: TIMESTAMPs must be rendered in UTC (the applier writes
+// over time_zone='+00:00' connections, so a process-local-time string
+// would shift stored values on any non-UTC host) and JSON must be
+// rendered as MySQL text (see the rationale in binlog.go). The GTID
+// client previously omitted TimestampStringLocation, silently corrupting
+// TIMESTAMP columns under --gtid on non-UTC hosts.
+func TestSyncerConfigDecodeOptions(t *testing.T) {
+	configs := map[string]replication.BinlogSyncerConfig{
+		"binlog": (&binlogClient{serverID: 123}).buildSyncerConfig("127.0.0.1", 3306),
+		"gtid":   (&gtidClient{serverID: 123}).buildSyncerConfig("127.0.0.1", 3306),
+	}
+	for name, cfg := range configs {
+		require.Equal(t, time.UTC, cfg.TimestampStringLocation, "%s client must decode TIMESTAMP values in UTC", name)
+		require.True(t, cfg.RenderJSONAsMySQLText, "%s client must render JSON as MySQL text", name)
+	}
+}
 
 // TestGTIDClient mirrors TestReplClient but uses the GTID-backed change
 // source. Verifies the basic INSERT → buffer → flush loop end-to-end.


### PR DESCRIPTION
## Problem

The GTID change source (`pkg/change/gtid.go`) builds its `replication.BinlogSyncerConfig` without setting `TimestampStringLocation`. When this field is nil, go-mysql decodes TIMESTAMP row values into a wall-clock string in the **spirit process's local timezone**. Every connection the applier uses is pinned to `time_zone='+00:00'` (see dbconn), so a local-time string written back over a UTC session shifts the stored value by the host's UTC offset — silently corrupting every replayed TIMESTAMP value under `--gtid` on any host whose timezone isn't UTC.

The binlog (file/offset) client was fixed in 083819ad, but the GTID client (added in 36b9cdcf, nine days earlier) was missed: it copied the `RenderJSONAsMySQLText` option "the same way the binlog client does" but omitted `TimestampStringLocation`.

## Fix

- Set `TimestampStringLocation: time.UTC` in the GTID client's syncer config, with a short comment pointing at the full rationale on the binlog client (same pattern as the existing `RenderJSONAsMySQLText` comment).
- Extract the config construction in both clients into a `buildSyncerConfig` method (a pure function of the client fields; `Start()` behavior is unchanged) so the decode options are unit-testable without connecting.

## Testing

- New `TestSyncerConfigDecodeOptions` asserts both clients set `TimestampStringLocation == time.UTC` and `RenderJSONAsMySQLText == true`, keeping the two configs from drifting apart again. Neither field had test coverage before.
- Full `pkg/change` suite passes locally against MySQL 8.0.45 (GTID mode ON), including `TestGTIDClient`/`TestReplClient` which exercise the refactored `Start()` paths end-to-end.
- No end-to-end timezone integration test: the process-local timezone can't be changed reliably mid-process. The fix mirrors the already-verified binlog-client behavior from 083819ad exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
