### PR TITLE
fix(statement): treat inline column UNIQUE as an index in Diff instead of dropping it

### DIFF
--- a/pkg/statement/columns_equal_guard_test.go
+++ b/pkg/statement/columns_equal_guard_test.go
@@ -39,7 +39,6 @@ var columnFieldsCompared = map[string]struct{}{
 	"SRID":            {},
 	"AutoInc":         {},
 	"PrimaryKey":      {},
-	"Unique":          {},
 	"Comment":         {},
 	"Charset":         {},
 	"Collation":       {},
@@ -61,6 +60,11 @@ var columnFieldsNotCompared = map[string]string{
 	// If you start populating Options with semantically meaningful data, it must
 	// be added to both comparisons and removed from this list.
 	"Options": "catch-all map for unmodeled options; currently not compared by diff.go",
+	// Column-level UNIQUE is representation, not state: MySQL canonicalizes it
+	// into a table-level UNIQUE KEY, and MODIFY COLUMN cannot express it. It is
+	// folded into index-level diffing (effectiveIndexes/diffIndexes) instead of
+	// being part of per-column equality.
+	"Unique": "folded into index-level diffing by effectiveIndexes; diffed by diffIndexes, not here",
 }
 
 // TestColumnsEqualAllFieldsAccounted is the primary tripwire: it enumerates the
@@ -174,7 +178,6 @@ func everyComparedFieldMutation() []struct {
 		{"SRID", func(c *Column) { c.SRID = new(uint32(3857)) }},
 		{"AutoInc", func(c *Column) { c.AutoInc = false }},
 		{"PrimaryKey", func(c *Column) { c.PrimaryKey = false }},
-		{"Unique", func(c *Column) { c.Unique = false }},
 		{"Comment", func(c *Column) { c.Comment = new("bye") }},
 		{"Charset", func(c *Column) { c.Charset = new("latin1") }},
 		{"Collation", func(c *Column) { c.Collation = new("latin1_swedish_ci") }},
@@ -198,6 +201,14 @@ func TestColumnsEqualWithContextDetectsEveryField(t *testing.T) {
 	b := baseColumn()
 	require.True(t, ct.columnsEqualWithContext(&a, &b, target, opts),
 		"identical columns must compare equal")
+
+	// Unique is deliberately ignored: inline column-level UNIQUE is folded
+	// into index-level diffing (effectiveIndexes/diffIndexes), so a
+	// Unique-only difference is a representation difference, not a change.
+	uniqueOnly := baseColumn()
+	uniqueOnly.Unique = !uniqueOnly.Unique
+	require.True(t, ct.columnsEqualWithContext(&a, &uniqueOnly, target, opts),
+		"columnsEqualWithContext must ignore a Unique-only difference")
 
 	for _, m := range everyComparedFieldMutation() {
 		t.Run(m.name, func(t *testing.T) {
@@ -228,6 +239,13 @@ func TestColumnsEqualIgnorePKDetectsEveryField(t *testing.T) {
 	pkOnly.PrimaryKey = !pkOnly.PrimaryKey
 	require.True(t, columnsEqualIgnorePK(&a, &pkOnly, opts),
 		"columnsEqualIgnorePK must ignore a PrimaryKey-only difference")
+
+	// Unique is deliberately ignored too — see the matching assertion in
+	// TestColumnsEqualWithContextDetectsEveryField.
+	uniqueOnly := baseColumn()
+	uniqueOnly.Unique = !uniqueOnly.Unique
+	require.True(t, columnsEqualIgnorePK(&a, &uniqueOnly, opts),
+		"columnsEqualIgnorePK must ignore a Unique-only difference")
 
 	for _, m := range everyComparedFieldMutation() {
 		if m.name == "PrimaryKey" {

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -406,6 +406,65 @@ func (ct *CreateTable) getEffectivePrimaryKeyColumns() []string {
 	return nil
 }
 
+// effectiveIndexes returns the table's indexes with any inline column-level
+// UNIQUE declarations (`c int UNIQUE`) folded in as table-level UNIQUE
+// indexes, plus the set of index names that were synthesized this way.
+//
+// MySQL never stores a column-level UNIQUE: it canonicalizes it into a
+// table-level `UNIQUE KEY` named after the column (suffixed _2, _3, ... when
+// that name is already taken — the same convention autoNameIndexes
+// replicates), which is what SHOW CREATE TABLE reports. Folding the inline
+// form here lets diffIndexes compare a user-written schema against the live
+// canonical form symmetrically: a representation-only difference produces no
+// clauses, while a real difference produces exactly one ADD/DROP.
+//
+// autoNameIndexes reserves these names before auto-naming unnamed table-level
+// indexes (the server names inline uniques first), so the names computed here
+// agree with the rest of the parsed schema; keep the two loops in sync.
+func (ct *CreateTable) effectiveIndexes() ([]Index, map[string]bool) {
+	hasInlineUnique := false
+	for i := range ct.Columns {
+		if ct.Columns[i].Unique {
+			hasInlineUnique = true
+			break
+		}
+	}
+	if !hasInlineUnique {
+		return ct.Indexes, nil
+	}
+
+	// Clone so the synthesized entries never leak into ct.Indexes.
+	indexes := slices.Clone(ct.Indexes)
+	inlineDerived := make(map[string]bool)
+	usedNames := make(map[string]bool, len(indexes))
+	for i := range indexes {
+		usedNames[indexes[i].Name] = true
+	}
+	for _, col := range ct.Columns {
+		if !col.Unique {
+			continue
+		}
+		// Guess the server-assigned name: the column name, or the first free
+		// _N suffix when an explicitly-declared index already claims it. If
+		// the guess is wrong (the live table named it differently), the
+		// content-based pairing in diffIndexes still prevents a spurious
+		// DROP/ADD of an equivalent unique index.
+		name := col.Name
+		for suffix := 2; usedNames[name]; suffix++ {
+			name = fmt.Sprintf("%s_%d", col.Name, suffix)
+		}
+		usedNames[name] = true
+		inlineDerived[name] = true
+		indexes = append(indexes, Index{
+			Name:       name,
+			Type:       "UNIQUE",
+			Columns:    []string{col.Name},
+			ColumnList: []IndexColumn{{Name: col.Name}},
+		})
+	}
+	return indexes, inlineDerived
+}
+
 // diffIndexes compares indexes and returns ALTER clauses for differences.
 //
 // Most index changes are emitted into the combined ALTER (the returned
@@ -417,15 +476,60 @@ func (ct *CreateTable) getEffectivePrimaryKeyColumns() []string {
 // must run as two separate ALTER statements. Those are returned via the second
 // value as standalone clause-lists (each becomes its own ALTER statement).
 func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separateStatements [][]string) {
+	// Fold inline column-level UNIQUEs into both index sets so that
+	// `c int UNIQUE` participates in index diffing like the table-level
+	// `UNIQUE KEY c (c)` MySQL canonicalizes it into.
+	sourceIdxList, sourceInlineDerived := ct.effectiveIndexes()
+	targetIdxList, targetInlineDerived := target.effectiveIndexes()
+
 	// Build maps for easier lookup
 	sourceIndexes := make(map[string]*Index)
-	for i := range ct.Indexes {
-		sourceIndexes[ct.Indexes[i].Name] = &ct.Indexes[i]
+	for i := range sourceIdxList {
+		sourceIndexes[sourceIdxList[i].Name] = &sourceIdxList[i]
 	}
 
 	targetIndexes := make(map[string]*Index)
-	for i := range target.Indexes {
-		targetIndexes[target.Indexes[i].Name] = &target.Indexes[i]
+	for i := range targetIdxList {
+		targetIndexes[targetIdxList[i].Name] = &targetIdxList[i]
+	}
+
+	// Safety net for inline-derived names: the synthesized name is only a
+	// guess at what the server assigned. Pair unique indexes that cover the
+	// same column set but carry different names whenever at least one side's
+	// name came from an inline declaration, so we never DROP a live unique
+	// index (or ADD a duplicate) that the other side's inline UNIQUE already
+	// expresses. Two explicitly named unique indexes that differ only in name
+	// are NOT paired — that is a real rename (DROP + ADD).
+	matchedSourceUnique := make(map[string]bool) // source name -> matched
+	matchedTargetUnique := make(map[string]bool) // target name -> matched
+	for i := range sourceIdxList {
+		sourceIdx := &sourceIdxList[i]
+		if sourceIdx.Type != "UNIQUE" {
+			continue
+		}
+		if _, exactMatch := targetIndexes[sourceIdx.Name]; exactMatch {
+			continue // handled by the normal name-based path
+		}
+		for j := range targetIdxList {
+			targetIdx := &targetIdxList[j]
+			if targetIdx.Type != "UNIQUE" {
+				continue
+			}
+			if _, exactMatch := sourceIndexes[targetIdx.Name]; exactMatch {
+				continue // this target index already has a name match in source
+			}
+			if matchedTargetUnique[targetIdx.Name] {
+				continue // already paired with another source index
+			}
+			if !sourceInlineDerived[sourceIdx.Name] && !targetInlineDerived[targetIdx.Name] {
+				continue // both explicitly named: a genuine rename
+			}
+			if indexColumnsIdenticalIgnoreName(sourceIdx, targetIdx) {
+				matchedSourceUnique[sourceIdx.Name] = true
+				matchedTargetUnique[targetIdx.Name] = true
+				break
+			}
+		}
 	}
 
 	// Collect DROP operations and sort by name for deterministic output
@@ -479,8 +583,11 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 	// column list. Such indexes are routed out of dropClauses/addClauses below.
 	optionOnlyChanged := make(map[string]bool)
 
-	for i := range ct.Indexes {
-		sourceIdx := &ct.Indexes[i]
+	for i := range sourceIdxList {
+		sourceIdx := &sourceIdxList[i]
+		if matchedSourceUnique[sourceIdx.Name] {
+			continue // equivalent unique index exists in target under an inline-derived pairing
+		}
 		targetIdx, existsInTarget := targetIndexes[sourceIdx.Name]
 
 		if !existsInTarget {
@@ -523,7 +630,10 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 
 	// Collect ADD operations and sort by name for deterministic output
 	var addClauses []string
-	for _, targetIdx := range target.Indexes {
+	for _, targetIdx := range targetIdxList {
+		if matchedTargetUnique[targetIdx.Name] {
+			continue // equivalent unique index exists in source under an inline-derived pairing
+		}
 		sourceIdx, existsInSource := sourceIndexes[targetIdx.Name]
 
 		if !existsInSource {
@@ -552,7 +662,7 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 
 	// Collect ALTER INDEX operations for visibility changes (must come after DROP/ADD)
 	var alterClauses []string
-	for _, targetIdx := range target.Indexes {
+	for _, targetIdx := range targetIdxList {
 		sourceIdx, existsInSource := sourceIndexes[targetIdx.Name]
 
 		if existsInSource && !indexesEqual(sourceIdx, &targetIdx) && indexesEqualIgnoreVisibility(sourceIdx, &targetIdx) {
@@ -830,9 +940,12 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	if a.PrimaryKey != b.PrimaryKey {
 		return false
 	}
-	if a.Unique != b.Unique {
-		return false
-	}
+	// Unique is intentionally NOT compared: a column-level UNIQUE is
+	// representation, not state. MySQL canonicalizes `c int UNIQUE` into a
+	// table-level UNIQUE KEY (that is what SHOW CREATE TABLE reports), and a
+	// MODIFY COLUMN cannot express uniqueness anyway (formatColumnDefinition
+	// never emits UNIQUE). Inline uniques are folded into index-level diffing
+	// instead — see effectiveIndexes / diffIndexes.
 	if !ptrEqual(a.Comment, b.Comment) {
 		return false
 	}
@@ -937,9 +1050,9 @@ func columnsEqualIgnorePK(a, b *Column, opts *DiffOptions) bool {
 		return false
 	}
 	// Skip PrimaryKey comparison
-	if a.Unique != b.Unique {
-		return false
-	}
+	// Unique is intentionally not compared — inline UNIQUE is folded into
+	// index-level diffing (see effectiveIndexes / diffIndexes and the
+	// matching comment in columnsEqualWithContext).
 	if !ptrEqual(a.Comment, b.Comment) {
 		return false
 	}
@@ -1060,6 +1173,14 @@ func indexColumnListIdentical(a, b *Index) bool {
 	if a.Name != b.Name {
 		return false
 	}
+	return indexColumnsIdenticalIgnoreName(a, b)
+}
+
+// indexColumnsIdenticalIgnoreName reports whether two indexes have the same
+// type and column list, regardless of their names or options. Used to pair a
+// unique index synthesized from an inline column-level UNIQUE (whose name is
+// only a guess at the server-assigned one) with an equivalent live index.
+func indexColumnsIdenticalIgnoreName(a, b *Index) bool {
 	if a.Type != b.Type {
 		return false
 	}

--- a/pkg/statement/diff_integration_test.go
+++ b/pkg/statement/diff_integration_test.go
@@ -125,6 +125,87 @@ func TestDiffIntegrationFulltextRebuildPreservesParser(t *testing.T) {
 	require.Nil(t, stmts)
 }
 
+// TestDiffIntegrationInlineUnique verifies that a desired schema written with
+// a column-level UNIQUE (`c int unique`) diffs cleanly against the live
+// canonical form MySQL reports (`c int` + `UNIQUE KEY c (c)`), and that when
+// the unique index is missing the emitted DDL creates it exactly once and the
+// re-diff converges.
+//
+// Regression: inline UNIQUE only existed as Column.Unique and was invisible to
+// diffIndexes, so this diff used to emit
+// `MODIFY COLUMN c int(11) NULL, DROP INDEX c` — silently dropping the live
+// uniqueness constraint — and never converged (a MODIFY COLUMN cannot
+// re-express UNIQUE).
+func TestDiffIntegrationInlineUnique(t *testing.T) {
+	// Create the table from the inline form; MySQL canonicalizes it.
+	tt := testutils.NewTestTable(t, "diff_inline_unique",
+		"CREATE TABLE diff_inline_unique (id int primary key, c int unique)")
+
+	desired, err := ParseCreateTable("CREATE TABLE diff_inline_unique (id int primary key, c int unique)")
+	require.NoError(t, err)
+
+	// The server names the canonicalized unique index after the column.
+	live := showCreateTable(t, tt.DB, tt.Name)
+	require.Contains(t, live, "UNIQUE KEY `c` (`c`)")
+
+	source, err := ParseCreateTable(live)
+	require.NoError(t, err)
+
+	// Headline regression: live-canonical vs desired-inline must be a no-op.
+	stmts, err := source.Diff(desired, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts)
+
+	// Drop the unique index out from under the desired schema; the diff must
+	// re-add it, exactly once.
+	_, err = tt.DB.ExecContext(t.Context(), "ALTER TABLE diff_inline_unique DROP INDEX c")
+	require.NoError(t, err)
+
+	source, err = ParseCreateTable(showCreateTable(t, tt.DB, tt.Name))
+	require.NoError(t, err)
+	stmts, err = source.Diff(desired, nil)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	require.Equal(t, "ALTER TABLE `diff_inline_unique` ADD UNIQUE INDEX `c` (`c`)", stmts[0].Statement)
+
+	_, err = tt.DB.ExecContext(t.Context(), stmts[0].Statement)
+	require.NoError(t, err)
+
+	// Convergence: the index is back under its canonical name and a re-diff
+	// yields nil.
+	postAlter := showCreateTable(t, tt.DB, tt.Name)
+	require.Contains(t, postAlter, "UNIQUE KEY `c` (`c`)")
+	source, err = ParseCreateTable(postAlter)
+	require.NoError(t, err)
+	stmts, err = source.Diff(desired, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts)
+}
+
+// TestDiffIntegrationInlineUniqueNameCollision verifies the synthesized names
+// follow the server's declaration-order naming when an inline unique and an
+// unnamed table-level key share a base name: the inline unique on c claims
+// `c` and the unnamed KEY (c, d) is pushed to `c_2`. The live canonical form
+// must diff as a no-op against the original inline form.
+func TestDiffIntegrationInlineUniqueNameCollision(t *testing.T) {
+	tt := testutils.NewTestTable(t, "diff_inline_uniq_col",
+		"CREATE TABLE diff_inline_uniq_col (id int primary key, c int unique, d int, key (c, d))")
+
+	live := showCreateTable(t, tt.DB, tt.Name)
+	require.Contains(t, live, "UNIQUE KEY `c` (`c`)")
+	require.Contains(t, live, "KEY `c_2` (`c`,`d`)",
+		"server is expected to push the unnamed key past the inline unique's name")
+
+	desired, err := ParseCreateTable("CREATE TABLE diff_inline_uniq_col (id int primary key, c int unique, d int, key (c, d))")
+	require.NoError(t, err)
+	source, err := ParseCreateTable(live)
+	require.NoError(t, err)
+
+	stmts, err := source.Diff(desired, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts)
+}
+
 // TestDiffIntegrationKeyBlockSize verifies that a KEY_BLOCK_SIZE difference on
 // an index whose column list is unchanged is detected, and that executing the
 // statements Diff() emits actually applies the change on a real MySQL server.

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -85,6 +85,87 @@ func TestDiff(t *testing.T) {
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, email VARCHAR(100), UNIQUE KEY idx_email (email))",
 			expected: "ALTER TABLE `t1` ADD UNIQUE INDEX `idx_email` (`email`)",
 		},
+		// Inline column-level UNIQUE: MySQL canonicalizes `c INT UNIQUE` into
+		// a table-level `UNIQUE KEY c (c)` (that is what SHOW CREATE TABLE
+		// reports), so the two representations must diff as equal. Regression:
+		// the inline form used to be invisible to diffIndexes, so diffing the
+		// live canonical form against a desired inline form emitted
+		// `MODIFY COLUMN c ..., DROP INDEX c` — silently dropping the
+		// uniqueness constraint — and never converged.
+		{
+			name:     "InlineUniqueVsCanonicalNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT, UNIQUE KEY c (c))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			expected: "",
+		},
+		{
+			name:     "CanonicalVsInlineUniqueNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT, UNIQUE KEY c (c))",
+			expected: "",
+		},
+		{
+			name:     "InlineUniqueBothSidesNoChange",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			expected: "",
+		},
+		{
+			// Uniqueness added via the inline form: emitted exactly once, as
+			// an index-level ADD (a MODIFY COLUMN cannot express UNIQUE).
+			name:     "AddInlineUnique",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			expected: "ALTER TABLE `t1` ADD UNIQUE INDEX `c` (`c`)",
+		},
+		{
+			// A NEW column declared inline-unique: the ADD COLUMN does not
+			// carry UNIQUE, so the folded index set must add the index —
+			// exactly once.
+			name:     "AddColumnWithInlineUnique",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			expected: "ALTER TABLE `t1` ADD COLUMN `c` int(11) NULL, ADD UNIQUE INDEX `c` (`c`)",
+		},
+		{
+			// Uniqueness removed relative to an inline declaration.
+			name:     "DropInlineUnique",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT)",
+			expected: "ALTER TABLE `t1` DROP INDEX `c`",
+		},
+		{
+			// Safety net: an inline-derived name is only a guess at the
+			// server-assigned one. A live unique index on the same column set
+			// under a different explicit name satisfies the inline
+			// declaration — it must never be dropped.
+			name:     "InlineUniqueMatchesDifferentlyNamedLiveUnique",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT, UNIQUE KEY uniq_c (c))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
+			expected: "",
+		},
+		{
+			// Name collision with an unnamed table-level key: the server
+			// names indexes in declaration order, so the inline unique claims
+			// `c` and the unnamed KEY (c, d) is pushed to `c_2`. The parsed
+			// inline form must synthesize the same names as the live
+			// canonical form.
+			name:     "InlineUniqueNameCollision",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT, d INT, UNIQUE KEY c (c), KEY c_2 (c, d))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE, d INT, KEY (c, d))",
+			expected: "",
+		},
+		{
+			// Interleaved declaration: an explicit KEY named after the unique
+			// column forces the server to suffix the inline unique to c_2
+			// (verified against MySQL 8.0: `d int, key c (d), c int unique`).
+			// Explicit names are reserved before inline uniques claim theirs,
+			// so the synthesized name matches.
+			name:     "InlineUniqueSuffixedPastExplicitKey",
+			source:   "CREATE TABLE t1 (d INT, c INT, UNIQUE KEY c_2 (c), KEY c (d))",
+			target:   "CREATE TABLE t1 (d INT, KEY c (d), c INT UNIQUE)",
+			expected: "",
+		},
 		{
 			// Adding WITH PARSER to an index with an unchanged column list is
 			// an option-only change. A combined DROP+ADD in a single ALTER is a

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -484,6 +484,28 @@ func (ct *CreateTable) autoNameIndexes() {
 		}
 	}
 
+	// Inline column-level UNIQUEs claim their server-assigned names BEFORE any
+	// unnamed table-level index is auto-named: the server names indexes in
+	// declaration order and column definitions normally precede table-level
+	// keys, so in `c int UNIQUE, KEY (c, d)` the unique index gets `c` and the
+	// unnamed key is pushed to `c_2`. The names are only reserved here — not
+	// materialized into ct.Indexes — so the inline declaration stays
+	// column-level state (Column.Unique) everywhere else. effectiveIndexes
+	// recomputes the same names at diff time; keep the two in sync.
+	for _, col := range ct.Columns {
+		if !col.Unique {
+			continue
+		}
+		name := col.Name
+		for suffix := 2; ; suffix++ {
+			if _, taken := usedNames[name]; !taken {
+				break
+			}
+			name = fmt.Sprintf("%s_%d", col.Name, suffix)
+		}
+		usedNames[name] = 0
+	}
+
 	for i := range ct.Indexes {
 		idx := &ct.Indexes[i]
 		if idx.Name != "" || idx.Type == "PRIMARY KEY" {


### PR DESCRIPTION
## Problem

A declarative apply could silently remove a uniqueness constraint. An inline column-level UNIQUE (`c int UNIQUE`) only exists as `Column.Unique` after parsing — it never appears in `CreateTable.Indexes` — so it was invisible to `diffIndexes`, which compares the `Indexes` sets directly.

Diffing a live table's canonical form (`c int` + `UNIQUE KEY c (c)`, what `SHOW CREATE TABLE` returns) against a desired schema written inline produced:

```sql
ALTER TABLE t MODIFY COLUMN c int(11) NULL, DROP INDEX c
```

The live unique index was dropped, and the `MODIFY` cannot re-add uniqueness (`formatColumnDefinition` never emits UNIQUE — even though `columnsEqual*` compared `col.Unique`, which also meant the no-op MODIFY was re-emitted forever; the diff never converged).

`diffPrimaryKey` already handles the analogous inline-PK <-> table-level-PK transitions; inline UNIQUE had no such handling.

## Fix

Make column-level UNIQUE participate in index diffing, mirroring the inline-PK philosophy:

- **`effectiveIndexes` (new)** folds inline column UNIQUEs into the index sets `diffIndexes` compares, synthesized under the server's naming convention (named after the column, suffixed `_2`, `_3`, ... on collision).
- **`autoNameIndexes`** now reserves those names *before* auto-naming unnamed table-level indexes, matching the server's declaration-order naming. Verified against MySQL 8.0: `c int unique, key (c, d)` names the unique `c` and pushes the unnamed key to `c_2` (previously our parse assigned the names the other way around).
- **Content-based safety net**: unique indexes covering the same column set are paired even when their names differ, provided at least one side's name was derived from an inline declaration — a wrong name guess can never emit `DROP INDEX` for a live unique index. Renames between two *explicitly* named unique indexes still emit DROP + ADD (existing behavior).
- **`Column.Unique` removed from column equality** (`columnsEqualWithContext` / `columnsEqualIgnorePK`): column-level UNIQUE is representation, not state — MySQL canonicalizes it to a table-level UNIQUE KEY, and MODIFY emission can't express it. Uniqueness now diffs exclusively at index level, exactly once (the guard test's field inventory is updated accordingly).

## Testing

- New `TestDiff` cases (unit): inline vs canonical in both directions and inline-vs-inline → nil; adding uniqueness inline → exactly one `ADD UNIQUE INDEX`; new column declared inline-unique → `ADD COLUMN` + one `ADD UNIQUE INDEX`; dropping uniqueness → `DROP INDEX` (unchanged); safety net (live `UNIQUE KEY uniq_c (c)` vs desired `c int UNIQUE` → nil, never a drop); name-collision and interleaved-declaration naming cases matching probed MySQL 8.0 behavior.
- New MySQL-backed integration tests (`TestDiffIntegrationInlineUnique`, `TestDiffIntegrationInlineUniqueNameCollision`): create from the inline form, diff live-canonical vs desired-inline → nil; drop the index, re-diff → exactly one `ADD UNIQUE INDEX`, apply it, re-diff → nil (convergence); collision naming verified against the server.
- Existing behavior locked in: `RenameUniqueIndex`, `UnnamedUniqueIndex`, multi-column unique keys, and the full existing diff suites pass.
- `go test ./pkg/statement/ ./pkg/lint/ ./pkg/move/check/ ./pkg/migration/check/ ./pkg/datasync/ ./pkg/fmt/` green against MySQL 8.0.45 (statement also with `-race`); `golangci-lint run ./pkg/statement/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
