### PR TITLE
statement: rely on normalization for inline PRIMARY KEY / UNIQUE (remove diff fudges)

### DIFF
--- a/pkg/statement/columns_equal_guard_test.go
+++ b/pkg/statement/columns_equal_guard_test.go
@@ -7,19 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// columnsEqualWithContext and columnsEqualIgnorePK (both in diff.go)
-// field-by-field compare the parsed Column struct to decide
-// whether a column differs between the source and target schema. If a newly
-// added Column field is NOT wired into these comparisons, two columns that
-// differ only in that field are silently treated as EQUAL — a real ALTER gets
-// dropped and Spirit applies the wrong schema diff. The tests below are the
-// safety net for that class of mistake.
+// columnsEqualWithContext (in diff.go) field-by-field compares the parsed
+// Column struct to decide whether a column differs between the source and
+// target schema. If a newly added Column field is NOT wired into that
+// comparison, two columns that differ only in that field are silently treated
+// as EQUAL — a real ALTER gets dropped and Spirit applies the wrong schema
+// diff. The tests below are the safety net for that class of mistake.
 
 // columnFieldsCompared lists the exported Column fields that the equality logic
-// (columnsEqualWithContext + columnsEqualIgnorePK + the shared
-// columnExtendedAttributesEqual helper) compares. PrimaryKey counts as compared:
-// it IS compared by columnsEqualWithContext and is only skipped by the dedicated
-// *IgnorePK* variant.
+// (columnsEqualWithContext + the shared columnExtendedAttributesEqual helper)
+// compares.
 var columnFieldsCompared = map[string]struct{}{
 	"Name":            {},
 	"Type":            {},
@@ -63,9 +60,9 @@ var columnFieldsNotCompared = map[string]string{
 	"Options": "catch-all map for unmodeled options; currently not compared by diff.go",
 	// Column-level UNIQUE is representation, not state: MySQL canonicalizes it
 	// into a table-level UNIQUE KEY, and MODIFY COLUMN cannot express it. It is
-	// folded into index-level diffing (effectiveIndexes/diffIndexes) instead of
-	// being part of per-column equality.
-	"Unique": "folded into index-level diffing by effectiveIndexes; diffed by diffIndexes, not here",
+	// materialized into a table-level index by indexNormalizer and diffed by
+	// diffIndexes instead of being part of per-column equality.
+	"Unique": "materialized into a table-level index by indexNormalizer; diffed by diffIndexes, not here",
 }
 
 // TestColumnsEqualAllFieldsAccounted is the primary tripwire: it enumerates the
@@ -75,11 +72,11 @@ var columnFieldsNotCompared = map[string]string{
 // decides how the comparison logic should treat it.
 //
 // IF THIS FAILS BECAUSE A FIELD WAS ADDED TO Column:
-// update BOTH columnsEqual functions in diff.go (columnsEqualWithContext AND
-// columnsEqualIgnorePK, plus columnExtendedAttributesEqual for extended
-// attributes) to compare the new field, then add it to columnFieldsCompared. If
-// the new field is intentionally NOT part of column equality (like Raw / Check /
-// Options), add it to columnFieldsNotCompared with a justifying comment instead.
+// update columnsEqualWithContext in diff.go (plus columnExtendedAttributesEqual
+// for extended attributes) to compare the new field, then add it to
+// columnFieldsCompared. If the new field is intentionally NOT part of column
+// equality (like Raw / Check / Options), add it to columnFieldsNotCompared with
+// a justifying comment instead.
 func TestColumnsEqualAllFieldsAccounted(t *testing.T) {
 	typ := reflect.TypeFor[Column]()
 
@@ -220,46 +217,6 @@ func TestColumnsEqualWithContextDetectsEveryField(t *testing.T) {
 			m.mutate(&tgt)
 			require.False(t, ct.columnsEqualWithContext(&src, &tgt, target, opts),
 				"columnsEqualWithContext must return false when %s differs; "+
-					"if you added field %s, make sure diff.go compares it", m.name, m.name)
-		})
-	}
-}
-
-// TestColumnsEqualIgnorePKDetectsEveryField mirrors the above for
-// columnsEqualIgnorePK, which compares the same fields EXCEPT PrimaryKey. Every
-// other comparable field, when flipped, must cause it to return false; flipping
-// PrimaryKey alone must NOT (that is the whole point of the IgnorePK variant).
-func TestColumnsEqualIgnorePKDetectsEveryField(t *testing.T) {
-	opts := &DiffOptions{}
-
-	a := baseColumn()
-	b := baseColumn()
-	require.True(t, columnsEqualIgnorePK(&a, &b, opts),
-		"identical columns must compare equal under columnsEqualIgnorePK")
-
-	// PrimaryKey is deliberately ignored by this function.
-	pkOnly := baseColumn()
-	pkOnly.PrimaryKey = !pkOnly.PrimaryKey
-	require.True(t, columnsEqualIgnorePK(&a, &pkOnly, opts),
-		"columnsEqualIgnorePK must ignore a PrimaryKey-only difference")
-
-	// Unique is deliberately ignored too — see the matching assertion in
-	// TestColumnsEqualWithContextDetectsEveryField.
-	uniqueOnly := baseColumn()
-	uniqueOnly.Unique = !uniqueOnly.Unique
-	require.True(t, columnsEqualIgnorePK(&a, &uniqueOnly, opts),
-		"columnsEqualIgnorePK must ignore a Unique-only difference")
-
-	for _, m := range everyComparedFieldMutation() {
-		if m.name == "PrimaryKey" {
-			continue // ignored by this function by design
-		}
-		t.Run(m.name, func(t *testing.T) {
-			src := baseColumn()
-			tgt := baseColumn()
-			m.mutate(&tgt)
-			require.False(t, columnsEqualIgnorePK(&src, &tgt, opts),
-				"columnsEqualIgnorePK must return false when %s differs; "+
 					"if you added field %s, make sure diff.go compares it", m.name, m.name)
 		})
 	}

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -176,11 +176,13 @@ func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []str
 		targetColumns[strings.ToLower(target.Columns[i].Name)] = &target.Columns[i]
 	}
 
-	// Handle PRIMARY KEY changes (inline column-level PRIMARY KEY)
-	pkDropClause, pkAddClause, pkDropped, pkColumn := ct.diffPrimaryKey(target, sourceColumns, targetColumns)
-	if pkDropClause != "" {
-		clauses = append(clauses, pkDropClause)
-	}
+	// Adding or dropping the PRIMARY KEY itself is emitted by diffIndexes (the
+	// PK is always a table-level index after normalization). We only need the
+	// source/target PK column sets here to recognize the implicit NOT NULL ->
+	// NULL relaxation that dropping a PK produces, and suppress the redundant
+	// MODIFY COLUMN it would otherwise generate.
+	sourcePKColumns := pkColumnSet(ct.getPrimaryKeyIndex())
+	targetPKColumns := pkColumnSet(target.getPrimaryKeyIndex())
 
 	// Collect DROP operations and sort by name for deterministic output
 	var dropClauses []string
@@ -216,26 +218,23 @@ func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []str
 			// If it's the last column, omit AFTER clause (implicit)
 			clauses = append(clauses, clause)
 		} else {
-			// Skip modification if only PRIMARY KEY changed (already handled in diffIndexes)
-			// When PRIMARY KEY is dropped, nullability change is implicit, so skip it
-			pkOnlyChange := sourceCol.PrimaryKey != targetCol.PrimaryKey &&
-				columnsEqualIgnorePK(sourceCol, &targetCol, opts)
-
-			// Also check if only nullability changed due to PK drop
-			// (PK columns are NOT NULL, dropping PK makes them NULL)
-			pkDroppedNullabilityChange := pkDropped &&
-				strings.EqualFold(sourceCol.Name, pkColumn) &&
-				sourceCol.PrimaryKey && !targetCol.PrimaryKey &&
+			// Suppress the MODIFY when a column's only change is the implicit
+			// NOT NULL -> NULL relaxation from dropping the primary key it
+			// belonged to (a PK column is NOT NULL; once the PK is gone the
+			// target can declare it NULL). The PK drop itself is emitted by
+			// diffIndexes.
+			lower := strings.ToLower(targetCol.Name)
+			pkDroppedNullabilityChange := sourcePKColumns[lower] && !targetPKColumns[lower] &&
 				!sourceCol.Nullable && targetCol.Nullable
 
 			// MODIFY existing column if:
-			// 1. Column definition changed (and not just PK-related changes)
+			// 1. Column definition changed (and not just the PK-drop nullability relaxation)
 			// 2. Column needs explicit positioning
 			// needsExplicitPosition is keyed by lowercased column name, so
 			// look up with the same normalization to avoid missing a
 			// position-only change when the target's spelling is in mixed
 			// or upper case.
-			needsModify := (!ct.columnsEqualWithContext(sourceCol, &targetCol, target, opts) && !pkOnlyChange && !pkDroppedNullabilityChange) ||
+			needsModify := (!ct.columnsEqualWithContext(sourceCol, &targetCol, target, opts) && !pkDroppedNullabilityChange) ||
 				needsExplicitPosition[strings.ToLower(targetCol.Name)]
 
 			if needsModify {
@@ -252,11 +251,6 @@ func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []str
 		}
 
 		prevColumn = targetCol.Name
-	}
-
-	// Handle PRIMARY KEY adds last
-	if pkAddClause != "" {
-		clauses = append(clauses, pkAddClause)
 	}
 
 	return clauses
@@ -319,150 +313,19 @@ func (ct *CreateTable) calculateColumnPositioning(target *CreateTable, sourceCol
 	return needsExplicitPosition
 }
 
-// diffPrimaryKey handles PRIMARY KEY changes between source and target tables.
-// Returns: dropClause, addClause, pkDropped (bool), pkColumn (string)
-func (ct *CreateTable) diffPrimaryKey(target *CreateTable, sourceColumns, targetColumns map[string]*Column) (string, string, bool, string) {
-	var dropClause, addClause string
-	var pkDropped bool
-	var pkColumn string
-
-	// Check if there's a table-level PK in source or target
-	sourcePKIndex := ct.getPrimaryKeyIndex()
-	targetPKIndex := target.getPrimaryKeyIndex()
-
-	// Get the effective PK columns for both source and target.
-	// PK can be defined as:
-	// 1. Inline PK: column definition includes PRIMARY KEY (column.PrimaryKey = true)
-	// 2. Table-level PK: separate PRIMARY KEY (col1, col2, ...) clause (in Indexes)
-	sourcePKColumns := ct.getEffectivePrimaryKeyColumns()
-	targetPKColumns := target.getEffectivePrimaryKeyColumns()
-
-	// If the PK columns are the same (regardless of inline vs table-level representation),
-	// no change is needed. MySQL normalizes inline PK to table-level PK in SHOW CREATE TABLE,
-	// so we need to compare semantically rather than syntactically. Column
-	// identifiers are case-insensitive in MySQL, so PK columns that differ
-	// only in case (e.g. `PRIMARY KEY (id)` vs `PRIMARY KEY (ID)`) are the
-	// same key.
-	if slices.EqualFunc(sourcePKColumns, targetPKColumns, strings.EqualFold) {
-		return "", "", false, ""
+// pkColumnSet returns the lowercased set of columns in the given PRIMARY KEY
+// index, or nil if idx is nil. Names are lowercased because MySQL column
+// identifiers are case-insensitive. Reading a missing key from the returned
+// (possibly nil) map yields false, so callers can index it directly.
+func pkColumnSet(idx *Index) map[string]bool {
+	if idx == nil {
+		return nil
 	}
-
-	// Check for inline PK removal (column-level PRIMARY KEY)
-	for _, sourceCol := range ct.Columns {
-		targetCol, exists := targetColumns[strings.ToLower(sourceCol.Name)]
-		if exists && sourceCol.PrimaryKey && !targetCol.PrimaryKey {
-			// PRIMARY KEY was removed from this column (inline PK)
-			// But only drop it if there's no table-level PK in target
-			// (if target has table-level PK, diffIndexes will handle the transition)
-			if targetPKIndex == nil {
-				pkDropped = true
-				pkColumn = sourceCol.Name
-				dropClause = "DROP PRIMARY KEY"
-				break
-			}
-		}
+	set := make(map[string]bool, len(idx.Columns))
+	for _, c := range idx.Columns {
+		set[strings.ToLower(c)] = true
 	}
-
-	// Check for inline PK addition (column-level PRIMARY KEY)
-	for _, targetCol := range target.Columns {
-		sourceCol, exists := sourceColumns[strings.ToLower(targetCol.Name)]
-		if exists && !sourceCol.PrimaryKey && targetCol.PrimaryKey {
-			// PRIMARY KEY was added to this column (inline PK)
-			// Add it if:
-			// 1. There's no table-level PK in source (inline PK -> inline PK transition), OR
-			// 2. Source has table-level PK and target has inline PK (table-level -> inline transition)
-			if sourcePKIndex == nil || (sourcePKIndex != nil && targetPKIndex == nil) {
-				pkColumn = targetCol.Name
-				addClause = fmt.Sprintf("ADD PRIMARY KEY (%s)", sqlescape.EscapeIdentifier(pkColumn))
-				break
-			}
-		}
-	}
-
-	// Special case: Table-level PK -> inline PK transition
-	// We need to drop the table-level PK before adding the inline PK
-	if sourcePKIndex != nil && targetPKIndex == nil && addClause != "" {
-		dropClause = "DROP PRIMARY KEY"
-	}
-
-	return dropClause, addClause, pkDropped, pkColumn
-}
-
-// getEffectivePrimaryKeyColumns returns the column names that make up the primary key,
-// regardless of whether it's defined inline (column PRIMARY KEY) or as table-level (PRIMARY KEY (cols)).
-func (ct *CreateTable) getEffectivePrimaryKeyColumns() []string {
-	// First check for table-level PK
-	if pk := ct.getPrimaryKeyIndex(); pk != nil {
-		return pk.Columns
-	}
-
-	// Check for inline PK (column-level)
-	for _, col := range ct.Columns {
-		if col.PrimaryKey {
-			return []string{col.Name}
-		}
-	}
-
-	return nil
-}
-
-// effectiveIndexes returns the table's indexes with any inline column-level
-// UNIQUE declarations (`c int UNIQUE`) folded in as table-level UNIQUE
-// indexes, plus the set of index names that were synthesized this way.
-//
-// MySQL never stores a column-level UNIQUE: it canonicalizes it into a
-// table-level `UNIQUE KEY` named after the column (suffixed _2, _3, ... when
-// that name is already taken — the same convention indexNameNormalizer
-// replicates), which is what SHOW CREATE TABLE reports. Folding the inline
-// form here lets diffIndexes compare a user-written schema against the live
-// canonical form symmetrically: a representation-only difference produces no
-// clauses, while a real difference produces exactly one ADD/DROP.
-//
-// indexNameNormalizer reserves these names before auto-naming unnamed table-level
-// indexes (the server names inline uniques first), so the names computed here
-// agree with the rest of the parsed schema; keep the two loops in sync.
-func (ct *CreateTable) effectiveIndexes() ([]Index, map[string]bool) {
-	hasInlineUnique := false
-	for i := range ct.Columns {
-		if ct.Columns[i].Unique {
-			hasInlineUnique = true
-			break
-		}
-	}
-	if !hasInlineUnique {
-		return ct.Indexes, nil
-	}
-
-	// Clone so the synthesized entries never leak into ct.Indexes.
-	indexes := slices.Clone(ct.Indexes)
-	inlineDerived := make(map[string]bool)
-	usedNames := make(map[string]bool, len(indexes))
-	for i := range indexes {
-		usedNames[indexes[i].Name] = true
-	}
-	for _, col := range ct.Columns {
-		if !col.Unique {
-			continue
-		}
-		// Guess the server-assigned name: the column name, or the first free
-		// _N suffix when an explicitly-declared index already claims it. If
-		// the guess is wrong (the live table named it differently), the
-		// content-based pairing in diffIndexes still prevents a spurious
-		// DROP/ADD of an equivalent unique index.
-		name := col.Name
-		for suffix := 2; usedNames[name]; suffix++ {
-			name = fmt.Sprintf("%s_%d", col.Name, suffix)
-		}
-		usedNames[name] = true
-		inlineDerived[name] = true
-		indexes = append(indexes, Index{
-			Name:       name,
-			Type:       "UNIQUE",
-			Columns:    []string{col.Name},
-			ColumnList: []IndexColumn{{Name: col.Name}},
-		})
-	}
-	return indexes, inlineDerived
+	return set
 }
 
 // diffIndexes compares indexes and returns ALTER clauses for differences.
@@ -476,11 +339,11 @@ func (ct *CreateTable) effectiveIndexes() ([]Index, map[string]bool) {
 // must run as two separate ALTER statements. Those are returned via the second
 // value as standalone clause-lists (each becomes its own ALTER statement).
 func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separateStatements [][]string) {
-	// Fold inline column-level UNIQUEs into both index sets so that
-	// `c int UNIQUE` participates in index diffing like the table-level
-	// `UNIQUE KEY c (c)` MySQL canonicalizes it into.
-	sourceIdxList, sourceInlineDerived := ct.effectiveIndexes()
-	targetIdxList, targetInlineDerived := target.effectiveIndexes()
+	// Inline column-level UNIQUE / PRIMARY KEY have already been materialized
+	// into ct.Indexes by normalization (see indexNormalizer, primaryKeyNormalizer),
+	// so both index sets can be walked directly.
+	sourceIdxList := ct.Indexes
+	targetIdxList := target.Indexes
 
 	// Build maps for easier lookup
 	sourceIndexes := make(map[string]*Index)
@@ -521,7 +384,7 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 			if matchedTargetUnique[targetIdx.Name] {
 				continue // already paired with another source index
 			}
-			if !sourceInlineDerived[sourceIdx.Name] && !targetInlineDerived[targetIdx.Name] {
+			if !sourceIdx.InlineDerived && !targetIdx.InlineDerived {
 				continue // both explicitly named: a genuine rename
 			}
 			if indexColumnsIdenticalIgnoreName(sourceIdx, targetIdx) {
@@ -535,46 +398,11 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 	// Collect DROP operations and sort by name for deterministic output
 	var dropClauses []string
 
-	// Handle inline PK <-> table-level PK transitions
-	targetPKIndex := target.getPrimaryKeyIndex()
-
-	// Track if we've already added a DROP PRIMARY KEY
+	// The primary key is a table-level index on both sides after normalization
+	// (see primaryKeyNormalizer), so its add/drop/change falls out of the normal
+	// index diff below — no inline-PK special cases are needed. pkDropAdded just
+	// guards against emitting "DROP PRIMARY KEY" twice from the source loop.
 	pkDropAdded := false
-
-	// Check if source has inline PK (column-level PRIMARY KEY)
-	sourceHasInlinePK := false
-	for _, col := range ct.Columns {
-		if col.PrimaryKey {
-			sourceHasInlinePK = true
-			break
-		}
-	}
-
-	// Check if target has inline PK
-	targetHasInlinePK := false
-	for _, col := range target.Columns {
-		if col.PrimaryKey {
-			targetHasInlinePK = true
-			break
-		}
-	}
-
-	// Get effective PK columns for both source and target
-	sourcePKColumns := ct.getEffectivePrimaryKeyColumns()
-	targetPKColumns := target.getEffectivePrimaryKeyColumns()
-
-	// Only handle inline PK <-> table-level PK transitions if the PK columns actually changed.
-	// If the columns are the same, the representations are semantically equivalent.
-	// Compare case-insensitively, matching MySQL's column-name semantics.
-	pkColumnsEqual := slices.EqualFunc(sourcePKColumns, targetPKColumns, strings.EqualFold)
-
-	if sourceHasInlinePK && targetPKIndex != nil && !pkColumnsEqual {
-		// Inline PK -> table-level PK with different columns: drop the inline PK
-		dropClauses = append(dropClauses, "DROP PRIMARY KEY")
-		pkDropAdded = true
-	}
-	// Note: Table-level PK -> inline PK is handled in diffColumns to ensure correct order
-	// (DROP PRIMARY KEY must come before ADD PRIMARY KEY)
 
 	// optionOnlyChanged tracks index names whose column list is unchanged but
 	// whose options differ (e.g. WITH PARSER / KEY_BLOCK_SIZE). These must be
@@ -593,8 +421,7 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 		if !existsInTarget {
 			// Index removed completely
 			if sourceIdx.Type == "PRIMARY KEY" {
-				// Skip if target has inline PK (handled in diffColumns)
-				if !targetHasInlinePK && !pkDropAdded {
+				if !pkDropAdded {
 					dropClauses = append(dropClauses, "DROP PRIMARY KEY")
 					pkDropAdded = true
 				}
@@ -637,11 +464,7 @@ func (ct *CreateTable) diffIndexes(target *CreateTable) (clauses []string, separ
 		sourceIdx, existsInSource := sourceIndexes[targetIdx.Name]
 
 		if !existsInSource {
-			// New index - add it, but skip PRIMARY KEY if source has equivalent inline PK
-			if targetIdx.Type == "PRIMARY KEY" && pkColumnsEqual {
-				// Source has inline PK with same columns - skip adding table-level PK
-				continue
-			}
+			// New index - add it
 			addClauses = append(addClauses, formatAddIndex(&targetIdx))
 		} else if !indexesEqual(sourceIdx, &targetIdx) {
 			// Index exists but changed - check if only visibility changed
@@ -968,8 +791,8 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	// representation, not state. MySQL canonicalizes `c int UNIQUE` into a
 	// table-level UNIQUE KEY (that is what SHOW CREATE TABLE reports), and a
 	// MODIFY COLUMN cannot express uniqueness anyway (formatColumnDefinition
-	// never emits UNIQUE). Inline uniques are folded into index-level diffing
-	// instead — see effectiveIndexes / diffIndexes.
+	// never emits UNIQUE). Inline uniques are materialized into table-level
+	// indexes by normalization — see indexNormalizer / diffIndexes.
 	if !ptrEqual(a.Comment, b.Comment) {
 		return false
 	}
@@ -1008,87 +831,6 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 		return false
 	}
 
-	if !slices.Equal(a.EnumValues, b.EnumValues) {
-		return false
-	}
-	if !slices.Equal(a.SetValues, b.SetValues) {
-		return false
-	}
-	return true
-}
-
-// columnsEqualIgnorePK checks if two columns are equal, ignoring the PrimaryKey attribute
-func columnsEqualIgnorePK(a, b *Column, opts *DiffOptions) bool {
-	// Column names are case-insensitive in MySQL.
-	if !strings.EqualFold(a.Name, b.Name) {
-		return false
-	}
-	if a.Type != b.Type {
-		return false
-	}
-	if !ptrEqual(a.Length, b.Length) {
-		return false
-	}
-	if !ptrEqual(a.Precision, b.Precision) {
-		return false
-	}
-	if !ptrEqual(a.Scale, b.Scale) {
-		return false
-	}
-	if !ptrEqual(a.Unsigned, b.Unsigned) {
-		return false
-	}
-	if !ptrEqual(a.Zerofill, b.Zerofill) {
-		return false
-	}
-	if a.Nullable != b.Nullable {
-		return false
-	}
-	// Normalize default values for nullable columns:
-	// For nullable columns, nil and the NULL *keyword* are semantically
-	// equivalent. A quoted string literal 'NULL' (DefaultIsString) is NOT
-	// the keyword and must not collapse.
-	sourceDefault := a.Default
-	targetDefault := b.Default
-	if a.Nullable {
-		if sourceDefault != nil && *sourceDefault == "NULL" && !a.DefaultIsString {
-			sourceDefault = nil
-		}
-		if targetDefault != nil && *targetDefault == "NULL" && !b.DefaultIsString {
-			targetDefault = nil
-		}
-	}
-	if !ptrEqual(sourceDefault, targetDefault) {
-		return false
-	}
-	if a.DefaultIsExpr != b.DefaultIsExpr {
-		return false
-	}
-	if !columnExtendedAttributesEqual(a, b) {
-		return false
-	}
-	// Numeric defaults are always rendered quoted by MySQL, so quotedness is
-	// not meaningful for them; for string columns it is. See the equivalent
-	// guard in columnsEqualWithContext.
-	if a.DefaultIsString != b.DefaultIsString && !isNumericColumnType(a.Type) {
-		return false
-	}
-	if !opts.IgnoreColumnAutoIncrement && a.AutoInc != b.AutoInc {
-		return false
-	}
-	// Skip PrimaryKey comparison
-	// Unique is intentionally not compared — inline UNIQUE is folded into
-	// index-level diffing (see effectiveIndexes / diffIndexes and the
-	// matching comment in columnsEqualWithContext).
-	if !ptrEqual(a.Comment, b.Comment) {
-		return false
-	}
-	if !ptrEqual(a.Charset, b.Charset) {
-		return false
-	}
-	if !ptrEqual(a.Collation, b.Collation) {
-		return false
-	}
 	if !slices.Equal(a.EnumValues, b.EnumValues) {
 		return false
 	}
@@ -1477,7 +1219,7 @@ func formatAddIndex(idx *Index) string {
 	var parts []string
 
 	// Build the ADD clause: keyword + optional name.
-	// The name is omitted when empty (safety net; indexNameNormalizer should
+	// The name is omitted when empty (safety net; indexNormalizer should
 	// have already assigned one during parsing).
 	var keyword string
 	switch idx.Type {

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -166,6 +166,53 @@ func TestDiff(t *testing.T) {
 			target:   "CREATE TABLE t1 (d INT, KEY c (d), c INT UNIQUE)",
 			expected: "",
 		},
+		// Type canonicalization: the live table (source) is in MySQL's canonical
+		// form, while the user's saved schema (target) uses a convenience spelling
+		// the parser folds to the same type. These must diff as equal so a schema
+		// file written with BOOL / BOOLEAN / SERIAL does not churn against the
+		// live table. See docs/fmt.md for the transformations MySQL applies.
+		{
+			// BOOL is an alias for tinyint(1); the parser folds it, so the user's
+			// `active BOOL` matches the live `active tinyint(1)`.
+			name:     "CanonicalTinyintVsBool",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, active tinyint(1))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, active BOOL)",
+			expected: "",
+		},
+		{
+			// BOOLEAN is likewise an alias for tinyint(1).
+			name:     "CanonicalTinyintVsBoolean",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, active tinyint(1))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, active BOOLEAN)",
+			expected: "",
+		},
+		{
+			// A numeric boolean default matches the canonical quoted form: MySQL
+			// renders numeric column defaults quoted (tinyint(1) DEFAULT '0'), and
+			// diff treats the bare and quoted numeric default as the same value.
+			name:     "CanonicalTinyintVsBooleanDefaultZero",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, active tinyint(1) DEFAULT '0')",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, active BOOLEAN DEFAULT 0)",
+			expected: "",
+		},
+		{
+			// SERIAL expands to BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE. The
+			// canonical live form is the expanded column plus a UNIQUE KEY named
+			// after the column; normalization materializes the inline UNIQUE the
+			// parser derives from SERIAL, so the two forms diff as equal.
+			name:     "CanonicalVsSerial",
+			source:   "CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, UNIQUE KEY id (id))",
+			target:   "CREATE TABLE t1 (id SERIAL)",
+			expected: "",
+		},
+		{
+			// Reverse direction: the user's BOOLEAN schema as source, canonical
+			// tinyint(1) as target. Still equal — canonicalization is symmetric.
+			name:     "BooleanVsCanonicalTinyint",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, active BOOLEAN)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, active tinyint(1))",
+			expected: "",
+		},
 		{
 			// Adding WITH PARSER to an index with an unchanged column list is
 			// an option-only change. A combined DROP+ADD in a single ALTER is a

--- a/pkg/statement/normalize_index_names.go
+++ b/pkg/statement/normalize_index_names.go
@@ -2,35 +2,46 @@ package statement
 
 import "fmt"
 
-func init() { registerNormalizer(indexNameNormalizer{}) }
+func init() { registerNormalizer(indexNormalizer{}) }
 
-// indexNameNormalizer assigns MySQL's default naming convention to any unnamed
-// non-PRIMARY KEY indexes. MySQL names indexes after the first column in the
-// index. If that name is already taken, it appends _2, _3, etc.
-// This ensures that unnamed indexes like INDEX (col) are treated identically
-// to their MySQL-normalized form KEY `col` (`col`) during diff comparisons.
-type indexNameNormalizer struct{}
+// indexNormalizer canonicalizes a table's secondary indexes the way MySQL does
+// when it stores the definition, so diffIndexes can compare two tables by
+// walking ct.Indexes directly:
+//
+//  1. Inline column-level UNIQUE (`c INT UNIQUE`) is materialized into a
+//     table-level UNIQUE index. MySQL never stores a column-level UNIQUE — it
+//     canonicalizes it into a `UNIQUE KEY` named after the column (suffixed
+//     _2, _3, ... on collision), which is what SHOW CREATE TABLE reports. The
+//     synthesized index is tagged InlineDerived because its name is only a
+//     guess at the server-assigned one.
+//  2. Unnamed table-level indexes are given MySQL's default name (the first
+//     column, suffixed on collision).
+//
+// The two steps share one name-reservation pass: the server names indexes in
+// declaration order and column definitions precede table-level keys, so inline
+// uniques claim their names before unnamed keys are numbered (e.g. in
+// `c INT UNIQUE, KEY (c, d)` the unique gets `c` and the key is pushed to
+// `c_2`). Keeping both steps in one rule is what makes that ordering reliable.
+// PRIMARY KEY indexes are left untouched (MySQL always names them PRIMARY).
+type indexNormalizer struct{}
 
-func (indexNameNormalizer) Name() string { return "auto-name-indexes" }
+func (indexNormalizer) Name() string { return "index-normalization" }
 
-func (indexNameNormalizer) Normalize(ct *CreateTable) *CreateTable {
-	// Track all used index names (including already-named indexes)
-	usedNames := make(map[string]int) // name -> highest suffix used (0 = base name)
+func (indexNormalizer) Normalize(ct *CreateTable) *CreateTable {
+	// Track all used index names (including already-named indexes). The value
+	// is the highest _N suffix seen for that base name (0 = base name only).
+	usedNames := make(map[string]int)
 	for i := range ct.Indexes {
 		if ct.Indexes[i].Name != "" {
 			usedNames[ct.Indexes[i].Name] = 0
 		}
 	}
 
-	// Inline column-level UNIQUEs claim their server-assigned names BEFORE any
-	// unnamed table-level index is auto-named: the server names indexes in
-	// declaration order and column definitions normally precede table-level
-	// keys, so in `c int UNIQUE, KEY (c, d)` the unique index gets `c` and the
-	// unnamed key is pushed to `c_2`. The names are only reserved here — not
-	// materialized into ct.Indexes — so the inline declaration stays
-	// column-level state (Column.Unique) everywhere else. effectiveIndexes
-	// recomputes the same names at diff time; keep the two in sync.
-	for _, col := range ct.Columns {
+	// Step 1: materialize inline column-level UNIQUEs as table-level indexes.
+	// This happens before unnamed table-level indexes are named so the unique
+	// claims the column name first, matching the server's declaration order.
+	for i := range ct.Columns {
+		col := &ct.Columns[i]
 		if !col.Unique {
 			continue
 		}
@@ -42,8 +53,17 @@ func (indexNameNormalizer) Normalize(ct *CreateTable) *CreateTable {
 			name = fmt.Sprintf("%s_%d", col.Name, suffix)
 		}
 		usedNames[name] = 0
+		ct.Indexes = append(ct.Indexes, Index{
+			Name:          name,
+			Type:          "UNIQUE",
+			Columns:       []string{col.Name},
+			ColumnList:    []IndexColumn{{Name: col.Name}},
+			InlineDerived: true,
+		})
+		col.Unique = false
 	}
 
+	// Step 2: assign MySQL's default name to any unnamed non-PRIMARY index.
 	for i := range ct.Indexes {
 		idx := &ct.Indexes[i]
 		if idx.Name != "" || idx.Type == "PRIMARY KEY" {

--- a/pkg/statement/normalize_primary_key.go
+++ b/pkg/statement/normalize_primary_key.go
@@ -1,0 +1,42 @@
+package statement
+
+func init() { registerNormalizer(primaryKeyNormalizer{}) }
+
+// primaryKeyNormalizer materializes an inline column-level PRIMARY KEY
+// (`id INT PRIMARY KEY`) into a table-level PRIMARY KEY index, the form MySQL
+// reports in SHOW CREATE TABLE. After this runs the primary key is always a
+// single entry in ct.Indexes (Type "PRIMARY KEY", empty name — the parser
+// reports every PK, named or not, with an empty index name), so diff can treat
+// the inline and table-level spellings identically without special-casing.
+//
+// The column keeps whatever nullability the parser assigned: an inline-PK
+// column already arrives NOT NULL, exactly as a table-level PK column declared
+// NOT NULL would. Only the PrimaryKey flag is cleared; the column definition is
+// otherwise untouched.
+type primaryKeyNormalizer struct{}
+
+func (primaryKeyNormalizer) Name() string { return "primary-key" }
+
+func (primaryKeyNormalizer) Normalize(ct *CreateTable) *CreateTable {
+	// A valid table has at most one PRIMARY KEY. If a table-level PK already
+	// exists, an inline PrimaryKey flag would be invalid SQL; leave it alone
+	// rather than synthesize a second PK index.
+	if ct.getPrimaryKeyIndex() != nil {
+		return ct
+	}
+	for i := range ct.Columns {
+		col := &ct.Columns[i]
+		if !col.PrimaryKey {
+			continue
+		}
+		ct.Indexes = append(ct.Indexes, Index{
+			Name:       "",
+			Type:       "PRIMARY KEY",
+			Columns:    []string{col.Name},
+			ColumnList: []IndexColumn{{Name: col.Name}},
+		})
+		col.PrimaryKey = false
+		break // only one column can carry an inline PRIMARY KEY
+	}
+	return ct
+}

--- a/pkg/statement/parse_create_table.go
+++ b/pkg/statement/parse_create_table.go
@@ -81,6 +81,14 @@ type Index struct {
 	KeyBlockSize *uint64           `json:"key_block_size,omitempty"`
 	ParserName   *string           `json:"parser_name,omitempty"`
 	Options      map[string]string `json:"options,omitempty"`
+
+	// InlineDerived marks a UNIQUE index that indexNormalizer synthesized
+	// from an inline column-level UNIQUE (`c INT UNIQUE`). Its name is only a
+	// guess at the server-assigned one (the column name, suffixed on collision),
+	// so diffIndexes pairs it with an equivalent live unique index by column set
+	// even when the names differ, rather than emitting a spurious DROP+ADD.
+	// Not serialized: it is a diff-time hint, not part of the logical schema.
+	InlineDerived bool `json:"-"`
 }
 
 // Constraint represents a table constraint

--- a/pkg/statement/parse_create_table_test.go
+++ b/pkg/statement/parse_create_table_test.go
@@ -268,7 +268,9 @@ func TestSchemaAnalyzer_JSONSerialization(t *testing.T) {
 
 	require.Equal(t, "id", deserializedColumns[0].Name)
 	require.Equal(t, "int", deserializedColumns[0].Type)
-	require.True(t, deserializedColumns[0].PrimaryKey)
+	// The inline PRIMARY KEY is normalized into a table-level index, so the
+	// column itself no longer carries the inline PrimaryKey flag.
+	require.False(t, deserializedColumns[0].PrimaryKey)
 
 	require.Equal(t, "name", deserializedColumns[1].Name)
 	require.Contains(t, deserializedColumns[1].Type, "varchar")
@@ -688,7 +690,9 @@ func TestSchemaAnalyzer_EnumSetJSONSerialization(t *testing.T) {
 	// Check id column
 	require.Equal(t, "id", deserializedColumns[0].Name)
 	require.Equal(t, "int", deserializedColumns[0].Type)
-	require.True(t, deserializedColumns[0].PrimaryKey)
+	// The inline PRIMARY KEY is normalized into a table-level index, so the
+	// column no longer carries the inline PrimaryKey flag.
+	require.False(t, deserializedColumns[0].PrimaryKey)
 	require.Nil(t, deserializedColumns[0].EnumValues)
 	require.Nil(t, deserializedColumns[0].SetValues)
 

--- a/pkg/statement/utils_test.go
+++ b/pkg/statement/utils_test.go
@@ -140,10 +140,14 @@ func TestHelperFunctions(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, ct1.getPrimaryKeyIndex())
 
-		// Table with inline primary key (column-level)
+		// Table with inline primary key (column-level): normalization
+		// materializes it into a table-level PRIMARY KEY index.
 		ct2, err := ParseCreateTable("CREATE TABLE t2 (id INT PRIMARY KEY)")
 		require.NoError(t, err)
-		require.Nil(t, ct2.getPrimaryKeyIndex()) // inline PK is not in Indexes
+		pk2 := ct2.getPrimaryKeyIndex()
+		require.NotNil(t, pk2)
+		require.Equal(t, "PRIMARY KEY", pk2.Type)
+		require.Equal(t, []string{"id"}, pk2.Columns)
 
 		// Table with table-level primary key
 		ct3, err := ParseCreateTable("CREATE TABLE t3 (id INT, PRIMARY KEY (id))")


### PR DESCRIPTION
**Stack: PR 3 of 5** — depends on #1054 (which depends on #1053).

> ⚠️ Cross-fork stacking: until the parents merge, this PR's diff includes their commits. Review the **top commit** (`statement: rely on normalization for inline PRIMARY KEY / UNIQUE`), or merge #1053 → #1054 first and this narrows to just its own change.

## What this does

Now that normalization runs at parse time (#1053), it can **materialize** the inline column-level forms into their MySQL-canonical table-level shape:

- `primaryKeyNormalizer` — inline `id INT PRIMARY KEY` → a table-level `PRIMARY KEY` index
- `indexNormalizer` — inline `c INT UNIQUE` → a table-level `UNIQUE KEY` (tagged `Index.InlineDerived`, since its name is only a guess at the server-assigned one)

With the canonical form guaranteed before `Diff` runs, the inline-vs-table-level equivalence fudges in `diff.go` are no longer needed and are **removed**:

- `effectiveIndexes`
- `getEffectivePrimaryKeyColumns`
- `diffPrimaryKey`
- `columnsEqualIgnorePK`

`diffIndexes` now walks `ct.Indexes` directly and pairs a name-guessed inline unique with a live one via `Index.InlineDerived`; `diffColumns` keeps only the PK-drop nullability suppression (`pkColumnSet`). Net `diff.go` change is **−218 lines**.

## Behavior

Diff output is unchanged for the existing test corpus (the fudges and the materialization produce the same ALTERs). New tests cover the payoff — a live `tinyint(1)` / `bigint … UNIQUE` (from `BOOL`/`BOOLEAN`/`SERIAL`) now diffs equal against a schema file that uses the convenience spelling.

**Contract change:** `Diff` now assumes normalized input — inline PK/UNIQUE in a hand-built (unparsed) `CreateTable` are no longer special-cased. Everything reaches `Diff` via `ParseCreateTable`, so this holds in practice.

`golangci-lint` + `statement`/`lint` suites green. (Package docs land in PR 5, once the file layout/filenames are final.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)