### PR TITLE
check: add ScopeStatement for statement-level refusal classification

### DIFF
--- a/pkg/migration/check/check.go
+++ b/pkg/migration/check/check.go
@@ -87,8 +87,11 @@ func registerCheck(name string, callback func(context.Context, Resources, *slog.
 // Checks run in name order so that a statement failing more than one
 // check always reports the same error.
 func RunChecks(ctx context.Context, r Resources, logger *slog.Logger, scope ScopeFlag) error {
-	for _, name := range slices.Sorted(maps.Keys(checks)) {
-		check := checks[name]
+	lock.Lock()
+	registered := maps.Clone(checks)
+	lock.Unlock()
+	for _, name := range slices.Sorted(maps.Keys(registered)) {
+		check := registered[name]
 		if check.scope&scope == 0 {
 			continue
 		}

--- a/pkg/migration/check/check.go
+++ b/pkg/migration/check/check.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -24,6 +26,18 @@ const (
 	ScopeCutover     ScopeFlag = 1 << 3
 	ScopePostCutover ScopeFlag = 1 << 4
 	ScopeTesting     ScopeFlag = 1 << 5
+	// ScopeStatement marks preflight checks that classify the ALTER statement
+	// itself: they decide from the parsed statement alone whether Spirit
+	// refuses to run it, never touching a database connection. Callers can run
+	// them via RunChecks with only Resources.Statement set (Table is optional
+	// and widens coverage when present) to determine up front that a statement
+	// would be refused — for example, a planning tool classifying DDL before
+	// an apply. Passing these checks is not a promise Spirit will accept the
+	// statement: checks that need a live connection (existing foreign keys,
+	// triggers, privileges, ...) still run only at preflight. A check tagged
+	// with this scope must tolerate every Resources field except Statement
+	// being unset.
+	ScopeStatement ScopeFlag = 1 << 6
 )
 
 type Resources struct {
@@ -69,9 +83,12 @@ func registerCheck(name string, callback func(context.Context, Resources, *slog.
 	checks[name] = check{callback: callback, scope: scope}
 }
 
-// RunChecks runs all checks that are registered for the given scope
+// RunChecks runs all checks that are registered for the given scope.
+// Checks run in name order so that a statement failing more than one
+// check always reports the same error.
 func RunChecks(ctx context.Context, r Resources, logger *slog.Logger, scope ScopeFlag) error {
-	for _, check := range checks {
+	for _, name := range slices.Sorted(maps.Keys(checks)) {
+		check := checks[name]
 		if check.scope&scope == 0 {
 			continue
 		}

--- a/pkg/migration/check/dropadd.go
+++ b/pkg/migration/check/dropadd.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCheck("dropadd", dropAddCheck, ScopePreflight)
+	registerCheck("dropadd", dropAddCheck, ScopePreflight|ScopeStatement)
 }
 
 // dropAddCheck checks for a DROP and then ADD in the same statement.

--- a/pkg/migration/check/foreignkey.go
+++ b/pkg/migration/check/foreignkey.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCheck("addforeignkey", addForeignKeyCheck, ScopePreflight)
+	registerCheck("addforeignkey", addForeignKeyCheck, ScopePreflight|ScopeStatement)
 	registerCheck("hasforeignkeys", hasForeignKeysCheck, ScopePreflight)
 }
 

--- a/pkg/migration/check/illegalclause.go
+++ b/pkg/migration/check/illegalclause.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	registerCheck("illegalClause", illegalClauseCheck, ScopePreflight)
+	registerCheck("illegalClause", illegalClauseCheck, ScopePreflight|ScopeStatement)
 }
 
 // illegalClauseCheck checks for the presence of specific, unsupported

--- a/pkg/migration/check/primarykey.go
+++ b/pkg/migration/check/primarykey.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registerCheck("primarykey", primaryKeyCheck, ScopePreflight)
+	registerCheck("primarykey", primaryKeyCheck, ScopePreflight|ScopeStatement)
 }
 
 func primaryKeyCheck(ctx context.Context, r Resources, logger *slog.Logger) error {

--- a/pkg/migration/check/rename.go
+++ b/pkg/migration/check/rename.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	registerCheck("rename", renameCheck, ScopePreflight)
+	registerCheck("rename", renameCheck, ScopePreflight|ScopeStatement)
 }
 
 // renameCheck validates rename operations in ALTER TABLE statements.

--- a/pkg/migration/check/statement_scope_test.go
+++ b/pkg/migration/check/statement_scope_test.go
@@ -1,0 +1,98 @@
+package check
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/block/spirit/pkg/statement"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatementScopeChecks runs the statement-scoped checks the way an
+// external classifier does: only Resources.Statement is set — no database
+// connection and no table metadata. Statements Spirit deterministically
+// refuses must fail with the same message preflight would report, and
+// ordinary schema changes must pass.
+func TestStatementScopeChecks(t *testing.T) {
+	tests := []struct {
+		name    string
+		stmt    string
+		wantErr string
+	}{
+		{
+			name:    "drop primary key is refused",
+			stmt:    "ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY (anothercol)",
+			wantErr: "dropping primary key is not supported",
+		},
+		{
+			name:    "add foreign key is refused",
+			stmt:    "ALTER TABLE t1 ADD CONSTRAINT fk FOREIGN KEY (user_id) REFERENCES users (id)",
+			wantErr: "adding foreign key constraints is not supported",
+		},
+		{
+			name:    "explicit algorithm clause is refused",
+			stmt:    "ALTER TABLE t1 ADD COLUMN b INT, ALGORITHM=INPLACE",
+			wantErr: "ALGORITHM=",
+		},
+		{
+			name:    "explicit lock clause is refused",
+			stmt:    "ALTER TABLE t1 ADD COLUMN b INT, LOCK=NONE",
+			wantErr: "LOCK=",
+		},
+		{
+			name:    "drop and re-add of the same column is refused",
+			stmt:    "ALTER TABLE t1 DROP COLUMN b, ADD COLUMN b INT",
+			wantErr: "mentioned 2 times",
+		},
+		{
+			name:    "table rename is refused",
+			stmt:    "ALTER TABLE t1 RENAME TO t2",
+			wantErr: "table renames are not supported",
+		},
+		{
+			name:    "rename overlapping an added column is refused",
+			stmt:    "ALTER TABLE t1 RENAME COLUMN c1 TO n1, ADD COLUMN c1 INT",
+			wantErr: "could cause data corruption",
+		},
+		{
+			name: "add column passes",
+			stmt: "ALTER TABLE t1 ADD COLUMN b INT",
+		},
+		{
+			name: "add index passes",
+			stmt: "ALTER TABLE t1 ADD INDEX idx_b (b)",
+		},
+		{
+			name: "column rename passes without table metadata",
+			stmt: "ALTER TABLE t1 RENAME COLUMN c1 TO c2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Resources{Statement: statement.MustNew(tt.stmt)[0]}
+			err := RunChecks(t.Context(), r, slog.Default(), ScopeStatement)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestStatementScopeChecksDeterministicError verifies that a statement failing
+// more than one statement-scoped check reports the same error every run:
+// RunChecks iterates checks in name order, so classifiers surfacing the error
+// to users see a stable message.
+func TestStatementScopeChecksDeterministicError(t *testing.T) {
+	const stmt = "ALTER TABLE t1 DROP PRIMARY KEY, ADD CONSTRAINT fk FOREIGN KEY (user_id) REFERENCES users (id)"
+	first := RunChecks(t.Context(), Resources{Statement: statement.MustNew(stmt)[0]}, slog.Default(), ScopeStatement)
+	require.Error(t, first)
+	for range 20 {
+		err := RunChecks(t.Context(), Resources{Statement: statement.MustNew(stmt)[0]}, slog.Default(), ScopeStatement)
+		require.Error(t, err)
+		assert.Equal(t, first.Error(), err.Error())
+	}
+}


### PR DESCRIPTION
## Why

Spirit's statement-level preflight checks — `primarykey`, `addforeignkey`, `illegalClause`, `dropadd`, `rename` — decide from the parsed statement alone whether Spirit refuses to run it. External tools that want to classify DDL *before* an apply (e.g. SchemaBot marking statements as engine-blocked at plan time) can't reach them today: the checks are unexported and registered in a private map, so callers re-implement them down to the exact error strings and drift silently when a check changes upstream.

## What

- New `ScopeStatement` scope flag, tagged onto the five checks that are pure functions of the parsed statement. Callers run exactly that set via the already-exported `check.RunChecks` with only `Resources.Statement` populated — no database connection. (`rename` additionally uses `Resources.Table` when present to also block PK-column renames; with no table metadata it still blocks table renames and rename/add overlap patterns.)
- `RunChecks` now iterates checks in name order, so a statement failing more than one check reports the same error every run — previously map iteration made the surfaced error nondeterministic (as noted in `pkg/move/runner.go`'s resume path).
- Tests run the statement scope exactly as an external classifier would: refused shapes report preflight's message with no DB, ordinary changes pass, and the multi-failure error is stable across runs.

Passing the statement-scoped checks is not a promise Spirit will accept the statement — checks that need a live connection (`hasforeignkeys`, triggers, privileges, …) still run only at preflight. The scope's contract is one-directional: any failure is a statement Spirit will always refuse.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5)