### PR TITLE
Suppress per-chunk log flood when chunk size is pinned at the floor

### DIFF
--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -355,15 +355,7 @@ func (t *chunkerComposite) Feedback(chunk *Chunk, d time.Duration, actualRows ui
 	// If any copyRows tasks take 5x the target size we reduce immediately
 	// and don't wait for more feedback.
 	if d > t.ChunkerTarget*DynamicPanicFactor {
-		newTarget := uint64(float64(t.chunkSize) / float64(DynamicPanicFactor*2))
-		t.logger.Info("high chunk processing time",
-			"time", d,
-			"threshold", t.ChunkerTarget*DynamicPanicFactor,
-			"target-rows", t.chunkSize,
-			"target-ms", t.ChunkerTarget,
-			"new-target-rows", newTarget,
-		)
-		t.updateChunkerTarget(newTarget)
+		t.panicShrink(t.logger, d)
 		return
 	}
 

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -381,15 +381,7 @@ func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, _ uint64) {
 	// If any copyRows tasks take 5x the target size we reduce immediately
 	// and don't wait for more feedback.
 	if d > t.ChunkerTarget*DynamicPanicFactor {
-		newTarget := uint64(float64(t.chunkSize) / float64(DynamicPanicFactor*2))
-		t.logger.Info("high chunk processing time",
-			"time", d,
-			"threshold", t.ChunkerTarget*DynamicPanicFactor,
-			"target-rows", t.chunkSize,
-			"target-ms", t.ChunkerTarget,
-			"new-target-rows", newTarget,
-		)
-		t.updateChunkerTarget(newTarget)
+		t.panicShrink(t.logger, d)
 		return
 	}
 

--- a/pkg/table/dynamic_chunk_sizer.go
+++ b/pkg/table/dynamic_chunk_sizer.go
@@ -1,6 +1,9 @@
 package table
 
-import "time"
+import (
+	"log/slog"
+	"time"
+)
 
 // dynamicChunkSizer holds the time-based chunk-sizing state shared by the
 // optimistic and composite chunkers. The chunker target is "spend
@@ -15,6 +18,49 @@ type dynamicChunkSizer struct {
 	chunkTimingInfo       []time.Duration
 	ChunkerTarget         time.Duration // e.g. 500ms target per chunk
 	disableDynamicChunker bool          // only used by the test suite
+	// pinnedAtFloor records that we have already warned about the chunk size
+	// being stuck at MinDynamicRowSize. It suppresses the per-chunk
+	// "high chunk processing time" log once shrinking is no longer possible,
+	// and is re-armed by updateChunkerTarget once the chunk size climbs back
+	// above the floor. See panicShrink.
+	pinnedAtFloor bool
+}
+
+// panicShrink reacts to a chunk whose processing time blew past the panic
+// threshold (ChunkerTarget*DynamicPanicFactor) by shrinking the chunk size
+// immediately, without waiting to accumulate more feedback.
+//
+// The per-chunk "high chunk processing time" line is only emitted while the
+// chunk size can still shrink. Once the chunk size is already at
+// MinDynamicRowSize, the recalculated target clamps straight back to the floor
+// and the message becomes unactionable — yet copiers call Feedback once per
+// chunk, so it would otherwise repeat for every chunk of the table (tens of
+// millions of identical lines on a wide-row table, enough to overflow a
+// downstream log store). At the floor we instead emit a single Warn describing
+// the real condition and suppress further lines until we climb back off the
+// floor. Caller must hold the chunker's mutex.
+func (d *dynamicChunkSizer) panicShrink(logger *slog.Logger, dur time.Duration) {
+	newTarget := uint64(float64(d.chunkSize) / float64(DynamicPanicFactor*2))
+	if d.chunkSize <= MinDynamicRowSize {
+		if !d.pinnedAtFloor {
+			logger.Warn("chunk size pinned at minimum; rows may be too wide to meet target-chunk-time",
+				"time", dur,
+				"threshold", d.ChunkerTarget*DynamicPanicFactor,
+				"min-rows", MinDynamicRowSize,
+				"target-ms", d.ChunkerTarget,
+			)
+			d.pinnedAtFloor = true
+		}
+	} else {
+		logger.Info("high chunk processing time",
+			"time", dur,
+			"threshold", d.ChunkerTarget*DynamicPanicFactor,
+			"target-rows", d.chunkSize,
+			"target-ms", d.ChunkerTarget,
+			"new-target-rows", newTarget,
+		)
+	}
+	d.updateChunkerTarget(newTarget)
 }
 
 // updateChunkerTarget applies a recalculated row target after clamping
@@ -24,6 +70,11 @@ type dynamicChunkSizer struct {
 // the chunker's mutex.
 func (d *dynamicChunkSizer) updateChunkerTarget(newTarget uint64) {
 	d.chunkSize = d.boundaryCheckTargetChunkSize(newTarget)
+	// Re-arm the pinned-at-floor warning once we successfully climb back above
+	// the minimum, so a later relapse is reported again. See panicShrink.
+	if d.chunkSize > MinDynamicRowSize {
+		d.pinnedAtFloor = false
+	}
 	d.chunkTimingInfo = []time.Duration{}
 }
 

--- a/pkg/table/dynamic_chunk_sizer_test.go
+++ b/pkg/table/dynamic_chunk_sizer_test.go
@@ -1,11 +1,31 @@
 package table
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// countingHandler is a minimal slog.Handler that tallies emitted records by
+// (level, message) so tests can assert on logging volume.
+type countingHandler struct {
+	counts map[string]int
+}
+
+func newCountingHandler() *countingHandler {
+	return &countingHandler{counts: make(map[string]int)}
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.counts[r.Level.String()+":"+r.Message]++
+	return nil
+}
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(string) slog.Handler      { return h }
 
 // TestBoundaryCheckTargetChunkSize verifies the dynamic-chunk-sizer
 // clamping rules. The 1.5x per-step growth cap is checked first and
@@ -60,4 +80,70 @@ func TestCalculateNewTargetChunkSize(t *testing.T) {
 	require.Equal(t, 100*time.Millisecond, p90)
 	require.Equal(t, uint64(5000), newTarget,
 		"newTarget = chunkSize * ChunkerTarget / p90")
+}
+
+const highChunkMsg = "INFO:high chunk processing time"
+const pinnedMsg = "WARN:chunk size pinned at minimum; rows may be too wide to meet target-chunk-time"
+
+// TestPanicShrinkAboveFloorLogs verifies that while the chunk size can still
+// shrink, panicShrink emits the per-shrink "high chunk processing time" line
+// and reduces the chunk size.
+func TestPanicShrinkAboveFloorLogs(t *testing.T) {
+	h := newCountingHandler()
+	d := &dynamicChunkSizer{chunkSize: 1000, ChunkerTarget: 100 * time.Millisecond}
+
+	d.panicShrink(slog.New(h), time.Second)
+
+	require.Equal(t, uint64(100), d.chunkSize,
+		"newTarget = 1000/(DynamicPanicFactor*2) = 100, still above the floor")
+	require.Equal(t, 1, h.counts[highChunkMsg], "should log the shrink once")
+	require.Zero(t, h.counts[pinnedMsg], "not at the floor yet")
+	require.False(t, d.pinnedAtFloor)
+}
+
+// TestPanicShrinkAtFloorSuppressesFlood is the regression test for the log
+// flood: once the chunk size is pinned at MinDynamicRowSize, repeated panic
+// feedback (one call per copied chunk) must NOT emit a line per chunk. Exactly
+// one Warn is emitted for the whole stuck period.
+func TestPanicShrinkAtFloorSuppressesFlood(t *testing.T) {
+	h := newCountingHandler()
+	logger := slog.New(h)
+	d := &dynamicChunkSizer{chunkSize: MinDynamicRowSize, ChunkerTarget: 100 * time.Millisecond}
+
+	// Simulate a wide-row table where every 10-row chunk blows past the panic
+	// threshold — the copier calls Feedback (→ panicShrink) once per chunk.
+	for range 10_000 {
+		d.panicShrink(logger, time.Second)
+	}
+
+	require.Equal(t, uint64(MinDynamicRowSize), d.chunkSize, "stays pinned at the floor")
+	require.Zero(t, h.counts[highChunkMsg],
+		"the per-chunk Info line must be suppressed at the floor")
+	require.Equal(t, 1, h.counts[pinnedMsg],
+		"exactly one Warn for the whole stuck period, not one per chunk")
+	require.True(t, d.pinnedAtFloor)
+}
+
+// TestPanicShrinkReArmsAfterRecovery verifies that if the chunk size climbs
+// back above the floor, a later relapse is reported again (the warning is not
+// permanently silenced).
+func TestPanicShrinkReArmsAfterRecovery(t *testing.T) {
+	h := newCountingHandler()
+	logger := slog.New(h)
+	d := &dynamicChunkSizer{chunkSize: MinDynamicRowSize, ChunkerTarget: 100 * time.Millisecond}
+
+	d.panicShrink(logger, time.Second) // pin + warn once
+	require.Equal(t, 1, h.counts[pinnedMsg])
+	require.True(t, d.pinnedAtFloor)
+
+	// Recover: normal feedback grows the chunk size back above the floor.
+	d.updateChunkerTarget(1000)
+	require.False(t, d.pinnedAtFloor, "climbing off the floor re-arms the warning")
+
+	// Relapse straight back to the floor and stay there.
+	d.panicShrink(logger, time.Second) // 1000/10 = 100, above floor → Info
+	d.chunkSize = MinDynamicRowSize    // simulate reaching the floor again
+	d.panicShrink(logger, time.Second) // at floor → Warn again
+
+	require.Equal(t, 2, h.counts[pinnedMsg], "relapse must warn again")
 }


### PR DESCRIPTION
## Problem

A migration permanently failed at 26% of the copy phase. The surfaced error was a downstream orchestrator failing to flush its execution log: `Result of concat() was larger than max_allowed_packet (67108864)`. That overflow was a **symptom** — Spirit had emitted a flood of log lines that blew the log store's append buffer past 64MB.

## Root cause

The dynamic chunker floors chunk size at `MinDynamicRowSize` (10). In the panic branch of `Feedback` (fires when a chunk exceeds `ChunkerTarget*DynamicPanicFactor`), the recalculated target is `chunkSize / (DynamicPanicFactor*2)`. Once `chunkSize == 10`, that computes to 1 and clamps straight back to 10 — the chunker is **pinned at the floor**.

For a table whose rows are wide/expensive enough that even a 10-row chunk exceeds the panic threshold, every subsequent chunk re-trips the panic branch. Copiers call `Feedback` once per chunk, so `"high chunk processing time"` was logged **once per chunk** — ~35M identical Info lines over 356M rows. The same path runs during checksum (`checksum/*` also call `Feedback`), so the flood is not copy-specific.

## Fix

Centralize the panic-branch shrink into a shared `dynamicChunkSizer.panicShrink`, used by both the optimistic and composite chunkers:

- **Above the floor:** unchanged — logs `high chunk processing time` at Info per shrink.
- **At the floor:** shrinking is impossible, so emit a single Warn (`chunk size pinned at minimum; rows may be too wide to meet target-chunk-time`) and suppress the per-chunk line.
- **Re-arms** once the chunk size climbs back above the floor, so a later relapse is reported again.

This removes the flood while preserving the real operational signal (this table can't meet `target-chunk-time` even at the minimum chunk size).

## Tests

Added `TestPanicShrink*` covering flood suppression at the floor, per-shrink logging above the floor, and re-arm after recovery. Existing chunker suite + `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)