### PR TITLE
fix(change): decode compressed transactions instead of silently dropping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Spirit works with the default configuration of MySQL 8.0, but checks that you ha
   - `log_slave_updates=1`
   - `performance_schema=1`
   - `binlog_row_value_options=''`
+  - `binlog_transaction_compression=OFF`
 
 Spirit also supports sources running **semi-synchronous replication** (`rpl_semi_sync_source_enabled=ON`). Semi-sync widens the window between when a transaction's row events become visible to replication clients and when its InnoDB commit becomes visible to local `SELECT`s; spirit's buffered replication subscription applies row images directly from the binlog and is robust against that window. This configuration is exercised by a dedicated CI lane — see `compose/semisync.yml` and [issue #746](https://github.com/block/spirit/issues/746).
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -578,7 +578,7 @@ The advantages of buffered copy are:
 
 Setting `--unbuffered` opts back into the **legacy** mechanism of using `INSERT IGNORE .. SELECT` directly in MySQL. This was the default in older versions of Spirit and is still supported for now, but it has the downside of requiring more locking on the source table: the `SELECT` side of `INSERT .. SELECT` takes shared row locks rather than using MVCC, so it can contend with production workloads touching the same rows. (Smaller `--target-chunk-time` values mitigate this by holding those locks for less time per chunk.)
 
-Both copiers require `binlog_row_image=FULL`, an empty `binlog_row_value_options` and `binlog_transaction_compression=OFF`, since Spirit's replication subscription reads all column values from the binary log.
+Both copiers require `binlog_row_image=FULL` and an empty `binlog_row_value_options`, since Spirit's replication subscription reads all column values from the binary log. Spirit also requires `@@global.binlog_transaction_compression=OFF` (a global ON default is not a supported configuration).
 
 ### username
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -578,7 +578,7 @@ The advantages of buffered copy are:
 
 Setting `--unbuffered` opts back into the **legacy** mechanism of using `INSERT IGNORE .. SELECT` directly in MySQL. This was the default in older versions of Spirit and is still supported for now, but it has the downside of requiring more locking on the source table: the `SELECT` side of `INSERT .. SELECT` takes shared row locks rather than using MVCC, so it can contend with production workloads touching the same rows. (Smaller `--target-chunk-time` values mitigate this by holding those locks for less time per chunk.)
 
-Both copiers require `binlog_row_image=FULL` and an empty `binlog_row_value_options`, since Spirit's replication subscription reads all column values from the binary log.
+Both copiers require `binlog_row_image=FULL`, an empty `binlog_row_value_options` and `binlog_transaction_compression=OFF`, since Spirit's replication subscription reads all column values from the binary log.
 
 ### username
 

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -645,6 +645,35 @@ func (c *binlogClient) readStream(ctx context.Context) {
 			for _, ddlTable := range ddlTables {
 				c.processDDLNotification(ddlTable.schema, ddlTable.table)
 			}
+		case *replication.TransactionPayloadEvent:
+			// binlog_transaction_compression=ON wraps an entire transaction —
+			// the BEGIN QueryEvent, TableMapEvents, row events and the
+			// XIDEvent — in one compressed payload event; only the GTID event
+			// stays outside. go-mysql has already decompressed and re-parsed
+			// the inner events into event.Events (with our decode options
+			// inherited), so we process them exactly as if they had arrived
+			// uncompressed. Letting this fall through to the default case
+			// would silently drop every change in the transaction.
+			//
+			// Inner event headers hold offsets into the uncompressed
+			// transaction cache, NOT file positions, so they must never feed
+			// position tracking: the replay-skip check below covers the whole
+			// payload using the outer end position, and bufferedPos advances
+			// only via the outer header in the generic update after the
+			// switch — once every inner event has been buffered. That makes
+			// replay all-or-nothing, which is safe because bufferedPos only
+			// ever lands on whole-payload boundaries.
+			eventPos := mysql.Position{Name: currentLogName, Pos: ev.Header.LogPos}
+			if shouldSkipReplayedEvent(eventPos, c.getBufferedPos()) {
+				c.logger.Debug("skipping replayed transaction payload event at or below the buffered position",
+					"event_position", eventPos)
+				continue
+			}
+			if err = c.processTransactionPayload(event, eventPos); err != nil {
+				c.logger.Error("fatal error processing binlog transaction payload event", "error", err)
+				c.fatalError(FatalReasonStreamError)
+				return
+			}
 		case *replication.GTIDEvent,
 			*replication.TableMapEvent,
 			*replication.XIDEvent,
@@ -815,6 +844,54 @@ func (c *binlogClient) processRowsEvent(ev *replication.BinlogEvent, e *replicat
 			sub.HasChanged(key, nil, true)
 		default:
 			c.logger.Error("unknown event type", "type", ev.Header.EventType)
+		}
+	}
+	return nil
+}
+
+// processTransactionPayload processes the events decompressed from a
+// TransactionPayloadEvent (binlog_transaction_compression=ON, settable
+// per-session by any client regardless of the global value the preflight
+// checks). The payload carries the whole transaction except its GTID
+// event: the BEGIN QueryEvent, TableMapEvents, row events and the XIDEvent
+// terminator. RowsEvents dispatch to subscriptions and QueryEvents go
+// through DDL detection, mirroring their uncompressed equivalents in
+// readStream. payloadPos is the outer event's end position and is used
+// only for log messages — inner headers hold transaction-cache offsets
+// that must not be mistaken for file positions.
+func (c *binlogClient) processTransactionPayload(e *replication.TransactionPayloadEvent, payloadPos mysql.Position) error {
+	for _, inner := range e.Events {
+		switch innerEvent := inner.Event.(type) {
+		case *replication.RowsEvent:
+			// No per-event replay check here: readStream already skipped the
+			// whole payload if its outer end position was at or below
+			// bufferedPos, and bufferedPos never lands inside a payload.
+			if err := c.processRowsEvent(inner, innerEvent); err != nil {
+				return err
+			}
+		case *replication.QueryEvent:
+			// Usually the transaction's BEGIN, which parses cleanly and
+			// yields no DDL tables. Unparseable statements are skipped the
+			// same way readStream skips them.
+			ddlTables, err := extractTablesFromDDLStmts(string(innerEvent.Schema), string(innerEvent.Query))
+			if err != nil {
+				c.logger.Error("Skipping query inside transaction payload that was unable to parse",
+					"file", payloadPos.Name, "pos", payloadPos.Pos)
+				continue
+			}
+			for _, ddlTable := range ddlTables {
+				c.processDDLNotification(ddlTable.schema, ddlTable.table)
+			}
+		case *replication.TableMapEvent, *replication.XIDEvent:
+			// Housekeeping inside the payload. The TableMapEvents were
+			// already consumed by go-mysql's inner parser to decode the
+			// RowsEvents above; position tracking advances via the outer
+			// event only.
+		default:
+			// Same rationale as readStream's default case: log genuinely
+			// unknown inner event types so a future row-event variant can't
+			// cause silent data loss without a trace.
+			c.logger.Debug("Received unknown event type inside transaction payload", "type", fmt.Sprintf("%T", inner.Event))
 		}
 	}
 	return nil

--- a/pkg/change/binlog_test.go
+++ b/pkg/change/binlog_test.go
@@ -3,6 +3,7 @@ package change
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -167,6 +168,97 @@ func TestReplClientComplex(t *testing.T) {
 	err = db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM replcomplext2").Scan(&count)
 	require.NoError(t, err)
 	require.Equal(t, 431, count) // 441 - 10
+}
+
+// compressedConn returns a *sql.Conn pinned to a session with
+// binlog_transaction_compression=ON, so every transaction it writes is
+// binlogged as a single ZSTD Transaction_payload event. Session-scoped on
+// purpose: the server default stays OFF, so this cannot race with other
+// test binaries' preflight configuration checks. Skips the test on servers
+// that predate the variable (< 8.0.20).
+func compressedConn(t *testing.T, db *sql.DB) *sql.Conn {
+	t.Helper()
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	_, err = conn.ExecContext(t.Context(), "SET SESSION binlog_transaction_compression = ON")
+	if myErr, ok := errors.AsType[*mysql2.MySQLError](err); ok && myErr.Number == 1193 { // ER_UNKNOWN_SYSTEM_VARIABLE
+		t.Skip("server does not support binlog_transaction_compression (requires MySQL 8.0.20+)")
+	}
+	require.NoError(t, err)
+	return conn
+}
+
+// TestReplClientTransactionCompression verifies that transactions written
+// with binlog_transaction_compression=ON are decoded and buffered rather
+// than silently dropped. The server wraps each such transaction — BEGIN
+// QueryEvent, TableMaps, row events and the XIDEvent — in one compressed
+// Transaction_payload event (only the GTID event stays outside), which the
+// raw BinlogSyncer does not unwrap for us. The preflight check rejects a
+// global ON, but any application session can still enable it for its own
+// transactions mid-migration, so the stream must handle these events; a
+// client that skips them loses every delta and fails the checksum.
+func TestReplClientTransactionCompression(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS replcompresst1, replcompresst2")
+	testutils.RunSQL(t, "CREATE TABLE replcompresst1 (a INT NOT NULL, b INT, c VARCHAR(255), PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE replcompresst2 (a INT NOT NULL, b INT, c VARCHAR(255), PRIMARY KEY (a))")
+
+	t1 := table.NewTableInfo(db, "test", "replcompresst1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "replcompresst2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*binlogClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	conn := compressedConn(t, db)
+
+	// Even a single-row autocommit INSERT is wrapped in a payload event.
+	_, err = conn.ExecContext(t.Context(), "INSERT INTO replcompresst1 (a, b, c) VALUES (1, 2, 'compressed')")
+	require.NoError(t, err)
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen(), "changes from a compressed transaction must be buffered, not dropped")
+
+	// A multi-statement transaction produces one payload containing several
+	// TableMap/RowsEvents plus the XID terminator.
+	tx, err := conn.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(t.Context(), "INSERT INTO replcompresst1 (a, b, c) VALUES (2, 2, REPEAT('x', 200)), (3, 3, REPEAT('y', 200))")
+	require.NoError(t, err)
+	_, err = tx.ExecContext(t.Context(), "UPDATE replcompresst1 SET b = 20 WHERE a = 1")
+	require.NoError(t, err)
+	_, err = tx.ExecContext(t.Context(), "DELETE FROM replcompresst1 WHERE a = 2")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	// Interleave an uncompressed change from another connection to show both
+	// formats coexist on the same stream.
+	testutils.RunSQL(t, "INSERT INTO replcompresst1 (a, b, c) VALUES (4, 4, 'plain')")
+
+	require.NoError(t, client.BlockWait(t.Context()))
+	// Keys pending: 1 (insert+update), 2 (insert+delete), 3 (insert), 4 (insert).
+	require.Equal(t, 4, client.GetDeltaLen())
+	require.NoError(t, client.Flush(t.Context()))
+	require.True(t, client.AllChangesFlushed())
+
+	// The new table must match: a=1 (with the in-transaction update applied),
+	// a=3, a=4; a=2 was deleted in the same compressed transaction.
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM replcompresst2").Scan(&count))
+	require.Equal(t, 3, count)
+	var b int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM replcompresst2 WHERE a = 1").Scan(&b))
+	require.Equal(t, 20, b)
 }
 
 func TestReplClientResumeFromImpossible(t *testing.T) {
@@ -567,6 +659,53 @@ func TestDDLNotification(t *testing.T) {
 
 	// CancelFunc was called, and DDL must be reported as a schema change so
 	// callers know to invalidate their checkpoints.
+	require.Equal(t, FatalReasonSchemaChange, <-cancelled)
+}
+
+// TestDDLNotificationTransactionCompression is TestDDLNotification with the
+// DDL issued from a session that has binlog_transaction_compression=ON. On
+// current MySQL versions DDL statements are excluded from compression and
+// arrive as plain QueryEvents, but the notification contract must hold either
+// way — the payload-unwrapping path also runs QueryEvents through DDL
+// detection in case a future server version wraps them.
+func TestDDLNotificationTransactionCompression(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS ddl_compress_t1, ddl_compress_t2")
+	testutils.RunSQL(t, "CREATE TABLE ddl_compress_t1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE ddl_compress_t2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+
+	t1 := table.NewTableInfo(db, "test", "ddl_compress_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "ddl_compress_t2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	cancelled := make(chan FatalReason, 1)
+	clientConfig := NewClientDefaultConfig()
+	clientConfig.CancelFunc = func(reason FatalReason) bool {
+		cancelled <- reason
+		return true
+	}
+	client := NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), clientConfig).(*binlogClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	conn := compressedConn(t, db)
+	// A compressed DML transaction on the watched table first, so the DDL is
+	// observed after at least one payload event has been processed.
+	_, err = conn.ExecContext(t.Context(), "INSERT INTO ddl_compress_t1 (a, b, c) VALUES (1, 2, 3)")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), "ALTER TABLE ddl_compress_t1 ADD COLUMN d INT")
+	require.NoError(t, err)
+
 	require.Equal(t, FatalReasonSchemaChange, <-cancelled)
 }
 

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -571,83 +571,21 @@ func (c *gtidClient) readStream(ctx context.Context) {
 				return
 			}
 		case *replication.QueryEvent:
-			// A "BEGIN" QueryEvent inside a transaction is not DDL — skip
-			// it cheaply rather than handing it to the parser. The pending
-			// GTID must stay pending: the transaction's row events have not
-			// been buffered yet.
-			q := strings.TrimSpace(string(event.Query))
-			if strings.EqualFold(q, "BEGIN") {
-				continue
-			}
-			// COMMIT/ROLLBACK QueryEvents end a transaction that involved a
-			// non-transactional engine (these get a QueryEvent terminator
-			// instead of an XIDEvent; a logged ROLLBACK is the mixed-engine
-			// case where the non-transactional writes survived the rollback).
-			// Either way the server has recorded the GTID in gtid_executed
-			// and we have buffered all of the transaction's row events, so
-			// promote — exactly as the XIDEvent path does. Skipping the
-			// promotion here would wedge BlockWait forever.
-			if strings.EqualFold(q, "COMMIT") || strings.EqualFold(q, "ROLLBACK") {
-				c.promotePendingGTID()
-				continue
-			}
-			// XA statements must not fall through to the parser path below
-			// (which promotes): see the XA group shape documented on
-			// promotePendingGTID. "XA START" opens the group exactly like
-			// BEGIN — its row events have not been buffered yet — and
-			// "XA END" is not a terminator either (the group ends at the
-			// XA_PREPARE_LOG_EVENT that follows), so for both the pending
-			// GTID must stay pending. Promoting here would let a concurrent
-			// flush publish g1 as a resume coordinate before its row events
-			// are buffered; a crash before the next flush then resumes past
-			// g1 and silently loses its rows. The server rewrites these
-			// statements canonically (`XA BEGIN 'x'` is binlogged as
-			// "XA START X'78',X'',1"), so a keyword prefix match is exact.
-			if hasPrefixFold(q, "XA START ") || hasPrefixFold(q, "XA END ") {
-				continue
-			}
-			// XA COMMIT / XA ROLLBACK (the two-phase outcome, decided after
-			// the prepare) are each their own single-statement transaction:
-			// own GTID, no row events. Promote, same as COMMIT/ROLLBACK
-			// above. (The one-phase variant `XA COMMIT ... ONE PHASE` never
-			// takes this path — it is logged as an XA_PREPARE_LOG_EVENT,
-			// handled below.)
-			if hasPrefixFold(q, "XA COMMIT ") || hasPrefixFold(q, "XA ROLLBACK ") {
-				c.promotePendingGTID()
-				continue
-			}
-			ddlTables, err := extractTablesFromDDLStmts(string(event.Schema), string(event.Query))
-			if err != nil {
-				// The TiDB parser does not understand all syntax (CREATE/DROP
-				// TRIGGER, certain ALTER USER variants, etc.) — these are
-				// expected misses, not bugs. We include the parser error and
-				// the schema so an operator can diagnose unexpected payloads,
-				// but deliberately omit the query itself: it can contain user
-				// data and ends up in logs. (Same rationale as the binlog
-				// client.)
-				c.logger.Error("Skipping query that was unable to parse",
-					"error", err,
-					"schema", string(event.Schema),
-					"gtid", c.getBufferedGTID().String())
-				// The statement was still a complete server transaction with
-				// its own GTID — promote it even though we could not parse
-				// it, otherwise bufferedGTID falls permanently behind
-				// gtid_executed and BlockWait/Flush never complete. Note the
-				// schema filter only applies after parsing, so *any*
-				// unparseable statement on the server (e.g. a stored
-				// procedure deploy in an unrelated schema) takes this path.
-				c.promotePendingGTID()
-				continue
-			}
-			// MySQL emits a synthetic GTID for DDL statements too, but the
-			// DDL is its own transaction (no XIDEvent). Promote any pending
-			// GTID now so a DDL-as-last-event still ends up in the resume
-			// set. This is best-effort — if the caller cancels on DDL we
-			// won't actually resume, but the position is consistent for
-			// non-cancelling filters.
-			c.promotePendingGTID()
-			for _, ddlTable := range ddlTables {
-				c.processDDLNotification(ddlTable.schema, ddlTable.table)
+			c.processQueryEvent(event)
+		case *replication.TransactionPayloadEvent:
+			// binlog_transaction_compression=ON wraps the whole transaction
+			// (BEGIN QueryEvent, TableMapEvents, row events, XIDEvent) in one
+			// compressed payload event; only the GTID event stays outside.
+			// go-mysql has already decompressed and re-parsed the inner
+			// events, so dispatch them exactly as if they had arrived
+			// uncompressed. Letting this fall through to the default case
+			// would silently drop the transaction's changes AND leave its
+			// pending GTID unpromoted (the XIDEvent is inside the payload),
+			// wedging BlockWait/Flush forever.
+			if err = c.processTransactionPayload(event); err != nil {
+				c.logger.Error("fatal error processing GTID transaction payload event", "error", err)
+				c.fatalError(FatalReasonStreamError)
+				return
 			}
 		case *replication.TableMapEvent,
 			*replication.FormatDescriptionEvent,
@@ -674,6 +612,141 @@ func (c *gtidClient) readStream(ctx context.Context) {
 			c.logger.Debug("Received unknown event type", "type", fmt.Sprintf("%T", ev.Event))
 		}
 	}
+}
+
+// processQueryEvent handles a QueryEvent, whether read directly from the
+// stream or decompressed from a transaction payload. Transaction-control
+// statements adjust the pending-GTID state; everything else goes through
+// DDL extraction. See promotePendingGTID for the group shapes that dictate
+// which statements promote and which must leave the pending GTID pending.
+func (c *gtidClient) processQueryEvent(event *replication.QueryEvent) {
+	// A "BEGIN" QueryEvent inside a transaction is not DDL — skip
+	// it cheaply rather than handing it to the parser. The pending
+	// GTID must stay pending: the transaction's row events have not
+	// been buffered yet.
+	q := strings.TrimSpace(string(event.Query))
+	if strings.EqualFold(q, "BEGIN") {
+		return
+	}
+	// COMMIT/ROLLBACK QueryEvents end a transaction that involved a
+	// non-transactional engine (these get a QueryEvent terminator
+	// instead of an XIDEvent; a logged ROLLBACK is the mixed-engine
+	// case where the non-transactional writes survived the rollback).
+	// Either way the server has recorded the GTID in gtid_executed
+	// and we have buffered all of the transaction's row events, so
+	// promote — exactly as the XIDEvent path does. Skipping the
+	// promotion here would wedge BlockWait forever.
+	if strings.EqualFold(q, "COMMIT") || strings.EqualFold(q, "ROLLBACK") {
+		c.promotePendingGTID()
+		return
+	}
+	// XA statements must not fall through to the parser path below
+	// (which promotes): see the XA group shape documented on
+	// promotePendingGTID. "XA START" opens the group exactly like
+	// BEGIN — its row events have not been buffered yet — and
+	// "XA END" is not a terminator either (the group ends at the
+	// XA_PREPARE_LOG_EVENT that follows), so for both the pending
+	// GTID must stay pending. Promoting here would let a concurrent
+	// flush publish g1 as a resume coordinate before its row events
+	// are buffered; a crash before the next flush then resumes past
+	// g1 and silently loses its rows. The server rewrites these
+	// statements canonically (`XA BEGIN 'x'` is binlogged as
+	// "XA START X'78',X'',1"), so a keyword prefix match is exact.
+	if hasPrefixFold(q, "XA START ") || hasPrefixFold(q, "XA END ") {
+		return
+	}
+	// XA COMMIT / XA ROLLBACK (the two-phase outcome, decided after
+	// the prepare) are each their own single-statement transaction:
+	// own GTID, no row events. Promote, same as COMMIT/ROLLBACK
+	// above. (The one-phase variant `XA COMMIT ... ONE PHASE` never
+	// takes this path — it is logged as an XA_PREPARE_LOG_EVENT,
+	// handled by readStream's GenericEvent case for uncompressed
+	// groups and by processTransactionPayload for compressed ones.)
+	if hasPrefixFold(q, "XA COMMIT ") || hasPrefixFold(q, "XA ROLLBACK ") {
+		c.promotePendingGTID()
+		return
+	}
+	ddlTables, err := extractTablesFromDDLStmts(string(event.Schema), string(event.Query))
+	if err != nil {
+		// The TiDB parser does not understand all syntax (CREATE/DROP
+		// TRIGGER, certain ALTER USER variants, etc.) — these are
+		// expected misses, not bugs. We include the parser error and
+		// the schema so an operator can diagnose unexpected payloads,
+		// but deliberately omit the query itself: it can contain user
+		// data and ends up in logs. (Same rationale as the binlog
+		// client.)
+		c.logger.Error("Skipping query that was unable to parse",
+			"error", err,
+			"schema", string(event.Schema),
+			"gtid", c.getBufferedGTID().String())
+		// The statement was still a complete server transaction with
+		// its own GTID — promote it even though we could not parse
+		// it, otherwise bufferedGTID falls permanently behind
+		// gtid_executed and BlockWait/Flush never complete. Note the
+		// schema filter only applies after parsing, so *any*
+		// unparseable statement on the server (e.g. a stored
+		// procedure deploy in an unrelated schema) takes this path.
+		c.promotePendingGTID()
+		return
+	}
+	// MySQL emits a synthetic GTID for DDL statements too, but the
+	// DDL is its own transaction (no XIDEvent). Promote any pending
+	// GTID now so a DDL-as-last-event still ends up in the resume
+	// set. This is best-effort — if the caller cancels on DDL we
+	// won't actually resume, but the position is consistent for
+	// non-cancelling filters.
+	c.promotePendingGTID()
+	for _, ddlTable := range ddlTables {
+		c.processDDLNotification(ddlTable.schema, ddlTable.table)
+	}
+}
+
+// processTransactionPayload processes the events decompressed from a
+// TransactionPayloadEvent (binlog_transaction_compression=ON, settable
+// per-session by any client regardless of the global value the preflight
+// checks). The payload carries the whole transaction except its GTID
+// event, so the pending {SID,GNO} stashed by the preceding (uncompressed)
+// GTIDEvent is promoted here, by the inner group terminator — XIDEvent,
+// COMMIT/ROLLBACK QueryEvent, or XA_PREPARE_LOG_EVENT — after the
+// transaction's row events have been buffered, keeping
+// promotePendingGTID's per-transaction resume contract intact.
+func (c *gtidClient) processTransactionPayload(e *replication.TransactionPayloadEvent) error {
+	for _, inner := range e.Events {
+		switch innerEvent := inner.Event.(type) {
+		case *replication.XIDEvent:
+			// Transaction commit (InnoDB), delivered inside the payload.
+			c.promotePendingGTID()
+		case *replication.RowsEvent:
+			if err := c.processRowsEvent(inner, innerEvent); err != nil {
+				return err
+			}
+		case *replication.QueryEvent:
+			c.processQueryEvent(innerEvent)
+		case *replication.TableMapEvent:
+			// Already consumed by go-mysql's inner parser to decode the
+			// RowsEvents above.
+		case *replication.GenericEvent:
+			// XA transactions are compressed too (verified against MySQL
+			// 8.0.43): the first binlog group — XA START, row events, XA END,
+			// XA_PREPARE_LOG_EVENT — arrives inside a payload, with only the
+			// terminal XA COMMIT / XA ROLLBACK QueryEvent outside under its
+			// own GTID. The XA_PREPARE_LOG_EVENT (surfaced as a GenericEvent)
+			// terminates that first group, so promote exactly as readStream's
+			// GenericEvent case does — the group's row events have all been
+			// buffered by this point.
+			if inner.Header.EventType == replication.XA_PREPARE_LOG_EVENT {
+				c.promotePendingGTID()
+				continue
+			}
+			c.logger.Debug("Received unknown event type inside transaction payload", "type", inner.Header.EventType.String())
+		default:
+			// Same rationale as readStream's default case: log genuinely
+			// unknown inner event types so a future row-event variant can't
+			// cause silent data loss without a trace.
+			c.logger.Debug("Received unknown event type inside transaction payload", "type", fmt.Sprintf("%T", inner.Event))
+		}
+	}
+	return nil
 }
 
 // processDDLNotification mirrors binlogClient.processDDLNotification.

--- a/pkg/change/gtid_test.go
+++ b/pkg/change/gtid_test.go
@@ -80,6 +80,78 @@ func TestGTIDClient(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
+// TestGTIDClientTransactionCompression verifies that transactions written
+// with binlog_transaction_compression=ON are decoded and buffered rather
+// than silently dropped. This matters twice over for the GTID client: the
+// row events carry the deltas, and the XIDEvent that promotes the pending
+// GTID into the resume set arrives *inside* the compressed payload (only
+// the GTID event stays outside). A client that skipped payload events would
+// lose the deltas AND leave bufferedGTID permanently behind gtid_executed,
+// so the BlockWait calls below would time out.
+func TestGTIDClientTransactionCompression(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS gtidcompresst1, gtidcompresst2")
+	testutils.RunSQL(t, "CREATE TABLE gtidcompresst1 (a INT NOT NULL, b INT, c VARCHAR(255), PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE gtidcompresst2 (a INT NOT NULL, b INT, c VARCHAR(255), PRIMARY KEY (a))")
+
+	t1 := table.NewTableInfo(db, "test", "gtidcompresst1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "gtidcompresst2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*gtidClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	conn := compressedConn(t, db)
+
+	// Even a single-row autocommit INSERT is wrapped in a payload event.
+	_, err = conn.ExecContext(t.Context(), "INSERT INTO gtidcompresst1 (a, b, c) VALUES (1, 2, 'compressed')")
+	require.NoError(t, err)
+	require.NoError(t, client.BlockWait(t.Context()), "bufferedGTID must catch up to gtid_executed: the promoting XIDEvent is inside the payload")
+	require.Equal(t, 1, client.GetDeltaLen(), "changes from a compressed transaction must be buffered, not dropped")
+
+	// A multi-statement transaction produces one payload containing several
+	// TableMap/RowsEvents plus the XID terminator.
+	tx, err := conn.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(t.Context(), "INSERT INTO gtidcompresst1 (a, b, c) VALUES (2, 2, REPEAT('x', 200)), (3, 3, REPEAT('y', 200))")
+	require.NoError(t, err)
+	_, err = tx.ExecContext(t.Context(), "UPDATE gtidcompresst1 SET b = 20 WHERE a = 1")
+	require.NoError(t, err)
+	_, err = tx.ExecContext(t.Context(), "DELETE FROM gtidcompresst1 WHERE a = 2")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	// Interleave an uncompressed change from another connection to show both
+	// formats coexist on the same stream.
+	testutils.RunSQL(t, "INSERT INTO gtidcompresst1 (a, b, c) VALUES (4, 4, 'plain')")
+
+	require.NoError(t, client.BlockWait(t.Context()))
+	// Keys pending: 1 (insert+update), 2 (insert+delete), 3 (insert), 4 (insert).
+	require.Equal(t, 4, client.GetDeltaLen())
+	require.NoError(t, client.Flush(t.Context()))
+	require.True(t, client.AllChangesFlushed())
+
+	// The new table must match: a=1 (with the in-transaction update applied),
+	// a=3, a=4; a=2 was deleted in the same compressed transaction.
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM gtidcompresst2").Scan(&count))
+	require.Equal(t, 3, count)
+	var b int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM gtidcompresst2 WHERE a = 1").Scan(&b))
+	require.Equal(t, 20, b)
+}
+
 // TestGTIDStartFromMalformedPosition verifies that StartFromPosition
 // rejects an input string that is not a valid GTID set (including the
 // common operator mistake of resuming a legacy file:offset checkpoint
@@ -448,6 +520,105 @@ func TestGTIDClientXATransaction(t *testing.T) {
 	require.NoError(t, client.Flush(t.Context()))
 	err = db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable)).Scan(&count)
 	require.NoError(t, err)
+	require.Equal(t, 3, count)
+}
+
+// TestGTIDClientXATransactionCompression re-runs the XA two-phase dance
+// with binlog_transaction_compression=ON on the XA session. The entire XA
+// first group — Query("XA START"), row events, Query("XA END") and the
+// terminating XA_PREPARE_LOG_EVENT — arrives inside one compressed
+// Transaction_payload event (verified against MySQL 8.0.43); only the
+// terminal XA COMMIT QueryEvent stays outside, under its own GTID. The
+// BlockWait after the prepare is the promotion-liveness assertion: it only
+// returns if processTransactionPayload promoted the pending GTID at the
+// inner XA_PREPARE_LOG_EVENT, and the delta count proves the inner row
+// events were buffered rather than dropped.
+//
+// Unique xids and per-run table names for the same reasons documented on
+// TestGTIDClientXATransaction.
+func TestGTIDClientXATransactionCompression(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	xid := xaTestXIDPrefix + "_comp_" + uuid.NewString()
+	xid1p := xaTestXIDPrefix + "_comp1p_" + uuid.NewString()
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")[:8]
+	srcTable := "gtidxacompt1_" + suffix
+	dstTable := "gtidxacompt2_" + suffix
+
+	// Best-effort sweep of stragglers from prior interrupted runs (a
+	// logged no-op without XA_RECOVER_ADMIN).
+	rollbackDanglingXATestTxns(t, db)
+	testutils.RunSQL(t, fmt.Sprintf("DROP TABLE IF EXISTS %s, %s", srcTable, dstTable))
+	testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE %s (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))", srcTable))
+	testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE %s (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))", dstTable))
+	t.Cleanup(func() {
+		// See TestGTIDClientXATransaction: terminate this run's XA
+		// transactions before dropping the tables, from a fresh connection.
+		cleanupDB, err := sql.Open("mysql", testutils.DSN())
+		if err != nil {
+			return
+		}
+		defer utils.CloseAndLog(cleanupDB)
+		rollbackDanglingXATestTxns(t, cleanupDB, xid, xid1p)
+		_, _ = cleanupDB.ExecContext(context.Background(), "SET SESSION lock_wait_timeout=5")
+		_, _ = cleanupDB.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s, %s", srcTable, dstTable))
+	})
+
+	t1 := table.NewTableInfo(db, "test", srcTable)
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", dstTable)
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*gtidClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	// XA transactions are session-scoped between XA START and XA PREPARE;
+	// the compression-enabled conn pins one session for the whole dance.
+	conn := compressedConn(t, db)
+	xaExec := func(stmt string) {
+		t.Helper()
+		_, err := conn.ExecContext(t.Context(), stmt)
+		require.NoError(t, err)
+	}
+
+	xaExec(fmt.Sprintf("XA START '%s'", xid))
+	xaExec(fmt.Sprintf("INSERT INTO %s (a, b, c) VALUES (1, 2, 3)", srcTable))
+	xaExec(fmt.Sprintf("INSERT INTO %s (a, b, c) VALUES (2, 3, 4)", srcTable))
+	xaExec(fmt.Sprintf("XA END '%s'", xid))
+	xaExec(fmt.Sprintf("XA PREPARE '%s'", xid))
+
+	// The prepare flushes the whole group as one compressed payload. A
+	// handler that dropped the payload (or failed to promote at the inner
+	// XA_PREPARE_LOG_EVENT) would time out here.
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 2, client.GetDeltaLen(), "row events inside the compressed XA group must be buffered")
+
+	xaExec(fmt.Sprintf("XA COMMIT '%s'", xid))
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable)).Scan(&count))
+	require.Equal(t, 2, count)
+
+	// One-phase variant: a single compressed group, likewise terminated by
+	// an XA_PREPARE_LOG_EVENT.
+	xaExec(fmt.Sprintf("XA START '%s'", xid1p))
+	xaExec(fmt.Sprintf("INSERT INTO %s (a, b, c) VALUES (3, 4, 5)", srcTable))
+	xaExec(fmt.Sprintf("XA END '%s'", xid1p))
+	xaExec(fmt.Sprintf("XA COMMIT '%s' ONE PHASE", xid1p))
+
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+	require.NoError(t, db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable)).Scan(&count))
 	require.Equal(t, 3, count)
 }
 

--- a/pkg/migration/check/configuration.go
+++ b/pkg/migration/check/configuration.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+
+	"github.com/go-sql-driver/mysql"
 )
+
+// erUnknownSystemVariable is MySQL error 1193 (ER_UNKNOWN_SYSTEM_VARIABLE),
+// returned when selecting a system variable the server predates.
+const erUnknownSystemVariable = 1193
 
 func init() {
 	registerCheck("configuration", configurationCheck, ScopePreflight)
@@ -55,6 +61,23 @@ func configurationCheck(ctx context.Context, r Resources, logger *slog.Logger) e
 	}
 	if binlogRowValueOptions != "" {
 		return errors.New("binlog_row_value_options must be empty: spirit does not support non-empty values")
+	}
+	// binlog_transaction_compression=ON delivers every transaction wrapped in
+	// a compressed Transaction_payload event. The change client can decode
+	// these — it has to, because any session can enable the setting for its
+	// own transactions regardless of the global value — but as a server-wide
+	// default it is not a supported configuration, so reject it up front with
+	// a clear message. Queried separately from the batch above because the
+	// variable only exists on MySQL 8.0.20+; on older servers compression
+	// cannot be enabled at all, so unknown-variable passes the check.
+	var binlogTransactionCompression string
+	err = r.DB.QueryRowContext(ctx, `SELECT @@global.binlog_transaction_compression`).Scan(&binlogTransactionCompression)
+	if err != nil {
+		if myErr, ok := errors.AsType[*mysql.MySQLError](err); !ok || myErr.Number != erUnknownSystemVariable {
+			return err
+		}
+	} else if binlogTransactionCompression != "0" {
+		return errors.New("binlog_transaction_compression must be OFF: spirit does not support compressed transactions in the binary log")
 	}
 
 	if logBin != "1" {

--- a/pkg/move/check/configuration.go
+++ b/pkg/move/check/configuration.go
@@ -5,7 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+
+	"github.com/go-sql-driver/mysql"
 )
+
+// erUnknownSystemVariable is MySQL error 1193 (ER_UNKNOWN_SYSTEM_VARIABLE),
+// returned when selecting a system variable the server predates.
+const erUnknownSystemVariable = 1193
 
 func init() {
 	registerCheck("configuration", configurationCheck, ScopePreflight)
@@ -48,6 +54,23 @@ func configurationCheck(ctx context.Context, r Resources, logger *slog.Logger) e
 		}
 		if binlogRowValueOptions != "" {
 			return fmt.Errorf("source %d: binlog_row_value_options must be empty for move operations", i)
+		}
+		// binlog_transaction_compression=ON delivers every transaction wrapped
+		// in a compressed Transaction_payload event. The change client can
+		// decode these — it has to, because any session can enable the setting
+		// for its own transactions regardless of the global value — but as a
+		// server-wide default it is not a supported configuration. Queried
+		// separately from the batch above because the variable only exists on
+		// MySQL 8.0.20+; on older servers compression cannot be enabled at
+		// all, so unknown-variable passes the check.
+		var binlogTransactionCompression string
+		err = src.DB.QueryRowContext(ctx, `SELECT @@global.binlog_transaction_compression`).Scan(&binlogTransactionCompression)
+		if err != nil {
+			if myErr, ok := errors.AsType[*mysql.MySQLError](err); !ok || myErr.Number != erUnknownSystemVariable {
+				return fmt.Errorf("source %d: %w", i, err)
+			}
+		} else if binlogTransactionCompression != "0" {
+			return fmt.Errorf("source %d: binlog_transaction_compression must be OFF for move operations", i)
 		}
 		if logBin != "1" {
 			return fmt.Errorf("source %d: log_bin must be enabled", i)


### PR DESCRIPTION
> No pre-existing issue covers this; found while reviewing how the change clients handle unknown binlog event types. Happy to split an issue out if discussion is needed.

## Problem

A source with `binlog_transaction_compression=ON` delivers each transaction as a single `Transaction_payload` event. go-mysql's raw `BinlogSyncer` (unlike canal) does not unwrap these, so both change clients fell into the `default:` case of their event switch and skipped the entire transaction with only a debug log:

- **binlog client**: every replication delta from a compressed session is silently lost → guaranteed checksum failures on write-hot tables.
- **GTID client**: additionally wedges `BlockWait`/`Flush` forever, because the `XIDEvent` that promotes the pending GTID into the resume set arrives *inside* the payload.

The setting doesn't have to be enabled globally to bite: any application session can `SET SESSION binlog_transaction_compression=ON` (MySQL 8.0.20+) and its transactions get compressed regardless of the server default.

## Fix (two parts)

**1. Preflight**: the migration and move configuration checks now reject `@@global.binlog_transaction_compression=ON` with a clear message, matching the existing `binlog_row_value_options` style. The variable is queried separately and tolerates `ER_UNKNOWN_SYSTEM_VARIABLE` (1193), so preflight still passes on MySQL 8.0.11–8.0.19 where the setting doesn't exist.

**2. Stream readers**: both clients now process the decompressed inner events (go-mysql has already parsed them into `TransactionPayloadEvent.Events`, inheriting our decode options — `RenderJSONAsMySQLText`, UTC timestamps, etc.). This is the safety net for *session-scoped* compression that preflight cannot see. Details that matter:

- Inner event headers hold offsets into the uncompressed transaction cache, **not** file positions (verified: `SHOW BINLOG EVENTS` reports the outer end position for all inner events). Position tracking and the replay-skip check therefore key off the outer payload header only; `bufferedPos` advances once the whole payload is buffered, making replay after `recreateStreamer` all-or-nothing.
- The GTID client promotes the pending GTID at the inner group terminator: `XIDEvent`, `COMMIT`/`ROLLBACK` QueryEvent, or `XA_PREPARE_LOG_EVENT`. The QueryEvent handling was extracted into `processQueryEvent` (comments preserved) so the payload path shares the BEGIN/COMMIT/XA/DDL logic with the uncompressed path.
- **XA transactions are compressed too** (verified on MySQL 8.0.43): the whole first group — `XA START`, row events, `XA END`, `XA_prepare` — arrives inside one payload, with only the terminal `XA COMMIT` outside under its own GTID. Without the `GenericEvent`/`XA_PREPARE_LOG_EVENT` case in the payload processor, compressed XA would wedge the GTID client.

## Testing

New integration tests use **session-scoped** compression on a dedicated connection, so the shared test server's global state is never touched (keeping with the no-`SET GLOBAL` convention in the check tests):

- `TestReplClientTransactionCompression` / `TestGTIDClientTransactionCompression`: single-row autocommit, a multi-statement transaction (insert/update/delete), and interleaved uncompressed DML; assert delta counts, flush, and final table contents.
- `TestGTIDClientXATransactionCompression`: the XA two-phase dance plus the one-phase variant under compression, mirroring `TestGTIDClientXATransaction`'s xid/table hygiene.
- `TestDDLNotificationTransactionCompression`: DDL from a compressed session still triggers the schema-change cancel (DDL is currently excluded from compression by the server, but the payload path also runs QueryEvents through DDL detection in case that changes).
- Tests skip on servers < 8.0.20; all CI lanes (8.0.28+) run them.

Verified the tests fail against the unfixed code with exactly the two production failure modes: `GetDeltaLen()==0` (silent delta loss) on the binlog client, and a `BlockWait` timeout on the GTID client. Full `pkg/change` suite passes with `-race`; the preflight negative branch and the 1193 tolerance path were both verified against a live server.

Docs: added `binlog_transaction_compression=OFF` to the README requirements list and `docs/migrate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
