### PR TITLE
fix(statement): preserve DESC index key parts through parse, diff, and emission

### DIFF
--- a/pkg/lint/lint_redundant_indexes.go
+++ b/pkg/lint/lint_redundant_indexes.go
@@ -151,15 +151,22 @@ func indexParts(index statement.Index) []statement.IndexColumn {
 }
 
 // renderIndexPart formats a single key part for human-readable messages,
-// including prefix lengths (col(10)) and expression parts ((LOWER(name))).
+// including prefix lengths (col(10)), expression parts ((LOWER(name))), and
+// descending key parts (col DESC).
 func renderIndexPart(p statement.IndexColumn) string {
-	if p.Expression != nil {
-		return "(" + *p.Expression + ")"
+	var rendered string
+	switch {
+	case p.Expression != nil:
+		rendered = "(" + *p.Expression + ")"
+	case p.Length != nil:
+		rendered = fmt.Sprintf("%s(%d)", p.Name, *p.Length)
+	default:
+		rendered = p.Name
 	}
-	if p.Length != nil {
-		return fmt.Sprintf("%s(%d)", p.Name, *p.Length)
+	if p.Desc {
+		rendered += " DESC"
 	}
-	return p.Name
+	return rendered
 }
 
 // renderIndexParts formats a list of key parts for human-readable messages.
@@ -192,7 +199,15 @@ func renderIndexColumns(index statement.Index) string {
 //     covering-scan and full-ordering capability.
 //   - Column-name comparison is case-insensitive, matching MySQL identifier
 //     semantics.
+//   - Key-part direction must match: a DESC key part stores the opposite
+//     ordering from an ASC one, so at the same position in two multi-column
+//     indexes they do not produce interchangeable orderings.
 func indexColumnPartCovers(a, b statement.IndexColumn) bool {
+	// Direction must match for both column and expression key parts.
+	if a.Desc != b.Desc {
+		return false
+	}
+
 	// Expression parts only match identical expressions.
 	if a.Expression != nil || b.Expression != nil {
 		if a.Expression == nil || b.Expression == nil {
@@ -305,11 +320,12 @@ func isRedundantToIndex(indexA statement.Index, indexB statement.Index) bool {
 }
 
 // isPlainPKColumn reports whether index key part p is a plain column reference
-// (no prefix length, no expression) whose name matches the given PK column.
-// InnoDB auto-appends the *full* PK column to secondary indexes, so a prefixed
-// or expression key part does not stand in for a PK column.
+// (no prefix length, no expression, ascending) whose name matches the given PK
+// column. InnoDB auto-appends the *full* PK column to secondary indexes in
+// ascending order, so a prefixed, expression, or DESC key part does not stand
+// in for a PK column.
 func isPlainPKColumn(p statement.IndexColumn, pkColumn string) bool {
-	return p.Expression == nil && p.Length == nil && strings.EqualFold(p.Name, pkColumn)
+	return p.Expression == nil && p.Length == nil && !p.Desc && strings.EqualFold(p.Name, pkColumn)
 }
 
 // hasRedundantPKPrefix checks if a secondary index leads with the full

--- a/pkg/lint/lint_redundant_indexes_test.go
+++ b/pkg/lint/lint_redundant_indexes_test.go
@@ -76,6 +76,30 @@ func TestRedundantIndexLinter_PrefixRedundancy(t *testing.T) {
 			)`,
 			expectViolated: false,
 		},
+		{
+			name: "index (a DESC) redundant to index (a DESC, b)",
+			createTable: `CREATE TABLE t1 (
+				id INT PRIMARY KEY,
+				a INT,
+				b INT,
+				INDEX idx_a (a DESC),
+				INDEX idx_ab (a DESC, b)
+			)`,
+			expectViolated: true,
+			violatedIndex:  "idx_a",
+			coveringIndex:  "idx_ab",
+		},
+		{
+			name: "index (a) NOT redundant to index (a DESC, b)",
+			createTable: `CREATE TABLE t1 (
+				id INT PRIMARY KEY,
+				a INT,
+				b INT,
+				INDEX idx_a (a),
+				INDEX idx_ab (a DESC, b)
+			)`,
+			expectViolated: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -1120,6 +1120,10 @@ func indexColumnsEqual(a, b *IndexColumn) bool {
 	if !ptrEqual(a.Length, b.Length) {
 		return false
 	}
+	// KEY (a) and KEY (a DESC) are physically different indexes.
+	if a.Desc != b.Desc {
+		return false
+	}
 	return true
 }
 
@@ -1322,17 +1326,23 @@ func formatAddIndex(idx *Index) string {
 	var columns []string
 	if len(idx.ColumnList) > 0 {
 		for _, col := range idx.ColumnList {
+			var colStr string
 			if col.Expression != nil {
 				// Expression index (functional index) - needs double parentheses
-				columns = append(columns, fmt.Sprintf("(%s)", *col.Expression))
+				colStr = fmt.Sprintf("(%s)", *col.Expression)
 			} else {
 				// Regular column reference
-				colStr := sqlescape.EscapeIdentifier(col.Name)
+				colStr = sqlescape.EscapeIdentifier(col.Name)
 				if col.Length != nil {
 					colStr += fmt.Sprintf("(%d)", *col.Length)
 				}
-				columns = append(columns, colStr)
 			}
+			// Descending key part (MySQL 8.0+). ASC is MySQL's canonical
+			// default and is never emitted explicitly.
+			if col.Desc {
+				colStr += " DESC"
+			}
+			columns = append(columns, colStr)
 		}
 	} else {
 		// Fall back to simple column names

--- a/pkg/statement/diff_integration_test.go
+++ b/pkg/statement/diff_integration_test.go
@@ -166,3 +166,42 @@ func TestDiffIntegrationKeyBlockSize(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, stmts)
 }
+
+// TestDiffIntegrationDescIndex verifies that changing an index key part from
+// ascending to descending (MySQL 8.0+) is detected by Diff(), that the emitted
+// combined `DROP INDEX k, ADD INDEX k (a DESC)` really rebuilds the index on a
+// real MySQL server (unlike the option-only cases, MySQL does not no-op a
+// direction change), and that a re-diff afterwards converges to nil.
+//
+// This is a regression test: the DESC modifier used to be dropped during
+// parsing, so KEY k (a) and KEY k (a DESC) diffed as equal and restored
+// descending indexes silently became ascending.
+func TestDiffIntegrationDescIndex(t *testing.T) {
+	tt := testutils.NewTestTable(t, "diff_desc_idx",
+		"CREATE TABLE diff_desc_idx (id int primary key, a int, b int, KEY k (a, b))")
+
+	target, err := ParseCreateTable("CREATE TABLE diff_desc_idx (id int primary key, a int, b int, KEY k (a DESC, b))")
+	require.NoError(t, err)
+
+	source, err := ParseCreateTable(showCreateTable(t, tt.DB, tt.Name))
+	require.NoError(t, err)
+
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	require.Equal(t, "ALTER TABLE `diff_desc_idx` DROP INDEX `k`, ADD INDEX `k` (`a` DESC, `b`)", stmts[0].Statement)
+
+	// Execute the emitted statement exactly as the Runner would, and verify
+	// the index really became descending.
+	_, err = tt.DB.ExecContext(t.Context(), stmts[0].Statement)
+	require.NoError(t, err)
+	postAlter := showCreateTable(t, tt.DB, tt.Name)
+	require.Contains(t, postAlter, "KEY `k` (`a` DESC,`b`)")
+
+	// Re-diff: the schemas now converge.
+	source, err = ParseCreateTable(postAlter)
+	require.NoError(t, err)
+	stmts, err = source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts)
+}

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -648,6 +648,34 @@ func TestDiff(t *testing.T) {
 			expected: "ALTER TABLE `t1` DROP INDEX `idx_abc`, ADD INDEX `idx_abc` (`a`, `b`)",
 		},
 
+		// Index Key Part Direction Changes (MySQL 8.0+ descending indexes).
+		// KEY (a) and KEY (a DESC) are physically different indexes, so a
+		// direction change must produce a DROP+ADD rather than a nil diff.
+		{
+			name:     "ChangeIndexAscToDesc",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, INDEX idx_a (a))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, INDEX idx_a (a DESC))",
+			expected: "ALTER TABLE `t1` DROP INDEX `idx_a`, ADD INDEX `idx_a` (`a` DESC)",
+		},
+		{
+			name:     "ChangeIndexDescToAsc",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, INDEX idx_a (a DESC))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, INDEX idx_a (a))",
+			expected: "ALTER TABLE `t1` DROP INDEX `idx_a`, ADD INDEX `idx_a` (`a`)",
+		},
+		{
+			name:     "NoChangesDescIndex",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT, INDEX idx_ab (a DESC, b))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT, INDEX idx_ab (a DESC, b))",
+			expected: "",
+		},
+		{
+			name:     "AddIndexWithDescParts",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, c VARCHAR(100))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, c VARCHAR(100), INDEX idx_mixed (a DESC, c(10) DESC, (lower(c)) DESC))",
+			expected: "ALTER TABLE `t1` ADD INDEX `idx_mixed` (`a` DESC, `c`(10) DESC, (LOWER(`c`)) DESC)",
+		},
+
 		// Foreign Key with ON DELETE / ON UPDATE
 		{
 			name:     "AddForeignKeyWithOnDelete",

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -64,6 +64,7 @@ type IndexColumn struct {
 	Name       string  `json:"name,omitempty"`       // Column name (empty for expression indexes)
 	Expression *string `json:"expression,omitempty"` // Expression for functional indexes
 	Length     *int    `json:"length,omitempty"`     // Prefix length for string columns
+	Desc       bool    `json:"desc,omitempty"`       // Descending key part (MySQL 8.0+), e.g. KEY (a DESC)
 }
 
 // Index represents an index definition
@@ -881,7 +882,9 @@ func (ct *CreateTable) parseIndexColumns(keys []*ast.IndexPartSpecification) []s
 func (ct *CreateTable) parseIndexColumnList(keys []*ast.IndexPartSpecification) []IndexColumn {
 	columns := make([]IndexColumn, 0, len(keys))
 	for _, key := range keys {
-		col := IndexColumn{}
+		// Desc applies to both column and expression key parts,
+		// e.g. KEY (a DESC) and KEY ((lower(b)) DESC).
+		col := IndexColumn{Desc: key.Desc}
 
 		// Check if this is a column reference or an expression
 		if key.Column != nil {
@@ -1555,6 +1558,11 @@ func GetMissingSecondaryIndexes(sourceCreateTable, targetCreateTable, tableName 
 				fmt.Fprintf(&sb, "(%s)", exprSb.String())
 			default:
 				return "", fmt.Errorf("index %q has a key part with neither a column nor an expression", constraint.Name)
+			}
+			// Descending key part (MySQL 8.0+). ASC is MySQL's canonical
+			// default and is never emitted explicitly.
+			if key.Desc {
+				sb.WriteString(" DESC")
 			}
 		}
 		sb.WriteString(")")

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -313,6 +313,50 @@ func TestSchemaAnalyzer_IndexVisibilityStructured(t *testing.T) {
 	require.True(t, invisibleNames["uk_email_multi"], "Should include uk_email_multi in invisible indexes")
 }
 
+// TestSchemaAnalyzer_DescendingIndexKeyParts verifies that DESC key parts
+// (MySQL 8.0+) are captured on IndexColumn for plain column, prefix, and
+// functional (expression) index parts. MySQL 8.0's SHOW CREATE TABLE prints
+// KEY `k` (`a` DESC), so dropping the flag would silently re-create
+// descending indexes as ascending.
+func TestSchemaAnalyzer_DescendingIndexKeyParts(t *testing.T) {
+	sql := `
+	CREATE TABLE desc_index_test (
+		id INT PRIMARY KEY,
+		a INT,
+		b VARCHAR(100),
+		c VARCHAR(100),
+		KEY k (a DESC, b),
+		KEY fidx ((lower(c)) DESC),
+		KEY pfx (c(10) DESC)
+	)
+	`
+
+	ct, err := ParseCreateTable(sql)
+	require.NoError(t, err)
+
+	indexes := ct.GetCreateTable().Indexes
+
+	k := indexes.ByName("k")
+	require.NotNil(t, k, "Should find k")
+	require.Len(t, k.ColumnList, 2)
+	require.Equal(t, "a", k.ColumnList[0].Name)
+	require.True(t, k.ColumnList[0].Desc, "a should be a descending key part")
+	require.Equal(t, "b", k.ColumnList[1].Name)
+	require.False(t, k.ColumnList[1].Desc, "b should be an ascending key part")
+
+	fidx := indexes.ByName("fidx")
+	require.NotNil(t, fidx, "Should find fidx")
+	require.Len(t, fidx.ColumnList, 1)
+	require.NotNil(t, fidx.ColumnList[0].Expression)
+	require.True(t, fidx.ColumnList[0].Desc, "functional key part should be descending")
+
+	pfx := indexes.ByName("pfx")
+	require.NotNil(t, pfx, "Should find pfx")
+	require.Len(t, pfx.ColumnList, 1)
+	require.NotNil(t, pfx.ColumnList[0].Length)
+	require.True(t, pfx.ColumnList[0].Desc, "prefix key part should be descending")
+}
+
 // Benchmark to show performance characteristics
 func BenchmarkParseCreateTable(b *testing.B) {
 	sql := `
@@ -1910,6 +1954,149 @@ func TestGetMissingSecondaryIndexes_FunctionalIndexesLiveMySQL(t *testing.T) {
 	// Execute the generated DDL against MySQL to prove it is valid.
 	_, err = db.ExecContext(t.Context(), alterStmt)
 	require.NoError(t, err)
+
+	// After applying, no indexes should be reported missing anymore.
+	alterStmt, err = GetMissingSecondaryIndexes(showCreate("src"), showCreate("dst"), "dst")
+	require.NoError(t, err)
+	require.Empty(t, alterStmt, "expected no missing indexes after applying DDL, got: %s", alterStmt)
+}
+
+// TestGetMissingSecondaryIndexes_DescendingIndexes covers DESC key parts
+// (MySQL 8.0+). Previously the DESC modifier was dropped from the generated
+// ADD INDEX, so a deferred KEY k (a DESC) was silently restored as the
+// ascending KEY k (a).
+func TestGetMissingSecondaryIndexes_DescendingIndexes(t *testing.T) {
+	testCases := []struct {
+		name              string
+		sourceCreateTable string
+		targetCreateTable string
+		tableName         string
+		expectedAlter     string
+		expectEmpty       bool
+	}{
+		{
+			name: "Descending index missing on target",
+			sourceCreateTable: `CREATE TABLE t1 (
+				a INT NOT NULL PRIMARY KEY,
+				b INT,
+				c VARCHAR(255),
+				KEY k (b DESC, c)
+			)`,
+			targetCreateTable: `CREATE TABLE t1 (
+				a INT NOT NULL PRIMARY KEY,
+				b INT,
+				c VARCHAR(255)
+			)`,
+			tableName:     "t1",
+			expectedAlter: "ALTER TABLE `t1` ADD INDEX `k` (`b` DESC, `c`)",
+		},
+		{
+			name: "Descending prefix and functional parts missing on target",
+			sourceCreateTable: `CREATE TABLE t1 (
+				a INT NOT NULL PRIMARY KEY,
+				b VARCHAR(255),
+				KEY k (b(10) DESC, (lower(b)) DESC)
+			)`,
+			targetCreateTable: `CREATE TABLE t1 (
+				a INT NOT NULL PRIMARY KEY,
+				b VARCHAR(255)
+			)`,
+			tableName:     "t1",
+			expectedAlter: "ALTER TABLE `t1` ADD INDEX `k` (`b`(10) DESC, (LOWER(`b`)) DESC)",
+		},
+		{
+			name: "Descending index present on both sides",
+			sourceCreateTable: `CREATE TABLE t1 (
+				a INT NOT NULL PRIMARY KEY,
+				b INT,
+				KEY k (b DESC)
+			)`,
+			targetCreateTable: `CREATE TABLE t1 (
+				a INT NOT NULL PRIMARY KEY,
+				b INT,
+				KEY k (b DESC)
+			)`,
+			tableName:   "t1",
+			expectEmpty: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := GetMissingSecondaryIndexes(tc.sourceCreateTable, tc.targetCreateTable, tc.tableName)
+			require.NoError(t, err)
+
+			if tc.expectEmpty {
+				require.Empty(t, result, "Expected empty result but got: %s", result)
+			} else {
+				require.Equal(t, tc.expectedAlter, result)
+			}
+		})
+	}
+}
+
+// TestGetMissingSecondaryIndexes_DescendingIndexesLiveMySQL verifies the full
+// round trip that spirit move performs for descending indexes: the source's
+// SHOW CREATE TABLE (which prints KEY `k` (`a` DESC)) is fed into
+// GetMissingSecondaryIndexes, the generated ALTER is executed on the target,
+// and the target really ends up with a descending index.
+func TestGetMissingSecondaryIndexes_DescendingIndexesLiveMySQL(t *testing.T) {
+	admin, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := admin.ExecContext(context.Background(), "DROP DATABASE IF EXISTS test_descidx")
+		require.NoError(t, err)
+		require.NoError(t, admin.Close())
+	})
+
+	_, err = admin.ExecContext(t.Context(), "DROP DATABASE IF EXISTS test_descidx")
+	require.NoError(t, err)
+	_, err = admin.ExecContext(t.Context(), "CREATE DATABASE test_descidx")
+	require.NoError(t, err)
+
+	db, err := sql.Open("mysql", testutils.DSNForDatabase("test_descidx"))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	// Source table with descending key parts, including a functional one.
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE src (
+		a INT NOT NULL PRIMARY KEY,
+		b INT,
+		c VARCHAR(255),
+		KEY k (b DESC, c),
+		KEY fidx ((lower(c)) DESC)
+	)`)
+	require.NoError(t, err)
+
+	// Target table with the same columns but no secondary indexes,
+	// as created during a move before indexes are restored.
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE dst (
+		a INT NOT NULL PRIMARY KEY,
+		b INT,
+		c VARCHAR(255)
+	)`)
+	require.NoError(t, err)
+
+	showCreate := func(table string) string {
+		var name, createStmt string
+		require.NoError(t, db.QueryRowContext(t.Context(), "SHOW CREATE TABLE `"+table+"`").Scan(&name, &createStmt))
+		return createStmt
+	}
+
+	alterStmt, err := GetMissingSecondaryIndexes(showCreate("src"), showCreate("dst"), "dst")
+	require.NoError(t, err)
+	require.NotEmpty(t, alterStmt)
+
+	// Execute the generated DDL against MySQL to prove it is valid.
+	_, err = db.ExecContext(t.Context(), alterStmt)
+	require.NoError(t, err)
+
+	// The restored indexes must be descending, not silently ascending.
+	dstCreate := showCreate("dst")
+	require.Contains(t, dstCreate, "KEY `k` (`b` DESC,`c`)")
+	require.Contains(t, dstCreate, "KEY `fidx` ((lower(`c`)) DESC)")
 
 	// After applying, no indexes should be reported missing anymore.
 	alterStmt, err = GetMissingSecondaryIndexes(showCreate("src"), showCreate("dst"), "dst")


### PR DESCRIPTION
## Problem

The TiDB parser exposes descending index key parts via `ast.IndexPartSpecification.Desc`, but `pkg/statement` never captured it:

- `parseIndexColumnList` built `IndexColumn{Name, Length, Expression}` and ignored `key.Desc`, so `KEY k (a DESC)` parsed identically to `KEY k (a)`.
- `indexColumnsEqual` therefore couldn't compare direction — `Diff()` treated the two as **equal**, so a direction change produced a nil diff and the post-move schema check (`pkg/move/check/schema_compare.go`) passed.
- `formatAddIndex` and `GetMissingSecondaryIndexes` emitted key parts without `DESC`, so a deferred `KEY k (a DESC)` was re-added as `ADD INDEX k (a)`.

MySQL 8.0's `SHOW CREATE TABLE` prints `KEY `k` (`a` DESC)`, so the information was present in the input and silently discarded. Consequence: `spirit move` strips secondary indexes at target create and restores them via `GetMissingSecondaryIndexes` — the restored index came back **ascending**, the DESC-blind schema check still passed, and the target permanently kept the wrong index order (descending-scan query plans regress). Same for datasync's deferred-index restore and the declarative diff.

## Fix

- Add `Desc bool` to `IndexColumn`, captured in `parseIndexColumnList` for both plain-column and expression (functional) key parts — `KEY ((lower(b)) DESC)` is valid MySQL 8.0.
- Compare `Desc` in `indexColumnsEqual`. A direction change now diffs as `DROP INDEX k, ADD INDEX k (a DESC)` in a combined ALTER — verified against MySQL 8.0.45 that a direction change really rebuilds the index (it is not one of the option-only no-op cases that need separate statements).
- Emit ` DESC` at both SQL-rendering sites: `formatAddIndex` (diff path) and `GetMissingSecondaryIndexes` (move/datasync deferred-index restore path, keeping the `sqlescape.EscapeIdentifier` quoting). `ASC` stays implicit, matching MySQL's canonical form.
- Make the redundant-index linter direction-aware: `indexColumnPartCovers` requires matching direction (so `KEY (a)` is no longer reported redundant to `KEY (a DESC, b)`), `isPlainPKColumn` no longer lets a `pk DESC` key part stand in for InnoDB's implicit (ascending) PK append, and violation messages render `DESC`.

Not changed (already correct): `convertCreateIndexToAlterTable` and `RemoveSecondaryIndexes` render through the parser's `Restore()`, which preserves `DESC`.

## Testing

All new tests fail without the fix (verified by reverting the behavioral hunks while keeping the struct field):

- **Parse**: `TestSchemaAnalyzer_DescendingIndexKeyParts` — `Desc` captured for plain, prefix (`c(10) DESC`), and functional (`(lower(c)) DESC`) key parts.
- **Diff**: `TestDiff` cases `ChangeIndexAscToDesc` / `ChangeIndexDescToAsc` (drop+add emitted with/without ` DESC`), `NoChangesDescIndex` (identical DESC on both sides → nil diff), `AddIndexWithDescParts` (mixed plain/prefix/functional DESC emission).
- **Emission**: `TestGetMissingSecondaryIndexes_DescendingIndexes` — generated `ADD INDEX` contains backtick-quoted parts with ` DESC`, including prefix and functional parts; present-on-both-sides → empty.
- **Round-trip against MySQL 8.0.45**: `TestGetMissingSecondaryIndexes_DescendingIndexesLiveMySQL` (SHOW CREATE TABLE → generate ALTER → execute → target really has `KEY `k` (`b` DESC,`c`)` and `KEY `fidx` ((lower(`c`)) DESC)`) and `TestDiffIntegrationDescIndex` (Diff emits combined drop+add, executing it really flips the index to DESC, re-diff converges to nil).
- **Lint**: `TestRedundantIndexLinter_PrefixRedundancy` — `(a DESC)` redundant to `(a DESC, b)`; `(a)` NOT redundant to `(a DESC, b)`.

Full `./pkg/statement/` and `./pkg/lint/` suites pass against MySQL 8.0.45; `gofmt` and `golangci-lint run` clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
