### PR TITLE
fix(dbconn): make MetadataLock refresh survive a failed reconnect instead of panicking

### DIFF
--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -32,6 +32,8 @@ type MetadataLock struct {
 	// newDBConn optionally overrides how the dedicated pool is established.
 	// It is a test seam (set via an option func) so tests can simulate
 	// reconnection failures deterministically; production leaves it nil.
+	// NewMetadataLock enforces the dedicated-pool invariants on whatever
+	// the factory returns, so the seam cannot weaken the lock semantics.
 	newDBConn func() (*sql.DB, error)
 }
 
@@ -75,16 +77,31 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 	// 1-minute refresh that holds for any sane wait_timeout (e.g. the 10
 	// minutes we configure). If the keepalive ever fails, the ticker tears
 	// the connection down and re-establishes it.
+	//
+	// The pool is opened by dial (which the test seam can substitute), but
+	// the invariants are enforced here regardless of which factory ran:
+	// GET_LOCK is session scoped, so the pool must serve exactly one
+	// connection and must never recycle it client-side.
+	dial := func() (*sql.DB, error) {
+		return New(dsn, &dbConfig)
+	}
+	if mdl.newDBConn != nil {
+		dial = mdl.newDBConn // test seam, see MetadataLock.newDBConn
+	}
 	newConnection := func() (*sql.DB, error) {
-		db, err := New(dsn, &dbConfig)
+		db, err := dial()
 		if err != nil {
 			return nil, err
 		}
+		if db == nil {
+			// A (nil, nil) return from a misbehaving factory would otherwise
+			// reintroduce the nil-pool dereference the refresh loop guards
+			// against; surface it as a connection failure instead.
+			return nil, errors.New("connection factory returned a nil database")
+		}
+		db.SetMaxOpenConns(1)
 		db.SetConnMaxLifetime(0) // see comment above; keepalive is the refresh ticker
 		return db, nil
-	}
-	if mdl.newDBConn != nil {
-		newConnection = mdl.newDBConn // test seam, see MetadataLock.newDBConn
 	}
 	var err error
 	mdl.db, err = newConnection()
@@ -148,10 +165,12 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 					// and we can try again on the next tick interval.
 					logger.Warn("could not refresh metadata locks", "error", err)
 
-					// try to close the existing connection before replacing it
+					// close the existing connection before replacing it. Even
+					// when Close() returns an error the pool is already marked
+					// as closed and unusable, so don't keep it: log, abandon
+					// it, and proceed straight to reconnection below.
 					if closeErr := mdl.db.Close(); closeErr != nil {
 						logger.Warn("could not close database connection", "error", closeErr)
-						continue
 					}
 				}
 

--- a/pkg/dbconn/metadatalock.go
+++ b/pkg/dbconn/metadatalock.go
@@ -29,6 +29,10 @@ type MetadataLock struct {
 	refreshInterval time.Duration
 	db              *sql.DB
 	lockNames       []string // Multiple lock names for multiple tables
+	// newDBConn optionally overrides how the dedicated pool is established.
+	// It is a test seam (set via an option func) so tests can simulate
+	// reconnection failures deterministically; production leaves it nil.
+	newDBConn func() (*sql.DB, error)
 }
 
 func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo, config *DBConfig, logger *slog.Logger, optionFns ...func(*MetadataLock)) (*MetadataLock, error) {
@@ -79,6 +83,9 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 		db.SetConnMaxLifetime(0) // see comment above; keepalive is the refresh ticker
 		return db, nil
 	}
+	if mdl.newDBConn != nil {
+		newConnection = mdl.newDBConn // test seam, see MetadataLock.newDBConn
+	}
 	var err error
 	mdl.db, err = newConnection()
 	if err != nil {
@@ -104,6 +111,16 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 		for {
 			select {
 			case <-ctx.Done():
+				// mdl.db is nil if the connection was torn down on a failed
+				// refresh and every reconnect attempt since has failed: there
+				// is no session left to release locks on and no pool to close.
+				if mdl.db == nil {
+					select {
+					case mdl.closeCh <- nil:
+					default:
+					}
+					return
+				}
 				// Explicitly release the locks before closing the connection.
 				// Relying on connection close alone leaves a small window where
 				// MySQL has not yet finished tearing down the session, so a
@@ -119,7 +136,11 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 				}
 				return
 			case <-ticker.C:
-				if err = mdl.getLocks(ctx, logger); err != nil {
+				if mdl.db != nil {
+					if err = mdl.getLocks(ctx, logger); err == nil {
+						logger.Debug("refreshed metadata locks")
+						continue
+					}
 					// if we can't refresh the lock, it's okay.
 					// We have other safety mechanisms in place to prevent corruption
 					// for example, we watch the binary log to see metadata changes
@@ -127,29 +148,30 @@ func NewMetadataLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 					// and we can try again on the next tick interval.
 					logger.Warn("could not refresh metadata locks", "error", err)
 
-					// try to close the existing connection
+					// try to close the existing connection before replacing it
 					if closeErr := mdl.db.Close(); closeErr != nil {
 						logger.Warn("could not close database connection", "error", closeErr)
 						continue
 					}
-
-					// try to re-establish the connection
-					mdl.db, err = newConnection()
-					if err != nil {
-						logger.Warn("could not re-establish database connection", "error", err)
-						continue
-					}
-
-					// try to acquire the locks again with the new connection
-					if err = mdl.getLocks(ctx, logger); err != nil {
-						logger.Warn("could not acquire metadata locks after re-establishing connection", "error", err)
-						continue
-					}
-
-					logger.Info("re-acquired metadata locks after re-establishing connection")
-				} else {
-					logger.Debug("refreshed metadata locks")
 				}
+
+				// try to (re-)establish the connection. newConnection pings
+				// the server, so while the outage persists it keeps returning
+				// (nil, err) and mdl.db stays nil; the next tick then lands
+				// back here and retries the connection first, instead of
+				// dereferencing the nil pool in getLocks.
+				if mdl.db, err = newConnection(); err != nil {
+					logger.Warn("could not re-establish database connection", "error", err)
+					continue
+				}
+
+				// try to acquire the locks again with the new connection
+				if err = mdl.getLocks(ctx, logger); err != nil {
+					logger.Warn("could not acquire metadata locks after re-establishing connection", "error", err)
+					continue
+				}
+
+				logger.Info("re-acquired metadata locks after re-establishing connection")
 			}
 		}
 	}()

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -3,8 +3,10 @@ package dbconn
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -356,6 +358,126 @@ func TestMetadataLockCloseReleasesStackedLock(t *testing.T) {
 	var released sql.NullInt64
 	stmt = sqlescape.MustEscapeSQL("SELECT RELEASE_LOCK(%?)", lockName)
 	require.NoError(t, observer.QueryRowContext(t.Context(), stmt).Scan(&released))
+}
+
+// failableConnFactory returns an option for NewMetadataLock that installs a
+// connection factory under test control, plus the knobs to drive it: set fail
+// to true and every (re-)connection attempt errors — exactly what the real
+// factory does during a server outage, since it pings before returning —
+// and failedAttempts counts how many attempts were denied.
+func failableConnFactory(refresh time.Duration) (option func(*MetadataLock), fail *atomic.Bool, failedAttempts *atomic.Int64) {
+	fail = &atomic.Bool{}
+	failedAttempts = &atomic.Int64{}
+	option = func(mdl *MetadataLock) {
+		mdl.refreshInterval = refresh
+		mdl.newDBConn = func() (*sql.DB, error) {
+			if fail.Load() {
+				failedAttempts.Add(1)
+				return nil, errors.New("simulated connection failure")
+			}
+			db, err := New(testutils.DSN(), NewDBConfig())
+			if err != nil {
+				return nil, err
+			}
+			db.SetConnMaxLifetime(0) // match the production factory
+			return db, nil
+		}
+	}
+	return option, fail, failedAttempts
+}
+
+// TestMetadataLockRefreshSurvivesReconnectFailure pins the fix for a crash
+// during exactly the outage the refresh loop exists to survive. When a
+// refresh fails, the loop tears down the pool and reconnects; newConnection
+// pings the server, so while the outage persists it returns (nil, err) and
+// leaves mdl.db nil. Before the fix, the next tick dereferenced the nil pool
+// in getLocks and panicked in a goroutine with no recover, crashing the whole
+// process mid-migration. The loop must instead keep retrying the connection
+// and re-acquire the locks once the server is reachable again.
+func TestMetadataLockRefreshSurvivesReconnectFailure(t *testing.T) {
+	lockTableInfo := table.TableInfo{SchemaName: "test", TableName: "reconnect-fail-retry"}
+	lockTables := []*table.TableInfo{&lockTableInfo}
+	logger := slog.Default()
+
+	option, fail, failedAttempts := failableConnFactory(100 * time.Millisecond)
+	mdl, err := NewMetadataLock(t.Context(), testutils.DSN(), lockTables, NewDBConfig(), logger, option)
+	require.NoError(t, err)
+	require.NotNil(t, mdl)
+	closeMDL := closeOnce(mdl)
+	t.Cleanup(func() { _ = closeMDL() })
+
+	// Start the outage. Capture the pool before flipping the switch: the
+	// refresh goroutine only reassigns mdl.db after a refresh failure, and
+	// the atomic Store orders this read before any such write. Closing the
+	// pool makes the next refresh tick fail and enter the reconnect path.
+	db := mdl.db
+	fail.Store(true)
+	require.NoError(t, db.Close())
+
+	// Survive several ticks with no usable pool: attempt 1 is the tick that
+	// lost the connection, attempts 2+ are ticks that started with mdl.db
+	// nil — the ticks that panicked the process before the fix.
+	require.Eventually(t, func() bool {
+		return failedAttempts.Load() >= 3
+	}, 30*time.Second, 10*time.Millisecond, "expected repeated reconnect attempts during the outage")
+
+	// End the outage: the loop must reconnect and re-acquire the locks.
+	fail.Store(false)
+
+	observer, err := New(testutils.DSN(), NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(observer)
+
+	lockName := computeLockName(&lockTableInfo)
+	stmt := sqlescape.MustEscapeSQL("SELECT IS_USED_LOCK(%?)", lockName)
+	require.Eventually(t, func() bool {
+		var owner sql.NullInt64
+		if err := observer.QueryRowContext(t.Context(), stmt).Scan(&owner); err != nil {
+			return false
+		}
+		return owner.Valid
+	}, 30*time.Second, 50*time.Millisecond, "metadata lock was not re-acquired after the outage ended")
+
+	require.NoError(t, closeMDL())
+}
+
+// TestMetadataLockCloseDuringOutage pins the shutdown half of the same fix:
+// if the migration finishes (context canceled / Close called) while the
+// connection is down and could not be re-established, Close must return
+// cleanly instead of panicking on the nil pool in releaseLocks/db.Close.
+func TestMetadataLockCloseDuringOutage(t *testing.T) {
+	lockTableInfo := table.TableInfo{SchemaName: "test", TableName: "reconnect-fail-close"}
+	lockTables := []*table.TableInfo{&lockTableInfo}
+	logger := slog.Default()
+
+	option, fail, failedAttempts := failableConnFactory(100 * time.Millisecond)
+	mdl, err := NewMetadataLock(t.Context(), testutils.DSN(), lockTables, NewDBConfig(), logger, option)
+	require.NoError(t, err)
+	require.NotNil(t, mdl)
+
+	// Start the outage (see TestMetadataLockRefreshSurvivesReconnectFailure
+	// for why the pool is captured before the Store).
+	db := mdl.db
+	fail.Store(true)
+	require.NoError(t, db.Close())
+
+	// Wait until the connection has been down across at least one full tick
+	// (>= 2 failed attempts means at least one tick ran with no pool at all).
+	require.Eventually(t, func() bool {
+		return failedAttempts.Load() >= 2
+	}, 30*time.Second, 10*time.Millisecond, "expected reconnect attempts during the outage")
+
+	// Close during the outage: it must not panic and must not block. There is
+	// no connection left, so there are no locks to release and nothing to
+	// close; the refresh goroutine reports a clean shutdown.
+	closed := make(chan error, 1)
+	go func() { closed <- mdl.Close() }()
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("MetadataLock.Close did not return during a connection outage")
+	}
 }
 
 func TestMetadataLockRefreshWithConnIssueSimulation(t *testing.T) {

--- a/pkg/dbconn/metadatalock_test.go
+++ b/pkg/dbconn/metadatalock_test.go
@@ -375,12 +375,10 @@ func failableConnFactory(refresh time.Duration) (option func(*MetadataLock), fai
 				failedAttempts.Add(1)
 				return nil, errors.New("simulated connection failure")
 			}
-			db, err := New(testutils.DSN(), NewDBConfig())
-			if err != nil {
-				return nil, err
-			}
-			db.SetConnMaxLifetime(0) // match the production factory
-			return db, nil
+			// The dedicated-pool invariants (single connection, no
+			// client-side recycling) are enforced by NewMetadataLock's
+			// wrapper around this factory, so a plain New suffices here.
+			return New(testutils.DSN(), NewDBConfig())
 		}
 	}
 	return option, fail, failedAttempts
@@ -406,10 +404,11 @@ func TestMetadataLockRefreshSurvivesReconnectFailure(t *testing.T) {
 	closeMDL := closeOnce(mdl)
 	t.Cleanup(func() { _ = closeMDL() })
 
-	// Start the outage. Capture the pool before flipping the switch: the
-	// refresh goroutine only reassigns mdl.db after a refresh failure, and
-	// the atomic Store orders this read before any such write. Closing the
-	// pool makes the next refresh tick fail and enter the reconnect path.
+	// Start the outage. Reading mdl.db here is safe (not a data race): the
+	// refresh goroutine only reassigns it after a refresh failure, and the
+	// first failure is only induced below, by closing the pool. The fail
+	// switch is flipped before the Close so that when the failing tick
+	// fires, its reconnect attempt is already set up to be denied.
 	db := mdl.db
 	fail.Store(true)
 	require.NoError(t, db.Close())
@@ -455,8 +454,8 @@ func TestMetadataLockCloseDuringOutage(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, mdl)
 
-	// Start the outage (see TestMetadataLockRefreshSurvivesReconnectFailure
-	// for why the pool is captured before the Store).
+	// Start the outage (see TestMetadataLockRefreshSurvivesReconnectFailure:
+	// reading mdl.db is safe until the first induced refresh failure below).
 	db := mdl.db
 	fail.Store(true)
 	require.NoError(t, db.Close())


### PR DESCRIPTION
## Problem

The MetadataLock refresh goroutine crashes the whole spirit process during exactly the transient outage it exists to survive.

On a failed lock refresh it closes the pool and reconnects:

```go
mdl.db, err = newConnection()
if err != nil {
    logger.Warn("could not re-establish database connection", "error", err)
    continue // mdl.db is now nil
}
```

`newConnection` pings the server, so while an outage persists it returns `(nil, err)` — guaranteed during a failover/network blip. After that `mdl.db` is nil and:

- the next ticker tick calls `getLocks` → `m.db.QueryRowContext` on a nil `*sql.DB` → nil-pointer panic in a goroutine with no recover → the whole process crashes mid-migration;
- the `ctx.Done()` path dereferences the nil pool in `releaseLocks` and `mdl.closeCh <- mdl.db.Close()` → same panic if the migration finishes during the outage.

Failure scenario: transient failover → refresh `GET_LOCK` fails → reconnect ping fails (same outage) → one refresh interval later, unrecovered panic.

## Fix

Restructure the ticker path so both the healthy and the connection-lost states flow through one reconnect sequence:

- if `mdl.db` is non-nil, refresh as before; on failure, close the pool and fall through to reconnection;
- if `mdl.db` is nil (a previous reconnect failed), skip straight to reconnection — nothing dereferences the nil pool;
- on `ctx.Done()` with a nil pool, there is no session to release locks on and no pool to close, so report a clean shutdown (`closeCh <- nil`) instead of panicking.

The retry-forever-with-warnings semantics are unchanged: every failure is still a `Warn` and the loop tries again on the next tick. `mdl.db` is still only written by the refresh goroutine, so the file's existing synchronization model is unchanged.

Also adds a package-private connection-factory seam (`newDBConn`, set via the existing option-func pattern) so tests can deny reconnection deterministically.

## Testing

Two new tests, both of which panic (crash the test binary) without the fix and pass with it:

- `TestMetadataLockRefreshSurvivesReconnectFailure` — denies reconnection for several ticks (so ticks run with `mdl.db == nil`), then restores connectivity and asserts via a separate observer connection (`IS_USED_LOCK`) that the lock is re-acquired.
- `TestMetadataLockCloseDuringOutage` — with the connection down and reconnects failing, `Close()` returns cleanly (no panic, no block, nil error).

Verified:

- new tests panic at `metadatalock.go` `getLocks` without the fix (reproducing the reported crash), pass with it
- full `TestMetadataLock*`/`TestComputeLockName*` suite passes under `-race` (13 tests)
- new tests pass `-race -count=5` (no flakes, no data races)
- `go build ./...`, `gofmt`, `golangci-lint run ./pkg/dbconn/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
