### PR TITLE
Fix early GTID promotion on unparseable mid-group QueryEvents

### DIFF
--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -213,11 +213,13 @@ func (c *gtidClient) getBufferedGTID() mysql.GTIDSet {
 // a no-op when there is no pending GTID (e.g. right after a reconnect).
 //
 // This must be called when — and only when — the current transaction's
-// binlog group ends: XIDEvent (InnoDB commit), a COMMIT or ROLLBACK
+// binlog group has ended: XIDEvent (InnoDB commit), a COMMIT or ROLLBACK
 // QueryEvent (non-transactional engines / mixed-engine rollbacks), a
-// standalone statement that is its own transaction (DDL, statements the
-// TiDB parser cannot parse such as CREATE TRIGGER or stored procedures),
-// an XA_PREPARE_LOG_EVENT, or an XA COMMIT / XA ROLLBACK QueryEvent.
+// parsed standalone statement that is its own transaction (DDL), an
+// XA_PREPARE_LOG_EVENT, an XA COMMIT / XA ROLLBACK QueryEvent, or the
+// next group's GTIDEvent — which proves the previous group ended, and is
+// what advances statements with no terminator we can recognize, such as
+// those the TiDB parser cannot parse (see processQueryEvent).
 // Every GTIDEvent the server streams corresponds to an entry in its
 // gtid_executed, so any path that drops a pending GTID instead of
 // promoting it leaves bufferedGTID permanently behind gtid_executed and
@@ -229,8 +231,10 @@ func (c *gtidClient) getBufferedGTID() mysql.GTIDSet {
 // and its row events are silently lost. This is why a mid-group QueryEvent
 // must not promote. Regular transactions have no mid-group QueryEvents
 // besides BEGIN and the SAVEPOINT family ("SAVEPOINT `x`", plus
-// "ROLLBACK TO `x`" in mixed-engine transactions), but XA transactions
-// do — their first group is written to
+// "ROLLBACK TO `x`" in mixed-engine transactions), but two group shapes
+// do: CREATE TABLE ... SELECT carries its unparseable CREATE TABLE
+// statement mid-group (see processQueryEvent), and XA transactions —
+// their first group is written to
 // the binlog in one piece at XA PREPARE time, shaped as (verified against
 // MySQL 8.0):
 //
@@ -556,8 +560,18 @@ func (c *gtidClient) readStream(ctx context.Context) {
 		switch event := ev.Event.(type) {
 		case *replication.GTIDEvent:
 			// The server emits a GTIDEvent at the start of every
-			// transaction. Stash its {SID,GNO} so we can promote it to
-			// bufferedGTID only after the matching XIDEvent.
+			// transaction, which also proves the previous group ended:
+			// groups never interleave within a binlog stream. A GTID
+			// still pending here belongs to that finished group — its
+			// terminator was not one we recognize (the QueryEvent of a
+			// standalone statement the parser cannot parse; see
+			// processQueryEvent) — and every one of its events has been
+			// processed by now, so promote it rather than dropping it,
+			// which would leave bufferedGTID permanently behind
+			// gtid_executed and wedge BlockWait/Flush forever. Then
+			// stash the new {SID,GNO} so the matching group terminator
+			// can promote it.
+			c.promotePendingGTID()
 			c.mu.Lock()
 			c.pendingSID = append(c.pendingSID[:0], event.SID...)
 			c.pendingGNO = event.GNO
@@ -707,14 +721,31 @@ func (c *gtidClient) processQueryEvent(event *replication.QueryEvent) {
 			"error", err,
 			"schema", string(event.Schema),
 			"gtid", c.getBufferedGTID().String())
-		// The statement was still a complete server transaction with
-		// its own GTID — promote it even though we could not parse
-		// it, otherwise bufferedGTID falls permanently behind
-		// gtid_executed and BlockWait/Flush never complete. Note the
-		// schema filter only applies after parsing, so *any*
-		// unparseable statement on the server (e.g. a stored
-		// procedure deploy in an unrelated schema) takes this path.
-		c.promotePendingGTID()
+		// An unparseable statement is usually a standalone
+		// single-statement transaction (CREATE TRIGGER, a stored
+		// procedure deploy) whose QueryEvent is also its group
+		// terminator — but not always: since 8.0.21 the server logs
+		// CREATE TABLE ... SELECT as GTIDEvent → Query(BEGIN) →
+		// Query("CREATE TABLE ... START TRANSACTION") → row events →
+		// XIDEvent (verified against MySQL 8.0.45), putting the
+		// unparseable statement mid-group with its row events still
+		// to come. We cannot tell the two shapes apart, so treat it
+		// like the other mid-group statements above and leave the
+		// pending GTID pending: promoting it here would let a
+		// concurrent flush publish it as a resume coordinate (and
+		// recreateStreamer resume past it after a stream hiccup)
+		// before the group's remaining events are buffered, silently
+		// losing them. The GTID is promoted by the group's own
+		// terminator if one follows (the XIDEvent, in the CTAS shape)
+		// or by the next GTIDEvent, which proves the group ended (see
+		// readStream). If such a statement is the very last thing the
+		// server executes, bufferedGTID trails gtid_executed by that
+		// one GTID until the next transaction arrives, so BlockWait
+		// can time out — loud and retryable, unlike a corrupted
+		// resume coordinate. Note the schema filter only applies
+		// after parsing, so *any* unparseable statement on the server
+		// (e.g. a stored procedure deploy in an unrelated schema)
+		// takes this path.
 		return
 	}
 	// MySQL emits a synthetic GTID for DDL statements too, but the

--- a/pkg/change/gtid_test.go
+++ b/pkg/change/gtid_test.go
@@ -193,8 +193,11 @@ func TestGTIDStartFromMalformedPosition(t *testing.T) {
 
 // TestGTIDClientUnparseableDDL is a regression test: a QueryEvent the
 // TiDB parser cannot parse (CREATE TRIGGER, stored procedure bodies,
-// certain ALTER USER variants, ...) must still promote the
-// transaction's pending GTID into bufferedGTID. (XA statements are also
+// certain ALTER USER variants, ...) must still get the transaction's
+// pending GTID into bufferedGTID — not at the QueryEvent itself (it
+// could sit mid-group; see
+// TestGTIDClientUnparseableQueryPromotionOrdering), but at the next
+// GTIDEvent, which proves the group ended. (XA statements are also
 // unparseable but never reach the parser — they get explicit handling
 // in readStream because promoting mid-XA-group would be incorrect; see
 // TestGTIDClientXAPromotionOrdering.) Every QueryEvent on
@@ -203,7 +206,8 @@ func TestGTIDStartFromMalformedPosition(t *testing.T) {
 // statement in a *completely unrelated schema* left bufferedGTID
 // permanently behind gtid_executed: BlockWait timed out forever, Flush
 // looped indefinitely, and a GTID-mode migration was wedged until
-// cancelled.
+// cancelled. The INSERT below doubles as the next-GTIDEvent promotion
+// trigger for the trigger-DDL's deferred GTID.
 func TestGTIDClientUnparseableDDL(t *testing.T) {
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
@@ -989,6 +993,242 @@ func TestGTIDClientSavepointTransaction(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1,2,4", pks,
 		"the row inserted between SAVEPOINT and ROLLBACK TO SAVEPOINT must not replicate; the rows before and after must")
+}
+
+// TestGTIDClientUnparseableQueryPromotionOrdering is the parser-failure
+// twin of TestGTIDClientSavepointPromotionOrdering. A QueryEvent the TiDB
+// parser cannot parse used to promote the pending GTID unconditionally,
+// on the assumption that an unparseable statement is always a standalone
+// single-statement transaction. It is not: since 8.0.21 the server logs
+// CREATE TABLE ... SELECT as GTIDEvent → Query(BEGIN) → Query("CREATE
+// TABLE ... START TRANSACTION") → row events → XIDEvent (shape verified
+// against MySQL 8.0.45), and the TiDB parser rejects the START
+// TRANSACTION suffix — so the promotion fired mid-group, before the
+// group's row events had been buffered. A flush in that window published
+// a resume coordinate that already covered the transaction (and
+// recreateStreamer resumed past it after a mere stream hiccup), so its
+// remaining events were silently lost.
+//
+// The fix defers instead: an unparseable QueryEvent never promotes, and
+// the pending GTID advances at the group's own terminator (the XIDEvent
+// here) or — for genuinely standalone statements such as CREATE TRIGGER,
+// which have no terminator we can recognize — at the next GTIDEvent,
+// which proves the group ended. Both shapes are covered below.
+//
+// Events are injected through a synthetic go-mysql BinlogStreamer for the
+// same reason as in the XA and savepoint tests: the server writes the
+// whole group to the binlog in one burst at commit, so wall-clock timing
+// cannot reliably observe the stream state between the unparseable
+// QueryEvent and the group terminator of the same burst. Row events for a
+// subscribed table are inert to the promotion logic and serve as ordering
+// barriers: events are consumed strictly in order, so once GetDeltaLen
+// reflects a row event, every event injected before it has been
+// processed. (In a real CTAS group the row events target the created —
+// unsubscribed — table; a subscribed table stands in for any group tail.)
+func TestGTIDClientUnparseableQueryPromotionOrdering(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	// Real tables so TableInfo has genuine column/PK metadata; the event
+	// stream itself is synthetic and never touches the server.
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS gtidunpsyn1, gtidunpsyn2")
+	testutils.RunSQL(t, "CREATE TABLE gtidunpsyn1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE gtidunpsyn2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+
+	t1 := table.NewTableInfo(db, "test", "gtidunpsyn1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "gtidunpsyn2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*gtidClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+
+	// Wire readStream to a synthetic streamer instead of client.Start().
+	empty, err := mysql.ParseMysqlGTIDSet("")
+	require.NoError(t, err)
+	streamer := replication.NewBinlogStreamer()
+	ctx, cancel := context.WithCancel(t.Context())
+	client.streamer = streamer
+	client.bufferedGTID = empty
+	client.flushedGTID = empty.Clone()
+	client.cancelFunc = cancel
+	client.streamWG.Add(1)
+	go client.readStream(ctx)
+	defer client.Close()
+
+	const sid = "aaaaaaaa-bbbb-cccc-dddd-000000000000"
+	sidUUID := uuid.MustParse(sid)
+	gtidEvent := func(gno int64) *replication.BinlogEvent {
+		return &replication.BinlogEvent{
+			Header: &replication.EventHeader{EventType: replication.GTID_EVENT},
+			Event:  &replication.GTIDEvent{SID: sidUUID[:], GNO: gno},
+		}
+	}
+	queryEvent := func(q string) *replication.BinlogEvent {
+		return &replication.BinlogEvent{
+			Header: &replication.EventHeader{EventType: replication.QUERY_EVENT},
+			Event:  &replication.QueryEvent{Schema: []byte("test"), Query: []byte(q)},
+		}
+	}
+	rowEvent := func(pk int32) *replication.BinlogEvent {
+		return &replication.BinlogEvent{
+			Header: &replication.EventHeader{EventType: replication.WRITE_ROWS_EVENTv2},
+			Event: &replication.RowsEvent{
+				Table: &replication.TableMapEvent{Schema: []byte("test"), Table: []byte("gtidunpsyn1")},
+				Rows:  [][]any{{pk, int32(0), int32(0)}},
+			},
+		}
+	}
+	inject := func(evs ...*replication.BinlogEvent) {
+		t.Helper()
+		for _, ev := range evs {
+			require.NoError(t, streamer.AddEventToStreamer(ev))
+		}
+	}
+	buffered := func(gno int64) bool {
+		target, err := mysql.ParseMysqlGTIDSet(fmt.Sprintf("%s:%d", sid, gno))
+		require.NoError(t, err)
+		return client.getBufferedGTID().Contain(target)
+	}
+
+	// Group 1: the CREATE TABLE ... SELECT shape, exactly as the server
+	// writes it (query text taken verbatim from a MySQL 8.0.45 binlog).
+	// The row event after the unparseable statement is the group tail the
+	// premature promotion used to put at risk.
+	inject(gtidEvent(300), queryEvent("BEGIN"),
+		queryEvent("CREATE TABLE `ctas1` (\n  `a` int NOT NULL,\n  `b` int DEFAULT NULL\n) START TRANSACTION"),
+		rowEvent(1))
+	require.Eventually(t, func() bool { return client.GetDeltaLen() == 1 },
+		5*time.Second, 5*time.Millisecond, "row event after the unparseable statement was not processed")
+	require.False(t, buffered(300),
+		"the GTID must not be promoted at an unparseable QueryEvent: the group's remaining events are not buffered yet")
+	client.mu.Lock()
+	pendingGNO := client.pendingGNO
+	client.mu.Unlock()
+	require.EqualValues(t, 300, pendingGNO, "the CTAS transaction's GTID must still be pending after the unparseable statement")
+
+	// The XIDEvent terminates the group; only now may the GTID enter the
+	// buffered (resume) set.
+	inject(&replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.XID_EVENT},
+		Event:  &replication.XIDEvent{XID: 1},
+	})
+	require.Eventually(t, func() bool { return buffered(300) },
+		5*time.Second, 5*time.Millisecond, "the XIDEvent must promote the pending GTID")
+
+	// Group 2: a genuinely standalone unparseable statement (CREATE
+	// TRIGGER). Its QueryEvent is its group terminator, but we cannot
+	// distinguish it from the CTAS shape above, so it must not promote
+	// either. (The row event is purely an ordering barrier — a real
+	// standalone-DDL group has none.)
+	inject(gtidEvent(301),
+		queryEvent("CREATE DEFINER=`root`@`localhost` TRIGGER trg BEFORE INSERT ON gtidunpsyn1 FOR EACH ROW SET @x = 1"),
+		rowEvent(2))
+	require.Eventually(t, func() bool { return client.GetDeltaLen() == 2 },
+		5*time.Second, 5*time.Millisecond, "row event after the trigger DDL was not processed")
+	require.False(t, buffered(301),
+		"a standalone unparseable statement must not promote at the QueryEvent: it is indistinguishable from a mid-group one")
+
+	// Liveness: the next GTIDEvent proves group 301 ended and must
+	// promote it before stashing its own — dropping it instead would
+	// leave bufferedGTID permanently behind gtid_executed.
+	inject(gtidEvent(302))
+	require.Eventually(t, func() bool { return buffered(301) },
+		5*time.Second, 5*time.Millisecond, "the next GTIDEvent must promote the deferred standalone statement's GTID")
+
+	// And the new group's own lifecycle is undisturbed by the leftover
+	// promotion: it still promotes at its XIDEvent, not before.
+	inject(queryEvent("BEGIN"), rowEvent(3))
+	require.Eventually(t, func() bool { return client.GetDeltaLen() == 3 },
+		5*time.Second, 5*time.Millisecond, "row event in the follow-up transaction was not processed")
+	require.False(t, buffered(302), "the follow-up transaction must not be promoted before its XIDEvent")
+	inject(&replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.XID_EVENT},
+		Event:  &replication.XIDEvent{XID: 2},
+	})
+	require.Eventually(t, func() bool { return buffered(302) },
+		5*time.Second, 5*time.Millisecond, "the follow-up transaction's XIDEvent must promote its GTID")
+}
+
+// TestGTIDClientCreateTableAsSelect drives a real CREATE TABLE ... SELECT
+// through the feed end-to-end. Since 8.0.21 the server logs it as a
+// single transaction — GTIDEvent → Query(BEGIN) → Query("CREATE TABLE ...
+// START TRANSACTION") → row events → XIDEvent — whose CREATE TABLE
+// statement the TiDB parser rejects mid-group.
+//
+// The premature-promotion window itself cannot be observed end-to-end
+// (the server writes the whole group in one burst at commit; that is what
+// TestGTIDClientUnparseableQueryPromotionOrdering covers
+// deterministically). What this test pins is liveness with the real
+// binlog shape: deferring promotion at the unparseable statement must not
+// suppress the promotion the group gets from its own XIDEvent — if it
+// did, bufferedGTID would fall permanently behind gtid_executed and the
+// BlockWait right after the CTAS would time out, with no later traffic to
+// bail it out.
+func TestGTIDClientCreateTableAsSelect(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS gtidctast1, gtidctast2")
+	testutils.RunSQL(t, "CREATE TABLE gtidctast1 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE gtidctast2 (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+
+	// A separate schema for the CTAS, as for the unparseable-DDL test:
+	// the parse happens before any schema filtering.
+	otherSchema, _ := testutils.CreateUniqueTestDatabase(t)
+	testutils.RunSQLInDatabase(t, otherSchema, "CREATE TABLE ctas_src (a INT NOT NULL PRIMARY KEY, b INT)")
+	testutils.RunSQLInDatabase(t, otherSchema, "INSERT INTO ctas_src VALUES (1, 1), (2, 2)")
+
+	t1 := table.NewTableInfo(db, "test", "gtidctast1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "gtidctast2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*gtidClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	testutils.RunSQLInDatabase(t, otherSchema, "CREATE TABLE ctas_dst AS SELECT * FROM ctas_src")
+
+	// Captured right after the CTAS (and before BlockWait) so the
+	// containment assertion below is deterministic even with unrelated
+	// concurrent load advancing gtid_executed on a shared server.
+	var executed string
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT @@GLOBAL.gtid_executed").Scan(&executed))
+	executedSet, err := mysql.ParseMysqlGTIDSet(normalizeGTIDString(executed))
+	require.NoError(t, err)
+
+	// The CTAS group's own XIDEvent must promote its (deferred) GTID.
+	require.NoError(t, client.BlockWait(t.Context()))
+
+	// A normal tracked-table write still replicates afterwards.
+	testutils.RunSQL(t, "INSERT INTO gtidctast1 (a, b, c) VALUES (1, 2, 3)")
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen())
+	require.NoError(t, client.Flush(t.Context()))
+
+	// The resume coordinate must cover the CTAS transaction: resuming
+	// from it must not re-request (or skip) any part of it.
+	flushedSet, err := mysql.ParseMysqlGTIDSet(normalizeGTIDString(client.Position()))
+	require.NoError(t, err)
+	require.True(t, flushedSet.Contain(executedSet),
+		"flushed position %s must cover the executed set %s (including the CTAS GTID)", flushedSet.String(), executedSet.String())
+
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM gtidctast2").Scan(&count))
+	require.Equal(t, 1, count)
 }
 
 // TestGTIDPromotePendingGTID unit-tests the promotion helper directly


### PR DESCRIPTION
## Problem

The GTID change source promotes the pending GTID into `bufferedGTID` whenever a
QueryEvent fails statement parsing, assuming an unparseable statement is always a
standalone single-statement transaction whose QueryEvent terminates its own binlog
group. That assumption doesn't hold. Since MySQL 8.0.21, `CREATE TABLE ... SELECT`
is logged as **one** transaction (verified against 8.0.45):

```
GTIDEvent → Query(BEGIN) → Query("CREATE TABLE ... START TRANSACTION")
          → Table_map → Write_rows → XIDEvent
```

The TiDB parser rejects the `START TRANSACTION` suffix, so the promotion fired
**mid-group**, before the group's row events and terminator had streamed. From
there:

- a concurrent (e.g. periodic) `flush()` publishes the GTID into `flushedGTID`,
  i.e. `Position()` → the checkpoint. A resume via `StartFromPosition` asks the
  server for everything *after* that GTID and permanently skips the rest of the
  group's events.
- worse, `recreateStreamer` resumes from `bufferedGTID` after transient stream
  errors — so the tail of the group could be skipped after a mere network hiccup,
  no crash or checkpoint involved.

The same window exists for any other mid-group statement-format QueryEvent the
parser can't handle (e.g. transactions from sessions running statement/mixed
binlog format).

## Fix

Never advance the GTID watermark for a group whose completion has not been
observed:

1. An unparseable QueryEvent no longer promotes. It's treated like the other
   recognized mid-group statements (`BEGIN`, the SAVEPOINT family, `XA START`/
   `XA END`): the pending GTID stays pending.
2. `readStream`'s GTIDEvent handler now promotes a still-pending GTID **before**
   stashing the new one. A new GTIDEvent proves the previous group ended (groups
   never interleave within a binlog stream), so every event of that group has
   been buffered by then. Previously a leftover pending GTID was silently
   overwritten here — which would have wedged `BlockWait`/`Flush` forever; this
   is what keeps standalone unparseable statements (`CREATE TRIGGER`, stored
   procedure deploys) advancing the watermark.

So the watermark advances only on genuine group termination: XIDEvent,
`COMMIT`/`ROLLBACK` QueryEvent, `XA COMMIT`/`XA ROLLBACK`, `XA_PREPARE_LOG_EVENT`,
or the next GTIDEvent. The compressed-transaction path is covered too, since
inner QueryEvents route through the same `processQueryEvent`.

## Trade-off (correctness over immediacy)

A *stream* of unparseable statements never stalls the watermark — each one is
promoted at the next GTIDEvent, so `bufferedGTID` trails by at most one group and
keeps advancing. The one residual case: an unparseable standalone statement that
is the *last* transaction the server ever executes, followed by total silence.
Its GTID then stays pending until the next transaction arrives, and `BlockWait`
can time out (30s) — a loud, retryable error, versus the previous behavior of a
silently corrupted resume coordinate. On any server with ongoing traffic
(including spirit's own copier/applier/checkpoint writes) the gap closes at the
next transaction.

The parse-*success* path still promotes eagerly; on a ROW-format source every
parseable statement reaching it is a standalone statement (DDL etc.), since all
mid-group QueryEvent shapes there are either intercepted earlier or unparseable.

## Tests

- `TestGTIDClientUnparseableQueryPromotionOrdering` (new, synthetic streamer,
  deterministic): replays the 8.0.45 CTAS group with the verbatim logged query
  text and asserts no promotion until the XIDEvent — fails on the previous code —
  plus the standalone-trigger shape, asserting deferral and next-GTIDEvent
  promotion (liveness).
- `TestGTIDClientCreateTableAsSelect` (new, end-to-end): a real
  `CREATE TABLE ... AS SELECT` against a GTID-mode server; pins that the group's
  own XIDEvent promotes the deferred GTID (BlockWait completes with no follow-up
  traffic) and that the resume coordinate covers the CTAS transaction.
- `TestGTIDClientUnparseableDDL` (existing) still passes: the trigger's GTID now
  enters the resume set at the next GTIDEvent instead of at the QueryEvent; doc
  comment updated.
- Full `pkg/change` suite, race-detector run on the GTID ordering tests, and
  `TestE2EGTIDChangeSource` in `pkg/migration` all pass against MySQL 8.0.45
  (`gtid_mode=ON`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
