### PR TITLE
feat(move): reverse-feed foundations — Source.CurrentPosition + ReverseFeed

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -297,6 +297,27 @@ func (c *binlogClient) getCurrentBinlogPosition(ctx context.Context) (mysql.Posi
 	}, nil
 }
 
+// CurrentPosition satisfies Source. See the interface doc for how it differs
+// from Position (in-memory feed progress vs a live server read). In binlog mode
+// it FLUSHes first, so the returned position is a fresh binlog-file boundary
+// (offset 4) — a feed later resuming from it starts at a clean file, avoiding
+// the table-map-on-a-mid-file-offset quirk.
+func (c *binlogClient) CurrentPosition(ctx context.Context) (string, error) {
+	if _, err := c.db.ExecContext(ctx, `FLUSH BINARY LOGS`); err != nil {
+		return "", fmt.Errorf("failed to flush binary logs: %w", err)
+	}
+	var binlogFile, ignored string
+	var binlogPos uint32
+	// SHOW MASTER STATUS (MySQL 8.0) with a fallback to SHOW BINARY LOG STATUS
+	// (MySQL 8.2+), mirroring getCurrentBinlogPosition.
+	if err := c.db.QueryRowContext(ctx, "SHOW MASTER STATUS").Scan(&binlogFile, &binlogPos, &ignored, &ignored, &ignored); err != nil {
+		if err2 := c.db.QueryRowContext(ctx, "SHOW BINARY LOG STATUS").Scan(&binlogFile, &binlogPos, &ignored, &ignored, &ignored); err2 != nil {
+			return "", fmt.Errorf("failed to read current binlog position: %w", err2)
+		}
+	}
+	return formatBinlogPosition(mysql.Position{Name: binlogFile, Pos: binlogPos}), nil
+}
+
 // buildSyncerConfig returns the BinlogSyncerConfig used by Start. Split
 // out (mirroring gtidClient.buildSyncerConfig) so tests can assert the
 // decode options below stay in sync between the two clients.

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -298,24 +298,18 @@ func (c *binlogClient) getCurrentBinlogPosition(ctx context.Context) (mysql.Posi
 }
 
 // CurrentPosition satisfies Source. See the interface doc for how it differs
-// from Position (in-memory feed progress vs a live server read). In binlog mode
-// it FLUSHes first, so the returned position is a fresh binlog-file boundary
-// (offset 4) — a feed later resuming from it starts at a clean file, avoiding
-// the table-map-on-a-mid-file-offset quirk.
+// from Position (in-memory feed progress vs a live server read). It delegates to
+// getCurrentBinlogPosition, so it FLUSHes first — the returned position is a
+// fresh binlog-file boundary (offset 4), and a feed later resuming from it
+// starts at a clean file, avoiding the table-map-on-a-mid-file-offset quirk —
+// and shares that helper's cached SHOW MASTER STATUS / SHOW BINARY LOG STATUS
+// statement rather than duplicating the fallback and paying an extra round-trip.
 func (c *binlogClient) CurrentPosition(ctx context.Context) (string, error) {
-	if _, err := c.db.ExecContext(ctx, `FLUSH BINARY LOGS`); err != nil {
-		return "", fmt.Errorf("failed to flush binary logs: %w", err)
+	pos, err := c.getCurrentBinlogPosition(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to read current binlog position: %w", err)
 	}
-	var binlogFile, ignored string
-	var binlogPos uint32
-	// SHOW MASTER STATUS (MySQL 8.0) with a fallback to SHOW BINARY LOG STATUS
-	// (MySQL 8.2+), mirroring getCurrentBinlogPosition.
-	if err := c.db.QueryRowContext(ctx, "SHOW MASTER STATUS").Scan(&binlogFile, &binlogPos, &ignored, &ignored, &ignored); err != nil {
-		if err2 := c.db.QueryRowContext(ctx, "SHOW BINARY LOG STATUS").Scan(&binlogFile, &binlogPos, &ignored, &ignored, &ignored); err2 != nil {
-			return "", fmt.Errorf("failed to read current binlog position: %w", err2)
-		}
-	}
-	return formatBinlogPosition(mysql.Position{Name: binlogFile, Pos: binlogPos}), nil
+	return formatBinlogPosition(pos), nil
 }
 
 // buildSyncerConfig returns the BinlogSyncerConfig used by Start. Split

--- a/pkg/change/currentposition_test.go
+++ b/pkg/change/currentposition_test.go
@@ -1,0 +1,87 @@
+package change
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// currentPositionRoundTrip exercises a Source implementation's CurrentPosition
+// against a live server, covering the two properties that matter:
+//
+//  1. Before the feed starts, Position() is empty (a running feed's flushed
+//     progress) while CurrentPosition() reports the live server head — the
+//     mechanical difference documented on the interface.
+//  2. The captured coordinate is a valid StartFromPosition seed: a feed resumed
+//     from it applies a write made after the capture. This proves the string is
+//     both correctly formatted for the implementation and points at "now",
+//     without asserting on the opaque encoding itself.
+func currentPositionRoundTrip(t *testing.T, prefix string, newClient func(db *sql.DB, host, user, pass string, appl applier.Applier, cfg *ClientConfig) Source) {
+	t.Helper()
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	srcTbl, dstTbl := prefix+"src", prefix+"dst"
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS "+srcTbl+", "+dstTbl)
+	testutils.RunSQL(t, "CREATE TABLE "+srcTbl+" (a INT NOT NULL PRIMARY KEY, b INT)")
+	testutils.RunSQL(t, "CREATE TABLE "+dstTbl+" (a INT NOT NULL PRIMARY KEY, b INT)")
+
+	t1 := table.NewTableInfo(db, "test", srcTbl)
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", dstTbl)
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := newClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig())
+	defer client.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+
+	// (1) Unstarted feed: no progress, but a live head is readable.
+	require.Empty(t, client.Position(), "Position() must be empty before the feed starts")
+	pos, err := client.CurrentPosition(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, pos, "CurrentPosition() must report the live server head without a running feed")
+
+	// (2) Resume from the captured coordinate, then write. The write is after
+	// the captured point, so a valid seed must replicate it.
+	require.NoError(t, client.StartFromPosition(t.Context(), pos))
+	require.NoError(t, client.SetWatermarkOptimization(t.Context(), false))
+	testutils.RunSQL(t, "INSERT INTO "+srcTbl+" (a, b) VALUES (1, 100)")
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM "+dstTbl).Scan(&count))
+	require.Equal(t, 1, count, "a write made after CurrentPosition must replicate when the feed resumes from it")
+
+	// After flushing, Position() has advanced off empty — now it reflects real
+	// feed progress, in contrast to the pre-start empty value above.
+	require.NotEmpty(t, client.Position(), "Position() must report progress after a flush")
+}
+
+// TestBinlogCurrentPosition covers binlogClient.CurrentPosition (FLUSH BINARY
+// LOGS + SHOW ... STATUS → file:offset).
+func TestBinlogCurrentPosition(t *testing.T) {
+	currentPositionRoundTrip(t, "curposbin", func(db *sql.DB, host, user, pass string, appl applier.Applier, cfg *ClientConfig) Source {
+		return NewBinlogClient(db, host, user, pass, appl, cfg)
+	})
+}
+
+// TestGTIDCurrentPosition covers gtidClient.CurrentPosition
+// (@@GLOBAL.gtid_executed). Requires gtid_mode=ON, like the rest of gtid_test.go.
+func TestGTIDCurrentPosition(t *testing.T) {
+	currentPositionRoundTrip(t, "curposgtid", func(db *sql.DB, host, user, pass string, appl applier.Applier, cfg *ClientConfig) Source {
+		return NewGTIDClient(db, host, user, pass, appl, cfg)
+	})
+}

--- a/pkg/change/currentposition_test.go
+++ b/pkg/change/currentposition_test.go
@@ -73,15 +73,11 @@ func currentPositionRoundTrip(t *testing.T, prefix string, newClient func(db *sq
 // TestBinlogCurrentPosition covers binlogClient.CurrentPosition (FLUSH BINARY
 // LOGS + SHOW ... STATUS → file:offset).
 func TestBinlogCurrentPosition(t *testing.T) {
-	currentPositionRoundTrip(t, "curposbin", func(db *sql.DB, host, user, pass string, appl applier.Applier, cfg *ClientConfig) Source {
-		return NewBinlogClient(db, host, user, pass, appl, cfg)
-	})
+	currentPositionRoundTrip(t, "curposbin", NewBinlogClient)
 }
 
 // TestGTIDCurrentPosition covers gtidClient.CurrentPosition
 // (@@GLOBAL.gtid_executed). Requires gtid_mode=ON, like the rest of gtid_test.go.
 func TestGTIDCurrentPosition(t *testing.T) {
-	currentPositionRoundTrip(t, "curposgtid", func(db *sql.DB, host, user, pass string, appl applier.Applier, cfg *ClientConfig) Source {
-		return NewGTIDClient(db, host, user, pass, appl, cfg)
-	})
+	currentPositionRoundTrip(t, "curposgtid", NewGTIDClient)
 }

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -283,6 +283,19 @@ func (c *gtidClient) Position() string {
 	return c.flushedGTID.String()
 }
 
+// CurrentPosition satisfies Source. See the interface doc for how it differs
+// from Position (in-memory feed progress vs a live server read). In GTID mode
+// it reads the server's @@GLOBAL.gtid_executed — no FLUSH and no running feed
+// required — and returns it in the same encoding Position uses, so it round
+// trips through StartFromPosition.
+func (c *gtidClient) CurrentPosition(ctx context.Context) (string, error) {
+	set, err := c.getCurrentGTIDSet(ctx)
+	if err != nil {
+		return "", err
+	}
+	return set.String(), nil
+}
+
 // StartFromPosition satisfies Source. It primes flushedGTID from the
 // previously-returned opaque string, validates it is still resumable
 // against gtid_purged, then begins streaming as Start would.

--- a/pkg/change/source.go
+++ b/pkg/change/source.go
@@ -71,7 +71,29 @@ type Source interface {
 	// it. Advances only at transaction commit boundaries. Returns "" if
 	// no position has been observed yet, signaling that a fresh Start is
 	// required.
+	//
+	// Position reports this *running* feed's in-memory progress and does no
+	// server I/O — contrast CurrentPosition, which reads the live server head.
 	Position() string
+
+	// CurrentPosition queries the source server for its current head position
+	// and returns it in the same opaque encoding as Position (so the result is
+	// a valid StartFromPosition input for this implementation).
+	//
+	// It is mechanically different from Position:
+	//   - Position returns in-memory state: the safe-to-resume point a *running*
+	//     feed has flushed, advancing only at commit boundaries and "" before
+	//     the feed has observed anything. No server round-trip.
+	//   - CurrentPosition issues a live query and needs no running feed. In
+	//     binlog mode it FLUSHes and reads SHOW [BINARY LOG|MASTER] STATUS
+	//     (file:offset); in GTID mode it reads @@GLOBAL.gtid_executed (a GTID
+	//     set). Because the encoding is per-implementation, this is why the
+	//     capture belongs on Source rather than a binlog-only helper.
+	//
+	// Its purpose is to capture a "start here, as of now" point to hand to a
+	// later StartFromPosition — e.g. seeding a reverse feed at cutover, before
+	// that feed has been started.
+	CurrentPosition(ctx context.Context) (string, error)
 
 	// Flush requests that all registered subscriptions flush their
 	// buffered changes to their targets. Blocks until the flush

--- a/pkg/checksum/continuous_test.go
+++ b/pkg/checksum/continuous_test.go
@@ -591,6 +591,7 @@ func (f *fakeFeed) AddSubscription(_, _ *table.TableInfo, _ table.MappedChunker)
 func (f *fakeFeed) Start(context.Context) error                                        { return nil }
 func (f *fakeFeed) StartFromPosition(context.Context, string) error                    { return nil }
 func (f *fakeFeed) Position() string                                                   { return "" }
+func (f *fakeFeed) CurrentPosition(context.Context) (string, error)                    { return "", nil }
 func (f *fakeFeed) FlushUnderTableLock(context.Context, []*dbconn.TableLock) error     { return nil }
 func (f *fakeFeed) BlockWait(context.Context) error                                    { return nil }
 func (f *fakeFeed) GetDeltaLen() int                                                   { return 0 }

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -47,6 +47,7 @@ func (s *noopChangeSource) AddSubscription(_, _ *table.TableInfo, _ table.Mapped
 func (s *noopChangeSource) Start(context.Context) error                     { return nil }
 func (s *noopChangeSource) StartFromPosition(context.Context, string) error { return nil }
 func (s *noopChangeSource) Position() string                                { return "" }
+func (s *noopChangeSource) CurrentPosition(context.Context) (string, error) { return "", nil }
 func (s *noopChangeSource) Flush(context.Context) error                     { return nil }
 func (s *noopChangeSource) FlushUnderTableLock(context.Context, []*dbconn.TableLock) error {
 	return nil

--- a/pkg/move/reversefeed.go
+++ b/pkg/move/reversefeed.go
@@ -1,0 +1,286 @@
+package move
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+)
+
+// ReverseFeed implements the data plane of the "reverse-window" move: after a
+// forward cutover, it tails the (former) target's binlog and applies changes
+// back to the (former) source in CHANGE-ONLY mode — no copy, no checksum — so
+// the source stays current and the move can be rolled back for a bounded
+// window. It is the mirror of the forward move: the former targets become the
+// reverse sources and the former source becomes the reverse target.
+//
+// It reuses change.Source exactly as the forward move does; the only new idea
+// is direction + "change-only" (SetWatermarkOptimization(false), started from a
+// position captured at cutover). Because the applier is idempotent (REPLACE
+// INTO / DELETE by PK), starting slightly early replays no-ops, so the cutover
+// position handoff does not need to be exact.
+//
+// This type is deliberately decoupled from the forward Runner and its cutover
+// so it can be exercised in isolation (see reversefeed_test.go): construct it
+// against two already-consistent databases, drive writes on the source side,
+// and assert the target converges.
+
+// ReverseSource is one reverse source: a former move target (shard S) whose
+// binlog is tailed to keep the former move source (U) current.
+//
+// DB's default database MUST be this source's schema. table.TableInfo.SetInfo
+// resolves columns via information_schema WHERE table_schema=DATABASE() — the
+// connection's default database, not the SchemaName argument — so a connection
+// defaulting to the wrong schema silently loads the wrong table's definition,
+// surfacing only at apply time as a fatal column-count mismatch.
+type ReverseSource struct {
+	DB       *sql.DB            // connection to S (default DB == its schema)
+	Addr     string             // host:port for the binlog syncer
+	User     string             // binlog syncer user
+	Password string             // binlog syncer password
+	Tables   []*table.TableInfo // S-side tables to watch, built on DB
+	// Position is the opaque change.Source position to resume from (captured at
+	// cutover). Empty means start from the source's current head.
+	Position string
+}
+
+// ReverseFeedConfig configures a ReverseFeed.
+type ReverseFeedConfig struct {
+	Sources []ReverseSource
+	// Target is the U side (single, unsharded). Target.DB's default database
+	// MUST be U's schema (see ReverseSource.DB).
+	Target applier.Target
+	// TargetTables maps each watched (reverse-source) table NAME to the U-side
+	// TableInfo it is written to, built on Target.DB. It is a map, not a slice,
+	// because the names can differ: after a forward cutover the source tables are
+	// renamed to their _old form, so a watched "t1" is written to "t1_old".
+	TargetTables map[string]*table.TableInfo
+
+	Logger        *slog.Logger
+	DBConfig      *dbconn.DBConfig
+	Threads       int           // applier write threads; 0 => default (4)
+	FlushInterval time.Duration // 0 => change.DefaultFlushInterval
+	// GTID selects the GTID-based change source (matching the forward move's
+	// --enable-experimental-gtid) instead of binlog file+offset, so the reverse
+	// feed uses the same coordinate scheme the operator chose for the move.
+	GTID bool
+}
+
+// ReverseFeed is a running change-only reverse feed: one change.Source per
+// ReverseSource, all sharing a single applier that writes to U (mirrors the
+// forward move, where N sources share one applier).
+type ReverseFeed struct {
+	sources  []ReverseSource
+	clients  []change.Source
+	appl     applier.Applier
+	logger   *slog.Logger
+	flushInt time.Duration
+
+	// A fatal error on any feed (schema change or stream failure) means U can no
+	// longer be trusted for rollback. We capture it once and close fatalCh so
+	// Run wakes immediately and the caller can degrade to complete-forward
+	// rather than silently letting U drift.
+	fatalOnce sync.Once
+	fatalCh   chan struct{}
+	fatalMu   sync.Mutex
+	fatalErr  error
+}
+
+// NewReverseFeed wires the feeds and their shared applier. It does not open any
+// binlog stream; call Start or Run for that.
+func NewReverseFeed(cfg ReverseFeedConfig) (*ReverseFeed, error) {
+	if len(cfg.Sources) == 0 {
+		return nil, errors.New("reverse feed: at least one source is required")
+	}
+	if cfg.Target.DB == nil {
+		return nil, errors.New("reverse feed: target DB must be non-nil")
+	}
+	if len(cfg.TargetTables) == 0 {
+		return nil, errors.New("reverse feed: at least one target table is required")
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	dbCfg := cfg.DBConfig
+	if dbCfg == nil {
+		dbCfg = dbconn.NewDBConfig()
+	}
+	flushInt := cfg.FlushInterval
+	if flushInt <= 0 {
+		flushInt = change.DefaultFlushInterval
+	}
+	threads := cfg.Threads
+	if threads <= 0 {
+		threads = 4
+	}
+
+	// One applier writing to U, shared across all source feeds.
+	appl, err := applier.NewSingleTargetApplier(cfg.Target, &applier.ApplierConfig{
+		DBConfig: dbCfg,
+		Logger:   logger,
+		Threads:  threads,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reverse feed: create applier: %w", err)
+	}
+
+	rf := &ReverseFeed{
+		sources:  cfg.Sources,
+		appl:     appl,
+		logger:   logger,
+		flushInt: flushInt,
+		fatalCh:  make(chan struct{}),
+	}
+
+	for si, src := range cfg.Sources {
+		if src.DB == nil {
+			return nil, fmt.Errorf("reverse feed: source %d DB must be non-nil", si)
+		}
+		if len(src.Tables) == 0 {
+			return nil, fmt.Errorf("reverse feed: source %d has no tables", si)
+		}
+		clientCfg := &change.ClientConfig{
+			Logger:     logger,
+			ServerID:   change.NewServerID(),
+			DBConfig:   dbCfg,
+			CancelFunc: rf.onFatal,
+		}
+		var client change.Source
+		if cfg.GTID {
+			client = change.NewGTIDClient(src.DB, src.Addr, src.User, src.Password, appl, clientCfg)
+		} else {
+			client = change.NewBinlogClient(src.DB, src.Addr, src.User, src.Password, appl, clientCfg)
+		}
+		for _, sTbl := range src.Tables {
+			uTbl, ok := cfg.TargetTables[sTbl.TableName]
+			if !ok {
+				client.Close()
+				return nil, fmt.Errorf("reverse feed: source %d has no target table for %q", si, sTbl.TableName)
+			}
+			chunker, err := table.NewChunker(sTbl, table.ChunkerConfig{NewTable: uTbl, Logger: logger})
+			if err != nil {
+				client.Close()
+				return nil, fmt.Errorf("reverse feed: chunker for %q: %w", sTbl.TableName, err)
+			}
+			if err := client.AddSubscription(sTbl, uTbl, chunker); err != nil {
+				client.Close()
+				return nil, fmt.Errorf("reverse feed: subscribe %q: %w", sTbl.TableName, err)
+			}
+		}
+		rf.clients = append(rf.clients, client)
+	}
+	return rf, nil
+}
+
+// onFatal records the first fatal feed condition and wakes Run. It returns true
+// (we always act on it: the window degrades to complete-forward).
+func (rf *ReverseFeed) onFatal(reason change.FatalReason) bool {
+	rf.fatalOnce.Do(func() {
+		rf.fatalMu.Lock()
+		rf.fatalErr = fmt.Errorf("reverse feed hit a fatal condition (%s); rollback is no longer safe", reason)
+		rf.fatalMu.Unlock()
+		rf.logger.Error("reverse feed fatal; source can no longer be trusted for rollback", "reason", reason.String())
+		close(rf.fatalCh)
+	})
+	return true
+}
+
+// Err returns the first fatal feed error, if any.
+func (rf *ReverseFeed) Err() error {
+	rf.fatalMu.Lock()
+	defer rf.fatalMu.Unlock()
+	return rf.fatalErr
+}
+
+// Start opens every feed (StartFromPosition when a Position is set, else from
+// current head), switches it to change-only mode, and begins periodic flush.
+func (rf *ReverseFeed) Start(ctx context.Context) error {
+	for i, client := range rf.clients {
+		var err error
+		if rf.sources[i].Position != "" {
+			err = client.StartFromPosition(ctx, rf.sources[i].Position)
+		} else {
+			err = client.Start(ctx)
+		}
+		if err != nil {
+			return fmt.Errorf("reverse feed: start source %d: %w", i, err)
+		}
+		// Change-only: apply every change regardless of copy watermark, since
+		// there is no copier. This is what the forward move disables at cutover.
+		if err := client.SetWatermarkOptimization(ctx, false); err != nil {
+			return fmt.Errorf("reverse feed: disable watermark optimization on source %d: %w", i, err)
+		}
+		client.StartPeriodicFlush(ctx, rf.flushInt)
+	}
+	return nil
+}
+
+// Flush drains all feeds synchronously (e.g. before a health check or a reverse
+// cutover, so U reflects everything written to the sources so far).
+func (rf *ReverseFeed) Flush(ctx context.Context) error {
+	for i, client := range rf.clients {
+		if err := client.Flush(ctx); err != nil {
+			return fmt.Errorf("reverse feed: flush source %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// Positions returns each source's current safe-to-resume position, in the same
+// order as the configured sources. Intended for the caller's checkpoint so the
+// window can resume in reverse mode after a restart.
+func (rf *ReverseFeed) Positions() []string {
+	out := make([]string, len(rf.clients))
+	for i, client := range rf.clients {
+		out[i] = client.Position()
+	}
+	return out
+}
+
+// Run opens the feeds and holds the rollback window for the given duration,
+// keeping U current. It returns:
+//   - nil when the window elapses normally (after a final flush);
+//   - ctx.Err() if the context is cancelled;
+//   - a fatal error if any feed dies (rollback is then unsafe and the caller
+//     must complete-forward).
+//
+// Run does not Close the feeds; the caller does that after deciding the
+// terminal action (complete-forward or roll back), since a reverse cutover
+// needs the feeds flushed one last time first.
+func (rf *ReverseFeed) Run(ctx context.Context, window time.Duration) error {
+	if err := rf.Start(ctx); err != nil {
+		return err
+	}
+	timer := time.NewTimer(window)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-rf.fatalCh:
+		return rf.Err()
+	case <-timer.C:
+	}
+	// Window elapsed normally: final drain so U reflects everything written to
+	// the sources during the window before the caller retires it.
+	return rf.Flush(ctx)
+}
+
+// Close stops periodic flush and closes all feeds. Safe to call more than once.
+// The applier is never Started (the subscription apply path is synchronous), so
+// there is nothing to Stop on it.
+func (rf *ReverseFeed) Close() {
+	for _, client := range rf.clients {
+		client.StopPeriodicFlush()
+		client.Close()
+	}
+}

--- a/pkg/move/reversefeed.go
+++ b/pkg/move/reversefeed.go
@@ -96,7 +96,7 @@ type ReverseFeed struct {
 
 // NewReverseFeed wires the feeds and their shared applier. It does not open any
 // binlog stream; call Start or Run for that.
-func NewReverseFeed(cfg ReverseFeedConfig) (*ReverseFeed, error) {
+func NewReverseFeed(cfg ReverseFeedConfig) (_ *ReverseFeed, err error) {
 	if len(cfg.Sources) == 0 {
 		return nil, errors.New("reverse feed: at least one source is required")
 	}
@@ -141,6 +141,15 @@ func NewReverseFeed(cfg ReverseFeedConfig) (*ReverseFeed, error) {
 		flushInt: flushInt,
 		fatalCh:  make(chan struct{}),
 	}
+	// If wiring the per-source feeds fails partway, tear down the feeds already
+	// created so we don't leak their binlog syncer goroutines and connections.
+	// The applier is inert until Start (nothing to stop) and does not own
+	// Target.DB, so closing the clients is the whole cleanup.
+	defer func() {
+		if err != nil {
+			rf.Close()
+		}
+	}()
 
 	for si, src := range cfg.Sources {
 		if src.DB == nil {
@@ -161,23 +170,22 @@ func NewReverseFeed(cfg ReverseFeedConfig) (*ReverseFeed, error) {
 		} else {
 			client = change.NewBinlogClient(src.DB, src.Addr, src.User, src.Password, appl, clientCfg)
 		}
+		// Track the client now so the deferred cleanup closes it — and every
+		// earlier client — if a later subscription or source fails to wire up.
+		rf.clients = append(rf.clients, client)
 		for _, sTbl := range src.Tables {
 			uTbl, ok := cfg.TargetTables[sTbl.TableName]
 			if !ok {
-				client.Close()
 				return nil, fmt.Errorf("reverse feed: source %d has no target table for %q", si, sTbl.TableName)
 			}
-			chunker, err := table.NewChunker(sTbl, table.ChunkerConfig{NewTable: uTbl, Logger: logger})
-			if err != nil {
-				client.Close()
-				return nil, fmt.Errorf("reverse feed: chunker for %q: %w", sTbl.TableName, err)
+			chunker, cerr := table.NewChunker(sTbl, table.ChunkerConfig{NewTable: uTbl, Logger: logger})
+			if cerr != nil {
+				return nil, fmt.Errorf("reverse feed: chunker for %q: %w", sTbl.TableName, cerr)
 			}
-			if err := client.AddSubscription(sTbl, uTbl, chunker); err != nil {
-				client.Close()
-				return nil, fmt.Errorf("reverse feed: subscribe %q: %w", sTbl.TableName, err)
+			if aerr := client.AddSubscription(sTbl, uTbl, chunker); aerr != nil {
+				return nil, fmt.Errorf("reverse feed: subscribe %q: %w", sTbl.TableName, aerr)
 			}
 		}
-		rf.clients = append(rf.clients, client)
 	}
 	return rf, nil
 }
@@ -213,11 +221,16 @@ func (rf *ReverseFeed) Start(ctx context.Context) error {
 			err = client.Start(ctx)
 		}
 		if err != nil {
+			// A partial start must not leave earlier feeds running in the
+			// background (leaking goroutines/connections and still applying
+			// changes). Close is idempotent, so the caller's own Close is fine.
+			rf.Close()
 			return fmt.Errorf("reverse feed: start source %d: %w", i, err)
 		}
 		// Change-only: apply every change regardless of copy watermark, since
 		// there is no copier. This is what the forward move disables at cutover.
 		if err := client.SetWatermarkOptimization(ctx, false); err != nil {
+			rf.Close()
 			return fmt.Errorf("reverse feed: disable watermark optimization on source %d: %w", i, err)
 		}
 		client.StartPeriodicFlush(ctx, rf.flushInt)

--- a/pkg/move/reversefeed_test.go
+++ b/pkg/move/reversefeed_test.go
@@ -184,3 +184,19 @@ func TestReverseFeedWindowHoldsAndReturns(t *testing.T) {
 	require.NoError(t, feed.Run(t.Context(), 500*time.Millisecond))
 	require.GreaterOrEqual(t, time.Since(start), 450*time.Millisecond, "Run must hold for ~the window")
 }
+
+// TestReverseFeedStartCleanupOnPartialFailure: when Start fails partway (here
+// the second source has a bogus resume position), the feed it already started
+// for the first source must be torn down, not left running. There is
+// deliberately no feed.Close() — a correct Start already cleaned up, and the
+// package's goleak TestMain fails if the first source's binlog-reader or
+// periodic-flush goroutines survive.
+func TestReverseFeedStartCleanupOnPartialFailure(t *testing.T) {
+	setupFanIn(t)
+	// Source 0 starts from head (succeeds, spawning goroutines); source 1
+	// resumes from an unparseable position and fails, tripping Start's cleanup.
+	feed, _ := newFanInFeed(t, []string{"", "not-a-valid-position"})
+	err := feed.Start(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "start source 1", "the second source must be the one that fails")
+}

--- a/pkg/move/reversefeed_test.go
+++ b/pkg/move/reversefeed_test.go
@@ -1,0 +1,186 @@
+package move
+
+// Isolated tests for the reverse-window data plane (ReverseFeed), exercised
+// WITHOUT any forward move or cutover: set up databases already in the
+// post-forward-copy state, then drive writes on the (former) target side and
+// assert they flow back to the (former) source.
+//
+// Layout: poc_rf_u = the unsharded source U (reverse target). poc_rf_s0 /
+// poc_rf_s1 = two former target shards S (reverse sources) holding DISJOINT,
+// globally-unique PKs — so U is exactly their union and the N:1 merge back is
+// collision-free (the sequences/globally-unique-PK precondition from the design).
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// openSchemaConn opens a connection whose DEFAULT database is `schema`, which
+// TableInfo.SetInfo requires (it resolves columns via DATABASE(), not the
+// SchemaName argument). Registered for cleanup so goleak stays clean.
+func openSchemaConn(t *testing.T, schema string) *sql.DB {
+	t.Helper()
+	db, err := dbconn.New(testutils.DSNForDatabase(schema), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+	return db
+}
+
+func reverseTableInfo(t *testing.T, db *sql.DB, schema, name string) *table.TableInfo {
+	t.Helper()
+	ti := table.NewTableInfo(db, schema, name)
+	require.NoError(t, ti.SetInfo(t.Context()))
+	return ti
+}
+
+// setupFanIn builds U + two shards in the post-forward-copy state (U == s0 ∪ s1).
+func setupFanIn(t *testing.T) {
+	t.Helper()
+	for _, s := range []string{"poc_rf_u", "poc_rf_s0", "poc_rf_s1"} {
+		testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+s)
+		testutils.RunSQL(t, "CREATE DATABASE "+s)
+		testutils.RunSQL(t, "CREATE TABLE "+s+".t1 (id INT NOT NULL PRIMARY KEY, val VARCHAR(255))")
+	}
+	testutils.RunSQL(t, "INSERT INTO poc_rf_s0.t1 VALUES (1,'one'),(3,'three'),(5,'five')")
+	testutils.RunSQL(t, "INSERT INTO poc_rf_s1.t1 VALUES (2,'two'),(4,'four'),(6,'six')")
+	testutils.RunSQL(t, "INSERT INTO poc_rf_u.t1  VALUES (1,'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'),(6,'six')")
+}
+
+// newFanInFeed wires a reverse feed s0,s1 → U. positions[i], when non-empty,
+// starts source i from that captured position instead of the current head.
+func newFanInFeed(t *testing.T, positions []string) (*ReverseFeed, *sql.DB) {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	uDB := openSchemaConn(t, "poc_rf_u")
+	uTbl := reverseTableInfo(t, uDB, "poc_rf_u", "t1")
+
+	mkSource := func(schema string, idx int) ReverseSource {
+		sDB := openSchemaConn(t, schema)
+		pos := ""
+		if idx < len(positions) {
+			pos = positions[idx]
+		}
+		return ReverseSource{
+			DB:       sDB,
+			Addr:     cfg.Addr,
+			User:     cfg.User,
+			Password: cfg.Passwd,
+			Tables:   []*table.TableInfo{reverseTableInfo(t, sDB, schema, "t1")},
+			Position: pos,
+		}
+	}
+
+	feed, err := NewReverseFeed(ReverseFeedConfig{
+		Sources:      []ReverseSource{mkSource("poc_rf_s0", 0), mkSource("poc_rf_s1", 1)},
+		Target:       applier.Target{DB: uDB, KeyRange: "0"},
+		TargetTables: map[string]*table.TableInfo{"t1": uTbl},
+	})
+	require.NoError(t, err)
+	return feed, uDB
+}
+
+func dumpRows(t *testing.T, db *sql.DB, query string) []string {
+	t.Helper()
+	rows, err := db.QueryContext(t.Context(), query)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+	var out []string
+	for rows.Next() {
+		var id int
+		var val string
+		require.NoError(t, rows.Scan(&id, &val))
+		out = append(out, fmt.Sprintf("%d=%s", id, val))
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// assertConverged asserts U equals the union of the two shards' current state.
+func assertConverged(t *testing.T, db *sql.DB) {
+	t.Helper()
+	union := dumpRows(t, db, "SELECT id,val FROM poc_rf_s0.t1 UNION ALL SELECT id,val FROM poc_rf_s1.t1 ORDER BY id")
+	got := dumpRows(t, db, "SELECT id,val FROM poc_rf_u.t1 ORDER BY id")
+	require.Equal(t, union, got, "U must equal the union of all shards")
+}
+
+// TestReverseFeedFanInConverges: writes to BOTH shards after cutover (insert,
+// update, delete) merge back into the single U. This is the N:1 case the
+// original PoC did not cover.
+func TestReverseFeedFanInConverges(t *testing.T) {
+	setupFanIn(t)
+	feed, uDB := newFanInFeed(t, nil)
+	defer feed.Close()
+	require.NoError(t, feed.Start(t.Context()))
+
+	// "App writes" landing on each shard after cutover.
+	testutils.RunSQL(t, "INSERT INTO poc_rf_s0.t1 VALUES (7,'seven')")
+	testutils.RunSQL(t, "UPDATE poc_rf_s0.t1 SET val='ONE' WHERE id=1")
+	testutils.RunSQL(t, "DELETE FROM poc_rf_s0.t1 WHERE id=3")
+	testutils.RunSQL(t, "INSERT INTO poc_rf_s1.t1 VALUES (8,'eight')")
+	testutils.RunSQL(t, "UPDATE poc_rf_s1.t1 SET val='TWO' WHERE id=2")
+	testutils.RunSQL(t, "DELETE FROM poc_rf_s1.t1 WHERE id=4")
+
+	require.NoError(t, feed.Flush(t.Context()))
+	assertConverged(t, uDB)
+}
+
+// TestReverseFeedIdempotentReplay: resuming a fresh feed from an EARLIER
+// captured position re-applies a window of events; idempotent REPLACE keeps U
+// correct. Confirms the imprecise-cutover-handoff safety, now per-source (N:1).
+func TestReverseFeedIdempotentReplay(t *testing.T) {
+	setupFanIn(t)
+	feed, uDB := newFanInFeed(t, nil)
+	require.NoError(t, feed.Start(t.Context()))
+
+	// Batch 1, then capture positions (non-empty after a flush).
+	testutils.RunSQL(t, "INSERT INTO poc_rf_s0.t1 VALUES (7,'seven')")
+	testutils.RunSQL(t, "INSERT INTO poc_rf_s1.t1 VALUES (8,'eight')")
+	require.NoError(t, feed.Flush(t.Context()))
+	assertConverged(t, uDB)
+
+	pos := feed.Positions()
+	require.Len(t, pos, 2)
+	for i, p := range pos {
+		require.NotEmpty(t, p, "source %d position", i)
+	}
+
+	// Batch 2 (applied by the live feed), then close.
+	testutils.RunSQL(t, "UPDATE poc_rf_s0.t1 SET val='ONE' WHERE id=1")
+	testutils.RunSQL(t, "DELETE FROM poc_rf_s1.t1 WHERE id=4")
+	require.NoError(t, feed.Flush(t.Context()))
+	assertConverged(t, uDB)
+	feed.Close()
+
+	// A fresh feed resumes from the batch-1 positions, replaying batch 2. U is
+	// already up to date, so idempotent apply must leave it converged.
+	replay, uDB2 := newFanInFeed(t, pos)
+	defer replay.Close()
+	require.NoError(t, replay.Start(t.Context()))
+	require.NoError(t, replay.Flush(t.Context()))
+	assertConverged(t, uDB2)
+}
+
+// TestReverseFeedWindowHoldsAndReturns: Run opens the feeds, holds for the
+// window, and returns nil (feeds healthy, no fatal). The window-loop skeleton
+// the eventual cutover integration will drive.
+func TestReverseFeedWindowHoldsAndReturns(t *testing.T) {
+	setupFanIn(t)
+	feed, _ := newFanInFeed(t, nil)
+	defer feed.Close()
+
+	start := time.Now()
+	require.NoError(t, feed.Run(t.Context(), 500*time.Millisecond))
+	require.GreaterOrEqual(t, time.Since(start), 450*time.Millisecond, "Run must hold for ~the window")
+}

--- a/pkg/move/runner_close_test.go
+++ b/pkg/move/runner_close_test.go
@@ -170,6 +170,7 @@ func (f *fakeChangeSource) AddSubscription(_, _ *table.TableInfo, _ table.Mapped
 func (f *fakeChangeSource) Start(_ context.Context) error                       { return nil }
 func (f *fakeChangeSource) StartFromPosition(_ context.Context, _ string) error { return nil }
 func (f *fakeChangeSource) Position() string                                    { return "" }
+func (f *fakeChangeSource) CurrentPosition(_ context.Context) (string, error)   { return "", nil }
 func (f *fakeChangeSource) Flush(_ context.Context) error                       { return nil }
 func (f *fakeChangeSource) FlushUnderTableLock(_ context.Context, _ []*dbconn.TableLock) error {
 	return nil


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

Foundational, independently-tested building blocks for the reverse-window move; the runner integration lands separately (keeps that PR to the wiring).

pkg/change — add Source.CurrentPosition(ctx) (string, error): a live read of the server's current head in the implementation's own coordinate scheme (binlog: FLUSH + SHOW ... STATUS -> file:offset; GTID: @@GLOBAL.gtid_executed). It is distinct from Position(), which reports only a *running* feed's in-memory flushed progress; the interface doc spells out the difference. Putting it on the interface (rather than a binlog-only helper) is what lets a caller seed a new feed at a known point in either mode. Binlog + GTID impls, the three Source test doubles updated, and a unit test covering both.

pkg/move — add ReverseFeed: a change-only reverse feed (one change.Source per reverse source, all sharing a single applier that writes to one target), with a GTID option. Covered by isolated tests: N:1 fan-in, idempotent replay from an earlier position, and the window hold/return.
