### PR TITLE
fix(move): acquire source metadata locks before destructive setup steps

### DIFF
--- a/pkg/move/checksum_invariant_test.go
+++ b/pkg/move/checksum_invariant_test.go
@@ -97,7 +97,8 @@ func setupRunnerForChecksumTest(t *testing.T, dbSuffix string) (*Runner, context
 	require.NoError(t, err)
 	r.targets = []applier.Target{{KeyRange: "0", DB: tgtDB, Config: tgtCfg}}
 
-	require.NoError(t, r.setup(ctx))
+	require.NoError(t, r.setupDiscovery(ctx))
+	require.NoError(t, r.setupUnderLocks(ctx))
 	require.NoError(t, r.copier.Run(ctx))
 
 	// Bring the checksum chunker into a state where it has a low-watermark.

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -130,7 +130,8 @@ func testResumeFromCheckpointE2E(t *testing.T, deferSecondaryIndexes bool) {
 		DB:       db,
 		Config:   targetConfig,
 	}}
-	require.NoError(t, r.setup(ctx))
+	require.NoError(t, r.setupDiscovery(ctx))
+	require.NoError(t, r.setupUnderLocks(ctx))
 
 	// copy what there is to be copied. we don't need to cancel it,
 	// we are just running the copier part.
@@ -371,7 +372,8 @@ func TestPostCopyAnalyzeTargetSchema(t *testing.T) {
 		DB:       targetDB,
 		Config:   targetConfig,
 	}}
-	require.NoError(t, r.setup(ctx))
+	require.NoError(t, r.setupDiscovery(ctx))
+	require.NoError(t, r.setupUnderLocks(ctx))
 	t.Cleanup(func() {
 		r.cancelFunc()
 		// Runner.Close() closes the target DB and repl clients but not the raw

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -397,7 +397,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	// have been purged anyway. This must happen before any destructive step
 	// (deleteAboveWatermark below modifies the targets). Unlike migrate,
 	// move cannot silently fall back to a fresh copy: the target tables are
-	// non-empty (that is exactly why setup() chose the resume path), so we
+	// non-empty (that is exactly why setupUnderLocks() chose the resume path), so we
 	// fail loudly and leave the decision to the operator.
 	if checkpointAge := rec.Age(); checkpointAge >= r.move.CheckpointMaxAge {
 		return fmt.Errorf("%w: checkpoint is %s old (max allowed: %s). To proceed, either re-run with a larger --checkpoint-max-age, or wipe the target tables (including '%s') and restart the move from scratch",
@@ -471,7 +471,13 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	return nil
 }
 
-func (r *Runner) setup(ctx context.Context) error {
+// setupDiscovery is the read-only first phase of setup: it runs the
+// preflight checks and populates the table lists (r.sourceTables and each
+// r.sources[i].tables). Run() calls it before acquiring the per-source
+// metadata locks — the lock names are derived from the table lists, so
+// discovery has to happen first — and nothing in here may modify the source
+// or the target. All potentially destructive setup lives in setupUnderLocks.
+func (r *Runner) setupDiscovery(ctx context.Context) error {
 	var err error
 
 	// Run preflight checks on the source database
@@ -499,8 +505,19 @@ func (r *Runner) setup(ctx context.Context) error {
 
 	if len(r.sourceTables) == 0 {
 		r.logger.Info("No tables found in source database; nothing to move")
-		return nil
 	}
+	return nil
+}
+
+// setupUnderLocks is the second phase of setup. It contains every step that
+// can modify the source or the target — the resume path's
+// delete-above-watermark, --force's target wipe, target table and checkpoint
+// creation, and starting the replication clients — so Run() only calls it
+// after the per-source metadata locks are held. That ordering guarantees a
+// concurrent second spirit invocation against the same sources fails on the
+// lock before it can destroy the first run's target data.
+func (r *Runner) setupUnderLocks(ctx context.Context) error {
+	var err error
 
 	// Resolve the number of apply (write) threads against the target now that
 	// it is connected. WriteThreads==0 means "auto-size": on Aurora it becomes
@@ -812,7 +829,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	slices.SortFunc(r.targets, func(a, b applier.Target) int {
 		return strings.Compare(targetKey(a), targetKey(b))
 	})
-	if err := r.setup(ctx); err != nil {
+	// Discovery is read-only: preflight checks plus building the per-source
+	// table lists (which the metadata lock names below are derived from).
+	if err := r.setupDiscovery(ctx); err != nil {
 		return err
 	}
 
@@ -858,6 +877,16 @@ func (r *Runner) Run(ctx context.Context) error {
 			}
 		}
 	}()
+
+	// Now that the locks are held, run the rest of setup. It includes steps
+	// that modify the target (the resume path deletes rows above the
+	// checkpointed watermark; --force drops the target tables), which must
+	// never race with another spirit process moving the same sources: a
+	// concurrent invocation has to die on the lock above before it can touch
+	// the first run's target.
+	if err := r.setupUnderLocks(ctx); err != nil {
+		return err
+	}
 
 	r.startBackgroundRoutines(ctx)
 	if err := r.setWatermarkOptimizationAll(ctx, true); err != nil {

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -511,6 +511,73 @@ func TestMoveForceWipesUnresumableTarget(t *testing.T) {
 	require.Zero(t, stale, "force must drop+recreate the target, not overlay the source onto stale rows")
 }
 
+// TestConcurrentMoveDoesNotWipeTarget is a regression test for the ordering of
+// Run(): the per-source metadata locks must be acquired before any setup step
+// that can modify the target. A second spirit invocation against the same
+// source (orchestrator retry, operator error) has to die on the lock while the
+// first run's target is still untouched. Before the reorder, the second run
+// executed all of setup first — under --force that wiped the first run's
+// target tables (and on the resume path deleted rows above the checkpointed
+// watermark) — and only then failed on the lock.
+func TestConcurrentMoveDoesNotWipeTarget(t *testing.T) {
+	srcDB := "source_concurrent_lock"
+	dstDB := "dest_concurrent_lock"
+	sourceDSN := testutils.DSNForDatabase(srcDB)
+	targetDSN := testutils.DSNForDatabase(dstDB)
+
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+srcDB)
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+dstDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+srcDB)
+	testutils.RunSQL(t, "CREATE DATABASE "+dstDB)
+	testutils.RunSQL(t, "CREATE TABLE "+srcDB+".t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50) NOT NULL)")
+	testutils.RunSQL(t, "INSERT INTO "+srcDB+".t1 (name) VALUES ('a'),('b'),('c')")
+
+	// The target already holds rows — conceptually the data a still-running
+	// move (run A) has copied so far. id 999 is outside the source's range so
+	// its survival proves the table was neither wiped nor overlaid.
+	testutils.RunSQL(t, "CREATE TABLE "+dstDB+".t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50) NOT NULL)")
+	testutils.RunSQL(t, "INSERT INTO "+dstDB+".t1 (id, name) VALUES (999, 'precious')")
+
+	// Simulate run A holding the source metadata lock: acquire the same lock
+	// name Run() derives (schema + table) via dbconn.NewMetadataLock directly.
+	// This stands in for a real in-flight move without needing to pause one.
+	lockTables := []*table.TableInfo{{SchemaName: srcDB, TableName: "t1"}}
+	lock, err := dbconn.NewMetadataLock(t.Context(), sourceDSN, lockTables, dbconn.NewDBConfig(), slog.Default())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, lock.Close())
+	}()
+
+	// Run B: --force against the same source. The non-empty, unresumable
+	// target is exactly the state --force wipes — but B must fail on the
+	// metadata lock before it gets the chance.
+	move := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         2,
+		WriteThreads:    2,
+		Force:           true,
+	}
+	err = move.Run()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to acquire metadata lock")
+
+	// The target must be untouched: the pre-existing row is intact and run B
+	// left no artifacts of a restarted copy (no checkpoint table).
+	targetDB, err := sql.Open("mysql", targetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+	var name string
+	require.NoError(t, targetDB.QueryRowContext(t.Context(), "SELECT name FROM t1 WHERE id = 999").Scan(&name))
+	require.Equal(t, "precious", name, "a concurrent run must not modify the target before acquiring the lock")
+	var artifacts int
+	require.NoError(t, targetDB.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+		dstDB, checkpointTableName).Scan(&artifacts))
+	require.Zero(t, artifacts, "a concurrent run must not create a checkpoint table before acquiring the lock")
+}
+
 // TestMoveWithVarcharPK verifies a move on a table with a non-memory-comparable
 // primary key (VARCHAR with a CI collation) — the case from issue #607. The
 // move runs under concurrent writes to exercise the binlog replay path.
@@ -663,7 +730,8 @@ func checkpointAndStop(t *testing.T, move *Move) {
 		DB:       targetDB,
 		Config:   targetConfig,
 	}}
-	require.NoError(t, r.setup(ctx))
+	require.NoError(t, r.setupDiscovery(ctx))
+	require.NoError(t, r.setupUnderLocks(ctx))
 
 	// Copy all rows, then write a checkpoint.
 	require.NoError(t, r.copier.Run(ctx))
@@ -1177,7 +1245,7 @@ func varcharPKWriteOne(ctx context.Context, db *sql.DB, srcDB string) error {
 // whose created_at exceeds CheckpointMaxAge. Unlike the migrate equivalent
 // (TestResumeFromCheckpointTooOld in pkg/migration), the move cannot fall
 // back to a fresh copy — the target tables already contain rows, which is
-// the very reason setup() chose the resume path — so the move must fail
+// the very reason setupUnderLocks() chose the resume path — so the move must fail
 // loudly with status.ErrCheckpointTooOld and leave the next step to the
 // operator (raise --checkpoint-max-age, or wipe the targets and restart).
 func TestResumeFromCheckpointTooOld(t *testing.T) {


### PR DESCRIPTION
## Problem

In `pkg/move`'s `Run()`, `setup()` executed **before** the per-source metadata locks were acquired — but setup contains destructive steps:

- the resume path's `deleteAboveWatermark` DELETEs target rows above the checkpointed watermark, and
- the `--force` path's `wipeTargets` DROPs all target tables plus the checkpoint table.

So a second spirit invocation against the same sources (orchestrator retry, operator error) ran that destructive setup against the **first run's live target** — deleting rows the first run had already copied past its last checkpoint, or with `--force` dropping its target tables outright — and only *then* died on the lock. If run A was in the sentinel wait with the checksum already passed, A could cut over with rows missing.

## Fix

Split `setup()` into two phases around the existing lock-acquisition block in `Run()`, keeping the diff mechanical:

- **`setupDiscovery`** (read-only, before the locks): preflight checks plus building the per-source table lists. This must precede the locks because the lock names are derived from `r.sources[i].tables`. The no-tables early exit (straight to `cutoverFunc`) is unchanged.
- **`setupUnderLocks`** (after the locks): everything else — write-thread resolution, applier/repl-client construction, post-setup checks, and the mutating paths they gate (resume's delete-above-watermark, `--force`'s target wipe, target table and checkpoint creation, starting replication). `Run()` calls it only after every source's metadata lock is held, inside the existing deferred-release scope; error wrapping and the partial-acquisition cleanup are preserved.

A concurrent second run now fails with `failed to acquire metadata lock on source ...` before it can touch anything.

## Testing

- New regression test `TestConcurrentMoveDoesNotWipeTarget`: holds the source metadata lock (same lock name `Run()` derives) to simulate a still-running move, then runs a `--force` move against a target with pre-existing rows. Asserts the run fails on the lock **and** the target rows/tables are untouched (no checkpoint table created). Verified it fails on the pre-fix ordering: the second run wipes the target row before dying on the lock (`sql: no rows in result set` on the survivor-row assert).
- Existing coverage re-run green: `TestBasicMove`, `TestEmptyDatabaseMove` (early-exit path), `TestMoveForceWipesUnresumableTarget` (--force under locks), `TestMoveResumeDeletesAboveWatermark`, `TestResumeFromCheckpointTooOld`/`NotTooOld`, `TestResumeFromCheckpointMultiTableE2E`, `TestMultiSourceResumeFromCheckpointE2E`, `TestSingleSourceResumeKeepsChecksumWatermark`, `TestChecksumErrorPreservesCheckpoint`, `TestPostCopyAnalyzeTargetSchema` (the last two cover the test-only call sites updated to the two-phase calls).
- `gofmt`, `go build ./...`, `golangci-lint run ./pkg/move/...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
