### PR TITLE
Reserve 2 vCPUs when auto-sizing write threads on Aurora

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -411,7 +411,9 @@ By default Spirit does not dynamically adjust the number of threads while runnin
 
 Sets the parallelism of the **replication applier** — the number of concurrent write threads used to apply changes (read from the binlog) to the new table. Copier and checksum parallelism are controlled separately by [threads](#threads).
 
-A value of `0` means **auto**: on Aurora, Spirit sets `write-threads` to the instance vCPU count (read from `@@innodb_buffer_pool_instances`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+A value of `0` means **auto**: on Aurora, Spirit sets `write-threads` to the instance vCPU count minus 2 (minimum 1), read from `@@innodb_buffer_pool_instances`. The reserved vCPUs leave headroom for the copier's read side, the checksum, and the server's own work. On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+
+When [autoscaling](#enable-experimental-autoscaling) is enabled, this auto-sized value is the *starting* point, and the controller can grow the pool back toward its ceiling when the instance has spare capacity.
 
 ### enable-experimental-autoscaling
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -186,6 +186,6 @@ How many chunks to copy in parallel from the source.
 
 How many concurrent write threads to use per target when inserting rows. This controls the fan-out parallelism of the buffered copier's write side.
 
-A value of `0` means **auto**: on Aurora, the value is set to the target instance's vCPU count (read from `@@innodb_buffer_pool_instances`). On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
+A value of `0` means **auto**: on Aurora, the value is set to the target instance's vCPU count minus 2 (minimum 1), read from `@@innodb_buffer_pool_instances`. The reserved vCPUs leave headroom for the read side and the server's own work. On non-Aurora targets there is no reliable vCPU signal, so the default of `4` is used instead. Because the default is already `4`, you only opt into auto-sizing by explicitly passing `--write-threads 0`.
 
 Move does not support the experimental write-thread autoscaling available in [`spirit migrate`](migrate.md#enable-experimental-autoscaling).

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -35,7 +35,7 @@ type Migration struct {
 	Table        string  `name:"table" help:"Table" optional:""`
 	Alter        string  `name:"alter" help:"The alter statement to run on the table" optional:""`
 	Threads      int     `name:"threads" help:"Number of concurrent threads for copy and checksum tasks" optional:"" default:"4"`
-	WriteThreads int     `name:"write-threads" help:"Number of concurrent apply (write) threads. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" optional:"" default:"4"`
+	WriteThreads int     `name:"write-threads" help:"Number of concurrent apply (write) threads. 0 = auto: on Aurora this is set to the instance vCPU count minus 2 (min 1), leaving CPU headroom; on non-Aurora targets it falls back to the default" optional:"" default:"4"`
 
 	// EnableExperimentalAutoscaling turns on dynamic write-thread scaling driven
 	// by throttler feedback; WriteThreads becomes the starting value and the

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -20,7 +20,7 @@ type Move struct {
 	// in). The Kong default below must stay equal to table.DefaultTargetChunkBytes.
 	TargetChunkSize       uint64        `name:"target-chunk-size" help:"In-memory byte budget per copy chunk (in bytes)." default:"16777216"`
 	Threads               int           `name:"threads" help:"How many chunks to copy in parallel" default:"2"`
-	WriteThreads          int           `name:"write-threads" help:"How many concurrent write threads to use per target. 0 = auto: on Aurora this is set to the instance vCPU count; on non-Aurora targets it falls back to the default" default:"4"`
+	WriteThreads          int           `name:"write-threads" help:"How many concurrent write threads to use per target. 0 = auto: on Aurora this is set to the instance vCPU count minus 2 (min 1), leaving CPU headroom; on non-Aurora targets it falls back to the default" default:"4"`
 	CreateSentinel        bool          `name:"create-sentinel" help:"Create a sentinel table on the first target database to block after table copy" default:"false"`
 	DeferSecondaryIndexes bool          `name:"defer-secondary-indexes" help:"Create target tables without secondary indexes, add them before cutover" default:"false"`
 	CheckpointMaxAge      time.Duration `name:"checkpoint-max-age" help:"Maximum age of a checkpoint before refusing to resume from it" optional:"" default:"168h"`

--- a/pkg/throttler/aurora_threads.go
+++ b/pkg/throttler/aurora_threads.go
@@ -189,13 +189,21 @@ func AuroraVCPUs(ctx context.Context, db *sql.DB) (int, error) {
 	return vCPUs, nil
 }
 
+// WriteThreadVCPUReserve is the number of vCPUs auto-sizing leaves free when
+// sizing the apply (write) thread pool on Aurora, so the pool does not consume
+// the whole instance: the copier's read side, the checksum, and the server's
+// own work need room too. Auto-sizing resolves to max(1, vCPUs - this). On 4+
+// vCPU instances it is the autoscaler's starting value (the controller can grow
+// back up under spare capacity); below MinAutoscaleVCPUs it is the fixed size.
+const WriteThreadVCPUReserve = 2
+
 // ResolveWriteThreads resolves the number of apply (write) threads to use
 // against a target. A positive requested value is returned unchanged. Zero
-// means "auto-size": on Aurora it resolves to the instance vCPU count
-// (@@innodb_buffer_pool_instances); on non-Aurora there is no reliable vCPU
-// signal to size from, so it falls back to DefaultWriteThreads (logging that it
-// did so).
-// A negative value is rejected.
+// means "auto-size": on Aurora it resolves to max(1, vCPUs -
+// WriteThreadVCPUReserve) from @@innodb_buffer_pool_instances (reserving vCPUs
+// for the rest of the workload); on non-Aurora there is no reliable vCPU signal
+// to size from, so it falls back to DefaultWriteThreads (logging that it did
+// so). A negative value is rejected.
 func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int, logger *slog.Logger) (int, error) {
 	if requested < 0 {
 		return 0, fmt.Errorf("write threads must be non-negative, got %d", requested)
@@ -220,7 +228,11 @@ func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int, logger 
 			"write_threads", DefaultWriteThreads)
 		return DefaultWriteThreads, nil
 	}
-	return AuroraVCPUs(ctx, db)
+	vCPUs, err := AuroraVCPUs(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	return max(1, vCPUs-WriteThreadVCPUReserve), nil
 }
 
 // MinAutoscaleVCPUs is the smallest instance size (in vCPUs) on which the

--- a/pkg/throttler/aurora_threads_test.go
+++ b/pkg/throttler/aurora_threads_test.go
@@ -291,6 +291,25 @@ func TestResolveWriteThreads_NonAuroraUsesDefault_LocalMySQL(t *testing.T) {
 	require.Equal(t, DefaultWriteThreads, n)
 }
 
+func TestWriteThreadVCPUReserve(t *testing.T) {
+	// Auto-sizing on Aurora resolves to max(1, vCPUs - WriteThreadVCPUReserve).
+	// The Aurora probe needs a real Aurora instance, so this pins the reserve
+	// and the resulting vCPU->threads mapping (including the floor at 1) that the
+	// auto-size branch of ResolveWriteThreads applies.
+	require.Equal(t, 2, WriteThreadVCPUReserve, "reserve is documented as 2 vCPUs in migrate.md/move.md and the flag help")
+	for _, tc := range []struct {
+		vCPUs, want int
+	}{
+		{1, 1}, // floors at 1
+		{2, 1}, // r6g.large: 2 vCPUs -> 1 applier
+		{3, 1},
+		{4, 2},
+		{8, 6},
+	} {
+		require.Equalf(t, tc.want, max(1, tc.vCPUs-WriteThreadVCPUReserve), "vCPUs=%d", tc.vCPUs)
+	}
+}
+
 func TestResolveMaxWriteThreads(t *testing.T) {
 	// Autoscaling disabled: the cap equals start so the count cannot move,
 	// regardless of mode or the commit-latency backstop.


### PR DESCRIPTION
## What

Auto-sizing the apply (write) thread pool on Aurora now reserves 2 vCPUs — it resolves to `max(1, vCPUs - 2)` from `@@innodb_buffer_pool_instances` instead of the full vCPU count.

## Why

Sizing the applier pool to the full vCPU count leaves no room for the rest of the migration's work — the copier's read side, the checksum, the replication reader — plus the server's own workload, so a small instance runs pinned. On an r6g.large (2 vCPUs) this took the applier pool from 2 threads down to 1, freeing roughly a full vCPU.

## Details

- Uniform across all Aurora sizes (no small-instance special case). On 4+ vCPU instances the auto-sized value is the autoscaler's *starting* point, so the controller can still grow the pool back toward its ceiling under spare capacity; below `MinAutoscaleVCPUs` (autoscaler disabled) it is the fixed pool size.
- An explicit `--write-threads` is honored unchanged — the reserve only affects auto-sizing (`--write-threads 0`).
- Non-Aurora targets are unaffected (no reliable vCPU signal; still fall back to the default).
- `datasync` is untouched — it does not auto-size write threads.
- Docs (migrate/move `write-threads` sections) and flag help updated; added `TestWriteThreadVCPUReserve` pinning the constant and the vCPU→threads mapping (2→1, 4→2, 8→6, floor at 1).
