### PR TITLE
Fix self-minted JSON checksum failures with asymmetric source/target casts

### DIFF
--- a/pkg/change/subscription_buffered_jsonfidelity_test.go
+++ b/pkg/change/subscription_buffered_jsonfidelity_test.go
@@ -22,14 +22,17 @@ import (
 // textual spelling interacts badly with MySQL's JSON parser, plus the
 // zero-value temporal opaques whose spelling go-mysql gets wrong.
 //
-// STATUS: the fail-today cases below are RED BY DESIGN on the current
-// go-mysql pin (v1.15.1-0.20260526024741-088eb1fbf0ea). They assert
-// correct behavior (source == destination); a go-mysql fix for
-// formatMySQLDouble (replication/json_mysql_text.go:102-111) is being
-// prepared and will turn the huge-double class green, with the
-// zero-temporal class covered by a separate follow-up
-// (replication/json_binary.go:539 and :561-563). Do not weaken these
-// assertions to make them pass.
+// STATUS: the go.mod pin (github.com/morgo/go-mysql
+// v1.16.1-0.20260723231236-3aced1dddcf4, the TEMP replace in go.mod)
+// carries the formatMySQLDouble my_gcvt-parity fix
+// (replication/json_mysql_text.go) and the zero-temporal opaque fix
+// (replication/json_binary.go), so the huge-double and zero-temporal
+// classes assert green and gate the pin: dropping the replace for an
+// upstream go-mysql without those fixes turns every CI job red here.
+// seventeen_digit_mantissa stays skipped BY DESIGN — MySQL's own JSON
+// text parser misrounds that class (bugs #116160/#112904), which no
+// client-side renderer can compensate; do not unskip it, and do not
+// weaken any assertions to make them pass.
 //
 // Every case asserts two per-row fingerprints between source and
 // destination:
@@ -71,19 +74,23 @@ type jsonFidelityCase struct {
 
 func jsonFidelityCases() []jsonFidelityCase {
 	return []jsonFidelityCase{
-		// ---- FAIL TODAY: huge integral doubles ------------------------
-		// go-mysql's formatMySQLDouble (replication/json_mysql_text.go:
-		// 102-111 at pin v1.15.1-0.20260526024741-088eb1fbf0ea) renders
-		// whole-number doubles with strconv.FormatFloat(f, 'f', 1, 64):
-		// the FULL decimal expansion, not MySQL's shortest round-trip
-		// spelling. MySQL reparses the applier's text with rapidjson's
+		// ---- PIN-GATED: huge integral doubles -------------------------
+		// Green under the current fork pin; red if the pin is dropped for
+		// an unfixed upstream go-mysql. Upstream's formatMySQLDouble
+		// (replication/json_mysql_text.go:102-111 at
+		// v1.15.1-0.20260526024741-088eb1fbf0ea) rendered whole-number
+		// doubles with strconv.FormatFloat(f, 'f', 1, 64): the FULL
+		// decimal expansion, not MySQL's shortest round-trip spelling.
+		// MySQL reparses the applier's text with rapidjson's
 		// normal-precision path, which is NOT correctly rounded (MySQL
 		// bugs #116160 / #112904), so long expansions can land on a
 		// different double than the source stored. The source values here
 		// are built with SQL DOUBLE constructors, which go through
-		// my_strtod and ARE correctly rounded.
+		// my_strtod and ARE correctly rounded. The pinned fork renders
+		// my_gcvt-parity shortest forms instead, which reparse exactly.
 		//
-		// Verified against MySQL 8.0.45; per-key expectations today:
+		// Verified against MySQL 8.0.45; per-key expectations under the
+		// UNFIXED upstream renderer (what this case guards against):
 		//
 		//   'a' 1e16:    applier writes "10000000000000000.0" where MySQL
 		//        renders "1e16" — but the expansion reparses exactly, so
@@ -115,17 +122,18 @@ func jsonFidelityCases() []jsonFidelityCase {
 			assertStrict: true,
 		},
 
-		// ---- FAIL TODAY: zero-value temporal opaques ------------------
-		// go-mysql renders the zero TIME as "00:00:00"
-		// (replication/json_binary.go:539) and the zero DATETIME as
-		// "0000-00-00 00:00:00" (json_binary.go:563), but MySQL's render
-		// of the temporal opaques always carries the 6-digit fraction:
-		// "00:00:00.000000" / "0000-00-00 00:00:00.000000". The applier's
-		// text write therefore persists a JSON STRING with the shorter
-		// spelling on the destination — a difference no reparse can heal,
-		// so STRICT and RELAXED both fail. NOT fixed by the
-		// formatMySQLDouble change (separate go-mysql follow-up); the
-		// assertions still state the correct behavior.
+		// ---- PIN-GATED: zero-value temporal opaques -------------------
+		// Green under the current fork pin; red if the pin is dropped for
+		// an unfixed upstream go-mysql. Upstream renders the zero TIME as
+		// "00:00:00" (replication/json_binary.go:539) and the zero
+		// DATETIME as "0000-00-00 00:00:00" (json_binary.go:563), but
+		// MySQL's render of the temporal opaques always carries the
+		// 6-digit fraction: "00:00:00.000000" /
+		// "0000-00-00 00:00:00.000000". An applier text write with the
+		// shorter spelling persists a differing JSON STRING on the
+		// destination — a difference no reparse can heal (STRICT and
+		// RELAXED would both fail). The pinned fork renders the fractions
+		// MySQL-identically.
 		{
 			// Midnight TIME is a valid value under strict sql_mode.
 			name:         "zero_time_opaque",

--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -60,9 +60,18 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 
 	c.logger.Debug("checksumming chunk", "chunk", chunk.String())
 
-	// Build the checksum query fragment. The same WHERE clause and column list
-	// applies to both sources and targets since all schemas are identical.
-	checksumColumns, _, err := chunk.ColumnMapping.ChecksumExprs()
+	// Build the checksum query fragments. The same WHERE clause applies to
+	// both sources and targets since all schemas are identical, but the
+	// column expressions are side-dependent: JSON columns round-trip through
+	// text on the source and render strictly on the target (see
+	// table.castExpr). Move/sync writes are text-mediated — the applier
+	// writes rendered text that the target re-parses — so the same
+	// text-image contract as the single-server checksum applies here. This
+	// does assume source and target servers parse JSON text identically; if
+	// a future server version changed parse behavior (e.g. fixed the double
+	// misrounding bugs), a cross-version move of affected values would fail
+	// the checksum safely rather than pass silently.
+	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
 	if err != nil {
 		return err
 	}
@@ -82,7 +91,7 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		defer c.sourcePools[i].trxPool.Put(srcTrx)
 
 		sourceQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-			checksumColumns,
+			sourceChecksumCols,
 			chunk.Table.QuotedTableName,
 			whereClause,
 		)
@@ -108,7 +117,7 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		defer targetTrxPool.Put(targetTrx)
 
 		targetQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-			checksumColumns,
+			targetChecksumCols,
 			chunk.Table.QuotedTableName,
 			whereClause,
 		)
@@ -207,6 +216,15 @@ func (c *DistributedChecker) replaceChunk(ctx context.Context, chunk *table.Chun
 	// Step 2: Read all rows from ALL sources for the chunk range and merge them.
 	// Use NonGeneratedColumns because the applier expects non-generated columns only.
 	// This ensures the column ordinals match when the applier extracts the sharding column.
+	//
+	// JSON columns are deliberately read bare here — no text round-trip cast.
+	// Unlike the single-server repair (see table.ColumnMapping.RepairExprs),
+	// this path is already text-mediated: the SELECT renders each document to
+	// text on the wire and the applier writes it back as a SQL literal that
+	// the target re-parses. The repaired row therefore lands as exactly the
+	// one-round-trip text image the checksum's source side predicts. Adding a
+	// round-trip cast on top would apply parse∘render twice, which does not
+	// converge for misparsed doubles.
 	columnList := table.QuoteColumns(chunk.Table.NonGeneratedColumns)
 	// Use the table name only; each source DB connection determines which database is queried.
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s",

--- a/pkg/checksum/json_test.go
+++ b/pkg/checksum/json_test.go
@@ -64,10 +64,11 @@ func TestJSONChecksumDecimalTypeDegradation(t *testing.T) {
 // cycles never converge — each cycle drifts a further ulp (verified on
 // 8.0.45: 4.3319172962174079e299 renders → re-parses → re-renders as
 // ...408, ...409, ...4094, never stabilizing). The target here is built with
-// exactly one text round-trip (CAST(CAST(j AS CHAR) AS JSON)), the same
-// image the buffered copier and binlog applier produce, so the asymmetric
-// checksum (source round-trips, target renders strictly) must pass on the
-// first attempt. Under the previous symmetric casts this population fails:
+// exactly one text round-trip (CAST(CAST(j AS CHAR CHARACTER SET utf8mb4)
+// AS JSON)), matching the production contract expression and the image the
+// buffered copier and binlog applier produce, so the asymmetric checksum
+// (source round-trips, target renders strictly) must pass on the first
+// attempt. Under the previous symmetric casts this population fails:
 // the target side's extra re-parse lands a drifting value on yet another
 // neighbor, a self-minted mismatch that no number of retries or recopies
 // could clear (verified: BIT_XOR CRCs 790255375 vs 3468554960 on 8.0.45).
@@ -88,7 +89,7 @@ func TestJSONChecksumFullMantissaTextImage(t *testing.T) {
 		(6, NULL),
 		(7, CAST('9.007199254740992e15' AS JSON))`)
 	// One text round-trip: the image every text-mediated write path stores.
-	testutils.RunSQL(t, `INSERT INTO _chkjsonasym1_new SELECT a, CAST(CAST(j AS CHAR) AS JSON) FROM chkjsonasym1`)
+	testutils.RunSQL(t, `INSERT INTO _chkjsonasym1_new SELECT a, CAST(CAST(j AS CHAR CHARACTER SET utf8mb4) AS JSON) FROM chkjsonasym1`)
 
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
@@ -191,7 +192,8 @@ func TestJSONChecksumMisparsedDoubleRepairConverges(t *testing.T) {
 	// fails this for rows 1 and 2, so this also proves rows were rewritten.
 	var notTextImage int
 	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM chkjsonasym2 s JOIN _chkjsonasym2_new t USING (a)
-		WHERE CAST(t.j AS CHAR) <> CAST(CAST(CAST(s.j AS CHAR) AS JSON) AS CHAR)`).Scan(&notTextImage)
+		WHERE CAST(t.j AS CHAR CHARACTER SET utf8mb4) <>
+		      CAST(CAST(CAST(s.j AS CHAR CHARACTER SET utf8mb4) AS JSON) AS CHAR CHARACTER SET utf8mb4)`).Scan(&notTextImage)
 	require.NoError(t, err)
 	require.Equal(t, 0, notTextImage)
 }

--- a/pkg/checksum/json_test.go
+++ b/pkg/checksum/json_test.go
@@ -57,6 +57,145 @@ func TestJSONChecksumDecimalTypeDegradation(t *testing.T) {
 	require.NoError(t, singleChecker.runChecksum(t.Context()))
 }
 
+// TestJSONChecksumFullMantissaTextImage pins the asymmetric-cast contract on
+// the class of values that motivated it: doubles whose shortest decimal form
+// needs 17 significant digits. MySQL's JSON text parser misrounds these by
+// ±1 ulp (bugs #116160/#112904), and for some values repeated parse/render
+// cycles never converge — each cycle drifts a further ulp (verified on
+// 8.0.45: 4.3319172962174079e299 renders → re-parses → re-renders as
+// ...408, ...409, ...4094, never stabilizing). The target here is built with
+// exactly one text round-trip (CAST(CAST(j AS CHAR) AS JSON)), the same
+// image the buffered copier and binlog applier produce, so the asymmetric
+// checksum (source round-trips, target renders strictly) must pass on the
+// first attempt. Under the previous symmetric casts this population fails:
+// the target side's extra re-parse lands a drifting value on yet another
+// neighbor, a self-minted mismatch that no number of retries or recopies
+// could clear (verified: BIT_XOR CRCs 790255375 vs 3468554960 on 8.0.45).
+func TestJSONChecksumFullMantissaTextImage(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS chkjsonasym1, _chkjsonasym1_new, _chkjsonasym1_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE chkjsonasym1 (a INT NOT NULL, j JSON, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _chkjsonasym1_new (a INT NOT NULL, j JSON, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _chkjsonasym1_chkpnt (a INT)") // for binlog advancement
+	// CAST(CAST(s AS DOUBLE) AS JSON) builds the JSON double via strtod
+	// (correct parsing), bypassing the buggy JSON text parser — the same
+	// binary value an application would have stored.
+	testutils.RunSQL(t, `INSERT INTO chkjsonasym1 VALUES
+		(1, CAST(CAST('4.3319172962174079e299' AS DOUBLE) AS JSON)),
+		(2, CAST(CAST('1.5709949153046066e-55' AS DOUBLE) AS JSON)),
+		(3, CAST(CAST('1.2345678901234567e34' AS DOUBLE) AS JSON)),
+		(4, JSON_OBJECT('nested', CAST(CAST('4.3319172962174079e299' AS DOUBLE) AS JSON), 'ok', 42)),
+		(5, JSON_ARRAY(1, 'two', true, NULL)),
+		(6, NULL),
+		(7, CAST('9.007199254740992e15' AS JSON))`)
+	// One text round-trip: the image every text-mediated write path stores.
+	testutils.RunSQL(t, `INSERT INTO _chkjsonasym1_new SELECT a, CAST(CAST(j AS CHAR) AS JSON) FROM chkjsonasym1`)
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "chkjsonasym1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_chkjsonasym1_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	// FixDifferences is left false (the default): a single pass must find
+	// zero differences, i.e. this passes on the first attempt with no repair.
+	checker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, NewCheckerDefaultConfig())
+	require.NoError(t, err)
+	singleChecker, ok := checker.(*SingleChecker)
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	require.NoError(t, singleChecker.runChecksum(t.Context()))
+	require.Equal(t, uint64(0), singleChecker.differencesFound.Load())
+}
+
+// TestJSONChecksumMisparsedDoubleRepairConverges proves the repair side of
+// the text-image contract. The target rows here hold the source documents
+// byte-for-byte (server-side INSERT..SELECT — the unbuffered copy path, or
+// tampering), NOT the one-text-round-trip image the checksum's source side
+// predicts, plus one genuinely different document. The asymmetric checksum
+// must flag this: for a misparsed double, byte-equal is the WRONG target
+// state (the deployed text write paths could never have produced it), and
+// notably the previous symmetric casts were blind to it — both sides
+// round-tripped onto the same value. The repair then recopies the chunk
+// through RepairExprs' text round-trip, so the recopied rows store exactly
+// the predicted image and the next attempt converges. A byte-faithful repair
+// would NOT converge (Run would exhaust MaxRetries=2 re-flagging the same
+// rows): that this test passes is the convergence proof.
+func TestJSONChecksumMisparsedDoubleRepairConverges(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS chkjsonasym2, _chkjsonasym2_new, _chkjsonasym2_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE chkjsonasym2 (a INT NOT NULL, j JSON, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _chkjsonasym2_new (a INT NOT NULL, j JSON, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _chkjsonasym2_chkpnt (a INT)") // for binlog advancement
+	testutils.RunSQL(t, `INSERT INTO chkjsonasym2 VALUES
+		(1, CAST(CAST('4.3319172962174079e299' AS DOUBLE) AS JSON)),
+		(2, CAST(CAST('1.2345678901234567e34' AS DOUBLE) AS JSON)),
+		(3, JSON_ARRAY(1, 'two', true, NULL))`)
+	// Byte-faithful target: matches source bytes, violates the text-image
+	// contract for rows 1 and 2 (their text image is a different double).
+	testutils.RunSQL(t, `INSERT INTO _chkjsonasym2_new SELECT a, j FROM chkjsonasym2`)
+	// Plus one unambiguous, parser-independent corruption.
+	testutils.RunSQL(t, `UPDATE _chkjsonasym2_new SET j = JSON_ARRAY(99) WHERE a = 3`)
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "chkjsonasym2")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_chkjsonasym2_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	// Phase 1: with FixDifferences off, the divergence must be flagged.
+	detectChecker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, NewCheckerDefaultConfig())
+	require.NoError(t, err)
+	singleChecker, ok := detectChecker.(*SingleChecker)
+	require.True(t, ok, "checker is not of type *SingleChecker")
+	err = singleChecker.runChecksum(t.Context())
+	require.ErrorContains(t, err, "checksum mismatch")
+
+	// Phase 2: with FixDifferences on, attempt 1 repairs and attempt 2 must
+	// come back clean — MaxRetries=2 leaves no room for a repair that fails
+	// to converge.
+	require.NoError(t, chunker.Reset())
+	config := NewCheckerDefaultConfig()
+	config.FixDifferences = true
+	config.MaxRetries = 2
+	fixChecker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+	require.NoError(t, fixChecker.Run(t.Context()))
+
+	// The repair must have rewritten the target as the text image, not the
+	// source bytes: every target document's stored rendering equals the
+	// render→parse→render of its source document. On 8.0.45 the byte image
+	// fails this for rows 1 and 2, so this also proves rows were rewritten.
+	var notTextImage int
+	err = db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM chkjsonasym2 s JOIN _chkjsonasym2_new t USING (a)
+		WHERE CAST(t.j AS CHAR) <> CAST(CAST(CAST(s.j AS CHAR) AS JSON) AS CHAR)`).Scan(&notTextImage)
+	require.NoError(t, err)
+	require.Equal(t, 0, notTextImage)
+}
+
 // TestJSONChecksumDecimalGenuineMismatchStillCaught is the flip side of
 // TestJSONChecksumDecimalTypeDegradation: the text round-trip must collapse
 // type-tag degradation, but it must not become blind to real value

--- a/pkg/checksum/json_test.go
+++ b/pkg/checksum/json_test.go
@@ -71,7 +71,8 @@ func TestJSONChecksumDecimalTypeDegradation(t *testing.T) {
 // attempt. Under the previous symmetric casts this population fails:
 // the target side's extra re-parse lands a drifting value on yet another
 // neighbor, a self-minted mismatch that no number of retries or recopies
-// could clear (verified: BIT_XOR CRCs 790255375 vs 3468554960 on 8.0.45).
+// could clear (verified on 8.0.45 by reverting to symmetric casts: the
+// misparse-affected rows 1, 2 and 4 flag on every attempt).
 func TestJSONChecksumFullMantissaTextImage(t *testing.T) {
 	testutils.RunSQL(t, "DROP TABLE IF EXISTS chkjsonasym1, _chkjsonasym1_new, _chkjsonasym1_chkpnt")
 	testutils.RunSQL(t, "CREATE TABLE chkjsonasym1 (a INT NOT NULL, j JSON, PRIMARY KEY (a))")
@@ -118,6 +119,87 @@ func TestJSONChecksumFullMantissaTextImage(t *testing.T) {
 	require.True(t, ok, "checker is not of type *SingleChecker")
 	require.NoError(t, singleChecker.runChecksum(t.Context()))
 	require.Equal(t, uint64(0), singleChecker.differencesFound.Load())
+}
+
+// TestDistributedJSONChecksumTextImage is the distributed (move/sync) twin
+// of TestJSONChecksumFullMantissaTextImage. The DistributedChecker builds
+// its checksum SQL independently of the single-server checker (see
+// ChecksumChunk), so the side-dependent JSON casts need their own
+// end-to-end pin: without it, reverting distributed.go's target side to the
+// source expression leaves every JSON test green. The target table here
+// lives in a separate database and holds exactly the one-text-round-trip
+// image that the move applier's text-mediated writes produce, over the same
+// misparse-affected population (17-significant-digit doubles that never
+// converge under repeated parse/render). The asymmetric checksum — source
+// round-trips, target renders strictly — must pass on the first attempt
+// with zero differences. With symmetric casts the target side's extra
+// re-parse lands the drifting values on yet another neighbor, self-minting
+// mismatches (verified on 8.0.45 by reverting targetChecksumCols to
+// sourceChecksumCols in ChecksumChunk: this test fails on rows 1, 2 and 4).
+func TestDistributedJSONChecksumTextImage(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	newDBName, _ := testutils.CreateUniqueTestDatabase(t)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS chkjsonasym_dist1")
+	testutils.RunSQL(t, "CREATE TABLE chkjsonasym_dist1 (a INT NOT NULL, j JSON, PRIMARY KEY (a))")
+	// Same population as TestJSONChecksumFullMantissaTextImage: the
+	// misparse-affected doubles built via strtod (correct parsing, the same
+	// binary values an application would have stored), plus nested, array,
+	// NULL and integer-boundary shapes.
+	testutils.RunSQL(t, `INSERT INTO chkjsonasym_dist1 VALUES
+		(1, CAST(CAST('4.3319172962174079e299' AS DOUBLE) AS JSON)),
+		(2, CAST(CAST('1.5709949153046066e-55' AS DOUBLE) AS JSON)),
+		(3, CAST(CAST('1.2345678901234567e34' AS DOUBLE) AS JSON)),
+		(4, JSON_OBJECT('nested', CAST(CAST('4.3319172962174079e299' AS DOUBLE) AS JSON), 'ok', 42)),
+		(5, JSON_ARRAY(1, 'two', true, NULL)),
+		(6, NULL),
+		(7, CAST('9.007199254740992e15' AS JSON))`)
+	// The target holds the one-text-round-trip image: what the move
+	// applier's writes leave on the target server, since they transfer each
+	// document as rendered text that the target re-parses.
+	testutils.RunSQL(t, "CREATE TABLE "+newDBName+".chkjsonasym_dist1 LIKE chkjsonasym_dist1")
+	testutils.RunSQL(t, "INSERT INTO "+newDBName+".chkjsonasym_dist1 SELECT a, CAST(CAST(j AS CHAR CHARACTER SET utf8mb4) AS JSON) FROM chkjsonasym_dist1")
+
+	destCfg := cfg.Clone()
+	destCfg.DBName = newDBName
+
+	src, err := dbconn.New(cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(src)
+	dest, err := dbconn.New(destCfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(dest)
+
+	t1 := table.NewTableInfo(src, "test", "chkjsonasym_dist1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(dest, newDBName, "chkjsonasym_dist1")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	target := applier.Target{DB: dest, KeyRange: "0", Config: destCfg}
+	app, err := applier.NewSingleTargetApplier(target, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	feed := change.NewBinlogClient(src, cfg.Addr, cfg.User, cfg.Passwd, app, change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	// Setting an Applier selects the DistributedChecker. FixDifferences is
+	// left false (the default): a single pass must find zero differences,
+	// i.e. this passes on the first attempt with no repair.
+	config := NewCheckerDefaultConfig()
+	config.Applier = app
+
+	checker, err := NewChecker([]*sql.DB{src}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+	distChecker, ok := checker.(*DistributedChecker)
+	require.True(t, ok, "checker is not of type *DistributedChecker")
+	require.NoError(t, checker.Run(t.Context()))
+	require.Equal(t, uint64(0), distChecker.differencesFound.Load())
 }
 
 // TestJSONChecksumMisparsedDoubleRepairConverges proves the repair side of

--- a/pkg/checksum/recopier.go
+++ b/pkg/checksum/recopier.go
@@ -108,7 +108,10 @@ func (r *MySQLRecopier) Recopy(ctx context.Context, chunk *table.Chunk) error {
 	// because the applier's write path expects exactly those (it can't
 	// write generated columns). The column ordering matches the applier's
 	// expectation as long as we use the same column-list helper the
-	// distributed checker's recopy uses.
+	// distributed checker's recopy uses. JSON columns are deliberately read
+	// bare — the SELECT+applier pair already constitutes the one text
+	// round-trip the checksum's JSON contract expects; see the matching
+	// comment in DistributedChecker.replaceChunk.
 	columnList := table.QuoteColumns(chunk.Table.NonGeneratedColumns)
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s",
 		columnList,

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -266,11 +266,21 @@ func (c *SingleChecker) replaceChunk(ctx context.Context, chunk *table.Chunk) er
 	// first so that any since-deleted rows (which wouldn't get removed by replace) are removed first.
 	// By doing this as two transactions we should be able to remove
 	// the opportunity for deadlocks.
-	sourceColumns, targetColumns := chunk.ColumnMapping.Columns()
+	//
+	// The SELECT list comes from RepairExprs, not Columns(): JSON columns are
+	// recopied through a text round-trip rather than byte-faithfully. The
+	// checksum asserts that the target holds the one-text-round-trip image of
+	// each source document (see table.ColumnMapping.RepairExprs), so a
+	// byte-faithful recopy of a document whose text image differs from its
+	// source bytes would be re-flagged by the next pass, indefinitely.
+	sourceExprs, targetColumns, err := chunk.ColumnMapping.RepairExprs()
+	if err != nil {
+		return err
+	}
 	replaceStmt := fmt.Sprintf("REPLACE INTO %s (%s) SELECT %s FROM %s WHERE %s",
 		chunk.NewTable.QuotedTableName,
 		targetColumns,
-		sourceColumns,
+		sourceExprs,
 		chunk.Table.QuotedTableName,
 		chunk.String(),
 	)

--- a/pkg/table/column_mapping.go
+++ b/pkg/table/column_mapping.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
@@ -121,7 +122,8 @@ const checksumSeparator = ", '#', "
 // CONCAT()) for source and target, wrapping each column in IFNULL(), ISNULL()
 // and CAST, with a '#' separator literal between every value (see
 // checksumSeparator). The CAST type always comes from the target table's type
-// definition. When there are no renames, both expressions are identical.
+// definition, but the cast itself is side-dependent for JSON columns (see
+// castExpr), so the two expressions can differ even without renames.
 func (m *ColumnMapping) ChecksumExprs() (source, target string, err error) {
 	sourceExprs := make([]string, len(m.sourceColumns))
 	targetExprs := make([]string, len(m.targetColumns))
@@ -130,11 +132,11 @@ func (m *ColumnMapping) ChecksumExprs() (source, target string, err error) {
 		// so that type conversions (e.g. INT→BIGINT) are applied consistently.
 		// For source: SQL references the old column name, type from target's new column name.
 		// For target: both SQL reference and type lookup use the new column name.
-		srcCast, err := m.targetTable.wrapCastTypeAs(m.sourceColumns[i], m.targetColumns[i])
+		srcCast, err := m.targetTable.wrapCastTypeAs(m.sourceColumns[i], m.targetColumns[i], castSource)
 		if err != nil {
 			return "", "", err
 		}
-		tgtCast, err := m.targetTable.wrapCastType(m.targetColumns[i])
+		tgtCast, err := m.targetTable.wrapCastType(m.targetColumns[i], castTarget)
 		if err != nil {
 			return "", "", err
 		}
@@ -142,6 +144,36 @@ func (m *ColumnMapping) ChecksumExprs() (source, target string, err error) {
 		targetExprs[i] = "IFNULL(" + tgtCast + ",'')" + checksumSeparator + "ISNULL(`" + m.targetColumns[i] + "`)"
 	}
 	return strings.Join(sourceExprs, checksumSeparator), strings.Join(targetExprs, checksumSeparator), nil
+}
+
+// RepairExprs returns the SELECT expression list and the INSERT column list
+// for the checksum's same-server chunk repair:
+//
+//	REPLACE INTO target (<targetColumns>) SELECT <sourceExprs> FROM source ...
+//
+// For most columns the source expression is the bare quoted column — a
+// byte-faithful server-side copy. JSON columns are instead wrapped in the
+// same text round-trip the checksum's source side uses (see castExpr): the
+// checksum asserts that the target holds the one-text-round-trip image of
+// each source document, so a repair that copied the raw bytes would store a
+// value the next checksum pass flags again — misparsed doubles would re-flag
+// forever. Like ChecksumExprs, the type decision comes from the target
+// table's column type.
+func (m *ColumnMapping) RepairExprs() (sourceExprs, targetColumns string, err error) {
+	srcExprs := make([]string, len(m.sourceColumns))
+	tgtQuoted := make([]string, len(m.targetColumns))
+	for i := range m.sourceColumns {
+		tgtQuoted[i] = sqlescape.EscapeIdentifier(m.targetColumns[i])
+		tp, ok := m.targetTable.columnsMySQLTps[m.targetColumns[i]]
+		if !ok {
+			return "", "", fmt.Errorf("column %q not found in table %s", m.targetColumns[i], m.targetTable.TableName)
+		}
+		srcExprs[i] = sqlescape.EscapeIdentifier(m.sourceColumns[i])
+		if castableTp(tp) == "json" {
+			srcExprs[i] = textRoundTripCast(srcExprs[i])
+		}
+	}
+	return strings.Join(srcExprs, ", "), strings.Join(tgtQuoted, ", "), nil
 }
 
 // SourceColumnIndices returns the indices into sourceTable.NonGeneratedColumns

--- a/pkg/table/column_mapping_test.go
+++ b/pkg/table/column_mapping_test.go
@@ -192,3 +192,66 @@ func TestColumnMappingTargetNil(t *testing.T) {
 	require.Equal(t, "`a`, `b`, `c`", tgt)
 	require.Equal(t, t1, m.TargetTable())
 }
+
+func TestColumnMappingChecksumExprsJSONAsymmetric(t *testing.T) {
+	// JSON columns are checksummed asymmetrically (see castExpr): the source
+	// expression predicts the one-text-round-trip image the copier/applier
+	// writes, while the target expression renders the stored document
+	// strictly — so the two sides differ even without renames.
+	t1 := NewTableInfo(nil, "test", "t1")
+	t1new := NewTableInfo(nil, "test", "t1_new")
+	t1.NonGeneratedColumns = []string{"id", "j"}
+	t1new.NonGeneratedColumns = []string{"id", "j"}
+	t1new.columnsMySQLTps = map[string]string{"id": "int", "j": "json"}
+
+	m := NewColumnMapping(t1, t1new, nil)
+	src, tgt, err := m.ChecksumExprs()
+	require.NoError(t, err)
+	require.Contains(t, src, "CAST(CAST(`j` AS char CHARACTER SET utf8mb4) AS json)")
+	require.Contains(t, tgt, "CAST(`j` AS json)")
+	require.NotContains(t, tgt, "CAST(CAST(`j`")
+	// Non-JSON columns cast identically on both sides.
+	require.Contains(t, src, "CAST(`id` AS signed)")
+	require.Contains(t, tgt, "CAST(`id` AS signed)")
+
+	// With a rename the source expression references the old name but the
+	// asymmetry is unchanged.
+	t1.NonGeneratedColumns = []string{"id", "old_j"}
+	m = NewColumnMapping(t1, t1new, map[string]string{"old_j": "j"})
+	src, tgt, err = m.ChecksumExprs()
+	require.NoError(t, err)
+	require.Contains(t, src, "CAST(CAST(`old_j` AS char CHARACTER SET utf8mb4) AS json)")
+	require.Contains(t, tgt, "CAST(`j` AS json)")
+}
+
+func TestColumnMappingRepairExprs(t *testing.T) {
+	// The repair (REPLACE INTO ... SELECT) must store the text image of JSON
+	// documents, not the source bytes — so JSON columns are wrapped in the
+	// text round-trip while all other columns copy byte-faithfully.
+	t1 := NewTableInfo(nil, "test", "t1")
+	t1new := NewTableInfo(nil, "test", "t1_new")
+	t1.NonGeneratedColumns = []string{"id", "name", "j"}
+	t1new.NonGeneratedColumns = []string{"id", "name", "j"}
+	t1new.columnsMySQLTps = map[string]string{"id": "int", "name": "varchar(100)", "j": "json"}
+
+	m := NewColumnMapping(t1, t1new, nil)
+	srcExprs, tgtCols, err := m.RepairExprs()
+	require.NoError(t, err)
+	require.Equal(t, "`id`, `name`, CAST(CAST(`j` AS char CHARACTER SET utf8mb4) AS json)", srcExprs)
+	require.Equal(t, "`id`, `name`, `j`", tgtCols)
+
+	// Renames: the SELECT references the old source name, the INSERT list
+	// the new target name; the JSON decision comes from the target type.
+	t1.NonGeneratedColumns = []string{"id", "old_j"}
+	t1new.NonGeneratedColumns = []string{"id", "j"}
+	m = NewColumnMapping(t1, t1new, map[string]string{"old_j": "j"})
+	srcExprs, tgtCols, err = m.RepairExprs()
+	require.NoError(t, err)
+	require.Equal(t, "`id`, CAST(CAST(`old_j` AS char CHARACTER SET utf8mb4) AS json)", srcExprs)
+	require.Equal(t, "`id`, `j`", tgtCols)
+
+	// A target column with no known type is an error (mirrors wrapCastType).
+	t1new.columnsMySQLTps = map[string]string{"id": "int"}
+	_, _, err = m.RepairExprs()
+	require.ErrorContains(t, err, "not found")
+}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -480,12 +480,12 @@ func (t *TableInfo) setBoundsIfUnset(minVal, maxVal Datum) {
 	}
 }
 
-func (t *TableInfo) wrapCastType(col string) (string, error) {
+func (t *TableInfo) wrapCastType(col string, side castSide) (string, error) {
 	tp, ok := t.columnsMySQLTps[col] // the tp keeps the width in this context.
 	if !ok {
 		return "", fmt.Errorf("column %q not found in table %s", col, t.TableName)
 	}
-	return castExpr(col, tp), nil
+	return castExpr(col, tp, side), nil
 }
 
 // wrapCastTypeAs generates a CAST expression using sqlCol as the column reference
@@ -493,12 +493,12 @@ func (t *TableInfo) wrapCastType(col string) (string, error) {
 // This is used for column renames where the SQL column name differs from the
 // type-lookup column name (e.g., source table uses old name, but cast type
 // comes from the target table's new name).
-func (t *TableInfo) wrapCastTypeAs(sqlCol, typeCol string) (string, error) {
+func (t *TableInfo) wrapCastTypeAs(sqlCol, typeCol string, side castSide) (string, error) {
 	tp, ok := t.columnsMySQLTps[typeCol]
 	if !ok {
 		return "", fmt.Errorf("column %q not found for type lookup in table %s", typeCol, t.TableName)
 	}
-	return castExpr(sqlCol, tp), nil
+	return castExpr(sqlCol, tp, side), nil
 }
 
 func (t *TableInfo) datumTp(col string) (datumTp, error) {

--- a/pkg/table/tableinfo_test.go
+++ b/pkg/table/tableinfo_test.go
@@ -90,10 +90,10 @@ func TestDiscovery(t *testing.T) {
 
 	// normalize for mysql 5.7 and 8.0
 	require.Equal(t, "int", removeWidth(t1.columnsMySQLTps["id"]))
-	castID, err := t1.wrapCastType("id")
+	castID, err := t1.wrapCastType("id", castSource)
 	require.NoError(t, err)
 	require.Equal(t, "CAST(`id` AS signed)", castID)
-	castName, err := t1.wrapCastType("name")
+	castName, err := t1.wrapCastType("name", castTarget)
 	require.NoError(t, err)
 	require.Equal(t, "CAST(`name` AS char CHARACTER SET utf8mb4)", castName)
 

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -63,8 +63,8 @@ func castableTp(tp string) string {
 	case "float", "double": // required for MySQL 5.7
 		return "char"
 	case "json":
-		// castExpr wraps json in a text round-trip rather than a plain
-		// CAST; see the comment there.
+		// castExpr casts json differently depending on which side of the
+		// comparison it is building; see the comment there.
 		return "json"
 	case "decimal":
 		return tp
@@ -76,32 +76,81 @@ func castableTp(tp string) string {
 	}
 }
 
+// castSide identifies which side of a source/target comparison a cast
+// expression is built for. Every type except JSON casts identically on both
+// sides; see castExpr for the JSON asymmetry.
+type castSide int
+
+const (
+	castSource castSide = iota
+	castTarget
+)
+
 // castExpr builds the CAST expression that the checksum uses for a single
 // column (see ColumnMapping.ChecksumExprs). col is the column referenced in
-// SQL (escaped here); tp is the MySQL column type the cast is derived from.
+// SQL (escaped here); tp is the MySQL column type the cast is derived from;
+// side says whether the expression reads the source or the target table.
 //
-// JSON columns are checksummed through a text round-trip — render to text,
-// re-parse as JSON — rather than a plain CAST(col AS json). A JSON document
-// can hold scalar types that JSON text cannot express: DECIMAL (e.g. from
-// JSON_OBJECT('a', CAST(169.09 AS DECIMAL(12,6)))) and temporal/binary
-// opaques. Spirit's buffered copier and binlog applier write JSON values as
-// text, so on the target those degrade to DOUBLE/strings. The values are
-// still equal under JSON comparison, but their canonical text can differ —
-// a DECIMAL renders at its declared scale ("169.090000") while the
-// re-parsed DOUBLE renders shortest ("169.09") — so a strict checksum
-// flags every applier-written row, and under concurrent DML re-flags rows
-// faster than repairs fix them, failing all attempts. Round-tripping BOTH
-// sides collapses each document to its text-expressible form: exactly the
-// fidelity the text-based copy/replication pipeline can deliver, and no
-// less — genuine value differences still hash differently, and int vs
-// double (which text does preserve) stays distinct.
-func castExpr(col, tp string) string {
+// JSON columns are checksummed asymmetrically:
+//
+//	source: CAST(CAST(col AS char CHARACTER SET utf8mb4) AS json) — render
+//	        to text and re-parse, i.e. one text round-trip
+//	target: CAST(col AS json) — render the stored document as-is
+//
+// This asserts the "text-image contract". Spirit's JSON write paths (the
+// buffered copier, the binlog applier, and the move/sync appliers) all
+// transfer JSON as rendered text that the target then re-parses, so for a
+// source document x the target is expected to store exactly parse(render(x)).
+// The source expression predicts that image; the target expression renders
+// what is actually stored. The two hash equal iff the target holds the
+// one-round-trip image, so every real divergence — a missed update, a stale
+// row, even a row byte-equal to the source where the text image would differ
+// — still fails the checksum.
+//
+// The round-trip exists because JSON text is lossier than binary JSON in two
+// ways, and the target can only ever hold what text delivered:
+//
+//   - Scalar types: a document can hold DECIMAL (e.g. from
+//     JSON_OBJECT('a', CAST(169.09 AS DECIMAL(12,6)))) and temporal/binary
+//     opaques, which degrade to DOUBLE/strings through text. A DECIMAL
+//     renders at its declared scale ("169.090000") while the re-parsed
+//     DOUBLE renders shortest ("169.09").
+//   - Parse fidelity: the server's JSON text parser misrounds doubles that
+//     need 17 significant digits by ±1 ulp (MySQL bugs #116160/#112904,
+//     unfixed through 8.0.45), so parse(render(x)) can differ from x — and
+//     for some values repeated parse/render cycles never converge (each
+//     cycle drifts a further ulp, or oscillates between two neighbors).
+//
+// The previous symmetric form round-tripped BOTH sides, which handled the
+// scalar degradation but re-parsed the target's already-degraded text: for
+// the non-converging values above that adds a fresh ±1 ulp to the target
+// side only, self-minting checksum failures on rows the copier wrote
+// perfectly — failures no repair could ever clear. Rendering the target
+// strictly makes the comparison exact for every write-path image while
+// staying sensitive to all genuine corruption.
+//
+// The checksum's repair must uphold the same contract: recopying a chunk has
+// to store the text image, not the source bytes. See
+// ColumnMapping.RepairExprs and the replaceChunk implementations in
+// pkg/checksum.
+func castExpr(col, tp string, side castSide) string {
 	quotedCol := sqlescape.EscapeIdentifier(col)
 	castTp := castableTp(tp)
 	if castTp == "json" {
-		return "CAST(CAST(" + quotedCol + " AS char CHARACTER SET utf8mb4) AS json)"
+		if side == castSource {
+			return textRoundTripCast(quotedCol)
+		}
+		return "CAST(" + quotedCol + " AS json)"
 	}
 	return "CAST(" + quotedCol + " AS " + castTp + ")"
+}
+
+// textRoundTripCast renders a JSON expression to utf8mb4 text and re-parses
+// it — the server-side equivalent of one trip through Spirit's text-based
+// write paths. Shared by castExpr (source side) and
+// ColumnMapping.RepairExprs (chunk repair).
+func textRoundTripCast(quotedCol string) string {
+	return "CAST(CAST(" + quotedCol + " AS char CHARACTER SET utf8mb4) AS json)"
 }
 
 func removeWidth(s string) string {

--- a/pkg/table/utils.go
+++ b/pkg/table/utils.go
@@ -120,6 +120,10 @@ const (
 //     unfixed through 8.0.45), so parse(render(x)) can differ from x — and
 //     for some values repeated parse/render cycles never converge (each
 //     cycle drifts a further ulp, or oscillates between two neighbors).
+//     MySQL 9.x parses the regression tests' probe values correctly (they
+//     are parse/render fixed points there), so the 8.0.x/8.4 CI legs —
+//     not the 9.x leg — carry the regression coverage for this class;
+//     don't trim them thinking the coverage is redundant.
 //
 // The previous symmetric form round-tripped BOTH sides, which handled the
 // scalar degradation but re-parsed the target's already-degraded text: for

--- a/pkg/table/utils_test.go
+++ b/pkg/table/utils_test.go
@@ -79,15 +79,18 @@ func TestCastableTp(t *testing.T) {
 }
 
 func TestCastExpr(t *testing.T) {
-	// JSON is normalized through a text round-trip so that scalar types
-	// unexpressible in JSON text (DECIMAL, temporal/binary opaques) hash the
-	// same as the text-degraded form the copier/applier writes. Everything
-	// else is a single CAST to castableTp.
-	require.Equal(t, "CAST(CAST(`j` AS char CHARACTER SET utf8mb4) AS json)", castExpr("j", "json"))
-	require.Equal(t, "CAST(`id` AS signed)", castExpr("id", "int(11)"))
-	require.Equal(t, "CAST(`name` AS char CHARACTER SET utf8mb4)", castExpr("name", "varchar(100)"))
-	require.Equal(t, "CAST(`b` AS binary(16))", castExpr("b", "binary(16)"))
-	require.Equal(t, "CAST(`d` AS decimal(6,2))", castExpr("d", "decimal(6,2)"))
+	// JSON casts are side-dependent (the "text-image contract", see castExpr):
+	// the source side is normalized through a text round-trip — predicting
+	// the text-degraded form the copier/applier writes — while the target
+	// side renders the stored document strictly, so it is never re-parsed.
+	// Everything else is a single CAST to castableTp on both sides.
+	require.Equal(t, "CAST(CAST(`j` AS char CHARACTER SET utf8mb4) AS json)", castExpr("j", "json", castSource))
+	require.Equal(t, "CAST(`j` AS json)", castExpr("j", "json", castTarget))
+	require.Equal(t, "CAST(`id` AS signed)", castExpr("id", "int(11)", castSource))
+	require.Equal(t, "CAST(`id` AS signed)", castExpr("id", "int(11)", castTarget))
+	require.Equal(t, "CAST(`name` AS char CHARACTER SET utf8mb4)", castExpr("name", "varchar(100)", castSource))
+	require.Equal(t, "CAST(`b` AS binary(16))", castExpr("b", "binary(16)", castTarget))
+	require.Equal(t, "CAST(`d` AS decimal(6,2))", castExpr("d", "decimal(6,2)", castSource))
 }
 
 func TestQuoteCols(t *testing.T) {


### PR DESCRIPTION
## Problem

MySQL's JSON *text* parser misrounds numbers whose shortest decimal form needs
17 significant digits by ±1 ulp (MySQL bugs #116160 / #112904, unfixed through
8.0.45). Only JSON-text parsing is affected — `CAST(str AS DOUBLE)` parses
correctly. Writing p for that parser and r for the server's JSON render, some
doubles never stabilize under repeated p∘r: each parse/render cycle drifts one
more ulp (verified on 8.0.45: `4.3319172962174079e299` re-renders as `…408`,
`…409`, `…4094`, never settling).

All of Spirit's JSON write paths are text-mediated — the buffered copier
SELECTs rendered text and writes an INSERT literal the target re-parses; the
binlog applier and the move/sync appliers do the same — so for a source
document x the target always stores exactly **y = p(r(x))**, the "text image".

The checksum previously cast JSON symmetrically,
`CAST(CAST(col AS char CHARACTER SET utf8mb4) AS json)` on both sides,
comparing r(p(r(x))) with r(p(r(y))). Since y = p(r(x)), that fails whenever y
is not a fixed point of p∘r: the target side's extra re-parse adds a fresh ulp
the source side doesn't get. In a random sample of 17-significant-digit values
on 8.0.45, ~29% mis-parse and ~10% sit on non-converging orbits — for those,
no retry and no repair of any kind can ever make the symmetric checksum pass.
Tables holding full-precision doubles inside JSON self-mint checksum failures.

## Fix: asymmetric casts (the text-image contract)

For JSON columns only, the cast is now side-dependent:

| side | expression | computes |
|---|---|---|
| source | `CAST(CAST(col AS char CHARACTER SET utf8mb4) AS json)` | r(p(r(x))) — the render of the predicted text image |
| target | `CAST(col AS json)` | r(y) — the stored document, never re-parsed |

The two hash equal **iff y = p(r(x))** — the checksum now asserts exactly the
contract the write paths guarantee. Every real divergence (missed update,
stale row, wrong value) still fails. It also closes a blindness of the
symmetric form: a target holding the source *bytes* where the text image
differs used to compare equal (both sides round-tripped onto the same value);
now it is caught and repaired. Non-JSON columns are unchanged.

## Repair must produce the text image

- `SingleChecker.replaceChunk`'s server-side `REPLACE INTO … SELECT` was
  byte-faithful; under asymmetric casts that re-flags forever (the repaired
  row holds x, the source predicts p(r(x))). Its SELECT list now comes from
  the new `ColumnMapping.RepairExprs`, which wraps JSON columns in the same
  text round-trip — repair converges in one pass even for non-converging
  values, because the stored image is rendered once and never re-parsed.
- The distributed `replaceChunk` and the continuous checker's `MySQLRecopier`
  are *already* text-mediated (SELECT to client, applier re-writes SQL
  literals): exactly one round trip. JSON deliberately stays bare there — a
  wrap would apply p∘r twice and diverge. Documented in comments.

## Scope notes

- **DistributedChecker (moves)** now uses the target-side expressions for
  target queries (it previously reused the source list on both sides), so the
  contract applies uniformly — move writes are text-mediated too. This assumes
  source and target servers parse JSON text identically; the misparse bugs are
  present in all current releases, and if a future version changed parse
  behavior, a cross-version move of affected values would fail the checksum
  safely rather than pass silently.
- **ContinuousChecker** inherits the asymmetric pair through `ChecksumExprs`;
  its recopy path is applier-mediated and correct as-is.
- **Binlog applier leg**: for binlog-applied rows the "rendered text" comes
  from the pinned go-mysql fork, not from the server, so the contract
  additionally depends on the fork's renderer matching the server's r for
  every stored document. The pin's fidelity fixes provide that, and
  `pkg/change/subscription_buffered_jsonfidelity_test.go` gates it: if the
  pin were dropped, upstream's remaining render divergences (huge integral
  doubles, zero-value temporal opaques) would make the applier write a
  *different* text image, which this checksum then correctly flags. In a
  migration that is a repairable checksum failure; under deferred cutover
  the ContinuousChecker treats divergence as fatal (no recopier), so one
  affected binlog write would abort the cutover — failing safe, but the
  dependency chain is worth stating.
- **Unbuffered copy mode** produces byte-exact rows: misparse-affected values
  now false-flag once, the round-trip repair rewrites them as text images, and
  the next attempt converges. Acceptable (this is what checksum retries are
  for), and not worth plumbing the copy mode into the checker.

## Verification

- New e2e test writes a mixed population of misparse-affected doubles through
  one text round trip (the buffered-writer image): the checksum passes on the
  **first attempt**. Reverting to symmetric casts makes it fail (verified on
  8.0.45: the misparse-affected rows flag on every attempt).
- New convergence e2e: target rows hold source bytes plus one genuinely
  different document → flagged with `FixDifferences=false`; `Run` with
  `FixDifferences=true, MaxRetries=2` repairs and passes; a SQL assertion
  proves every target row then stores the text image. Reverting the repair to
  byte-faithful makes it fail (differences on every attempt).
- New distributed e2e (`TestDistributedJSONChecksumTextImage`): same
  population, target table in a separate database holding the one-round-trip
  image, checksummed by the `DistributedChecker` — which builds its checksum
  SQL independently of the single-server checker, so its side-dependent casts
  need their own pin (previously no test exercised them: reverting the
  target side to the source expression left the whole suite green). Passes
  on the first attempt with zero differences; the same reversion now fails it.
- Unit tests cover the side-dependent cast, asymmetric `ChecksumExprs`, and
  `RepairExprs` (including column renames).
- `pkg/table`, `pkg/checksum`, `pkg/datasync` suites green; JSON-related
  `pkg/change` and checksum-related `pkg/migration` tests green; `gofmt`,
  `go vet`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


