### PR TITLE
fix(migration): reject ALGORITHM=/LOCK= before direct DDL and narrow the INPLACE VARCHAR fast path

### DIFF
--- a/pkg/migration/ddl_test.go
+++ b/pkg/migration/ddl_test.go
@@ -92,6 +92,56 @@ func TestIndexVisibility(t *testing.T) {
 	require.NoError(t, m.Close())
 }
 
+// TestUnsupportedClauseRejectedBeforeDDL tests that a user-supplied ALGORITHM=
+// or LOCK= clause fails the migration before any DDL is attempted directly on
+// MySQL. attemptMySQLDDL prepends its own ALGORITHM= assertion, and MySQL
+// resolves duplicate options last-one-wins — so without the early check, a
+// trailing user clause would override Spirit's and could execute a blocking
+// table rebuild (the preflight illegalClause check only runs after the direct
+// DDL attempt has already been made).
+func TestUnsupportedClauseRejectedBeforeDDL(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "rejectalgorithm", `CREATE TABLE rejectalgorithm (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		b INT NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+
+	columnExists := func(name string) bool {
+		var count int
+		require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='rejectalgorithm' AND column_name=?",
+			name).Scan(&count))
+		return count > 0
+	}
+
+	// --alter path: a trailing ALGORITHM= clause must fail fast.
+	m := NewTestRunner(t, "rejectalgorithm", "ADD COLUMN c INT, ALGORITHM=INPLACE", WithThreads(1))
+	err := m.Run(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unsupported clause")
+	require.False(t, m.usedInstantDDL)
+	require.False(t, m.usedInplaceDDL)
+	require.NoError(t, m.Close())
+	require.False(t, columnExists("c")) // no DDL may have been executed
+
+	// --statement path: ALGORITHM= and LOCK= must also fail fast.
+	m = NewTestRunnerFromStatement(t, "ALTER TABLE rejectalgorithm ADD COLUMN d INT, ALGORITHM=COPY, LOCK=SHARED", WithThreads(1))
+	err = m.Run(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unsupported clause")
+	require.False(t, m.usedInstantDDL)
+	require.False(t, m.usedInplaceDDL)
+	require.NoError(t, m.Close())
+	require.False(t, columnExists("d")) // no DDL may have been executed
+
+	// The same ALTER without the illegal clauses still works.
+	m = NewTestRunner(t, "rejectalgorithm", "ADD COLUMN c INT", WithThreads(1))
+	require.NoError(t, m.Run(t.Context()))
+	require.NoError(t, m.Close())
+	require.True(t, columnExists("c"))
+}
+
 // TestStatementWorkflowStillInstant tests that a Statement-based ALTER that qualifies
 // for instant DDL is still detected and applied instantly.
 func TestStatementWorkflowStillInstant(t *testing.T) {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -312,6 +312,23 @@ func (r *Runner) Run(ctx context.Context) error {
 			r.logger.Error("failed to release metadata lock", "error", err)
 		}
 	}()
+	// Reject ALTERs that contain unsupported clauses such as ALGORITHM=
+	// or LOCK= *before* any DDL is attempted directly on MySQL.
+	// attemptMySQLDDL prepends its own ALGORITHM= (and LOCK=) assertions,
+	// and MySQL resolves duplicate options last-one-wins: a user-supplied
+	// "ALGORITHM=COPY, LOCK=SHARED" would override our ALGORITHM=INSTANT
+	// and execute as a blocking table rebuild. The preflight illegalClause
+	// check below also rejects these clauses, but it only runs after the
+	// direct DDL attempt has already failed, which is too late to protect
+	// this path.
+	for _, change := range r.changes {
+		if !change.stmt.IsAlterTable() {
+			continue // the check only applies to ALTER TABLE statements
+		}
+		if err := change.stmt.AlterContainsUnsupportedClause(); err != nil {
+			return err
+		}
+	}
 	// This step is technically optional, but first we attempt to
 	// use MySQL's built-in DDL. This is because it's usually faster
 	// when it is compatible. If it returns no error, that means it

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -274,6 +274,24 @@ func (r *Runner) Run(ctx context.Context) error {
 			return nil
 		}
 	}
+	// Reject ALTERs that contain unsupported clauses such as ALGORITHM=
+	// or LOCK= *before* any DDL is attempted directly on MySQL.
+	// attemptMySQLDDL below prepends its own ALGORITHM= (and LOCK=)
+	// assertions, and MySQL resolves duplicate options last-one-wins: a
+	// user-supplied "ALGORITHM=COPY, LOCK=SHARED" would override our
+	// ALGORITHM=INSTANT and execute as a blocking table rebuild. The
+	// preflight illegalClause check also rejects these clauses, but it
+	// only runs after the direct DDL attempt has already failed, which is
+	// too late to protect this path. This is a pure parse-level check, so
+	// it runs before any table introspection or metadata locking.
+	for _, change := range r.changes {
+		if !change.stmt.IsAlterTable() {
+			continue // the check only applies to ALTER TABLE statements
+		}
+		if err := change.stmt.AlterContainsUnsupportedClause(); err != nil {
+			return err
+		}
+	}
 	// Set info for all of the tables.
 	tables := make([]*table.TableInfo, 0, len(r.changes))
 	for _, change := range r.changes {
@@ -312,23 +330,6 @@ func (r *Runner) Run(ctx context.Context) error {
 			r.logger.Error("failed to release metadata lock", "error", err)
 		}
 	}()
-	// Reject ALTERs that contain unsupported clauses such as ALGORITHM=
-	// or LOCK= *before* any DDL is attempted directly on MySQL.
-	// attemptMySQLDDL prepends its own ALGORITHM= (and LOCK=) assertions,
-	// and MySQL resolves duplicate options last-one-wins: a user-supplied
-	// "ALGORITHM=COPY, LOCK=SHARED" would override our ALGORITHM=INSTANT
-	// and execute as a blocking table rebuild. The preflight illegalClause
-	// check below also rejects these clauses, but it only runs after the
-	// direct DDL attempt has already failed, which is too late to protect
-	// this path.
-	for _, change := range r.changes {
-		if !change.stmt.IsAlterTable() {
-			continue // the check only applies to ALTER TABLE statements
-		}
-		if err := change.stmt.AlterContainsUnsupportedClause(); err != nil {
-			return err
-		}
-	}
 	// This step is technically optional, but first we attempt to
 	// use MySQL's built-in DDL. This is because it's usually faster
 	// when it is compatible. If it returns no error, that means it

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -234,7 +234,16 @@ func (a *AbstractStatement) AlgorithmInplaceConsideredSafe() error {
 			// Only safe if changing length of a VARCHAR column. We don't know the type of the column
 			// or its length, so we cannot determine if this is safe only by parsing. We can simply try
 			// INPLACE, and if it fails we will retry with our own schema change process.
-			if spec.NewColumns[0].Tp != nil && spec.NewColumns[0].Tp.GetType() == mysql.TypeVarchar {
+			//
+			// "Try INPLACE and let MySQL reject it" does not protect against
+			// rebuild-class changes that MySQL *accepts* under ALGORITHM=INPLACE
+			// though: converting a column to NOT NULL and reordering a column
+			// (FIRST/AFTER) both succeed as INPLACE with a full table rebuild,
+			// which can block replicas. A NOT NULL redeclaration can't be proven
+			// unchanged from the statement alone (we don't have the current
+			// nullability here), so it conservatively routes to the copy process.
+			if spec.NewColumns[0].Tp != nil && spec.NewColumns[0].Tp.GetType() == mysql.TypeVarchar &&
+				!columnReordered(spec) && !columnDeclaredNotNull(spec.NewColumns[0]) {
 				continue
 			}
 			unsafeClauses++
@@ -249,6 +258,23 @@ func (a *AbstractStatement) AlgorithmInplaceConsideredSafe() error {
 		return ErrUnsafeForInplace
 	}
 	return nil
+}
+
+// columnReordered returns true if a MODIFY/CHANGE COLUMN spec moves the
+// column with a FIRST or AFTER clause.
+func columnReordered(spec *ast.AlterTableSpec) bool {
+	return spec.Position != nil && spec.Position.Tp != ast.ColumnPositionNone
+}
+
+// columnDeclaredNotNull returns true if the new column definition
+// declares NOT NULL.
+func columnDeclaredNotNull(col *ast.ColumnDef) bool {
+	for _, opt := range col.Options {
+		if opt.Tp == ast.ColumnOptionNotNull {
+			return true
+		}
+	}
+	return false
 }
 
 // AlterContainsUnsupportedClause checks to see if any clauses of an ALTER

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -188,6 +188,16 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	require.NoError(t, test("change column `a` `a` varchar(100)"))
 	require.NoError(t, test("modify `a` varchar(255)"))
 	require.NoError(t, test("change column `a` `new_a` varchar(50)"))
+	require.NoError(t, test("modify `a` varchar(100) NULL")) // explicit NULL never converts
+
+	// VARCHAR modifications that MySQL *accepts* under ALGORITHM=INPLACE but
+	// performs with a full table rebuild are unsafe: NOT NULL conversion and
+	// column reorder (FIRST/AFTER).
+	require.ErrorIs(t, test("modify `a` varchar(200) NOT NULL"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("change column `a` `a` varchar(200) NOT NULL"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("modify `a` varchar(200) FIRST"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("modify `a` varchar(200) AFTER `b`"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("change column `a` `a` varchar(200) AFTER `b`"), ErrUnsafeForInplace)
 
 	// Non-VARCHAR column modifications should be unsafe (table-rebuilding)
 	require.ErrorIs(t, test("modify `a` int"), ErrUnsafeForInplace)


### PR DESCRIPTION
## Problem

Two related ways spirit could execute a **blocking table rebuild directly on the primary**, verified live on MySQL 8.0.45:

**1. User-supplied `ALGORITHM=`/`LOCK=` bypasses the illegal-clause guard.**
`Run()` calls `attemptMySQLDDL()` *before* the `ScopePreflight` checks, and when the direct DDL succeeds it returns immediately — so the preflight `illegalClause` check (which rejects `ALGORITHM=`/`LOCK=` in the user's alter) never runs on the success path. `attemptInstantDDL` builds `ALTER TABLE t ALGORITHM=INSTANT, <user alter>`, and MySQL applies duplicate `ALGORITHM`/`LOCK` options last-one-wins. So:

```
spirit --alter "ADD COLUMN c INT, ALGORITHM=COPY, LOCK=SHARED"
```

executes as `ALTER TABLE t ALGORITHM=INSTANT, ADD COLUMN c INT, ALGORITHM=COPY, LOCK=SHARED` — a full **blocking** rebuild directly on the primary. Both the `--alter` and `--statement` paths are affected.

**2. `AlgorithmInplaceConsideredSafe` misclassifies rebuild-class INPLACE changes.**
The `MODIFY`/`CHANGE` case treats *any* spec whose new type is VARCHAR as safe, on the assumption that unsafe variants get rejected by MySQL when tried INPLACE. That assumption is false for rebuild-class changes MySQL *accepts* under `ALGORITHM=INPLACE`: a `NULL` → `NOT NULL` conversion and a column reorder (`FIRST`/`AFTER`) both succeed as INPLACE with a **full table rebuild** (verified: `MODIFY c VARCHAR(200) NOT NULL, ALGORITHM=INPLACE, LOCK=NONE` succeeds while `ALGORITHM=INSTANT` is rejected). Spirit then executes an unthrottled full rebuild directly — replicas stall for the duration, defeating spirit's purpose.

## Fix

**1.** `Run()` now checks `AlterContainsUnsupportedClause()` for every ALTER TABLE change *before* any direct DDL attempt, and fails fast with the same error the preflight check produces. Non-ALTER statements (the CREATE/DROP/RENAME single-table path) are skipped and unaffected; multi-table mode checks each ALTER. The preflight `illegalClause` check stays as-is (defense in depth).

**2.** The VARCHAR fast path in `AlgorithmInplaceConsideredSafe` now additionally requires that the spec has no `FIRST`/`AFTER` position clause and no `NOT NULL` declaration in the new column definition; otherwise it is unsafe and routes to the copy path. This is parse-only — `TableInfo` carries no nullability metadata at this layer, so a precise old-vs-new comparison isn't available.

**Trade-off (deliberate, safety over speed):** `MODIFY c VARCHAR(bigger) NOT NULL` on an *already*-`NOT NULL` column can no longer be proven a metadata-only change from the statement alone, so it loses the INPLACE fast path and is migrated via copy. A future metadata-aware check (comparing against the current column's nullability) could restore the fast path for that case. 

**Known residual gap (same parse-only limitation):** MySQL also rebuilds under INPLACE when a column is made *nullable*, so a bare `MODIFY c VARCHAR(bigger)` on a currently-`NOT NULL` column — i.e. the user is implicitly dropping the constraint, likely by accident — still takes the fast path and rebuilds. Detecting it requires knowing the column's current nullability, which is the same metadata-aware follow-up described above; blocking every bare `MODIFY ... VARCHAR` here would remove the fast path for the common nullable-extension case entirely.

## Testing

- New `TestUnsupportedClauseRejectedBeforeDDL` (pkg/migration): `--alter "ADD COLUMN c INT, ALGORITHM=INPLACE"` and `--statement "... ADD COLUMN d INT, ALGORITHM=COPY, LOCK=SHARED"` both fail fast with the unsupported-clause error, and the columns are verified **not** added (no DDL executed); the same alter without the illegal clauses still succeeds (via INSTANT).
- Extended `TestAlgorithmInplaceConsideredSafe` (pkg/statement): bare `MODIFY a VARCHAR(200)` / explicit `NULL` remain safe; `NOT NULL`, `FIRST`, and `AFTER x` variants (both `MODIFY` and `CHANGE`) now return `ErrUnsafeForInplace`.
- Ran against MySQL 8.0.45: full `pkg/statement` and `pkg/migration/check` suites, plus targeted `pkg/migration` runs covering `TestAlterExtendVarcharE2E`, `TestOnline`, `TestIndexVisibility`, `TestStatementWorkflowStillInstant`, `TestTrailingSemicolon`, `TestStmtWorkflow` (non-ALTER path), `TestChangeDatatype*`, `TestEnumToVarchar`, `TestSetToVarchar`, `TestRenameColumn*`, `TestRenameInMySQL80`, `TestChangeNonIntPK`, `TestForNonInstantBurn`, and the multi-table migration tests — all pass.
- Grepped existing tests for alters containing `ALGORITHM=`/`LOCK=` that previously slipped through: the only occurrences are direct SQL via `testutils.RunSQL`/`dbconn.Exec` and the illegal-clause check's own unit tests; none relied on the bypass.
- `gofmt`, `go build ./...`, `golangci-lint run` clean on changed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

