### PR TITLE
statement: treat table COMMENT changes as safe for INPLACE

### DIFF
--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -230,6 +230,16 @@ func (a *AbstractStatement) AlgorithmInplaceConsideredSafe() error {
 			ast.AlterTableAddPartitions,
 			ast.AlterTableDropIndex:
 			continue
+		case ast.AlterTableOption:
+			// A table COMMENT change is in-place and metadata-only. Note it is
+			// not INSTANT: MySQL rejects ALGORITHM=INSTANT but accepts INPLACE.
+			// AlterTableOption also covers rebuild-class options (ENGINE=,
+			// ROW_FORMAT=, AUTO_INCREMENT=, ...), so only treat it as safe when
+			// every option in this spec is COMMENT.
+			if allOptionsComment(spec) {
+				continue
+			}
+			unsafeClauses++
 		case ast.AlterTableModifyColumn, ast.AlterTableChangeColumn:
 			// Only safe if changing length of a VARCHAR column. We don't know the type of the column
 			// or its length, so we cannot determine if this is safe only by parsing. We can simply try
@@ -258,6 +268,23 @@ func (a *AbstractStatement) AlgorithmInplaceConsideredSafe() error {
 		return ErrUnsafeForInplace
 	}
 	return nil
+}
+
+// allOptionsComment returns true if every table option in an AlterTableOption
+// spec is a COMMENT change. A table comment change is in-place and
+// metadata-only, but other table options (ENGINE=, ROW_FORMAT=,
+// AUTO_INCREMENT=, ...) can force a table rebuild, so a spec that mixes any of
+// them in is not safe for INPLACE.
+func allOptionsComment(spec *ast.AlterTableSpec) bool {
+	if len(spec.Options) == 0 {
+		return false
+	}
+	for _, opt := range spec.Options {
+		if opt.Tp != ast.TableOptionComment {
+			return false
+		}
+	}
+	return true
 }
 
 // columnReordered returns true if a MODIFY/CHANGE COLUMN spec moves the

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -183,6 +183,10 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	require.NoError(t, test("add partition (partition `p1` values less than (100))"))
 	require.NoError(t, test("add partition partitions 4"))
 
+	// A table COMMENT change is in-place and metadata-only (INPLACE, not INSTANT)
+	require.NoError(t, test("COMMENT='hello world'"))
+	require.NoError(t, test("comment 'hello world'")) // alternate syntax without '='
+
 	// VARCHAR column modifications are safe (metadata-only)
 	require.NoError(t, test("modify `a` varchar(100)"))
 	require.NoError(t, test("change column `a` `a` varchar(100)"))
@@ -214,13 +218,19 @@ func TestAlgorithmInplaceConsideredSafe(t *testing.T) {
 	require.ErrorIs(t, test("engine=innodb"), ErrUnsafeForInplace)
 	require.ErrorIs(t, test("partition by HASH(`id`) partitions 8;"), ErrUnsafeForInplace)
 	require.ErrorIs(t, test("remove partitioning"), ErrUnsafeForInplace)
+	// COMMENT combined with a rebuild-class option in the *same* clause (space
+	// separated, so a single spec with multiple options) is unsafe.
+	require.ErrorIs(t, test("COMMENT='x' engine=innodb"), ErrUnsafeForInplace)
+	require.ErrorIs(t, test("engine=innodb COMMENT='x'"), ErrUnsafeForInplace)
 
 	// Mixed safe and unsafe operations should be unsafe - these cannot be split
 	// because we cannot safely detect which operations are INSTANT vs INPLACE
 	require.ErrorIs(t, test("drop index `a`, add column `b` int"), ErrMultipleAlterClauses)
 	require.ErrorIs(t, test("ALTER INDEX b INVISIBLE, add column `c` int"), ErrMultipleAlterClauses)
 	require.ErrorIs(t, test("modify `a` varchar(100), add index (b)"), ErrMultipleAlterClauses)
-	require.ErrorIs(t, test("drop index `a`, modify `b` int"), ErrMultipleAlterClauses) // non-VARCHAR modification makes it unsafe
+	require.ErrorIs(t, test("drop index `a`, modify `b` int"), ErrMultipleAlterClauses)  // non-VARCHAR modification makes it unsafe
+	require.ErrorIs(t, test("COMMENT='x', add column `b` int"), ErrMultipleAlterClauses) // safe COMMENT + unsafe clause
+	require.NoError(t, test("COMMENT='x', drop index `a`"))                              // COMMENT + another safe clause
 }
 
 func TestAlterIsAddUnique(t *testing.T) {


### PR DESCRIPTION
## What

Teach Spirit's INPLACE-safety parser that a table `COMMENT` change is safe to apply directly with `ALGORITHM=INPLACE`.

A table comment change is in-place and metadata-only in MySQL 8.0 (In Place = Yes, Rebuilds Table = No, Only Modifies Metadata = Yes), but it is **not** `INSTANT` — MySQL rejects `ALGORITHM=INSTANT` and requires `INPLACE`:

```
mysql> ALTER TABLE yield_t1 COMMENT='acdc', ALGORITHM=instant;
ERROR 1845 (0A000): ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
mysql> ALTER TABLE yield_t1 COMMENT='acdc', ALGORITHM=inplace;
Query OK, 0 rows affected (0.01 sec)
```

Previously `AlgorithmInplaceConsideredSafe` did not recognize the `AlterTableOption` spec, so `attemptMySQLDDL` would fail the INSTANT attempt, decline INPLACE, and fall through to the **full copy-based change process** for what should be an instant metadata change.

## How

Add an `ast.AlterTableOption` case that is considered safe only when **every** option in the spec is a `COMMENT`. `AlterTableOption` is a catch-all that also covers rebuild-class options (`ENGINE=`, `ROW_FORMAT=`, `AUTO_INCREMENT=`, …), so an `allOptionsComment` guard keeps any spec that mixes those in on the copy path.

Behavior after this change:

| ALTER | Result |
|-------|--------|
| `COMMENT='x'` | INPLACE (safe) |
| `COMMENT='x' ENGINE=innodb` (one spec, two options) | copy (`ErrUnsafeForInplace`) |
| `COMMENT='x', ENGINE=innodb` (two specs) | copy (`ErrMultipleAlterClauses`) |
| `COMMENT='x', DROP INDEX a` | INPLACE (both clauses safe) |

## Testing

Extended `TestAlgorithmInplaceConsideredSafe` with the cases above (safe COMMENT, alternate `COMMENT '...'` syntax, mixed-in unsafe option in the same spec, and mixed clauses). `go build ./...`, `go vet`, and `gofmt` are clean.

Fixes #1049
