### PR TITLE
Fix flaky TestMoveReverseWindowResumesAfterKill

### DIFF
--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -59,6 +59,20 @@ func tableExists(t *testing.T, db *sql.DB, schema, name string) bool {
 	return true
 }
 
+// waitForTable polls until a table exists (or the deadline passes). Used to
+// synchronize on a rename that lands shortly after another observable signal.
+func waitForTable(t *testing.T, db *sql.DB, schema, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if tableExists(t, db, schema, name) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s.%s to exist", schema, name)
+}
+
 // waitForReverseWindow polls the checkpoint until the move has entered its
 // reverse window (move_phase = reverse_window), i.e. cutover has happened.
 func waitForReverseWindow(t *testing.T, db *sql.DB, dstDBName string) {
@@ -248,6 +262,12 @@ func TestMoveReverseWindowResumesAfterKill(t *testing.T) {
 	go func() { _ = run1.Run(ctx1); close(run1Done) }()
 
 	waitForReverseWindow(t, ctl, "rwrk_dst")
+	// The checkpoint (phase=reverse_window) is written under the source lock
+	// just BEFORE the source rename to _old, so observing the phase alone races
+	// the rename. Wait for the retire to actually land before "killing" the
+	// process, so run 1 is interrupted in the state this test means to resume
+	// from: source retired to _old, target serving.
+	waitForTable(t, ctl, "rwrk_src", "t1_old")
 	cancel1() // "kill" the process mid-window
 	<-run1Done
 	utils.CloseAndLog(run1)


### PR DESCRIPTION
## Problem

`TestMoveReverseWindowResumesAfterKill` fails intermittently in CI:

```
reversewindow_test.go:256:
    Error:   Should be true
    Messages: source should be retired to _old mid-window
```

## Root cause

A test/product ordering race, not a product bug.

During cutover, the `postSwitch` hook (`captureReverseWindow`) writes the checkpoint `phase=reverse_window` while still under the source lock — **before** `renameAllSources` retires the source `t1` → `t1_old` (`cutover.go`). The checkpoint precedes the rename intentionally: the reverse-feed start position must be captured while the source is quiescent under lock.

The test's `waitForReverseWindow` polls only the checkpoint phase, so it can return in the gap between the checkpoint write and the source rename. `cancel1()` then kills run 1 before `t1` → `t1_old` completes, so the "interrupted state" assertion at line 256 fails.

## Fix

Test-only. After `waitForReverseWindow`, wait for the source retire to actually land (`t1_old` exists) before "killing" the process, so run 1 is interrupted in exactly the state this test means to resume from: source retired to `_old`, target serving. Adds a small `waitForTable` polling helper.

No product change — the reverse-window ordering is left as-is.

## Verification

- `go vet ./pkg/move/` clean
- `TestMoveReverseWindowResumesAfterKill` — 10/10 passes (was flaky)
- Full `TestMoveReverseWindow*` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)