### PR TITLE
fix(checksum): reset isInvalid between retry attempts to prevent a vacuous pass

### DIFF
--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -492,6 +492,10 @@ func (c *DistributedChecker) Run(ctx context.Context) error {
 			}
 			// Reset differences found counter
 			c.differencesFound.Store(0)
+			// Reset the invalid flag left set by a failed attempt: it makes
+			// isHealthy() false, which would skip every chunk and turn this
+			// retry into a vacuous pass.
+			c.setInvalid(false)
 		}
 
 		// If the parent context is already cancelled, retrying is pointless.

--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -482,6 +482,10 @@ func (c *DistributedChecker) Run(ctx context.Context) error {
 		_ = c.applier.Stop()
 	}()
 
+	// A previous Run may have left the checker poisoned (isInvalid=true from
+	// an errored attempt); every Run starts healthy.
+	c.setInvalid(false)
+
 	// Try the checksum up to n times if differences are found and we can fix them
 	for attempt := 1; attempt <= c.maxRetries; attempt++ {
 		if attempt > 1 {

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -278,14 +278,73 @@ func TestDistributedRetryDoesNotVacuouslyPass(t *testing.T) {
 	err = checker.Run(t.Context())
 	require.ErrorContains(t, err, "checksum mismatch")
 
-	// Second Run on the same checker: attempt 1 still sees the leftover
-	// differencesFound from the first Run, so the retry loop advances to
-	// attempt 2, which must clear the poisoned flag and re-verify the
-	// still-divergent data. Without the reset this returned nil ("checksum
+	// A second Run on the same checker must start healthy, re-verify the
+	// still-divergent data, and fail again. Without the isInvalid resets (at
+	// Run entry and between retry attempts) this returned nil ("checksum
 	// passed") having checked zero chunks.
 	err = checker.Run(t.Context())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "checksum mismatch")
+}
+
+// TestDistributedRunResetsPriorInvalidState is the distributed analog of
+// TestRunResetsPriorInvalidState (single checker): a prior Run that errored
+// WITHOUT recording differences (e.g. a transient connection failure) leaves
+// isInvalid=true and differencesFound==0. A reused checker's next Run must
+// start healthy — otherwise attempt 1 skips every chunk (isHealthy()==false),
+// sees differencesFound==0, and returns nil having verified zero rows.
+func TestDistributedRunResetsPriorInvalidState(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	newDBName, _ := testutils.CreateUniqueTestDatabase(t)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS runpoison_dist_t1")
+	testutils.RunSQL(t, "CREATE TABLE runpoison_dist_t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "INSERT INTO runpoison_dist_t1 VALUES (1, 2, 3), (2, 2, 3)")
+
+	testutils.RunSQL(t, "CREATE TABLE "+newDBName+".runpoison_dist_t1 LIKE runpoison_dist_t1")
+	testutils.RunSQL(t, "INSERT INTO "+newDBName+".runpoison_dist_t1 SELECT * FROM runpoison_dist_t1")
+
+	destCfg := cfg.Clone()
+	destCfg.DBName = newDBName
+
+	src, err := dbconn.New(cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(src)
+	dest, err := dbconn.New(destCfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(dest)
+
+	t1 := table.NewTableInfo(src, "test", "runpoison_dist_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(dest, newDBName, "runpoison_dist_t1")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	target := applier.Target{DB: dest, KeyRange: "0", Config: destCfg}
+	app, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	feed := change.NewBinlogClient(src, cfg.Addr, cfg.User, cfg.Passwd, app, change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.Applier = app
+	checker, err := NewChecker([]*sql.DB{src}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+	distChecker, ok := checker.(*DistributedChecker)
+	require.True(t, ok)
+	// Simulate the state left by a prior errored Run that found no differences.
+	distChecker.setInvalid(true)
+
+	// The data is identical, so the pass must succeed — with real work done.
+	require.NoError(t, checker.Run(t.Context()))
+	require.True(t, chunker.IsRead(), "the chunker must be fully read; a vacuous pass reads no chunks")
+	require.Positive(t, checker.GetProgress().RowsChecked, "rows must actually be verified")
 }
 
 func TestDistributedChecksum(t *testing.T) {

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -217,6 +217,77 @@ func TestFixCorruptWithApplier(t *testing.T) {
 	require.Equal(t, "3/3 100.00%", checker.GetProgress().String())
 }
 
+// TestDistributedRetryDoesNotVacuouslyPass is the distributed analog of
+// TestRetryDoesNotVacuouslyPass (single checker). A failed pass leaves
+// isInvalid=true; if a retry attempt does not clear it, isHealthy() stays
+// false, the attempt dispatches zero chunks, and Run reports "checksum
+// passed" with zero rows verified. Unlike the single checker,
+// DistributedChecker.Run returns hard errors immediately (no retry
+// continue), so the poisoned-retry path is reached by reusing the checker
+// for a subsequent Run — the same reuse pattern as move's
+// continuous-checksum loop. The second Run must fail again on the
+// still-divergent data, not return nil.
+func TestDistributedRetryDoesNotVacuouslyPass(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	newDBName, _ := testutils.CreateUniqueTestDatabase(t)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS retrypoison_dist_t1")
+	testutils.RunSQL(t, "CREATE TABLE retrypoison_dist_t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "INSERT INTO retrypoison_dist_t1 VALUES (1, 2, 3)")
+
+	testutils.RunSQL(t, "CREATE TABLE "+newDBName+".retrypoison_dist_t1 LIKE retrypoison_dist_t1")
+	testutils.RunSQL(t, "INSERT INTO "+newDBName+".retrypoison_dist_t1 VALUES (1, 9, 9)") // divergent row
+
+	destCfg := cfg.Clone()
+	destCfg.DBName = newDBName
+
+	src, err := dbconn.New(cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(src)
+	dest, err := dbconn.New(destCfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(dest)
+
+	t1 := table.NewTableInfo(src, "test", "retrypoison_dist_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(dest, newDBName, "retrypoison_dist_t1")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	target := applier.Target{DB: dest, KeyRange: "0", Config: destCfg}
+	app, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	feed := change.NewBinlogClient(src, cfg.Addr, cfg.User, cfg.Passwd, app, change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.Applier = app
+	config.FixDifferences = false // surface the mismatch as an error
+	config.MaxRetries = 2
+	checker, err := NewChecker([]*sql.DB{src}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+
+	// The first Run fails on the divergent row and returns immediately,
+	// leaving the checker poisoned (isInvalid=true) for the next Run.
+	err = checker.Run(t.Context())
+	require.ErrorContains(t, err, "checksum mismatch")
+
+	// Second Run on the same checker: attempt 1 still sees the leftover
+	// differencesFound from the first Run, so the retry loop advances to
+	// attempt 2, which must clear the poisoned flag and re-verify the
+	// still-divergent data. Without the reset this returned nil ("checksum
+	// passed") having checked zero chunks.
+	err = checker.Run(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "checksum mismatch")
+}
+
 func TestDistributedChecksum(t *testing.T) {
 	// Create source database with test data
 	// use a reserved word in the column names.

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -377,6 +377,10 @@ func (c *SingleChecker) Run(ctx context.Context) error {
 		c.execTime = time.Since(startTime)
 	}()
 
+	// A previous Run may have left the checker poisoned (isInvalid=true from
+	// an errored attempt); every Run starts healthy.
+	c.setInvalid(false)
+
 	// Try the checksum up to n times if differences are found and we can fix them
 	var lastErr error
 	for attempt := 1; attempt <= c.maxRetries; attempt++ {

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -388,6 +388,10 @@ func (c *SingleChecker) Run(ctx context.Context) error {
 			}
 			// Reset differences found counter
 			c.differencesFound.Store(0)
+			// Reset the invalid flag left set by the failed attempt: it makes
+			// isHealthy() false, which would skip every chunk and turn this
+			// retry into a vacuous pass.
+			c.setInvalid(false)
 		}
 
 		// If the parent context is already cancelled, retrying is pointless —

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -249,6 +249,53 @@ func TestRetryDoesNotVacuouslyPass(t *testing.T) {
 	require.Positive(t, singleChecker.differencesFound.Load())
 }
 
+// TestRunResetsPriorInvalidState covers the cross-Run leak of isInvalid: a
+// prior Run that errored WITHOUT recording differences (e.g. a transient
+// connection failure) leaves isInvalid=true and differencesFound==0. A
+// subsequent Run on the same checker must start healthy — without the reset
+// at the top of Run, attempt 1 skipped every chunk (isHealthy()==false), saw
+// differencesFound==0, and returned nil having verified zero rows. Run must
+// instead do real work: the chunker ends fully read with rows checked.
+func TestRunResetsPriorInvalidState(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS runpoison_t1, _runpoison_t1_new, _runpoison_t1_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE runpoison_t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _runpoison_t1_new (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _runpoison_t1_chkpnt (a INT)") // for binlog advancement
+	testutils.RunSQL(t, "INSERT INTO runpoison_t1 VALUES (1, 2, 3), (2, 2, 3)")
+	testutils.RunSQL(t, "INSERT INTO _runpoison_t1_new VALUES (1, 2, 3), (2, 2, 3)")
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "runpoison_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_runpoison_t1_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	checker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, NewCheckerDefaultConfig())
+	require.NoError(t, err)
+	singleChecker, ok := checker.(*SingleChecker)
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	// Simulate the state left by a prior errored Run that found no differences.
+	singleChecker.setInvalid(true)
+
+	// The data is identical, so the pass must succeed — with real work done.
+	require.NoError(t, checker.Run(t.Context()))
+	require.True(t, chunker.IsRead(), "the chunker must be fully read; a vacuous pass reads no chunks")
+	require.Positive(t, checker.GetProgress().RowsChecked, "rows must actually be verified")
+}
+
 func TestCorruptChecksum(t *testing.T) {
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS chkpcorruptt1, _chkpcorruptt1_new, _chkpcorruptt1_chkpnt")
 	testutils.RunSQL(t, "CREATE TABLE chkpcorruptt1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -194,6 +194,61 @@ func TestFixCorrupt(t *testing.T) {
 	require.Equal(t, uint64(0), singleChecker.differencesFound.Load())
 }
 
+// TestRetryDoesNotVacuouslyPass is a regression test for the retry loop in
+// Run. A failed attempt leaves isInvalid=true (set by the errgroup workers),
+// and the retry reset previously did not clear it. Because isHealthy()
+// returns false while isInvalid is set, the next attempt dispatched zero
+// chunks and completed with differencesFound==0 — logging "checksum passed"
+// and returning nil without having verified a single row. With
+// FixDifferences=false a persistent mismatch must fail every attempt and
+// surface an error, never nil.
+func TestRetryDoesNotVacuouslyPass(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS retrypoison_t1, _retrypoison_t1_new, _retrypoison_t1_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE retrypoison_t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _retrypoison_t1_new (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _retrypoison_t1_chkpnt (a INT)") // for binlog advancement
+	testutils.RunSQL(t, "INSERT INTO retrypoison_t1 VALUES (1, 2, 3)")
+	testutils.RunSQL(t, "INSERT INTO _retrypoison_t1_new VALUES (1, 2, 3)")
+	testutils.RunSQL(t, "INSERT INTO _retrypoison_t1_new VALUES (2, 2, 3)") // corrupt: row not in source
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "retrypoison_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_retrypoison_t1_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.FixDifferences = false // surface the mismatch as an error on every attempt
+	config.MaxRetries = 2
+	checker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+
+	err = checker.Run(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "checksum errored on every attempt")
+	require.ErrorContains(t, err, "checksum mismatch")
+
+	// The final attempt must have actually re-verified chunks: its counter
+	// was reset at the start of the attempt, so a non-zero value proves the
+	// mismatch was re-detected rather than skipped.
+	singleChecker, ok := checker.(*SingleChecker)
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	require.Positive(t, singleChecker.differencesFound.Load())
+}
+
 func TestCorruptChecksum(t *testing.T) {
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS chkpcorruptt1, _chkpcorruptt1_new, _chkpcorruptt1_chkpnt")
 	testutils.RunSQL(t, "CREATE TABLE chkpcorruptt1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")


### PR DESCRIPTION
## Problem

Both `SingleChecker` and `DistributedChecker` mark themselves invalid (`isInvalid=true`) when any chunk errors during a checksum pass — including the ordinary `checksum mismatch` error raised when a chunk diverges and `FixDifferences=false`. `isHealthy()` returns `!isInvalid`, and the chunk-dispatch loop in `runChecksum` is gated on it:

```go
for !c.chunker.IsRead() && c.isHealthy(errGrpCtx) {
```

The flag was only ever cleared on the yield/resume paths — never by the retry loop in `Run`, and never at the start of a new `Run` call. That leaks a poisoned flag into two places where it silently turns verification into a no-op:

**1. Within one Run (single checker), reproduced by `TestRetryDoesNotVacuouslyPass`:**

1. Attempt 1: a target chunk diverges → `differencesFound++`, the chunk returns `checksum mismatch`, `isInvalid` is set, the attempt fails.
2. Attempt 2: `Run` resets the chunker and `differencesFound`, but `isInvalid` is still true → `isHealthy()` is false → the work loop dispatches **zero** goroutines → `g.Wait()` returns nil, and the fresh yield context hasn't expired, so `runChecksum` returns nil.
3. `Run` sees `differencesFound == 0`, logs `checksum passed`, and returns nil — the cutover safety gate passes having verified zero chunks.

So with `FixDifferences=false` and `MaxRetries>=2`, real corruption produced a false PASS instead of an error.

**2. Across Run calls on a reused checker (both checkers), reproduced by `TestRunResetsPriorInvalidState` / `TestDistributedRunResetsPriorInvalidState`:**

A `Run` that errors WITHOUT recording differences (e.g. a transient connection failure) exits with `isInvalid=true` and `differencesFound==0`. Checkers are reused across `Run` calls (move's continuous-checksum loop does exactly this), and the next `Run` hits attempt 1 already poisoned: the work loop is skipped, `differencesFound==0`, and `Run` returns nil — the same vacuous `checksum passed` across the `Run()` boundary. The distributed checker also reaches a poisoned retry attempt this way even though its `Run` returns hard errors immediately: a first `Run` that failed on a mismatch leaves leftover `differencesFound`, which pushes a second `Run` past attempt 1 into a poisoned attempt 2 (`TestDistributedRetryDoesNotVacuouslyPass`).

## Fix

The invariant: `isInvalid` never survives into a new attempt or a new `Run()` call. Two one-line resets in both `single.go` and `distributed.go`:

1. At `Run` entry, before the attempt loop — a previous `Run` may have left the checker poisoned; every `Run` starts healthy.
2. In the `attempt > 1` retry block, alongside the existing `chunker.Reset()` and `differencesFound.Store(0)` — a failed attempt must not turn the next one into a vacuous pass.

The chunker reset intentionally stays `attempt > 1`-only: attempt 1 may be resuming from a watermark-opened chunker.

## Testing

Four new regression tests, each verified to fail without the corresponding reset (temporarily reverting the fix: they observe `Run` returning nil right after logging `checksum passed`, with zero chunks read) and pass with it:

- `TestRetryDoesNotVacuouslyPass` (single, per-retry reset): divergent `_new` row, `FixDifferences=false`, `MaxRetries=2`. `Run` must return the `checksum errored on every attempt … checksum mismatch` error, and `differencesFound` must be non-zero after the final attempt, proving the retry actually re-verified chunks.
- `TestDistributedRetryDoesNotVacuouslyPass` (distributed, per-retry reset): same divergence; the first `Run` fails and poisons the checker, and a second `Run` on the same checker must fail again rather than return nil.
- `TestRunResetsPriorInvalidState` (single, Run-entry reset): identical source/target data, checker poisoned via `setInvalid(true)` to simulate a prior errored `Run` that recorded no differences. `Run` must return nil AND have done real work — `chunker.IsRead()` true and `GetProgress().RowsChecked > 0` — distinguishing a genuine pass from a vacuous one.
- `TestDistributedRunResetsPriorInvalidState` (distributed): same shape as above.

Also ran the package's Run-path tests, all passing: `TestBasicChecksum`, `TestBasicValidation`, `TestUnfixableUniqueChecksum`, `TestFixCorrupt`, `TestCorruptChecksum`, `TestCorruptBinaryChecksum`, `TestBoundaryCases`, `TestChangeDataTypeDatetime`, `TestFromWatermark`, `TestColumnBoundaryShift`, `TestFixCorruptWithApplier`, `TestDistributedChecksum`, `TestDistributedChecksumNtoM`, `TestDistributedChecksumPairCancellation`, `TestDistributedChecksumFlushUnderLock`, `TestDistributedCheckerHonorsYieldTimeoutConfig`, `TestYieldTimeout`, `TestDistributedCheckerYieldTimeout`. `gofmt`, `go build ./...`, and `golangci-lint run ./pkg/checksum/...` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
