### PR TITLE
feat(move): reverse-window rollback for MoveTables

### DIFF
--- a/docs/move.md
+++ b/docs/move.md
@@ -18,6 +18,7 @@ This will copy all tables from the source database to the target database, verif
 - [defer-secondary-indexes](#defer-secondary-indexes)
 - [enable-experimental-gtid](#enable-experimental-gtid)
 - [force](#force)
+- [reverse-window](#reverse-window)
 - [source-dsn](#source-dsn)
 - [target-chunk-time](#target-chunk-time)
 - [target-dsn](#target-dsn)
@@ -102,6 +103,42 @@ a partial failure on one source still resumes the others from their own GTID set
 
 ```bash
 spirit move --enable-experimental-gtid \
+            --source-dsn "user:pass@tcp(source-host:3306)/mydb" \
+            --target-dsn "user:pass@tcp(target-host:3306)/mydb"
+```
+
+### reverse-window
+
+- Type: Duration
+- Default value: `0` (disabled)
+
+A normal Move ends with a one-way cutover: traffic moves to the target and the source tables are renamed to `_old`. `--reverse-window` makes that cutover **reversible** for a bounded period. Given a non-zero duration, Move does not exit after cutover — it stays running and, in change-only mode, streams writes from the target(s) *back* to the source's now-retired `_old` tables, keeping the source current so the move can be rolled back.
+
+While the window is open the run reports the `reverseWindow` state. The reverse feed uses the same change-source coordinate (binlog file+offset, or GTID with [`--enable-experimental-gtid`](#enable-experimental-gtid)) as the forward move. One of three things ends the window:
+
+1. **It elapses.** Move finalizes forward exactly as a normal cutover would — the source stays retired as `_old`, the checkpoint is dropped — and exits.
+2. **A rollback is requested** (see below). Move rolls back to the source and exits.
+3. **The reverse feed dies** (a schema change on a target, or an unrecoverable stream error). Rollback is no longer safe, so Move finalizes forward and exits, logging the reason.
+
+#### Requesting a rollback
+
+A rollback is triggered out of band by creating a table named `_spirit_move_revert` on the **first target** database — the same database that holds the checkpoint. (The log line printed when the window opens names the exact host and database.) The window loop polls for the marker; on seeing it, Move:
+
+1. flushes the reverse feed so the source reflects every target write, then stops it;
+2. renames the source's `_old` tables back to their real names, un-retiring the source;
+3. runs the reverse-cutover hook if the embedding application registered one (the `spirit` CLI does not — programmatic callers use it to switch routing back to the source); and
+4. retires the former target tables to a `_revert` suffix — distinct from `_old`, so a later move can recognize and clean them up.
+
+The marker and the checkpoint are dropped once the rollback completes.
+
+#### Constraints and resume
+
+- **Unsharded source only.** `--reverse-window` requires a single source (a 1→M move). A sharded source would need an M:N reverse and is rejected at startup.
+- **Stale marker.** If `_spirit_move_revert` already exists when a move starts, or when it reaches cutover — e.g. left over from a prior interrupted rollback — the move refuses to run, so a leftover marker is never mistaken for a fresh request.
+- **Resume.** The checkpoint records that the move entered its reverse window (via a `move_phase` column and the cutover time), so a move killed *during* the window resumes back into it rather than re-copying. A move killed *mid-rollback* is not auto-resumed and must be completed manually.
+
+```bash
+spirit move --reverse-window 30m \
             --source-dsn "user:pass@tcp(source-host:3306)/mydb" \
             --target-dsn "user:pass@tcp(target-host:3306)/mydb"
 ```

--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -67,6 +67,16 @@ type Record struct {
 	// single-table migration can detect the rare case where two long table
 	// names truncate to the same checkpoint table name. Empty otherwise.
 	OriginalTableName string
+	// Phase is the move's reverse-window lifecycle: "" (copying — the default,
+	// and the only value migration/datasync ever use), "reverse_window" (forward
+	// cutover done, reverse feed live), or "reverting" (reverse cutover under
+	// way). It gates resume so a restart neither re-copies nor re-cuts-over.
+	// Stored in move_phase.
+	Phase string
+	// CutoverAt is when the forward cutover completed, used to compute the
+	// reverse-window deadline across a resume. Zero when not past cutover; stored
+	// in cutover_at as an RFC3339 string ("" when zero).
+	CutoverAt time.Time
 	// CreatedAt is when the row was written (UTC; spirit connections use
 	// time_zone="+00:00").
 	CreatedAt time.Time
@@ -123,6 +133,8 @@ const tableDDL = `(
 	binlog_position TEXT,
 	statement TEXT,
 	original_table_name VARCHAR(64) NOT NULL DEFAULT '',
+	move_phase VARCHAR(32) NOT NULL DEFAULT '',
+	cutover_at TEXT,
 	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 )`
 
@@ -160,10 +172,15 @@ func (t *Table) Drop(ctx context.Context) error {
 // statement — a crash mid-write leaves either the old row or the new one, never
 // none. created_at is (re)assigned by the server on each write.
 func (t *Table) Write(ctx context.Context, rec Record) error {
+	var cutoverAt string
+	if !rec.CutoverAt.IsZero() {
+		cutoverAt = rec.CutoverAt.UTC().Format(time.RFC3339Nano)
+	}
 	return dbconn.Exec(ctx, t.db,
-		"REPLACE INTO %n (id, copier_watermark, checksum_watermark, binlog_position, statement, original_table_name) VALUES (1, %?, %?, %?, %?, %?)",
+		"REPLACE INTO %n (id, copier_watermark, checksum_watermark, binlog_position, statement, original_table_name, move_phase, cutover_at) VALUES (1, %?, %?, %?, %?, %?, %?, %?)",
 		t.name,
 		rec.CopierWatermark, rec.ChecksumWatermark, rec.Position, rec.Statement, rec.OriginalTableName,
+		rec.Phase, cutoverAt,
 	)
 }
 
@@ -175,18 +192,26 @@ func (t *Table) Write(ctx context.Context, rec Record) error {
 // error, so resume fails safely rather than silently misreading.
 func (t *Table) ReadLatest(ctx context.Context) (Record, error) {
 	query := fmt.Sprintf(
-		"SELECT copier_watermark, checksum_watermark, binlog_position, statement, original_table_name, created_at FROM `%s` ORDER BY id DESC LIMIT 1",
+		"SELECT copier_watermark, checksum_watermark, binlog_position, statement, original_table_name, move_phase, cutover_at, created_at FROM `%s` ORDER BY id DESC LIMIT 1",
 		t.name)
 
 	var rec Record
 	var createdAt string
+	var cutoverAt sql.NullString
 	err := t.db.QueryRowContext(ctx, query).Scan(
-		&rec.CopierWatermark, &rec.ChecksumWatermark, &rec.Position, &rec.Statement, &rec.OriginalTableName, &createdAt)
+		&rec.CopierWatermark, &rec.ChecksumWatermark, &rec.Position, &rec.Statement, &rec.OriginalTableName,
+		&rec.Phase, &cutoverAt, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Record{}, ErrNotFound
 	}
 	if err != nil {
 		return Record{}, err
+	}
+	if cutoverAt.Valid && cutoverAt.String != "" {
+		rec.CutoverAt, err = time.Parse(time.RFC3339Nano, cutoverAt.String)
+		if err != nil {
+			return Record{}, fmt.Errorf("could not parse checkpoint cutover_at timestamp: %w", err)
+		}
 	}
 	// Spirit connections use time_zone="+00:00", so created_at is UTC.
 	rec.CreatedAt, err = time.Parse(time.DateTime, createdAt)

--- a/pkg/move/README.md
+++ b/pkg/move/README.md
@@ -12,6 +12,7 @@ A move operation follows this sequence:
 4. **Initial checksum** (post-copy phase) — flush the binlog backlog, restore any secondary indexes that were deferred during table creation (see `DeferSecondaryIndexes` below), run ANALYZE TABLE, and verify data consistency between source and targets. This is the correctness gate; cutover does not proceed unless this checksum succeeds.
 5. **Sentinel wait** — optionally pause before cutover, allowing external orchestration to confirm readiness. While the sentinel blocks cutover, a **continuous checksum** loop runs in the background to keep re-verifying the data; the loop is interrupted as soon as the sentinel is dropped.
 6. **Cutover** — acquire a table lock, flush remaining replication changes, execute the caller-provided cutover function, and rename original tables out of the way.
+7. **Reverse window** (optional) — when `ReverseWindow` is set, the move does not exit after cutover; it holds a change-only reverse feed (targets → the source's `_old` tables) for the configured duration so the move can be rolled back. See [Reverse Window](#reverse-window) below.
 
 ## Design Decisions
 
@@ -51,3 +52,17 @@ While the sentinel blocks the cutover, the runner re-runs the checksum in a loop
 The cutover is split into two parts: a caller-provided function and a table rename. The caller's function runs under a table lock with all replication changes flushed, giving it a consistent view. If it succeeds, the runner renames the original tables to `_old` suffixes.
 
 This separation allows orchestration systems to perform routing changes, such as updating a DNS server or Vitess topology server as part of the atomic cutover.
+
+### Reverse Window
+
+`ReverseWindow` (the `--reverse-window` flag) makes a cutover reversible for a bounded period. Instead of exiting after the cutover rename, the runner stands up a **change-only reverse feed** — the former targets become change sources and the source's now-retired `_old` tables become the write target (`reversefeed.go`, from the reverse-feed foundations) — and holds it for the window (`reversewindow.go`). The feed's start position is captured in the cutover's `postSwitch` hook, under the source lock, so no target write is missed.
+
+The window ends in one of three ways: it elapses (finalize forward — the source stays retired, checkpoint dropped), the feed dies (finalize forward — rollback is no longer safe), or a rollback is requested.
+
+A rollback is requested by creating a `_spirit_move_revert` marker table on the first target (`revertmarker.go`), mirroring the sentinel but with inverted polarity (the operator *creates* it to act, rather than dropping it to proceed). The reverse cutover mirrors the forward one with roles swapped, plus one asymmetry: the source's `_old` tables are renamed back to their real names before traffic returns. The former targets are then retired to a `_revert` suffix — distinct from `_old` so a subsequent move can recognize and drop them (`dropStaleRevertTables` clears leftovers, making revert→retry idempotent). A separate `reverseCutoverFunc` (registered via `SetReverseCutover`, the mirror of the cutover function above) performs the routing switch back to the source.
+
+Two constraints and one resume note:
+
+- **Unsharded source only** — reverse-window is a 1→M forward move reversed as M→1; a sharded source would need an M:N reverse and is rejected at startup.
+- **Stale-marker guard** — a `_spirit_move_revert` present at pre-flight or pre-cutover aborts the run, so a leftover from an interrupted rollback is never read as a fresh request.
+- **Resume** — the checkpoint gains `move_phase` (`reverse_window` / `reverting`) and `cutover_at` columns, so a move killed during the window resumes back into it rather than re-copying. The `reverting` phase (mid-rollback) is not auto-resumed and must be completed manually.

--- a/pkg/move/check/rename_safety.go
+++ b/pkg/move/check/rename_safety.go
@@ -25,6 +25,15 @@ func CutoverOldName(tableName string) string {
 	return tableName + "_old"
 }
 
+// RevertRetiredName returns the name a reverse-window rollback renames a former
+// target table to (`<table>_revert`). It is deliberately distinct from
+// CutoverOldName's `_old` (which retires the *source* on a forward cutover):
+// only a revert ever produces `_revert`, so a later move can unambiguously drop
+// a leftover `_revert` table without risking a forward move's `_old` backup.
+func RevertRetiredName(tableName string) string {
+	return tableName + "_revert"
+}
+
 // renameSafetyCheck verifies, before any rows are copied, that the final
 // cutover's RENAME TABLE `<table>` TO `<table>_old` can succeed on every
 // source:

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -46,6 +46,22 @@ type CutOver struct {
 	// any later step must not reopen the window where straggler writes to
 	// the (now stale) source could be replayed over newer rows on the target.
 	cutoverFuncSucceeded bool
+
+	// postSwitch, when set, runs once under the source locks after the traffic
+	// switch (cutoverFunc) succeeds and before the sources are renamed out of
+	// the way. The reverse-window move uses it to capture each target's binlog
+	// position and persist that the move has entered its reverse window, while
+	// the sources are quiescent (writes switched away, replication flushed) so
+	// the captured positions cleanly bound the post-cutover writes. Like
+	// cutoverFunc it must run at most once; postSwitchDone guards that.
+	postSwitch     func(ctx context.Context) error
+	postSwitchDone bool
+}
+
+// SetPostSwitch registers a hook to run once under the source locks, after the
+// traffic switch and before the source rename. See CutOver.postSwitch.
+func (c *CutOver) SetPostSwitch(fn func(ctx context.Context) error) {
+	c.postSwitch = fn
 }
 
 // NewCutOver creates a new CutOver that handles multiple sources.
@@ -171,6 +187,19 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 		}
 		c.cutoverFuncSucceeded = true
 		c.logger.Info("Cutover function complete")
+	}
+
+	// Reverse-window hook: after the traffic switch and before retiring the
+	// sources, capture the reverse-feed start positions and record that the
+	// move has entered its reverse window. Runs once, under the source locks,
+	// while the sources are quiescent. If it fails the cutover fails: the
+	// routing switch has already succeeded, so (like a rename failure past that
+	// point) Run does not retry from the top and surfaces the error.
+	if c.postSwitch != nil && !c.postSwitchDone {
+		if err := c.postSwitch(ctx); err != nil {
+			return fmt.Errorf("reverse-window post-switch hook failed: %w", err)
+		}
+		c.postSwitchDone = true
 	}
 
 	// Rename the source tables out of the way. Once the cutover function has

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -25,6 +25,17 @@ type Move struct {
 	// validate). Without it, an unresumable non-empty target is a hard error.
 	Force bool `name:"force" help:"When the target cannot resume from a checkpoint, wipe the target tables and start the copy fresh instead of failing." default:"false"`
 
+	// ReverseWindow, when > 0, keeps the move alive after cutover in change-only
+	// reverse mode (targets→source) for this long, so the move can be rolled back
+	// before the source is retired. 0 (the default) is a normal cutover. During
+	// the window the source's now-retired _old tables are kept current from the
+	// targets; an operator rolls back by creating the _spirit_move_revert table on
+	// the first target (see revertmarker.go), otherwise the window elapses and the
+	// move finalizes forward. Requires an unsharded (single) source — see the
+	// guard in Runner.Run. The data plane is ReverseFeed (reversefeed.go); the
+	// post-cutover driver is reverseWindow (reversewindow.go).
+	ReverseWindow time.Duration `name:"reverse-window" help:"After cutover, reverse the move (change-only) and keep it alive for this long to allow rollback. 0 disables (normal cutover)." default:"0"`
+
 	// EnableExperimentalGTID switches the change source from binlog file+position to MySQL GTIDs.
 	// EXPERIMENTAL — see pkg/change/gtid.go. Requires gtid_mode=ON and
 	// enforce_gtid_consistency=ON on every source.
@@ -62,6 +73,9 @@ func (m *Move) Validate() error {
 	}
 	if m.TargetChunkTime < 0 {
 		return fmt.Errorf("--target-chunk-time must be non-negative, got %s", m.TargetChunkTime)
+	}
+	if m.ReverseWindow < 0 {
+		return fmt.Errorf("--reverse-window must be non-negative, got %s", m.ReverseWindow)
 	}
 	return nil
 }

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -169,6 +169,14 @@ func (w *reverseWindow) buildFeed(ctx context.Context) error {
 	w.watched = make([][]*table.TableInfo, len(r.targets))
 	for i := range r.targets {
 		tgt := &r.targets[i]
+		// The reverse feed MUST resume from the position captured at cutover. A
+		// missing/empty entry (e.g. a corrupted or partial checkpoint on resume)
+		// would otherwise fall back to the target's current head, silently
+		// skipping post-cutover writes and making rollback unsafe — so fail loudly.
+		pos, ok := r.reversePositions[targetKey(*tgt)]
+		if !ok || pos == "" {
+			return fmt.Errorf("reverse window: no captured start position for target %d (%s); refusing to start the reverse feed, which would miss post-cutover writes and make rollback unsafe", i, targetKey(*tgt))
+		}
 		watched := make([]*table.TableInfo, 0, len(src.tables))
 		for _, t := range src.tables {
 			wt := table.NewTableInfo(tgt.DB, tgt.Config.DBName, t.TableName)
@@ -184,7 +192,7 @@ func (w *reverseWindow) buildFeed(ctx context.Context) error {
 			User:     tgt.Config.User,
 			Password: tgt.Config.Passwd,
 			Tables:   watched,
-			Position: r.reversePositions[targetKey(*tgt)],
+			Position: pos,
 		})
 	}
 

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -1,0 +1,310 @@
+package move
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/checkpoint"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
+	"github.com/block/spirit/pkg/move/check"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/utils"
+)
+
+// Checkpoint phase values for a reverse-window move. The empty string ("") is
+// the copy phase — the only value migration/datasync ever write, and what a
+// normal move writes right up to (and including) its cutover.
+const (
+	phaseReverseWindow = "reverse_window" // forward cutover done, reverse feed live
+	phaseReverting     = "reverting"      // reverse cutover under way
+)
+
+// reverseWindowPollInterval is how often the window loop checks for a revert
+// request, feed death, or the deadline. A var so tests can shorten it.
+var reverseWindowPollInterval = 1 * time.Second
+
+// targetCurrentPosition reads target tgt's current head position in the change
+// feed's coordinate scheme — matching the mode the reverse feed will use
+// (r.move.EnableExperimentalGTID) — so the captured string round-trips through
+// StartFromPosition. It uses a short-lived, unstarted Source purely for the
+// Source.CurrentPosition read (the applier is unused on that path, hence nil),
+// because at cutover the reverse feed itself cannot exist yet: its target-side
+// _old tables are created by the rename that immediately follows this hook.
+func targetCurrentPosition(ctx context.Context, r *Runner, tgt *applier.Target) (string, error) {
+	cfg := change.NewClientDefaultConfig()
+	cfg.Logger = r.logger
+	cfg.DBConfig = r.dbConfig
+	var src change.Source
+	if r.move.EnableExperimentalGTID {
+		src = change.NewGTIDClient(tgt.DB, tgt.Config.Addr, tgt.Config.User, tgt.Config.Passwd, nil, cfg)
+	} else {
+		src = change.NewBinlogClient(tgt.DB, tgt.Config.Addr, tgt.Config.User, tgt.Config.Passwd, nil, cfg)
+	}
+	defer src.Close()
+	return src.CurrentPosition(ctx)
+}
+
+// captureReverseWindow runs as the cutover postSwitch hook (under the source
+// lock, after the traffic switch, before the source rename). It records each
+// target's current position — the reverse feeds' start points — and persists
+// that the move has entered its reverse window. The background checkpoint
+// dumper has already been stopped, so this write is authoritative.
+func captureReverseWindow(ctx context.Context, r *Runner) error {
+	positions := make(map[string]string, len(r.targets))
+	for i := range r.targets {
+		pos, err := targetCurrentPosition(ctx, r, &r.targets[i])
+		if err != nil {
+			return fmt.Errorf("capture reverse-feed start position for target %d: %w", i, err)
+		}
+		positions[targetKey(r.targets[i])] = pos
+	}
+	r.reversePositions = positions
+	r.cutoverAt = time.Now()
+
+	posJSON, err := json.Marshal(positions)
+	if err != nil {
+		return fmt.Errorf("marshal reverse positions: %w", err)
+	}
+	// Persist that the move has entered its reverse window. Pre-flight and
+	// pre-cutover already guaranteed no revert marker was present up to here, so
+	// any _spirit_move_revert that appears on targets[0] from now on is a genuine
+	// operator revert request for THIS window — never dropped as "stale".
+	return r.checkpointTbl().Write(ctx, checkpoint.Record{
+		Position:  string(posJSON),
+		Phase:     phaseReverseWindow,
+		CutoverAt: r.cutoverAt,
+	})
+}
+
+// reverseWindow drives the post-cutover reverse window: it stands up a
+// change-only reverse feed (targets → the source's _old tables) so the source
+// stays current, then holds until the window elapses (complete forward), a
+// revert is requested (reverse cutover), or the feed dies (complete forward —
+// rollback is no longer safe). It is a separate type so the Runner's methods
+// stay in runner.go.
+type reverseWindow struct {
+	r    *Runner
+	feed *ReverseFeed
+	// watched[i] is target i's real-name tables, used to lock and then retire
+	// the targets during a reverse cutover.
+	watched [][]*table.TableInfo
+}
+
+func newReverseWindow(r *Runner) *reverseWindow { return &reverseWindow{r: r} }
+
+// run holds the window and performs the terminal action. It owns the feed's
+// lifecycle.
+func (w *reverseWindow) run(ctx context.Context) error {
+	if err := w.buildFeed(ctx); err != nil {
+		return err
+	}
+	defer w.feed.Close() // idempotent; the terminal actions also close explicitly
+	if err := w.feed.Start(ctx); err != nil {
+		return fmt.Errorf("reverse window: start feed: %w", err)
+	}
+
+	r := w.r
+	deadline := r.cutoverAt.Add(r.move.ReverseWindow)
+	// Where an operator creates the revert marker to trigger a rollback:
+	// targets[0]'s host and database.
+	revertLoc := r.targets[0].Config.Addr + "." + r.targets[0].Config.DBName
+	r.logger.Info(fmt.Sprintf("reverse window open; watching for a table named %s to be created on %s (create it to roll back)",
+		revertMarkerName, revertLoc),
+		"window", r.move.ReverseWindow, "deadline", deadline, "reverse_sources", len(r.targets))
+	r.status.Set(status.ReverseWindow)
+
+	ticker := time.NewTicker(reverseWindowPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if ferr := w.feed.Err(); ferr != nil {
+				r.logger.Error("reverse feed died mid-window; completing forward (rollback no longer safe)", "error", ferr)
+				return w.completeForward(ctx)
+			}
+			requested, err := w.revertRequested(ctx)
+			if err != nil {
+				// A transient read error should not abandon the window; log and
+				// retry on the next tick.
+				r.logger.Warn("could not read revert flag; continuing window", "error", err)
+			} else if requested {
+				r.logger.Info(fmt.Sprintf("revert triggered: detected a table named %s on %s; rolling back to source",
+					revertMarkerName, revertLoc))
+				return w.reverseCutover(ctx)
+			}
+			if !time.Now().Before(deadline) {
+				r.logger.Info("reverse window elapsed; completing forward")
+				return w.completeForward(ctx)
+			}
+		}
+	}
+}
+
+// buildFeed constructs the reverse feed: reverse sources are the former targets
+// (watched under their real names); the reverse target is the source, written
+// to its _old tables (the forward cutover renamed source real → _old).
+func (w *reverseWindow) buildFeed(ctx context.Context) error {
+	r := w.r
+	src := &r.sources[0] // single source (guarded in Run)
+
+	targetTables := make(map[string]*table.TableInfo, len(src.tables))
+	for _, t := range src.tables {
+		oldName := check.CutoverOldName(t.TableName)
+		oldTbl := table.NewTableInfo(src.db, src.config.DBName, oldName)
+		if err := oldTbl.SetInfo(ctx); err != nil {
+			return fmt.Errorf("reverse window: load renamed source table %q: %w", oldName, err)
+		}
+		targetTables[t.TableName] = oldTbl
+	}
+
+	sources := make([]ReverseSource, 0, len(r.targets))
+	w.watched = make([][]*table.TableInfo, len(r.targets))
+	for i := range r.targets {
+		tgt := &r.targets[i]
+		watched := make([]*table.TableInfo, 0, len(src.tables))
+		for _, t := range src.tables {
+			wt := table.NewTableInfo(tgt.DB, tgt.Config.DBName, t.TableName)
+			if err := wt.SetInfo(ctx); err != nil {
+				return fmt.Errorf("reverse window: load target table %q on shard %d: %w", t.TableName, i, err)
+			}
+			watched = append(watched, wt)
+		}
+		w.watched[i] = watched
+		sources = append(sources, ReverseSource{
+			DB:       tgt.DB,
+			Addr:     tgt.Config.Addr,
+			User:     tgt.Config.User,
+			Password: tgt.Config.Passwd,
+			Tables:   watched,
+			Position: r.reversePositions[targetKey(*tgt)],
+		})
+	}
+
+	feed, err := NewReverseFeed(ReverseFeedConfig{
+		Sources:      sources,
+		Target:       applier.Target{DB: src.db},
+		TargetTables: targetTables,
+		Logger:       r.logger,
+		DBConfig:     r.dbConfig,
+		Threads:      r.move.WriteThreads,
+		GTID:         r.move.EnableExperimentalGTID,
+	})
+	if err != nil {
+		return err
+	}
+	w.feed = feed
+	return nil
+}
+
+func (w *reverseWindow) revertRequested(ctx context.Context) (bool, error) {
+	return revertMarkerExists(ctx, w.r.targets[0].DB)
+}
+
+// completeForward reaches the same terminal state as a normal move: the source
+// tables are already renamed to _old (left in place, as after any move) and the
+// checkpoint is dropped. The reverse feed is stopped.
+func (w *reverseWindow) completeForward(ctx context.Context) error {
+	w.feed.Close()
+	if err := dropRevertMarker(ctx, w.r.targets[0].DB); err != nil {
+		return fmt.Errorf("reverse window: drop revert marker on complete-forward: %w", err)
+	}
+	if err := w.r.checkpointTbl().Drop(ctx); err != nil {
+		return fmt.Errorf("reverse window: drop checkpoint on complete-forward: %w", err)
+	}
+	w.r.logger.Info("reverse window complete; move finalized forward (source retired)")
+	return nil
+}
+
+// reverseCutover rolls the move back to the source. It mirrors the forward
+// cutover with roles swapped, plus one asymmetry: the source tables sit under
+// their _old names and must be un-retired before traffic returns to them.
+func (w *reverseWindow) reverseCutover(ctx context.Context) error {
+	r := w.r
+	src := &r.sources[0]
+
+	// Record that we are rolling back (best-effort; for a future resume).
+	if err := r.checkpointTbl().Write(ctx, checkpoint.Record{Phase: phaseReverting, CutoverAt: r.cutoverAt}); err != nil {
+		r.logger.Warn("could not persist reverting phase; continuing", "error", err)
+	}
+
+	// Clear any stale _revert tables on the targets before the retire (step 5)
+	// renames each target table to its _revert form — a leftover from a prior
+	// reverse cutover would otherwise collide. Done before locking, since the
+	// leftovers are not in the lock set (DROP under LOCK TABLES is disallowed for
+	// unlocked tables).
+	if err := r.dropStaleRevertTables(ctx); err != nil {
+		return err
+	}
+
+	// 1. Lock the reverse sources (former targets) to freeze their writes.
+	var locks []*dbconn.TableLock
+	closeLocks := func() {
+		for _, l := range locks {
+			utils.CloseAndLogWithContext(ctx, l)
+		}
+	}
+	for i := range r.targets {
+		lock, err := dbconn.NewTableLock(ctx, r.targets[i].DB, w.watched[i], r.dbConfig, r.logger)
+		if err != nil {
+			closeLocks()
+			return fmt.Errorf("reverse cutover: lock target %d: %w", i, err)
+		}
+		locks = append(locks, lock)
+	}
+	defer closeLocks()
+
+	// 2. Flush the reverse feed so the source's _old tables reflect every target
+	//    write, then stop it (no more writes to _old during the renames below).
+	if err := w.feed.Flush(ctx); err != nil {
+		return fmt.Errorf("reverse cutover: final flush: %w", err)
+	}
+	w.feed.Close()
+
+	// 3. Un-retire the source: rename its _old tables back to their real names
+	//    so it can serve again. The feed is stopped, so nothing writes them.
+	for _, t := range src.tables {
+		oldName := check.CutoverOldName(t.TableName)
+		if err := dbconn.Exec(ctx, src.db, "RENAME TABLE %n TO %n", oldName, t.TableName); err != nil {
+			return fmt.Errorf("reverse cutover: un-retire source table %q: %w", t.TableName, err)
+		}
+	}
+
+	// 4. Switch traffic back to the source.
+	if r.reverseCutoverFunc != nil {
+		if err := r.reverseCutoverFunc(ctx); err != nil {
+			return fmt.Errorf("reverse cutover: traffic switch failed: %w", err)
+		}
+	}
+
+	// 5. Retire the former targets to their _revert form under their lock —
+	//    fencing straggler writes after the switch, mirroring the forward
+	//    cutover's source rename. _revert (not _old) marks these as revert
+	//    artifacts, so a later move can safely drop them.
+	for i := range r.targets {
+		for _, t := range src.tables {
+			revertName := check.RevertRetiredName(t.TableName)
+			stmt := sqlescape.MustEscapeSQL("RENAME TABLE %n TO %n", t.TableName, revertName)
+			if err := locks[i].ExecUnderLock(ctx, stmt); err != nil {
+				return fmt.Errorf("reverse cutover: retire target %d table %q: %w", i, t.TableName, err)
+			}
+		}
+	}
+
+	// 6. Drop the revert marker and the checkpoint.
+	if err := dropRevertMarker(ctx, r.targets[0].DB); err != nil {
+		return fmt.Errorf("reverse cutover: drop revert marker: %w", err)
+	}
+	if err := r.checkpointTbl().Drop(ctx); err != nil {
+		return fmt.Errorf("reverse cutover: drop checkpoint: %w", err)
+	}
+	r.logger.Info("reverse cutover complete; move rolled back to source")
+	return nil
+}

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -1,0 +1,320 @@
+package move
+
+// End-to-end tests for the reverse-window move driven through the real Runner
+// (forward copy + cutover + reverse window + terminal action). 1 source → 1
+// target keeps the harness simple; the N:1 reverse feed itself is covered by
+// reversefeed_test.go. Uses the :8033 test MySQL (binlog=ROW).
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func setupReverseWindowMove(t *testing.T, srcDBName, dstDBName string) (sourceDSN, targetDSN string, ctl *sql.DB) {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = srcDBName
+	dst := cfg.Clone()
+	dst.DBName = dstDBName
+
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+srcDBName)
+	testutils.RunSQL(t, "CREATE DATABASE "+srcDBName)
+	testutils.RunSQL(t, "CREATE TABLE "+srcDBName+".t1 (id INT PRIMARY KEY, val VARCHAR(255))")
+	testutils.RunSQL(t, "INSERT INTO "+srcDBName+".t1 (id, val) VALUES (1,'one'),(2,'two'),(3,'three')")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+dstDBName)
+	testutils.RunSQL(t, "CREATE DATABASE "+dstDBName)
+
+	ctl, err = sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(ctl) })
+	return src.FormatDSN(), dst.FormatDSN(), ctl
+}
+
+// shortenReverseWindowPolling makes the window loop responsive in tests.
+func shortenReverseWindowPolling(t *testing.T) {
+	t.Helper()
+	old := reverseWindowPollInterval
+	reverseWindowPollInterval = 100 * time.Millisecond
+	t.Cleanup(func() { reverseWindowPollInterval = old })
+}
+
+func tableExists(t *testing.T, db *sql.DB, schema, name string) bool {
+	t.Helper()
+	var one int
+	err := db.QueryRowContext(t.Context(),
+		"SELECT 1 FROM information_schema.tables WHERE table_schema=? AND table_name=?", schema, name).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	require.NoError(t, err)
+	return true
+}
+
+// waitForReverseWindow polls the checkpoint until the move has entered its
+// reverse window (move_phase = reverse_window), i.e. cutover has happened.
+func waitForReverseWindow(t *testing.T, db *sql.DB, dstDBName string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var phase string
+		err := db.QueryRowContext(t.Context(),
+			"SELECT move_phase FROM "+dstDBName+"."+checkpointTableName+" WHERE id=1").Scan(&phase)
+		if err == nil && phase == phaseReverseWindow {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for the reverse window to open")
+}
+
+// TestMoveReverseWindowCompleteForward: with a reverse window and no revert, the
+// move holds the window then finalizes forward — source retired to _old, target
+// serving, checkpoint dropped.
+func TestMoveReverseWindowCompleteForward(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	sourceDSN, targetDSN, ctl := setupReverseWindowMove(t, "rwcf_src", "rwcf_dst")
+
+	m := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: time.Second,
+		Threads:         1,
+		WriteThreads:    1,
+		ReverseWindow:   2 * time.Second,
+	}
+	runner, err := NewRunner(m)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+
+	var cutoverCalled, reverseCutoverCalled bool
+	runner.SetCutover(func(context.Context) error { cutoverCalled = true; return nil })
+	runner.SetReverseCutover(func(context.Context) error { reverseCutoverCalled = true; return nil })
+
+	require.NoError(t, runner.Run(t.Context()))
+
+	require.True(t, cutoverCalled, "forward cutover func must run")
+	require.False(t, reverseCutoverCalled, "reverse cutover func must NOT run when the window elapses")
+	// Source retired to _old; target serving.
+	require.True(t, tableExists(t, ctl, "rwcf_src", "t1_old"), "source table should be retired to _old")
+	require.False(t, tableExists(t, ctl, "rwcf_src", "t1"), "source real table should be gone after retire")
+	require.True(t, tableExists(t, ctl, "rwcf_dst", "t1"), "target table should be serving")
+	require.False(t, tableExists(t, ctl, "rwcf_dst", checkpointTableName), "checkpoint should be dropped")
+}
+
+// TestMoveReverseWindowRevert: a revert requested during the window rolls the
+// move back — writes that landed on the target during the window flow back to
+// the source, the source is un-retired and serving, the target is retired.
+func TestMoveReverseWindowRevert(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	sourceDSN, targetDSN, ctl := setupReverseWindowMove(t, "rwrv_src", "rwrv_dst")
+
+	m := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: time.Second,
+		Threads:         1,
+		WriteThreads:    1,
+		ReverseWindow:   30 * time.Second, // long; the revert ends it early
+	}
+	runner, err := NewRunner(m)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+
+	var reverseCutoverCalled bool
+	runner.SetCutover(func(context.Context) error { return nil })
+	runner.SetReverseCutover(func(context.Context) error { reverseCutoverCalled = true; return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Run(context.Background()) }()
+
+	// Once the window is open, a write to the target and then a revert request.
+	// The revert is triggered the way the operator's revert command will:
+	// create the revert marker on targets[0] (here, rwrv_dst).
+	waitForReverseWindow(t, ctl, "rwrv_dst")
+	testutils.RunSQL(t, "INSERT INTO rwrv_dst.t1 (id, val) VALUES (99,'late')")
+	testutils.RunSQL(t, "CREATE TABLE rwrv_dst."+revertMarkerName+" (id INT)")
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the reverse cutover to complete")
+	}
+
+	require.True(t, reverseCutoverCalled, "reverse cutover func must run on revert")
+	// Source un-retired and serving, with the window's write flowed back.
+	require.True(t, tableExists(t, ctl, "rwrv_src", "t1"), "source should be un-retired")
+	require.False(t, tableExists(t, ctl, "rwrv_src", "t1_old"), "source _old should be gone after un-retire")
+	var val string
+	require.NoError(t, ctl.QueryRowContext(t.Context(), "SELECT val FROM rwrv_src.t1 WHERE id=99").Scan(&val))
+	require.Equal(t, "late", val, "a write made on the target during the window must flow back to the source")
+	// Target retired to its _revert form.
+	require.True(t, tableExists(t, ctl, "rwrv_dst", "t1_revert"), "target should be retired to _revert")
+	require.False(t, tableExists(t, ctl, "rwrv_dst", "t1"), "target real table should be gone after retire")
+	require.False(t, tableExists(t, ctl, "rwrv_dst", "t1_old"), "target must not use the _old (forward) suffix")
+	require.False(t, tableExists(t, ctl, "rwrv_dst", checkpointTableName), "checkpoint should be dropped")
+}
+
+// runRevertingMove runs one reverse-window move against the given DSNs and, once
+// the window opens, requests a revert (creates the marker), returning when the
+// reverse cutover has completed. Fails the test on any error.
+func runRevertingMove(t *testing.T, sourceDSN, targetDSN string, ctl *sql.DB, dstDBName string, gtid bool) {
+	t.Helper()
+	m := &Move{
+		SourceDSN:              sourceDSN,
+		TargetDSN:              targetDSN,
+		TargetChunkTime:        time.Second,
+		Threads:                1,
+		WriteThreads:           1,
+		ReverseWindow:          30 * time.Second, // long; the revert ends it early
+		EnableExperimentalGTID: gtid,
+	}
+	runner, err := NewRunner(m)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+	runner.SetCutover(func(context.Context) error { return nil })
+	runner.SetReverseCutover(func(context.Context) error { return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Run(context.Background()) }()
+
+	waitForReverseWindow(t, ctl, dstDBName)
+	testutils.RunSQL(t, "CREATE TABLE "+dstDBName+"."+revertMarkerName+" (id INT)")
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the reverse cutover to complete")
+	}
+}
+
+// TestMoveReverseWindowRevertIdempotentAcrossRetries: running move+revert twice
+// against the same source/target must not collide with the first revert's
+// retired (_revert) target tables — the fresh-start cleanup drops them.
+func TestMoveReverseWindowRevertIdempotentAcrossRetries(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	sourceDSN, targetDSN, ctl := setupReverseWindowMove(t, "rwidem_src", "rwidem_dst")
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		runRevertingMove(t, sourceDSN, targetDSN, ctl, "rwidem_dst", false)
+		require.True(t, tableExists(t, ctl, "rwidem_src", "t1"), "attempt %d: source should be serving", attempt)
+		require.True(t, tableExists(t, ctl, "rwidem_dst", "t1_revert"), "attempt %d: target retired to _revert", attempt)
+		require.False(t, tableExists(t, ctl, "rwidem_dst", "t1"), "attempt %d: target real table gone", attempt)
+	}
+}
+
+// TestMoveReverseWindowRevertGTID: the reverse window works end-to-end with the
+// GTID change source (--enable-experimental-gtid), exercising the GTID path of
+// Source.CurrentPosition (position capture at cutover) and the GTID reverse feed
+// — proving the feature is not binlog-only.
+func TestMoveReverseWindowRevertGTID(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	sourceDSN, targetDSN, ctl := setupReverseWindowMove(t, "rwgtid_src", "rwgtid_dst")
+	runRevertingMove(t, sourceDSN, targetDSN, ctl, "rwgtid_dst", true)
+	require.True(t, tableExists(t, ctl, "rwgtid_src", "t1"), "source should be serving after rollback")
+	require.True(t, tableExists(t, ctl, "rwgtid_dst", "t1_revert"), "target retired to _revert")
+	require.False(t, tableExists(t, ctl, "rwgtid_dst", "t1"), "target real table gone")
+}
+
+// TestMoveReverseWindowResumesAfterKill: killing a move while it is in the
+// reverse window and re-running it must RESUME the window (from the checkpoint)
+// — not re-discover/re-copy the source's now-_old tables. This is the reported
+// failure mode.
+func TestMoveReverseWindowResumesAfterKill(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	sourceDSN, targetDSN, ctl := setupReverseWindowMove(t, "rwrk_src", "rwrk_dst")
+
+	// Run 1: reach the reverse window, then simulate a kill (cancel the context)
+	// without completing it. The checkpoint (phase=reverse_window) survives.
+	run1, err := NewRunner(&Move{
+		SourceDSN: sourceDSN, TargetDSN: targetDSN,
+		TargetChunkTime: time.Second, Threads: 1, WriteThreads: 1,
+		ReverseWindow: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	run1.SetCutover(func(context.Context) error { return nil })
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	run1Done := make(chan struct{})
+	go func() { _ = run1.Run(ctx1); close(run1Done) }()
+
+	waitForReverseWindow(t, ctl, "rwrk_dst")
+	cancel1() // "kill" the process mid-window
+	<-run1Done
+	utils.CloseAndLog(run1)
+
+	// The interrupted state: source retired to _old, target serving, checkpoint present.
+	require.True(t, tableExists(t, ctl, "rwrk_src", "t1_old"), "source should be retired to _old mid-window")
+	require.False(t, tableExists(t, ctl, "rwrk_src", "t1"), "source real table renamed away at cutover")
+	require.True(t, tableExists(t, ctl, "rwrk_dst", "t1"), "target should be serving")
+	require.True(t, tableExists(t, ctl, "rwrk_dst", checkpointTableName), "checkpoint must survive the kill")
+
+	// Run 2: re-run the move. It must RESUME the window, not re-copy. Prove it by
+	// failing if the forward cutover runs again, then request a revert and confirm
+	// the rollback completes.
+	run2, err := NewRunner(&Move{
+		SourceDSN: sourceDSN, TargetDSN: targetDSN,
+		TargetChunkTime: time.Second, Threads: 1, WriteThreads: 1,
+		ReverseWindow: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	defer utils.CloseAndLog(run2)
+	run2.SetCutover(func(context.Context) error {
+		t.Error("resume must NOT run the forward cutover again (it re-copied instead of resuming)")
+		return nil
+	})
+	var reverseCutoverCalled bool
+	run2.SetReverseCutover(func(context.Context) error { reverseCutoverCalled = true; return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- run2.Run(context.Background()) }()
+
+	waitForReverseWindow(t, ctl, "rwrk_dst") // already reverse_window from run 1
+	testutils.RunSQL(t, "CREATE TABLE rwrk_dst."+revertMarkerName+" (id INT)")
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the resumed reverse window to roll back")
+	}
+
+	require.True(t, reverseCutoverCalled, "resumed window must be able to roll back")
+	require.True(t, tableExists(t, ctl, "rwrk_src", "t1"), "source un-retired after rollback")
+	require.True(t, tableExists(t, ctl, "rwrk_dst", "t1_revert"), "target retired to _revert after rollback")
+	require.False(t, tableExists(t, ctl, "rwrk_dst", "t1"), "target real table gone after rollback")
+}
+
+// TestMoveReverseWindowRefusesStaleRevertMarker: a leftover revert marker on
+// targets[0] (a prior reverse-window move that didn't complete) must make the
+// move refuse at pre-flight rather than start on an unknown-state target.
+func TestMoveReverseWindowRefusesStaleRevertMarker(t *testing.T) {
+	sourceDSN, targetDSN, _ := setupReverseWindowMove(t, "rwsm_src", "rwsm_dst")
+	testutils.RunSQL(t, "CREATE TABLE rwsm_dst."+revertMarkerName+" (id INT)")
+
+	m := &Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: time.Second,
+		Threads:         1,
+		WriteThreads:    1,
+		ReverseWindow:   2 * time.Second,
+	}
+	runner, err := NewRunner(m)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+	runner.SetCutover(func(context.Context) error { return nil })
+
+	err = runner.Run(t.Context())
+	require.Error(t, err, "move must refuse to start when a revert marker is present")
+	require.Contains(t, err.Error(), "revert marker")
+}

--- a/pkg/move/revertmarker.go
+++ b/pkg/move/revertmarker.go
@@ -1,0 +1,45 @@
+package move
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/block/spirit/pkg/dbconn"
+)
+
+// revertMarkerName is the table an operator creates to ask an in-flight reverse
+// window to roll back. Like the pre-cutover sentinel (pkg/sentinel), it is a
+// coordination signal expressed as a table's existence — the difference is
+// polarity: the sentinel is created by the move and dropped by the operator to
+// proceed, whereas the revert marker is created by the operator to trigger a
+// rollback.
+//
+// The reverse-window driver polls for it on targets[0] (where the checkpoint
+// also lives). A stale marker (from a prior reverse-window move that did not
+// complete) makes a new move refuse at pre-flight/pre-cutover; the marker is
+// removed by the terminal action (complete-forward or reverse cutover). Keeping
+// the trigger in its own table decouples the operator-owned signal from the
+// move-owned checkpoint row.
+const revertMarkerName = "_spirit_move_revert"
+
+// revertMarkerExists reports whether the revert marker is present in db's
+// currently-selected schema (DATABASE()).
+func revertMarkerExists(ctx context.Context, db *sql.DB) (bool, error) {
+	var one int
+	err := db.QueryRowContext(ctx,
+		"SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?",
+		revertMarkerName).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// dropRevertMarker removes the revert marker (idempotent).
+func dropRevertMarker(ctx context.Context, db *sql.DB) error {
+	return dbconn.Exec(ctx, db, "DROP TABLE IF EXISTS %n", revertMarkerName)
+}

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -121,6 +121,17 @@ type Runner struct {
 	usedResumeFromCheckpoint bool
 
 	cutoverFunc func(ctx context.Context) error
+	// reverseCutoverFunc is the reverse-window rollback's traffic switch (route
+	// back to the source). Set via SetReverseCutover; used only when
+	// move.ReverseWindow > 0 and a revert is requested during the window.
+	reverseCutoverFunc func(ctx context.Context) error
+	// reversePositions holds each target's binlog position captured at cutover
+	// (keyed by targetKey) — the start points for the reverse feeds. cutoverAt
+	// is when the forward cutover completed (the reverse-window deadline is
+	// measured from it). Both are set by the cutover postSwitch hook when
+	// move.ReverseWindow > 0.
+	reversePositions map[string]string
+	cutoverAt        time.Time
 
 	logger     *slog.Logger
 	cancelFunc context.CancelFunc
@@ -139,6 +150,11 @@ type Runner struct {
 	// Set in startBackgroundRoutines and invoked from Close() so that
 	// late status/checkpoint goroutine activity cannot race with teardown.
 	watchTaskWait func()
+	// bgCancel cancels the context the WatchTask (status + checkpoint dumper)
+	// goroutines run under. Reverse-window mode stops the dumper before cutover
+	// (stopWatchTask) so the reverse window is the sole writer of the checkpoint
+	// row.
+	bgCancel context.CancelFunc
 }
 
 var _ status.Task = (*Runner)(nil)
@@ -397,6 +413,14 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	rec, err := r.checkpointTbl().ReadLatest(ctx)
 	if err != nil {
 		return fmt.Errorf("could not read from checkpoint table '%s' on target: %w", checkpointTableName, err)
+	}
+	// A checkpoint past the forward cutover (reverse-window mode) must never be
+	// resumed down the copy path: the copy and cutover are already done, and
+	// re-running them would re-invoke the traffic switch and rename the
+	// already-retired tables. Resuming an in-flight reverse window is not yet
+	// supported, so fail loudly rather than corrupt state.
+	if rec.Phase != "" {
+		return fmt.Errorf("cannot resume move: checkpoint is past cutover (phase=%q); resuming an in-flight reverse window is not yet supported", rec.Phase)
 	}
 	copierWatermark := rec.CopierWatermark
 	r.checksumWatermark = rec.ChecksumWatermark
@@ -696,8 +720,127 @@ func (r *Runner) wipeTargets(ctx context.Context) error {
 	return r.checkpointTbl().Drop(ctx) // Transient → DROP TABLE IF EXISTS
 }
 
+// dropStaleRevertTables drops any leftover <table>_revert tables on every
+// target. A reverse-window rollback retires the former targets to their
+// _revert form (check.RevertRetiredName); a later fresh move — and the reverse
+// cutover itself — must clear those first so the retire RENAME cannot collide
+// with a leftover. Safe because only a revert ever creates a _revert table.
+func (r *Runner) dropStaleRevertTables(ctx context.Context) error {
+	for i := range r.targets {
+		for _, t := range r.sourceTables {
+			revertName := check.RevertRetiredName(t.TableName)
+			if err := dbconn.Exec(ctx, r.targets[i].DB, "DROP TABLE IF EXISTS %n", revertName); err != nil {
+				return fmt.Errorf("drop stale revert table %q on target %d: %w", revertName, i, err)
+			}
+		}
+	}
+	return nil
+}
+
+// maybeResumeReverseWindow takes over the run when a prior attempt reached the
+// reverse window, rather than falling through to discovery/copy (which would
+// re-copy the source's now-_old tables — the reported failure mode). It reads
+// the checkpoint before any locks or discovery. Returns handled=true when it
+// owns the run.
+//
+// Not yet handled: an interrupted reverse *cutover* (phase "reverting") leaves
+// an ambiguous half-renamed state, so that surfaces as an error for manual
+// completion rather than an unsafe auto-resume.
+func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
+	rec, err := r.checkpointTbl().ReadLatest(ctx)
+	if err != nil {
+		// No usable checkpoint (fresh move, empty, or a layout this version
+		// can't read) — not a reverse resume; let the normal flow decide
+		// copy-resume vs fresh.
+		return false, nil //nolint:nilerr
+	}
+	switch rec.Phase {
+	case phaseReverseWindow:
+		r.logger.Warn("resuming an interrupted reverse window from checkpoint", "cutover_at", rec.CutoverAt)
+		return true, r.resumeReverseWindow(ctx, rec)
+	case phaseReverting:
+		return true, fmt.Errorf("a reverse cutover was interrupted (checkpoint phase=%q); resuming a partial rollback is not yet supported — complete it manually", rec.Phase)
+	default:
+		return false, nil // phase "" (copy) — the normal flow handles resume/fresh
+	}
+}
+
+// resumeReverseWindow rebuilds the reverse-window state from the checkpoint and
+// re-enters the window. The reverse feeds restart from the checkpointed
+// positions and catch up whatever the source missed while the process was down.
+//
+// v1 note: no metadata locks are re-acquired here (a concurrent second restart
+// of the same move is an operator error), and the feed always resumes from the
+// original cutover position — correct via idempotent apply, at the cost of
+// re-reading the window's binlog.
+func (r *Runner) resumeReverseWindow(ctx context.Context, rec checkpoint.Record) error {
+	var positions map[string]string
+	if err := json.Unmarshal([]byte(rec.Position), &positions); err != nil {
+		return fmt.Errorf("resume reverse window: parse stored positions: %w", err)
+	}
+	r.reversePositions = positions
+	r.cutoverAt = rec.CutoverAt
+
+	logical, err := r.reverseWindowLogicalTables(ctx)
+	if err != nil {
+		return err
+	}
+	if len(logical) == 0 {
+		return fmt.Errorf("resume reverse window: found no retired (_old) source tables to resume from")
+	}
+	src := &r.sources[0] // reverse-window is single-source (guarded at cutover)
+	src.tables = make([]*table.TableInfo, 0, len(logical))
+	for _, name := range logical {
+		// Only the name is read downstream (buildFeed derives the _old source
+		// and real target TableInfos itself), so no SetInfo — the logical table
+		// no longer exists on the source under this name.
+		src.tables = append(src.tables, table.NewTableInfo(src.db, src.config.DBName, name))
+	}
+	r.sourceTables = src.tables
+
+	return newReverseWindow(r).run(ctx)
+}
+
+// reverseWindowLogicalTables recovers the logical names of the moved tables when
+// resuming a reverse window: the forward cutover renamed each to <name>_old on
+// the source, so it lists those and strips the suffix. When an explicit table
+// list was supplied it is used to filter (ignoring unrelated _old tables).
+func (r *Runner) reverseWindowLogicalTables(ctx context.Context) ([]string, error) {
+	src := &r.sources[0]
+	rows, err := src.db.QueryContext(ctx,
+		"SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name LIKE '%\\_old'",
+		src.config.DBName)
+	if err != nil {
+		return nil, fmt.Errorf("resume reverse window: list retired source tables: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+	wanted := make(map[string]bool, len(r.move.SourceTables))
+	for _, t := range r.move.SourceTables {
+		wanted[t] = true
+	}
+	var logical []string
+	for rows.Next() {
+		var oldName string
+		if err := rows.Scan(&oldName); err != nil {
+			return nil, err
+		}
+		name := strings.TrimSuffix(oldName, "_old")
+		if len(wanted) > 0 && !wanted[name] {
+			continue // an unrelated _old table, not part of this move
+		}
+		logical = append(logical, name)
+	}
+	return logical, rows.Err()
+}
+
 func (r *Runner) newCopy(ctx context.Context) error {
-	// We are starting fresh:
+	// Starting fresh. Clear any leftover _revert tables from an earlier
+	// reverse-window rollback on these targets, so this run's own reverse
+	// cutover can retire the targets without colliding (and so they don't
+	// linger). Only on the fresh path — a resume must not drop tables.
+	if err := r.dropStaleRevertTables(ctx); err != nil {
+		return err
+	}
 	// For each table, fetch the CREATE TABLE statement from the source and run it on the target.
 	if err := r.createTargetTables(ctx); err != nil {
 		return err
@@ -814,6 +957,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		"dirty", bi.Modified,
 	)
 
+	if r.move.ReverseWindow > 0 && len(r.move.SourceDSNs) > 1 {
+		// Reverse-window is only defined for an unsharded source (1 source →
+		// M targets ⇒ an M:1 reverse). A sharded source would need an M:N
+		// reverse with a reverse sharding provider, which is out of scope.
+		return fmt.Errorf("--reverse-window requires an unsharded (single) source, got %d source shards", len(r.move.SourceDSNs))
+	}
+
 	var err error
 	r.dbConfig = dbconn.NewDBConfig()
 	// ForceKill is now true by default in NewDBConfig(), no need to set explicitly.
@@ -886,6 +1036,27 @@ func (r *Runner) Run(ctx context.Context) error {
 	slices.SortFunc(r.targets, func(a, b applier.Target) int {
 		return strings.Compare(targetKey(a), targetKey(b))
 	})
+
+	// If a prior run reached the reverse window (or a reverse cutover), resume
+	// that here instead of the normal discovery/copy path. The forward cutover
+	// renamed the source tables to _old, so the normal path would otherwise
+	// treat them as fresh data and re-copy them. This must run before the
+	// revert-marker pre-flight guard, since a resumed window legitimately honors
+	// a marker created before the crash.
+	if handled, err := r.maybeResumeReverseWindow(ctx); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+
+	// Pre-flight: refuse to start if a revert marker is already present on
+	// targets[0]. It means a prior reverse-window move on this target requested a
+	// rollback and did not complete cleanly, so the target is in an unknown state
+	// — starting a new move on top of it is unsafe. (The marker is otherwise
+	// created only during a reverse window and dropped by its terminal action.)
+	if err := r.assertNoRevertMarker(ctx, "pre-flight"); err != nil {
+		return err
+	}
 	// Discovery is read-only: preflight checks plus building the per-source
 	// table lists (which the metadata lock names below are derived from).
 	if err := r.setupDiscovery(ctx); err != nil {
@@ -993,6 +1164,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
+	if r.move.ReverseWindow > 0 {
+		// From here the reverse window is the sole writer of the checkpoint row,
+		// so stop the periodic checkpoint dumper first — otherwise it would
+		// clobber the reverse-window phase / revert flag with a copy-phase row.
+		r.stopWatchTask()
+	}
 	r.logger.Info("Sentinel released, starting cutover")
 	// Create a cutover.
 	r.status.Set(status.CutOver)
@@ -1008,9 +1185,29 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if r.move.ReverseWindow > 0 {
+		// Under the cutover lock, right after the traffic switch, capture the
+		// reverse-feed start positions and record that the move has entered its
+		// reverse window (see captureReverseWindow). The source rename still runs.
+		cutover.SetPostSwitch(func(ctx context.Context) error { return captureReverseWindow(ctx, r) })
+	}
+	// Pre-cutover: refuse to switch traffic if a revert has been requested (a
+	// marker appeared on targets[0] during the copy). Cutting over only to
+	// immediately roll back is pointless — abort while the source is still live.
+	if err := r.assertNoRevertMarker(ctx, "pre-cutover"); err != nil {
+		return err
+	}
 	if err = cutover.Run(ctx); err != nil {
 		return err
 	}
+
+	if r.move.ReverseWindow > 0 {
+		// Hold the reverse window keeping the source current, then complete
+		// forward (retire the source) or roll back. The checkpoint is dropped by
+		// the terminal action, not here.
+		return newReverseWindow(r).run(ctx)
+	}
+
 	// Delete checkpoint table from targets[0].
 	tgt0 := &r.targets[0]
 	if err := dbconn.Exec(ctx, tgt0.DB, "DROP TABLE IF EXISTS %n", checkpointTableName); err != nil {
@@ -1038,8 +1235,43 @@ func (r *Runner) startBackgroundRoutines(ctx context.Context) {
 
 	// Start go routines for checkpointing and dumping status. The returned
 	// wait function is invoked from Close() so we can be sure no late
-	// checkpoint INSERT lands after teardown begins.
-	r.watchTaskWait = status.WatchTask(ctx, r, r.logger)
+	// checkpoint INSERT lands after teardown begins. They run under a child
+	// context so reverse-window mode can stop them independently of Run's ctx
+	// (see stopWatchTask).
+	bgCtx, bgCancel := context.WithCancel(ctx)
+	r.bgCancel = bgCancel
+	r.watchTaskWait = status.WatchTask(bgCtx, r, r.logger)
+}
+
+// stopWatchTask stops the background status/checkpoint dumper and waits for it
+// to exit. Idempotent. Reverse-window mode calls it before cutover so the
+// reverse window owns the checkpoint row exclusively — no periodic dump can
+// clobber the reverse-window phase or the revert flag. Close() then skips the
+// dumper because watchTaskWait is cleared.
+func (r *Runner) stopWatchTask() {
+	if r.bgCancel != nil {
+		r.bgCancel()
+		r.bgCancel = nil
+	}
+	if r.watchTaskWait != nil {
+		r.watchTaskWait()
+		r.watchTaskWait = nil
+	}
+}
+
+// assertNoRevertMarker fails if the revert marker is present on targets[0].
+// Called at pre-flight and pre-cutover (phase names the caller): a marker there
+// means a reverse-window rollback is pending, or a prior reverse-window move did
+// not complete, so neither starting a move nor cutting over makes sense.
+func (r *Runner) assertNoRevertMarker(ctx context.Context, phase string) error {
+	present, err := revertMarkerExists(ctx, r.targets[0].DB)
+	if err != nil {
+		return fmt.Errorf("%s: could not check for revert marker on targets[0]: %w", phase, err)
+	}
+	if present {
+		return fmt.Errorf("%s: revert marker %q is present on targets[0]; a reverse-window rollback is pending or a prior move did not complete — investigate and drop it before proceeding", phase, revertMarkerName)
+	}
+	return nil
 }
 
 // fatalError is the callback provided to the replication client.
@@ -1433,6 +1665,13 @@ func (r *Runner) analyzeTable(ctx context.Context, db *sql.DB, tableName string)
 
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {
 	r.cutoverFunc = cutover
+}
+
+// SetReverseCutover registers the rollback traffic switch used if a revert is
+// requested during the reverse window (route back to the source). It mirrors
+// SetCutover and is only consulted when move.ReverseWindow > 0.
+func (r *Runner) SetReverseCutover(fn func(ctx context.Context) error) {
+	r.reverseCutoverFunc = fn
 }
 
 func (r *Runner) Progress() status.Progress {

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -414,13 +414,14 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not read from checkpoint table '%s' on target: %w", checkpointTableName, err)
 	}
-	// A checkpoint past the forward cutover (reverse-window mode) must never be
-	// resumed down the copy path: the copy and cutover are already done, and
-	// re-running them would re-invoke the traffic switch and rename the
-	// already-retired tables. Resuming an in-flight reverse window is not yet
-	// supported, so fail loudly rather than corrupt state.
+	// A checkpoint past the forward cutover (a reverse-window phase) is resumed
+	// earlier by maybeResumeReverseWindow, before discovery/locks — it should
+	// never reach this copy-path resume. This is a defensive backstop: getting
+	// here with a non-empty phase means that earlier handoff was bypassed, so
+	// fail loudly rather than re-run the copy and cutover (which would re-invoke
+	// the traffic switch and rename the already-retired tables).
 	if rec.Phase != "" {
-		return fmt.Errorf("cannot resume move: checkpoint is past cutover (phase=%q); resuming an in-flight reverse window is not yet supported", rec.Phase)
+		return fmt.Errorf("cannot resume move down the copy path: checkpoint is past cutover (phase=%q); a reverse-window resume is handled earlier (see maybeResumeReverseWindow)", rec.Phase)
 	}
 	copierWatermark := rec.CopierWatermark
 	r.checksumWatermark = rec.ChecksumWatermark

--- a/pkg/status/README.md
+++ b/pkg/status/README.md
@@ -8,9 +8,11 @@ The `status` package provides state management, progress reporting, and periodic
 
 The states are defined in lifecycle order:
 
-`Initial` → `CopyRows` → `WaitingOnSentinelTable` → `ApplyChangeset` → `RestoreSecondaryIndexes` → `AnalyzeTable` → `Checksum` → `PostChecksum` → `CutOver` → `Close` → `ErrCleanup`
+`Initial` → `CopyRows` → `WaitingOnSentinelTable` → `ApplyChangeset` → `RestoreSecondaryIndexes` → `AnalyzeTable` → `Checksum` → `PostChecksum` → `CutOver` → `ReverseWindow` → `Close` → `ErrCleanup`
 
 This ordering is deliberate — the code uses ordinal comparisons (e.g., `state >= CutOver`) to determine when to stop checkpointing and status reporting.
+
+`ReverseWindow` is entered only by a `move` run with [`--reverse-window`](../../docs/move.md#reverse-window) set. It sorts immediately after `CutOver`: the forward cutover is done and traffic is on the target, but Spirit keeps the source current in change-only mode so the move can still be rolled back. Because it is `>= CutOver`, the background status/checkpoint loops have already stopped (the reverse-window driver manages its own checkpoint writes) while orchestration can still observe that a revert is possible.
 
 ## Task Interface
 

--- a/pkg/status/state.go
+++ b/pkg/status/state.go
@@ -31,6 +31,12 @@ const (
 	// described in docs/migrate.md.
 	WaitingOnSentinelTable
 	CutOver
+	// ReverseWindow is the post-cutover reverse window, entered only when
+	// --reverse-window > 0: traffic is on the target and spirit keeps the source
+	// current in change-only mode while watching for a revert request. It sorts
+	// after CutOver (so `state >= Checksum` stays true) and lets orchestration
+	// surface that a revert is still possible.
+	ReverseWindow
 	Close
 	ErrCleanup
 )
@@ -55,6 +61,8 @@ func (s State) String() string {
 		return "postChecksum"
 	case CutOver:
 		return "cutOver"
+	case ReverseWindow:
+		return "reverseWindow"
 	case Close:
 		return "close"
 	case ErrCleanup:

--- a/pkg/status/state_order_test.go
+++ b/pkg/status/state_order_test.go
@@ -23,6 +23,9 @@ import (
 //   - state.go itself documents that WaitingOnSentinelTable must sort AFTER
 //     Checksum so that `state >= Checksum` stays true while the sentinel wait
 //     blocks the cutover.
+//   - pkg/move/reversewindow.go: the ReverseWindow state sorts AFTER CutOver so
+//     the post-cutover reverse window satisfies `state >= CutOver` (fatalError
+//     becomes a no-op; the status/checkpoint dumpers stop) — intended.
 //
 // If you INTENTIONALLY reorder or insert a State, update the expected values
 // below AND audit every `>=` / `>` / `<` comparison against a State constant to
@@ -44,8 +47,9 @@ func TestStateOrder(t *testing.T) {
 		{"PostChecksum", PostChecksum, 6},
 		{"WaitingOnSentinelTable", WaitingOnSentinelTable, 7},
 		{"CutOver", CutOver, 8},
-		{"Close", Close, 9},
-		{"ErrCleanup", ErrCleanup, 10},
+		{"ReverseWindow", ReverseWindow, 9},
+		{"Close", Close, 10},
+		{"ErrCleanup", ErrCleanup, 11},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -67,6 +71,8 @@ func TestStateOrder(t *testing.T) {
 		"CutOver must sort strictly after WaitingOnSentinelTable (the sentinel wait precedes cutover)")
 	require.Greater(t, int32(CutOver), int32(PostChecksum),
 		"CutOver must sort strictly after PostChecksum")
+	require.Greater(t, int32(ReverseWindow), int32(CutOver),
+		"ReverseWindow must sort strictly after CutOver: the post-cutover reverse window is 'past cutover', so it must satisfy the same `state >= CutOver` gates (fatalError no-op; status/checkpoint dumpers stop)")
 
 	// (b cont.) Assert the FULL monotonic ordering of the declared states. The
 	// slice is written in the intended logical order; each entry must have a
@@ -84,6 +90,7 @@ func TestStateOrder(t *testing.T) {
 		{"PostChecksum", PostChecksum},
 		{"WaitingOnSentinelTable", WaitingOnSentinelTable},
 		{"CutOver", CutOver},
+		{"ReverseWindow", ReverseWindow},
 		{"Close", Close},
 		{"ErrCleanup", ErrCleanup},
 	}


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Add an optional post-cutover **reverse window** to `move`: after a MoveTables cutover, `--reverse-window=<duration>` keeps the source current in change-only reverse mode (targets → source) so the move can be rolled back before the source is retired. On timeout — or if the reverse feed dies — the move finalizes forward; on an operator revert request it reverse-cuts-over back to the source. `0` (the default) is a normal one-way cutover.

Builds on the reverse-feed foundations merged in #1060 (`change.Source.CurrentPosition` + `move.ReverseFeed`); this PR is the integration only.

- **Driver** (`reversewindow.go`) — stands up the change-only reverse feed at cutover, holds the window, and takes a terminal action: complete-forward on timeout or feed death, reverse cutover on a revert request.
- **Revert trigger** (`revertmarker.go`) — the operator creates a `_spirit_move_revert` table on the first target; the driver polls for it. Pre-flight and pre-cutover refuse to run if a stale marker is already present.
- **Reverse cutover** — un-retires the source (`_old` → real) and retires the former targets to a `_revert` suffix (distinct from `_old`); `dropStaleRevertTables` makes revert→retry idempotent.
- **Checkpoint** (`checkpoint.go`) — adds `move_phase` and `cutover_at` columns so a move killed *during* the window resumes back into it (`maybeResumeReverseWindow`) rather than re-copying. An interrupted reverse *cutover* (phase `reverting`) is intentionally left for manual completion, not auto-resumed.
- **Status** — new `ReverseWindow` state (sorts after `CutOver`).
- **Runner wiring** — postSwitch position capture under the source lock, the `--reverse-window` gate, the `SetReverseCutover` hook, and a single-(unsharded)-source guard.
- **Docs** — `docs/move.md` (flag reference), `pkg/status/README.md`, `pkg/move/README.md`.

Requires an unsharded (single) source. Tested against MySQL: complete-forward, revert (binlog + GTID), resume-after-kill, idempotent revert→retry, and stale-marker refusal.

Out of scope (separate strata-side PR): the strata `revert` command and the cutover-func split.

**Note:** this changes the move checkpoint format (adds `move_phase` / `cutover_at`).
