### PR TITLE
statement: normalize integer display widths (int(11) -> int)

### DIFF
--- a/pkg/statement/diff_column_options_test.go
+++ b/pkg/statement/diff_column_options_test.go
@@ -65,13 +65,13 @@ func TestDiffColumnAttributeOptions(t *testing.T) {
 			name:     "GeneratedStoredAdded",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) GENERATED ALWAYS AS (`a`+1) STORED NULL",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int GENERATED ALWAYS AS (`a`+1) STORED NULL",
 		},
 		{
 			name:     "GeneratedRemoved",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) NULL",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int NULL",
 		},
 		{
 			name:     "GeneratedNoChange",
@@ -92,13 +92,13 @@ func TestDiffColumnAttributeOptions(t *testing.T) {
 			name:     "GeneratedStoredVsVirtual",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) VIRTUAL)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) GENERATED ALWAYS AS (`a`+1) VIRTUAL NULL",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int GENERATED ALWAYS AS (`a`+1) VIRTUAL NULL",
 		},
 		{
 			name:     "GeneratedExpressionChanged",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 2) STORED)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) GENERATED ALWAYS AS (`a`+2) STORED NULL",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int GENERATED ALWAYS AS (`a`+2) STORED NULL",
 		},
 		// SRID (spatial columns)
 		{

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -35,19 +35,19 @@ func TestDiff(t *testing.T) {
 			name:     "AddColumn",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT)",
-			expected: "ALTER TABLE `t1` ADD COLUMN `b` int(11) NULL",
+			expected: "ALTER TABLE `t1` ADD COLUMN `b` int NULL",
 		},
 		{
 			name:     "AddColumnInMiddle",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT, c INT)",
-			expected: "ALTER TABLE `t1` ADD COLUMN `b` int(11) NULL AFTER `id`",
+			expected: "ALTER TABLE `t1` ADD COLUMN `b` int NULL AFTER `id`",
 		},
 		{
 			name:     "AddColumnAtEnd",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT, c INT)",
-			expected: "ALTER TABLE `t1` ADD COLUMN `c` int(11) NULL",
+			expected: "ALTER TABLE `t1` ADD COLUMN `c` int NULL",
 		},
 		{
 			name:     "DropColumn",
@@ -65,7 +65,7 @@ func TestDiff(t *testing.T) {
 			name:     "ReorderColumn",
 			source:   "CREATE TABLE t1 (a INT, b INT, c INT)",
 			target:   "CREATE TABLE t1 (c INT, a INT, b INT)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `c` int(11) NULL FIRST, MODIFY COLUMN `a` int(11) NULL AFTER `c`, MODIFY COLUMN `b` int(11) NULL AFTER `a`",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `c` int NULL FIRST, MODIFY COLUMN `a` int NULL AFTER `c`, MODIFY COLUMN `b` int NULL AFTER `a`",
 		},
 		{
 			name:     "AddIndex",
@@ -125,7 +125,7 @@ func TestDiff(t *testing.T) {
 			name:     "AddColumnWithInlineUnique",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, c INT UNIQUE)",
-			expected: "ALTER TABLE `t1` ADD COLUMN `c` int(11) NULL, ADD UNIQUE INDEX `c` (`c`)",
+			expected: "ALTER TABLE `t1` ADD COLUMN `c` int NULL, ADD UNIQUE INDEX `c` (`c`)",
 		},
 		{
 			// Uniqueness removed relative to an inline declaration.
@@ -299,7 +299,7 @@ func TestDiff(t *testing.T) {
 			name:     "UnsignedColumn",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, count INT)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, count INT UNSIGNED)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `count` int(11) unsigned NULL",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `count` int unsigned NULL",
 		},
 		{
 			name:     "ColumnComment",
@@ -311,7 +311,7 @@ func TestDiff(t *testing.T) {
 			name:     "ColumnCommentRogueValues1",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY COMMENT 'Line1\\nLine2\\rLine3')",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int(11) NOT NULL COMMENT 'Line1\\nLine2\\rLine3'",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int NOT NULL COMMENT 'Line1\\nLine2\\rLine3'",
 		},
 		{
 			name:   "ColumnCommentRogueValues2",
@@ -328,7 +328,7 @@ func TestDiff(t *testing.T) {
 			name:     "AutoIncrement",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int(11) NOT NULL AUTO_INCREMENT",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int NOT NULL AUTO_INCREMENT",
 		},
 		{
 			name:     "SetColumn",
@@ -364,7 +364,7 @@ func TestDiff(t *testing.T) {
 			name:     "MultipleChanges",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, b INT, c VARCHAR(50))",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, b VARCHAR(100), d INT, INDEX idx_d (d))",
-			expected: "ALTER TABLE `t1` DROP COLUMN `c`, MODIFY COLUMN `b` varchar(100) NULL, ADD COLUMN `d` int(11) NULL, ADD INDEX `idx_d` (`d`)",
+			expected: "ALTER TABLE `t1` DROP COLUMN `c`, MODIFY COLUMN `b` varchar(100) NULL, ADD COLUMN `d` int NULL, ADD INDEX `idx_d` (`d`)",
 		},
 		{
 			name:     "DefaultValueFunction_NOW",
@@ -690,13 +690,13 @@ func TestDiff(t *testing.T) {
 			name:     "AddColumnFirst",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
 			target:   "CREATE TABLE t1 (new_col INT, id INT PRIMARY KEY)",
-			expected: "ALTER TABLE `t1` ADD COLUMN `new_col` int(11) NULL FIRST",
+			expected: "ALTER TABLE `t1` ADD COLUMN `new_col` int NULL FIRST",
 		},
 		{
 			name:     "ChangeColumnOrder",
 			source:   "CREATE TABLE t1 (a INT, b INT, c INT)",
 			target:   "CREATE TABLE t1 (b INT, c INT, a INT)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int(11) NULL FIRST, MODIFY COLUMN `c` int(11) NULL AFTER `b`, MODIFY COLUMN `a` int(11) NULL AFTER `c`",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` int NULL FIRST, MODIFY COLUMN `c` int NULL AFTER `b`, MODIFY COLUMN `a` int NULL AFTER `c`",
 		},
 		// Binary/Blob Types
 		{
@@ -935,7 +935,7 @@ func TestDiff(t *testing.T) {
 			name:     "CompositePrimaryKeyWithAutoIncrement",
 			source:   "CREATE TABLE t1 (a INT NOT NULL, b INT NOT NULL)",
 			target:   "CREATE TABLE t1 (a INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, PRIMARY KEY (a, b))",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `a` int(11) NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (`a`, `b`)",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `a` int NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (`a`, `b`)",
 		},
 
 		// Column Rename Tests - Should show as DROP + ADD (not safe to rename)
@@ -1215,7 +1215,7 @@ func TestDiff(t *testing.T) {
 			name:     "ReorderUppercaseColumns",
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, A INT NOT NULL, B INT NOT NULL)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, B INT NOT NULL, A INT NOT NULL)",
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `B` int(11) NOT NULL AFTER `id`, MODIFY COLUMN `A` int(11) NOT NULL AFTER `B`",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `B` int NOT NULL AFTER `id`, MODIFY COLUMN `A` int NOT NULL AFTER `B`",
 		},
 	}
 
@@ -1401,7 +1401,7 @@ func TestDiff_DiffOptions(t *testing.T) {
 			source:   "CREATE TABLE t1 (id INT PRIMARY KEY)",
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT)",
 			opts:     nil, // nil uses NewDiffOptions(): IgnoreColumnAutoIncrement=false
-			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int(11) NOT NULL AUTO_INCREMENT",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `id` int NOT NULL AUTO_INCREMENT",
 		},
 		{
 			name:     "IgnoreColumnAutoIncrement_TargetAdds",

--- a/pkg/statement/normalize_integer_display_width.go
+++ b/pkg/statement/normalize_integer_display_width.go
@@ -1,0 +1,37 @@
+package statement
+
+func init() { registerNormalizer(integerDisplayWidthNormalizer{}) }
+
+// integerDisplayWidthNormalizer drops the deprecated display width from integer
+// columns, matching MySQL 8.0.19+ SHOW CREATE TABLE. The parser always
+// populates a width — INT and INT(11) both arrive as int(11) — but MySQL
+// reports a plain `int`, so an int(11) written in a schema file would otherwise
+// produce a spurious MODIFY when diffed against the live int. Stripping also
+// makes the unspecified and specified spellings converge (INT == INT(11)).
+//
+// Two widths are preserved, because MySQL preserves them:
+//   - tinyint(1): the canonical BOOLEAN form (also how the parser folds BOOL).
+//   - any integer with ZEROFILL: the width drives the zero-padding, so it is
+//     semantically meaningful and kept in SHOW CREATE TABLE.
+type integerDisplayWidthNormalizer struct{}
+
+func (integerDisplayWidthNormalizer) Name() string { return "integer-display-width" }
+
+func (integerDisplayWidthNormalizer) Normalize(ct *CreateTable) *CreateTable {
+	for i := range ct.Columns {
+		c := &ct.Columns[i]
+		switch c.Type {
+		case "tinyint", "smallint", "mediumint", "int", "bigint":
+		default:
+			continue // not an integer type
+		}
+		if c.Zerofill != nil && *c.Zerofill {
+			continue // width is meaningful under ZEROFILL
+		}
+		if c.Type == "tinyint" && c.Length != nil && *c.Length == 1 {
+			continue // tinyint(1) is preserved by MySQL
+		}
+		c.Length = nil
+	}
+	return ct
+}

--- a/pkg/statement/normalize_integer_display_width_test.go
+++ b/pkg/statement/normalize_integer_display_width_test.go
@@ -1,0 +1,47 @@
+package statement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripIntegerDisplayWidth(t *testing.T) {
+	tests := []struct {
+		sql     string
+		wantLen *int // nil = width stripped
+	}{
+		{"CREATE TABLE t (a int(11))", nil},
+		{"CREATE TABLE t (a int)", nil}, // parser injects (11); still stripped
+		{"CREATE TABLE t (a bigint(20))", nil},
+		{"CREATE TABLE t (a smallint(6))", nil},
+		{"CREATE TABLE t (a mediumint(9))", nil},
+		{"CREATE TABLE t (a tinyint(4))", nil},
+		{"CREATE TABLE t (a tinyint(1))", new(1)},                 // BOOLEAN form, preserved
+		{"CREATE TABLE t (a boolean)", new(1)},                    // folds to tinyint(1)
+		{"CREATE TABLE t (a int(10) unsigned zerofill)", new(10)}, // width kept under zerofill
+		{"CREATE TABLE t (a varchar(11))", new(11)},               // not an integer type
+	}
+	for _, tc := range tests {
+		t.Run(tc.sql, func(t *testing.T) {
+			ct, err := ParseCreateTable(tc.sql)
+			require.NoError(t, err)
+			require.Len(t, ct.Columns, 1)
+			assert.Equal(t, tc.wantLen, ct.Columns[0].Length)
+		})
+	}
+}
+
+// TestStripIntegerDisplayWidthConverges is the payoff: an int(11) authored in a
+// schema file no longer diffs against a live `int`.
+func TestStripIntegerDisplayWidthConverges(t *testing.T) {
+	authored, err := ParseCreateTable("CREATE TABLE t (id int(11) NOT NULL, PRIMARY KEY (id))")
+	require.NoError(t, err)
+	live, err := ParseCreateTable("CREATE TABLE t (id int NOT NULL, PRIMARY KEY (id))")
+	require.NoError(t, err)
+
+	stmts, err := authored.Diff(live, nil)
+	require.NoError(t, err)
+	assert.Nil(t, stmts, "int(11) should normalize to int and produce no diff")
+}


### PR DESCRIPTION
**Stack: PR 2 of 5** — depends on #1053 (normalization framework).

> ⚠️ Cross-fork stacking: until #1053 merges, this PR's diff includes #1053's commit. Review the **top commit** (`statement: normalize integer display widths`) here, or review/merge #1053 first — GitHub will then narrow this PR to just its own change.

## What this does

Adds `integerDisplayWidthNormalizer`, the first *new* rule on the framework from #1053. It strips the deprecated display width from integer columns to match MySQL 8.0.19+ `SHOW CREATE TABLE`:

- `int(11)` → `int`, `bigint(20)` → `bigint`, etc.
- **preserves** `tinyint(1)` (the canonical `BOOLEAN` form) and any `ZEROFILL` width (where the width is meaningful)

This stops an `int(11)` written in a schema file from diffing spuriously against a live `int`, and makes the specified/unspecified spellings converge (`INT` == `INT(11)`).

## Test churn

The rule changes generated DDL, so the affected `ALTER` expectations in `diff_test.go` / `diff_column_options_test.go` are updated to the unwidened form (18 fixtures). No logic in those tests changed. `golangci-lint` and the `statement`/`lint` suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)