### PR TITLE
Validate checkpoint GTID set against gtid_executed on resume

### DIFF
--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -168,6 +168,32 @@ func (c *gtidClient) getPurgedGTIDSet(ctx context.Context) (mysql.GTIDSet, error
 	return gset, nil
 }
 
+// validateResumeGTIDSet checks that a checkpointed GTID set is still a
+// usable resume coordinate on this server, wrapping failures with
+// ErrPositionNotFound so callers discard the checkpoint and start fresh.
+// Two containments must hold. flushed must cover purged: any purged GTID
+// missing from flushed is a change we still need whose binary log the
+// server has dropped. executed must contain flushed: any flushed GTID
+// missing from executed is a transaction this server never executed —
+// the server's GTID history has regressed relative to the checkpoint
+// (restore from an earlier backup/PITR, or failover to a replica that
+// lagged the server the checkpoint was written against). The protocol
+// does not catch the regression case for us: COM_BINLOG_DUMP_GTID treats
+// the requested set as "already applied" and never streams transactions
+// it does not know about, so resuming would silently skip every change
+// the checkpoint wrongly records as applied.
+func validateResumeGTIDSet(flushed, executed, purged mysql.GTIDSet) error {
+	if !flushed.Contain(purged) {
+		return fmt.Errorf("%w: requested GTID set does not cover @@GLOBAL.gtid_purged (purged=%s, requested=%s)",
+			ErrPositionNotFound, purged.String(), flushed.String())
+	}
+	if !executed.Contain(flushed) {
+		return fmt.Errorf("%w: @@GLOBAL.gtid_executed does not contain the requested GTID set; the server never executed transactions the checkpoint records as applied (failover or restore from backup?), so the migration must restart fresh (executed=%s, requested=%s)",
+			ErrPositionNotFound, executed.String(), flushed.String())
+	}
+	return nil
+}
+
 // normalizeGTIDString strips whitespace (including embedded newlines, which
 // MySQL injects when gtid_executed contains many UUID groups) before parse.
 func normalizeGTIDString(s string) string {
@@ -300,7 +326,8 @@ func (c *gtidClient) CurrentPosition(ctx context.Context) (string, error) {
 
 // StartFromPosition satisfies Source. It primes flushedGTID from the
 // previously-returned opaque string, validates it is still resumable
-// against gtid_purged, then begins streaming as Start would.
+// against the server's GTID state (see validateResumeGTIDSet), then
+// begins streaming as Start would.
 //
 // Parse failures are wrapped with ErrPositionNotFound. This matters
 // because the most likely real-world parse failure is an operator
@@ -350,8 +377,8 @@ func (c *gtidClient) buildSyncerConfig(host string, port uint16) replication.Bin
 
 // Start satisfies Source. On a fresh start it reads @@GLOBAL.gtid_executed
 // and begins streaming from there; on a resume (flushedGTID already
-// primed by StartFromPosition) it validates the position covers
-// gtid_purged before connecting.
+// primed by StartFromPosition) it validates the position against the
+// server's GTID state (see validateResumeGTIDSet) before connecting.
 func (c *gtidClient) Start(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -375,22 +402,24 @@ func (c *gtidClient) Start(ctx context.Context) error {
 
 	// Determine the starting GTID set. On fresh start, this is
 	// gtid_executed; on resume, the caller has primed flushedGTID and
-	// we just validate that the source still has the data after it.
+	// we validate it against the server's current GTID state before
+	// connecting.
 	if c.flushedGTID == nil || c.flushedGTID.IsEmpty() {
 		c.flushedGTID, err = c.getCurrentGTIDSet(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to read current GTID set, is gtid_mode=ON?: %w", err)
 		}
 	} else {
+		executed, err := c.getCurrentGTIDSet(ctx)
+		if err != nil {
+			return fmt.Errorf("could not verify GTID position: %w", err)
+		}
 		purged, err := c.getPurgedGTIDSet(ctx)
 		if err != nil {
 			return fmt.Errorf("could not verify GTID position: %w", err)
 		}
-		// If any GTID in purged is missing from our requested set, the
-		// source has dropped binlogs we'd need to apply.
-		if !c.flushedGTID.Contain(purged) {
-			return fmt.Errorf("%w: requested GTID set does not cover @@GLOBAL.gtid_purged (purged=%s, requested=%s)",
-				ErrPositionNotFound, purged.String(), c.flushedGTID.String())
+		if err := validateResumeGTIDSet(c.flushedGTID, executed, purged); err != nil {
+			return err
 		}
 	}
 	c.bufferedGTID = c.flushedGTID.Clone()

--- a/pkg/change/gtid_test.go
+++ b/pkg/change/gtid_test.go
@@ -191,6 +191,154 @@ func TestGTIDStartFromMalformedPosition(t *testing.T) {
 	require.ErrorIs(t, err, ErrPositionNotFound)
 }
 
+// TestValidateResumeGTIDSet pins the set algebra of the resume-time GTID
+// validation with synthetic sets, including multi-UUID sets, without
+// touching the shared server's global GTID state (which is why the
+// gtid_purged direction has no live-server test — see the note on
+// TestGTIDStartFromMalformedPosition). The executed direction does have
+// live-server coverage: TestGTIDResumeAfterGTIDHistoryRegression.
+//
+// The empty-flushed edge (a checkpoint written before any position was
+// observed) never reaches this validation: Position() returns "" then,
+// StartFromPosition rejects "", and a position that parses to an empty
+// set takes Start's fresh-start branch via IsEmpty.
+func TestValidateResumeGTIDSet(t *testing.T) {
+	const (
+		sidA = "11111111-2222-3333-4444-555555555555"
+		sidB = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+	)
+	tests := []struct {
+		name     string
+		flushed  string
+		executed string
+		purged   string
+		wantErr  string // required error substring; "" means the validation passes
+	}{
+		{
+			name:     "flushed strictly inside executed",
+			flushed:  sidA + ":1-5",
+			executed: sidA + ":1-10",
+		},
+		{
+			name:     "flushed equals executed",
+			flushed:  sidA + ":1-10",
+			executed: sidA + ":1-10",
+		},
+		{
+			name:     "multi-UUID flushed inside multi-UUID executed",
+			flushed:  sidA + ":1-5," + sidB + ":1-3",
+			executed: sidA + ":1-10," + sidB + ":1-3",
+			purged:   sidA + ":1-2",
+		},
+		{
+			name: "empty flushed passes trivially (defensive; Start never routes it here)",
+		},
+		{
+			name:     "flushed extends past executed on the same UUID",
+			flushed:  sidA + ":1-20",
+			executed: sidA + ":1-10",
+			wantErr:  "@@GLOBAL.gtid_executed does not contain",
+		},
+		{
+			name:     "flushed holds a UUID the server never executed",
+			flushed:  sidA + ":1-5," + sidB + ":1-3",
+			executed: sidA + ":1-10",
+			wantErr:  "@@GLOBAL.gtid_executed does not contain",
+		},
+		{
+			name:    "executed empty but flushed is not",
+			flushed: sidA + ":1-5",
+			wantErr: "@@GLOBAL.gtid_executed does not contain",
+		},
+		{
+			name:     "flushed does not cover purged",
+			flushed:  sidA + ":1-100",
+			executed: sidA + ":1-200",
+			purged:   sidA + ":1-105",
+			wantErr:  "does not cover @@GLOBAL.gtid_purged",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flushed, err := mysql.ParseMysqlGTIDSet(tt.flushed)
+			require.NoError(t, err)
+			executed, err := mysql.ParseMysqlGTIDSet(tt.executed)
+			require.NoError(t, err)
+			purged, err := mysql.ParseMysqlGTIDSet(tt.purged)
+			require.NoError(t, err)
+			err = validateResumeGTIDSet(flushed, executed, purged)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, ErrPositionNotFound,
+				"validation failures must classify as definitive so the caller restarts fresh instead of failing the run")
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// TestGTIDResumeAfterGTIDHistoryRegression covers the executed direction
+// of the resume validation against a live server: a checkpointed flushed
+// set containing GTIDs beyond @@GLOBAL.gtid_executed is exactly what a
+// checkpoint looks like after the server is restored from an earlier
+// backup/PITR or fails over to a replica that lagged the checkpointed
+// server. StartFromPosition must refuse it — the server itself would
+// not: COM_BINLOG_DUMP_GTID simply never streams transactions it does
+// not know about, so before this validation the resume proceeded and
+// silently skipped every change the checkpoint wrongly recorded as
+// applied. Unlike the gtid_purged direction this needs no global-state
+// mutation: gtid_executed only ever grows, so a synthetic future GTID
+// stays unexecuted no matter what concurrent tests commit.
+func TestGTIDResumeAfterGTIDHistoryRegression(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS gtidregresst1, gtidregresst2")
+	testutils.RunSQL(t, "CREATE TABLE gtidregresst1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE gtidregresst2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+
+	t1 := table.NewTableInfo(db, "test", "gtidregresst1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "gtidregresst2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	// Read gtid_executed after the DDL above so the server's own UUID is
+	// guaranteed to appear in it, and @@server_uuid for the same-UUID case.
+	var executedStr, serverUUID string
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT @@GLOBAL.gtid_executed").Scan(&executedStr))
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT @@server_uuid").Scan(&serverUUID))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	regressions := map[string]string{
+		// The checkpointed server had executed further than this
+		// (post-restore) server under the same UUID.
+		"same uuid, interval past executed": serverUUID + ":999999999999",
+		// The checkpoint was written against a different server entirely
+		// (failover to a peer that never replicated from it).
+		"uuid absent from executed": "abcdefab-1234-5678-9abc-def012345678:1",
+	}
+	for name, extra := range regressions {
+		t.Run(name, func(t *testing.T) {
+			flushed, err := mysql.ParseMysqlGTIDSet(normalizeGTIDString(executedStr))
+			require.NoError(t, err)
+			require.NoError(t, flushed.Update(extra))
+
+			client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*gtidClient)
+			chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+			require.NoError(t, err)
+			require.NoError(t, client.AddSubscription(t1, t2, chunker))
+
+			err = client.StartFromPosition(t.Context(), flushed.String())
+			require.ErrorIs(t, err, ErrPositionNotFound)
+			require.ErrorContains(t, err, "@@GLOBAL.gtid_executed does not contain")
+		})
+	}
+}
+
 // TestGTIDClientUnparseableDDL is a regression test: a QueryEvent the
 // TiDB parser cannot parse (CREATE TRIGGER, stored procedure bodies,
 // certain ALTER USER variants, ...) must still promote the


### PR DESCRIPTION
## Problem

When resuming a `--gtid` migration from a checkpoint, `Start()` validated only one
direction: the checkpoint's flushed GTID set had to cover `@@GLOBAL.gtid_purged`
(i.e. the binlogs spirit still needs have not been dropped). It never validated the
inverse — that the flushed set is contained in `@@GLOBAL.gtid_executed`.

If the server's GTID history regresses relative to the checkpoint — a restore from
an earlier backup/PITR, or a failover to a replica that lagged the server the
checkpoint was written against — the flushed set contains GTIDs the current server
never executed. The replication protocol does not catch this: `COM_BINLOG_DUMP_GTID`
treats the requested set as "already applied" and simply never streams transactions
it does not know about. The resume therefore proceeded, spirit positioned its stream
believing those transactions were applied to `_new`, and every change the checkpoint
wrongly recorded as applied was silently skipped — wrong rows on the target with no
error. (The checksum can catch it only if those rows are touched again later; rows in
already-checksummed or untouched ranges diverge silently.)

## Fix

Both containment checks now live in `validateResumeGTIDSet`:

- `flushed ⊇ purged` — unchanged, byte-identical error.
- `executed ⊇ flushed` — new. Failure means the server's GTID history has regressed
  relative to the checkpoint (failover or backup/PITR restore), and resuming would
  silently skip changes.

The new failure wraps `ErrPositionNotFound` exactly like the existing gtid_purged
check, so the migration runner classifies it as a definitive "cannot resume" and
falls back to a fresh migration instead of resuming into silent divergence.

## Tests

- `TestValidateResumeGTIDSet`: synthetic-set unit coverage — flushed ⊂ executed
  (pass), flushed == executed (pass), multi-UUID subset (pass), empty flushed
  (pass; `Start()` routes empty sets to the fresh-start branch anyway), same-UUID
  intervals past executed (fail), UUID absent from executed (fail), empty executed
  (fail), purged not covered (fail, pre-existing direction).
- `TestGTIDResumeAfterGTIDHistoryRegression`: live-server coverage. Builds a
  "regressed history" checkpoint by extending the server's own `gtid_executed`
  with `@@server_uuid:<huge GNO>` (restore flavor) and a foreign UUID (failover
  flavor) and asserts `StartFromPosition` refuses both with `ErrPositionNotFound`.
  Safe on a shared test server: `gtid_executed` only ever grows, so no global
  state is mutated. Both subtests fail without the fix (the resume returns nil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
