### PR TITLE
build: bump Go to 1.26.5 (fixes GO-2026-5856)

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6.5.0
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
       - name: Checkout code
         uses: actions/checkout@v7
       - name: golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.26 as builder
+FROM golang:1.26.5 as builder
 
 RUN go install github.com/mfridman/tparse@latest
 
 # copy the installed tparse binary to the final image
-FROM golang:1.26
+FROM golang:1.26.5
 
 COPY --from=builder /go/bin/tparse /usr/local/bin/tparse
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/block/spirit
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

go1.26.4's crypto/tls carries GO-2026-5856 (Encrypted Client Hello privacy leak), which govulncheck flags in CI (spirit reaches it via BinlogSyncer.Close → tls.Conn.Handshake, and other traces). It is fixed in go1.26.5.

Bump the pinned Go version everywhere it is set: the go.mod floor, the govulncheck and linter workflows (explicit go-version), and the test Dockerfile. Verified locally: govulncheck reports no vulnerabilities under go1.26.5.
