### PR TITLE
refactor(move): put the sentinel on targets[0], not the source

### DIFF
--- a/docs/move.md
+++ b/docs/move.md
@@ -40,7 +40,7 @@ The same caveats about [resuming across Spirit binary versions](migrate.md#resum
 - Type: Boolean
 - Default value: `false`
 
-When set to `true`, a sentinel table (`_spirit_sentinel`) is created on the **source** database during setup, before the row copy starts. Move continues through copy and the initial checksum, then blocks before cutover until the sentinel table is manually dropped, giving the operator a chance to verify the copy before proceeding.
+When set to `true`, a sentinel table (`_spirit_sentinel`) is created on the first **target** database (targets[0], alongside the checkpoint) during setup, before the row copy starts. Move continues through copy and the initial checksum, then blocks before cutover until the sentinel table is manually dropped, giving the operator a chance to verify the copy before proceeding.
 
 #### Two-checksum model
 

--- a/pkg/move/README.md
+++ b/pkg/move/README.md
@@ -42,7 +42,7 @@ A run interrupted *before its first checkpoint dump* leaves the checkpoint table
 
 ### Sentinel Table
 
-When `CreateSentinel` is enabled, the runner creates a `_spirit_sentinel` table on the source during setup (before the copy starts) and then *blocks before cutover* until it is dropped by an external actor. The wait sits between the initial checksum and the cutover. This provides a coordination point for orchestration systems that need to perform additional steps between copy completion and cutover.
+When `CreateSentinel` is enabled, the runner creates a `_spirit_sentinel` table on the first target (targets[0], alongside the checkpoint) during setup (before the copy starts) and then *blocks before cutover* until it is dropped by an external actor. The wait sits between the initial checksum and the cutover. This provides a coordination point for orchestration systems that need to perform additional steps between copy completion and cutover.
 
 While the sentinel blocks the cutover, the runner re-runs the checksum in a loop (the "continuous checksum") so that the data is re-verified close to the moment of cutover, even if the sentinel sits for hours. The first iteration starts one hour after the initial checksum, and subsequent iterations are capped at one per hour so that small tables do not churn the table lock back-to-back; the wait is interrupted when the sentinel is dropped. One exception: if a pass had already detected a mismatch and is mid-recopy, the in-flight repair runs to completion (bounded by an internal per-chunk timeout) before cutover continues, because the DELETE-from-targets + re-apply-from-sources pair must stay atomic. See [docs/move.md](../../docs/move.md) for the user-facing description.
 

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -16,7 +16,7 @@ type Move struct {
 	TargetChunkTime       time.Duration `name:"target-chunk-time" help:"How long each chunk should take to copy" default:"5s"`
 	Threads               int           `name:"threads" help:"How many chunks to copy in parallel" default:"2"`
 	WriteThreads          int           `name:"write-threads" help:"How many concurrent write threads to use per target. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" default:"4"`
-	CreateSentinel        bool          `name:"create-sentinel" help:"Create a sentinel table on the source database to block after table copy" default:"false"`
+	CreateSentinel        bool          `name:"create-sentinel" help:"Create a sentinel table on the first target database to block after table copy" default:"false"`
 	DeferSecondaryIndexes bool          `name:"defer-secondary-indexes" help:"Create target tables without secondary indexes, add them before cutover" default:"false"`
 	CheckpointMaxAge      time.Duration `name:"checkpoint-max-age" help:"Maximum age of a checkpoint before refusing to resume from it" optional:"" default:"168h"`
 	// Force makes the runner wipe the target tables and start the copy fresh when

--- a/pkg/move/move_sharded_test.go
+++ b/pkg/move/move_sharded_test.go
@@ -435,7 +435,10 @@ func TestShardedMoveVindexUpdateFails(t *testing.T) {
 		require.Error(t, err, "a vindex-changing UPDATE must fail the move")
 	case <-time.After(60 * time.Second):
 		// Unblock the sentinel wait so the Run goroutine can exit before we fail.
-		testutils.RunSQLInDatabase(t, srcName, "DROP TABLE IF EXISTS "+sentinel.TableName)
+		// The sentinel lives on targets[0]; drop it on both targets since which
+		// one sorts first is not fixed here.
+		testutils.RunSQLInDatabase(t, tgt0Name, "DROP TABLE IF EXISTS "+sentinel.TableName)
+		testutils.RunSQLInDatabase(t, tgt1Name, "DROP TABLE IF EXISTS "+sentinel.TableName)
 		<-errCh
 		t.Fatal("the move did not fail after a vindex-changing UPDATE")
 	}

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -683,7 +683,8 @@ func (r *Runner) decideResume(ctx context.Context) (resumeDecision, error) {
 // wipeTargets drops the move's target tables (on every target) and the
 // checkpoint table, so a fresh copy can proceed. Used by --force when the target
 // cannot resume, and by the empty-checkpoint fresh-start recovery
-// (resumeFreshOwned). The source — including any sentinel — is left untouched.
+// (resumeFreshOwned). The source is left untouched; so is the sentinel on
+// targets[0] (a fresh copy recreates it idempotently).
 func (r *Runner) wipeTargets(ctx context.Context) error {
 	for i := range r.targets {
 		for _, t := range r.sourceTables {

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -702,11 +702,12 @@ func (r *Runner) newCopy(ctx context.Context) error {
 		return err
 	}
 
-	// Create sentinel on SOURCE. Idempotent (CREATE IF NOT EXISTS): the
-	// sentinel is shared with every spirit process in the schema and must
-	// never pass through a "table absent" state a concurrent poll could see.
+	// Create the sentinel on targets[0], alongside the checkpoint, so all of
+	// move's coordination tables live in one place (the source tables are
+	// renamed out of the way at cutover). Idempotent (CREATE IF NOT EXISTS) so a
+	// resume recreates it and a concurrent existence probe never sees it absent.
 	if r.move.CreateSentinel {
-		if err := sentinel.Create(ctx, r.sources[0].db); err != nil {
+		if err := sentinel.Create(ctx, r.targets[0].DB); err != nil {
 			return err
 		}
 	}
@@ -983,7 +984,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// invalidateChecksumWatermark blanks the whole per-move checkpoint table),
 	// so they are injected as callbacks. See pkg/sentinel.
 	if err := sentinel.Wait(ctx, sentinel.WaitConfig{
-		Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.sources[0].db) },
+		Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
 		RunChecksum:         r.runContinuousChecksum,
 		InvalidateWatermark: r.invalidateChecksumWatermark,
 		Logger:              r.logger,
@@ -1445,7 +1446,7 @@ func (r *Runner) Progress() status.Progress {
 	case status.WaitingOnSentinelTable:
 		r.logger.Info("migration status",
 			"state", r.status.Get().String(),
-			"sentinel-table", fmt.Sprintf("%s.%s", r.sources[0].config.DBName, sentinel.TableName),
+			"sentinel-table", fmt.Sprintf("%s.%s", r.targets[0].Config.DBName, sentinel.TableName),
 			"total-time", time.Since(r.startTime).Round(time.Second).String(),
 			"sentinel-wait-time", time.Since(r.sentinelWaitStartTime).Round(time.Second).String(),
 			"sentinel-max-wait-time", sentinel.WaitLimit.String(),

--- a/pkg/move/sentinel_test.go
+++ b/pkg/move/sentinel_test.go
@@ -1,0 +1,96 @@
+package move
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/sentinel"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func sentinelTestTableExists(t *testing.T, db *sql.DB, schema, name string) bool {
+	t.Helper()
+	var one int
+	err := db.QueryRowContext(t.Context(),
+		"SELECT 1 FROM information_schema.tables WHERE table_schema=? AND table_name=?", schema, name).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	require.NoError(t, err)
+	return true
+}
+
+// TestMoveSentinelDropReleasesCutover: with --create-sentinel, dropping the
+// sentinel must RELEASE the cutover and let the move finish — not be seen as a
+// schema change that cancels it. The sentinel lives on targets[0], so the drop
+// is a target-side DDL that the source-watching change feed must ignore. Uses a
+// move-all move (no explicit table list), so the source feed cancels on any
+// source DDL — the strongest case.
+func TestMoveSentinelDropReleasesCutover(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sentrel_src"
+	dst := cfg.Clone()
+	dst.DBName = "sentrel_dst"
+
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sentrel_src")
+	testutils.RunSQL(t, "CREATE DATABASE sentrel_src")
+	testutils.RunSQL(t, "CREATE TABLE sentrel_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))")
+	testutils.RunSQL(t, "INSERT INTO sentrel_src.t1 VALUES (1,'one'),(2,'two')")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sentrel_dst")
+	testutils.RunSQL(t, "CREATE DATABASE sentrel_dst")
+
+	ctl, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(ctl)
+
+	m := &Move{
+		SourceDSN:       src.FormatDSN(),
+		TargetDSN:       dst.FormatDSN(),
+		TargetChunkTime: time.Second,
+		Threads:         1,
+		WriteThreads:    1,
+		CreateSentinel:  true,
+	}
+	runner, err := NewRunner(m)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+	var cutoverCalled bool
+	runner.SetCutover(func(context.Context) error { cutoverCalled = true; return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Run(context.Background()) }()
+
+	// Wait until the move is blocked on the sentinel.
+	deadline := time.Now().Add(60 * time.Second)
+	for runner.status.Get() != status.WaitingOnSentinelTable {
+		select {
+		case err := <-errCh:
+			t.Fatalf("move finished before reaching the sentinel wait: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the move to reach the sentinel wait")
+		}
+	}
+
+	// Drop the sentinel on targets[0] to release the cutover.
+	testutils.RunSQL(t, "DROP TABLE sentrel_dst."+sentinel.TableName)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "dropping the sentinel must release the cutover, not cancel the move")
+	case <-time.After(60 * time.Second):
+		t.Fatal("move did not complete after the sentinel was dropped")
+	}
+	require.True(t, cutoverCalled, "cutover must run once the sentinel is dropped")
+	require.True(t, sentinelTestTableExists(t, ctl, "sentrel_src", "t1_old"), "source retired after cutover")
+	require.True(t, sentinelTestTableExists(t, ctl, "sentrel_dst", "t1"), "target serving after cutover")
+}


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Move's checkpoint lives on targets[0], but the CreateSentinel sentinel was on the source. Two problems with source placement: (1) dropping the sentinel to release a deferred cutover is a DDL in the source schema, which the source-watching change feed treats as a schema change and cancels the move on; (2) the source tables are renamed to _old at cutover, a messy home for a coordination table.

Put the sentinel on targets[0], alongside the checkpoint. Updated create + existence-poll + the operator-facing status line + CLI help + README/docs; the sharded sentinel test drops it on the targets.

Add TestMoveSentinelDropReleasesCutover: with --create-sentinel, wait for the sentinel block, drop it on targets[0], and assert the move finishes (cutover runs, source retired, target serving) rather than cancelling. No prior test covered the sentinel-drop happy path. It uses a move-all move so the source feed cancels on any source DDL — the strongest case.
