### PR TITLE
applier: add Stats() pipeline snapshot with queue-wait/write-time percentiles

### DIFF
--- a/pkg/applier/README.md
+++ b/pkg/applier/README.md
@@ -119,6 +119,10 @@ The applier tracks all pending work internally and invokes the callback only whe
 
 This allows the copier to continue reading and queuing more work without blocking, while still maintaining correctness by only advancing the watermark after writes complete.
 
+### Pipeline observability (`Stats()`)
+
+Both appliers expose a point-in-time `Stats()` snapshot (see `stats.go`): queue depth/capacity, pending work, live write workers, and rolling p50/p90 of per-chunklet **queue wait** (time between `Apply()` offering a chunklet to the buffer and a worker dequeueing it, including send-side backpressure) and **write time**. This exists because the copier's chunk feedback is end-to-end — read + queue wait + write — so a saturated write side otherwise presents as a read/chunker problem. A queue pegged at capacity with queue-wait far above write time means the pipeline is write-limited; a near-empty queue means it is read-limited.
+
 
 ## Implementation Details
 

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -67,6 +67,12 @@ type Applier interface {
 	// For the subscription: callback will update binlog coordinates
 	Apply(ctx context.Context, chunk *table.Chunk, rows [][]any, callback ApplyCallback) error
 
+	// Stats returns a point-in-time snapshot of the write pipeline: queue
+	// occupancy, pending work, live workers, and rolling queue-wait /
+	// write-time percentiles. Safe to call concurrently with Apply; values
+	// are approximate. See the Stats type for field semantics.
+	Stats() Stats
+
 	// DeleteKeys deletes rows by their key values synchronously. Each entry
 	// in keys is one key tuple of the original (typed) column values, in
 	// sourceTable.KeyColumns order.

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -52,6 +52,12 @@ type ShardedApplier struct {
 	cancelFunc context.CancelFunc
 	wg         sync.WaitGroup
 
+	// timings is a rolling window of per-chunklet queue-wait and write
+	// durations across all shards, reported by Stats(). A single shared ring
+	// is deliberate: the bottleneck question ("is the write side saturated?")
+	// does not need per-shard attribution.
+	timings timingRing
+
 	// State management to make Start/Stop idempotent
 	stopped bool
 	started bool
@@ -73,10 +79,11 @@ type shardTarget struct {
 
 // shardedChunklet represents a chunklet destined for a specific shard
 type shardedChunklet struct {
-	workID  int64        // ID of the parent work
-	shardID int          // Which shard this belongs to
-	chunk   *table.Chunk // Original chunk for column info
-	rows    []rowData    // Rows for this shard
+	workID     int64        // ID of the parent work
+	shardID    int          // Which shard this belongs to
+	chunk      *table.Chunk // Original chunk for column info
+	rows       []rowData    // Rows for this shard
+	enqueuedAt time.Time    // when Apply() offered this chunklet to the shard buffer; queue wait = dequeue - enqueuedAt
 }
 
 // shardedChunkletCompletion represents a completed sharded chunklet
@@ -309,6 +316,10 @@ func (a *ShardedApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][
 	// coordinator already claimed the work (e.g. an error completion raced
 	// this cancellation), `exists` is false and we return without invoking.
 	for _, chunkletData := range allChunklets {
+		// Stamp before the send so queue wait includes send-side
+		// backpressure: when the shard buffer is full, time blocked here is
+		// exactly "waiting for a write worker".
+		chunkletData.enqueuedAt = time.Now()
 		select {
 		case a.shards[chunkletData.shardID].chunkletBuffer <- chunkletData:
 		case <-ctx.Done():
@@ -411,6 +422,40 @@ func (a *ShardedApplier) Stop() error {
 	return nil
 }
 
+// Stats returns a point-in-time snapshot of the write pipeline, aggregated
+// across shards: queue depth/cap are summed, and active workers is the sum of
+// each shard's live (started minus finished) workers. The embedded mutex is
+// held so the buffer reads cannot race Start()'s channel reinitialization on
+// restart; len/cap on a closed channel are safe.
+func (a *ShardedApplier) Stats() Stats {
+	a.Lock()
+	var queueDepth, queueCap, activeWorkers int
+	for _, shard := range a.shards {
+		queueDepth += len(shard.chunkletBuffer)
+		queueCap += cap(shard.chunkletBuffer)
+		if a.started {
+			activeWorkers += int(shard.writeWorkersCount - atomic.LoadInt32(&shard.writeWorkersFinished))
+		}
+	}
+	a.Unlock()
+
+	a.pendingMutex.Lock()
+	pending := len(a.pendingWork)
+	a.pendingMutex.Unlock()
+
+	queueWaitP50, queueWaitP90, writeTimeP50, writeTimeP90 := a.timings.percentiles()
+	return Stats{
+		QueueDepth:    queueDepth,
+		QueueCap:      queueCap,
+		PendingWork:   pending,
+		ActiveWorkers: activeWorkers,
+		QueueWaitP50:  queueWaitP50,
+		QueueWaitP90:  queueWaitP90,
+		WriteTimeP50:  writeTimeP50,
+		WriteTimeP90:  writeTimeP90,
+	}
+}
+
 // writeWorker processes chunklets for a specific shard
 func (a *ShardedApplier) writeWorker(ctx context.Context, shard *shardTarget) {
 	defer a.wg.Done()
@@ -441,7 +486,10 @@ func (a *ShardedApplier) writeWorker(ctx context.Context, shard *shardTarget) {
 		a.logger.Debug("writeWorker processing chunklet", "shardID", shard.shardID,
 			"workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
 
+		queueWait := time.Since(chunkletData.enqueuedAt)
+		writeStart := time.Now()
 		affectedRows, err := a.writeChunklet(ctx, shard, chunkletData)
+		a.timings.record(queueWait, time.Since(writeStart))
 
 		shard.chunkletCompletions <- shardedChunkletCompletion{
 			workID:       chunkletData.workID,

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -59,6 +59,10 @@ type SingleTargetApplier struct {
 	scalingClosed bool            // set true when Stop begins, to block new spawns
 	workersWg     sync.WaitGroup  // tracks write workers only
 
+	// timings is a rolling window of per-chunklet queue-wait and write
+	// durations, reported by Stats().
+	timings timingRing
+
 	// Context management
 	cancelFunc context.CancelFunc
 	wg         sync.WaitGroup // tracks the feedbackCoordinator goroutine only
@@ -71,9 +75,10 @@ type SingleTargetApplier struct {
 // chunklet represents a small batch of rows for internal processing
 // Limited by either chunkletMaxRows or MaxStatementSizeBytes, whichever is reached first
 type chunklet struct {
-	workID int64        // ID of the parent work
-	chunk  *table.Chunk // Original chunk for column info
-	rows   []rowData    // Batch of rows limited by row count or size
+	workID     int64        // ID of the parent work
+	chunk      *table.Chunk // Original chunk for column info
+	rows       []rowData    // Batch of rows limited by row count or size
+	enqueuedAt time.Time    // when Apply() offered this chunklet to the buffer; queue wait = dequeue - enqueuedAt
 }
 
 // chunkletCompletion represents a completed chunklet
@@ -217,6 +222,10 @@ func (a *SingleTargetApplier) Apply(ctx context.Context, chunk *table.Chunk, row
 	// coordinator already claimed the work (e.g. an error completion raced
 	// this cancellation), `exists` is false and we return without invoking.
 	for _, chunkletData := range chunklets {
+		// Stamp before the send so queue wait includes send-side
+		// backpressure: when the buffer is full, time blocked here is
+		// exactly "waiting for a write worker".
+		chunkletData.enqueuedAt = time.Now()
 		select {
 		case a.chunkletBuffer <- chunkletData:
 		case <-ctx.Done():
@@ -389,6 +398,32 @@ func (a *SingleTargetApplier) ActiveWriteWorkers() int {
 	return int(a.activeWorkers.Load())
 }
 
+// Stats returns a point-in-time snapshot of the write pipeline. The embedded
+// mutex is held so the buffer read cannot race Start()'s channel
+// reinitialization on restart; len/cap on a closed channel are safe.
+func (a *SingleTargetApplier) Stats() Stats {
+	a.Lock()
+	queueDepth := len(a.chunkletBuffer)
+	queueCap := cap(a.chunkletBuffer)
+	a.Unlock()
+
+	a.pendingMutex.Lock()
+	pending := len(a.pendingWork)
+	a.pendingMutex.Unlock()
+
+	queueWaitP50, queueWaitP90, writeTimeP50, writeTimeP90 := a.timings.percentiles()
+	return Stats{
+		QueueDepth:    queueDepth,
+		QueueCap:      queueCap,
+		PendingWork:   pending,
+		ActiveWorkers: int(a.activeWorkers.Load()),
+		QueueWaitP50:  queueWaitP50,
+		QueueWaitP90:  queueWaitP90,
+		WriteTimeP50:  writeTimeP50,
+		WriteTimeP90:  writeTimeP90,
+	}
+}
+
 // writeWorker processes chunklets from the buffer until either its quit channel
 // is closed (scale-down) or the buffer is closed by Stop().
 func (a *SingleTargetApplier) writeWorker(ctx context.Context, quit <-chan struct{}) {
@@ -417,7 +452,10 @@ func (a *SingleTargetApplier) writeWorker(ctx context.Context, quit <-chan struc
 			}
 			a.logger.Debug("writeWorker processing chunklet", "workerID", workerID, "workID", chunkletData.workID, "rowCount", len(chunkletData.rows))
 
+			queueWait := time.Since(chunkletData.enqueuedAt)
+			writeStart := time.Now()
 			affectedRows, err := a.writeChunklet(ctx, chunkletData)
+			a.timings.record(queueWait, time.Since(writeStart))
 
 			a.chunkletCompletions <- chunkletCompletion{
 				workID:       chunkletData.workID,

--- a/pkg/applier/stats.go
+++ b/pkg/applier/stats.go
@@ -1,0 +1,107 @@
+package applier
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+// timingRingSize is the number of most-recent chunklet timings retained for
+// the rolling percentiles reported by Stats(). It matches defaultBufferSize,
+// so at full occupancy the window covers roughly one buffer's worth of
+// writes.
+const timingRingSize = 128
+
+// Stats is a point-in-time snapshot of an applier's write pipeline. It exists
+// so status lines and metrics can distinguish a read-limited pipeline (queue
+// near empty) from a write-limited one (queue pegged at capacity with
+// queue-wait far above write time) — without this, write-side saturation is
+// invisible: the copier's end-to-end chunk feedback misattributes it to the
+// read side. All fields are approximate; they are read without pausing the
+// pipeline.
+type Stats struct {
+	// QueueDepth is the number of chunklets currently waiting in the
+	// buffer(s) — summed across shards for the sharded applier.
+	QueueDepth int
+	// QueueCap is the total buffer capacity (summed across shards).
+	QueueCap int
+	// PendingWork is the number of chunks accepted by Apply() whose
+	// callback has not fired yet (queued + in-flight).
+	PendingWork int
+	// ActiveWorkers is the number of live write workers.
+	ActiveWorkers int
+
+	// Rolling percentiles over the last timingRingSize chunklets. QueueWait
+	// is the time a chunklet spent between Apply() offering it to the buffer
+	// and a write worker dequeueing it (including send-side backpressure when
+	// the buffer is full). WriteTime is the time spent writing it to the
+	// target(s). Zero when no chunklet has completed yet.
+	QueueWaitP50 time.Duration
+	QueueWaitP90 time.Duration
+	WriteTimeP50 time.Duration
+	WriteTimeP90 time.Duration
+}
+
+// chunkletTiming is one completed chunklet's queue-wait and write durations.
+type chunkletTiming struct {
+	queueWait time.Duration
+	writeTime time.Duration
+}
+
+// timingRing is a fixed-size ring of the most recent chunklet timings.
+// record is called by write workers on the hot path — one mutex acquire and
+// one slot write per chunklet; percentiles are computed on read, which is
+// infrequent (status/metrics cadence).
+type timingRing struct {
+	mu      sync.Mutex
+	entries [timingRingSize]chunkletTiming
+	next    int  // next write position
+	full    bool // true once the ring has wrapped
+}
+
+func (r *timingRing) record(queueWait, writeTime time.Duration) {
+	r.mu.Lock()
+	r.entries[r.next] = chunkletTiming{queueWait: queueWait, writeTime: writeTime}
+	r.next++
+	if r.next == timingRingSize {
+		r.next = 0
+		r.full = true
+	}
+	r.mu.Unlock()
+}
+
+// percentiles returns the p50/p90 of queue-wait and write time over the
+// entries recorded so far. All zeros when nothing has been recorded.
+func (r *timingRing) percentiles() (queueWaitP50, queueWaitP90, writeTimeP50, writeTimeP90 time.Duration) {
+	r.mu.Lock()
+	n := r.next
+	if r.full {
+		n = timingRingSize
+	}
+	if n == 0 {
+		r.mu.Unlock()
+		return 0, 0, 0, 0
+	}
+	queueWaits := make([]time.Duration, n)
+	writeTimes := make([]time.Duration, n)
+	for i := range n {
+		queueWaits[i] = r.entries[i].queueWait
+		writeTimes[i] = r.entries[i].writeTime
+	}
+	r.mu.Unlock()
+
+	slices.Sort(queueWaits)
+	slices.Sort(writeTimes)
+	return percentile(queueWaits, 50), percentile(queueWaits, 90),
+		percentile(writeTimes, 50), percentile(writeTimes, 90)
+}
+
+// percentile returns the p-th percentile of a sorted slice using the
+// nearest-rank method (ceil(n*p/100), 1-indexed).
+func percentile(sorted []time.Duration, p int) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := max((len(sorted)*p+99)/100, 1)
+	return sorted[idx-1]
+}

--- a/pkg/applier/stats_test.go
+++ b/pkg/applier/stats_test.go
@@ -1,0 +1,244 @@
+package applier
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPercentileNearestRank(t *testing.T) {
+	require.Equal(t, time.Duration(0), percentile(nil, 50))
+	require.Equal(t, time.Duration(0), percentile([]time.Duration{}, 90))
+
+	one := []time.Duration{7 * time.Millisecond}
+	require.Equal(t, 7*time.Millisecond, percentile(one, 50))
+	require.Equal(t, 7*time.Millisecond, percentile(one, 90))
+
+	two := []time.Duration{1 * time.Millisecond, 2 * time.Millisecond}
+	require.Equal(t, 1*time.Millisecond, percentile(two, 50))
+	require.Equal(t, 2*time.Millisecond, percentile(two, 90))
+
+	// 1..100ms: nearest-rank p50 = 50ms, p90 = 90ms
+	hundred := make([]time.Duration, 100)
+	for i := range hundred {
+		hundred[i] = time.Duration(i+1) * time.Millisecond
+	}
+	require.Equal(t, 50*time.Millisecond, percentile(hundred, 50))
+	require.Equal(t, 90*time.Millisecond, percentile(hundred, 90))
+}
+
+func TestTimingRingPercentiles(t *testing.T) {
+	var r timingRing
+
+	// Empty ring: all zeros.
+	qw50, qw90, wt50, wt90 := r.percentiles()
+	require.Zero(t, qw50)
+	require.Zero(t, qw90)
+	require.Zero(t, wt50)
+	require.Zero(t, wt90)
+
+	// Partial fill: 10 entries with queueWait = i ms, writeTime = 10*i ms.
+	for i := 1; i <= 10; i++ {
+		r.record(time.Duration(i)*time.Millisecond, time.Duration(10*i)*time.Millisecond)
+	}
+	qw50, qw90, wt50, wt90 = r.percentiles()
+	require.Equal(t, 5*time.Millisecond, qw50)
+	require.Equal(t, 9*time.Millisecond, qw90)
+	require.Equal(t, 50*time.Millisecond, wt50)
+	require.Equal(t, 90*time.Millisecond, wt90)
+}
+
+func TestTimingRingWraps(t *testing.T) {
+	var r timingRing
+
+	// Overfill: 2*timingRingSize entries. The first half records 1h (which
+	// must be evicted); the second half records 1ms.
+	for range timingRingSize {
+		r.record(time.Hour, time.Hour)
+	}
+	for range timingRingSize {
+		r.record(time.Millisecond, time.Millisecond)
+	}
+	qw50, qw90, wt50, wt90 := r.percentiles()
+	require.Equal(t, time.Millisecond, qw50)
+	require.Equal(t, time.Millisecond, qw90)
+	require.Equal(t, time.Millisecond, wt50)
+	require.Equal(t, time.Millisecond, wt90)
+}
+
+// TestSingleTargetApplierStatsFresh verifies the zero-value snapshot of a
+// constructed-but-not-started applier.
+func TestSingleTargetApplierStatsFresh(t *testing.T) {
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	db, err := sql.Open("mysql", base.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	a, err := NewSingleTargetApplier(Target{DB: db, Config: base, KeyRange: "0"}, NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	stats := a.Stats()
+	require.Zero(t, stats.QueueDepth)
+	require.Equal(t, defaultBufferSize, stats.QueueCap)
+	require.Zero(t, stats.PendingWork)
+	require.Zero(t, stats.ActiveWorkers)
+	require.Zero(t, stats.QueueWaitP90)
+	require.Zero(t, stats.WriteTimeP90)
+}
+
+// TestSingleTargetApplierStatsQueueDepth verifies that chunklets enqueued
+// while no worker is draining are visible as queue depth and pending work —
+// the "write-limited pipeline" signal Stats exists to expose.
+func TestSingleTargetApplierStatsQueueDepth(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS stats_queue_source")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS stats_queue_target")
+	testutils.RunSQL(t, "CREATE DATABASE stats_queue_source")
+	testutils.RunSQL(t, "CREATE DATABASE stats_queue_target")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	source := base.Clone()
+	source.DBName = "stats_queue_source"
+	sourceDB, err := sql.Open("mysql", source.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(sourceDB)
+
+	target := base.Clone()
+	target.DBName = "stats_queue_target"
+	targetDB, err := sql.Open("mysql", target.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+
+	createTableSQL := `CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100))`
+	_, err = sourceDB.ExecContext(t.Context(), createTableSQL)
+	require.NoError(t, err)
+	_, err = targetDB.ExecContext(t.Context(), createTableSQL)
+	require.NoError(t, err)
+
+	sourceTable := table.NewTableInfo(sourceDB, source.DBName, "t1")
+	require.NoError(t, sourceTable.SetInfo(t.Context()))
+	targetTable := table.NewTableInfo(targetDB, target.DBName, "t1")
+	require.NoError(t, targetTable.SetInfo(t.Context()))
+
+	a, err := NewSingleTargetApplier(Target{DB: targetDB, Config: target, KeyRange: "0"}, NewApplierDefaultConfig())
+	require.NoError(t, err)
+	// Deliberately NOT started: no worker drains the buffer, so enqueued
+	// chunklets stay visible.
+
+	chunk := &table.Chunk{
+		Table:         sourceTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(sourceTable, targetTable, nil),
+	}
+	rows := [][]any{{int64(1), "a"}, {int64(2), "b"}}
+	require.NoError(t, a.Apply(t.Context(), chunk, rows, func(int64, error) {}))
+
+	stats := a.Stats()
+	require.Equal(t, 1, stats.QueueDepth, "one chunklet should be waiting in the buffer")
+	require.Equal(t, 1, stats.PendingWork, "one chunk should be pending completion")
+	require.Zero(t, stats.ActiveWorkers)
+}
+
+// TestShardedApplierStats verifies the aggregated snapshot: queue capacity
+// sums across shards, and a completed write populates the shared timings.
+func TestShardedApplierStats(t *testing.T) {
+	sourceTable, _, _, _, a := setupShardedUnderLockTest(t, "test_stats_sharded")
+	ctx := t.Context()
+
+	// Fresh (not started): capacity aggregates both shards, nothing active.
+	stats := a.Stats()
+	require.Zero(t, stats.QueueDepth)
+	require.Equal(t, 2*defaultBufferSize, stats.QueueCap)
+	require.Zero(t, stats.PendingWork)
+	require.Zero(t, stats.ActiveWorkers)
+
+	require.NoError(t, a.Start(ctx))
+	defer func() {
+		require.NoError(t, a.Stop())
+	}()
+
+	chunk := &table.Chunk{
+		Table:         sourceTable,
+		NewTable:      sourceTable,
+		ColumnMapping: table.NewColumnMapping(sourceTable, sourceTable, nil),
+	}
+	// user_id 2 (even) routes to shard 1, user_id 3 (odd) to shard 2.
+	rows := [][]any{{int64(1), int64(2), "a"}, {int64(2), int64(3), "b"}}
+	require.NoError(t, a.Apply(ctx, chunk, rows, func(int64, error) {}))
+	require.NoError(t, a.Wait(ctx))
+
+	stats = a.Stats()
+	require.Zero(t, stats.QueueDepth, "shard buffers should be drained")
+	require.Zero(t, stats.PendingWork)
+	require.Positive(t, stats.ActiveWorkers)
+	require.Positive(t, stats.QueueWaitP90)
+	require.Positive(t, stats.WriteTimeP90)
+}
+
+// TestSingleTargetApplierStatsRoundTrip verifies that a completed write
+// populates the rolling timings and drains pending work.
+func TestSingleTargetApplierStatsRoundTrip(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS stats_rt_source")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS stats_rt_target")
+	testutils.RunSQL(t, "CREATE DATABASE stats_rt_source")
+	testutils.RunSQL(t, "CREATE DATABASE stats_rt_target")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	source := base.Clone()
+	source.DBName = "stats_rt_source"
+	sourceDB, err := sql.Open("mysql", source.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(sourceDB)
+
+	target := base.Clone()
+	target.DBName = "stats_rt_target"
+	targetDB, err := sql.Open("mysql", target.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+
+	createTableSQL := `CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100))`
+	_, err = sourceDB.ExecContext(t.Context(), createTableSQL)
+	require.NoError(t, err)
+	_, err = targetDB.ExecContext(t.Context(), createTableSQL)
+	require.NoError(t, err)
+
+	sourceTable := table.NewTableInfo(sourceDB, source.DBName, "t1")
+	require.NoError(t, sourceTable.SetInfo(t.Context()))
+	targetTable := table.NewTableInfo(targetDB, target.DBName, "t1")
+	require.NoError(t, targetTable.SetInfo(t.Context()))
+
+	a, err := NewSingleTargetApplier(Target{DB: targetDB, Config: target, KeyRange: "0"}, NewApplierDefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, a.Start(t.Context()))
+	defer func() {
+		require.NoError(t, a.Stop())
+	}()
+
+	chunk := &table.Chunk{
+		Table:         sourceTable,
+		NewTable:      targetTable,
+		ColumnMapping: table.NewColumnMapping(sourceTable, targetTable, nil),
+	}
+	rows := [][]any{{int64(1), "a"}, {int64(2), "b"}}
+	require.NoError(t, a.Apply(t.Context(), chunk, rows, func(int64, error) {}))
+	require.NoError(t, a.Wait(t.Context()))
+
+	stats := a.Stats()
+	require.Zero(t, stats.QueueDepth, "buffer should be drained")
+	require.Zero(t, stats.PendingWork, "no work should be pending after Wait")
+	require.Positive(t, stats.ActiveWorkers)
+	require.Positive(t, stats.QueueWaitP90, "queue wait should have been recorded")
+	require.Positive(t, stats.WriteTimeP90, "write time should have been recorded")
+	require.GreaterOrEqual(t, stats.QueueWaitP90, stats.QueueWaitP50)
+	require.GreaterOrEqual(t, stats.WriteTimeP90, stats.WriteTimeP50)
+}

--- a/pkg/change/subscription_buffered_test.go
+++ b/pkg/change/subscription_buffered_test.go
@@ -1818,6 +1818,13 @@ func (c *countingApplier) Start(ctx context.Context) error {
 	return nil
 }
 
+func (c *countingApplier) Stats() applier.Stats {
+	if c.inner != nil {
+		return c.inner.Stats()
+	}
+	return applier.Stats{}
+}
+
 func (c *countingApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][]any, callback applier.ApplyCallback) error {
 	if c.inner != nil {
 		return c.inner.Apply(ctx, chunk, rows, callback)

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -35,6 +35,7 @@ func (a *noopDistributedApplier) UpsertRows(context.Context, *table.ColumnMappin
 
 func (a *noopDistributedApplier) Wait(context.Context) error { return nil }
 func (a *noopDistributedApplier) Stop() error                { return nil }
+func (a *noopDistributedApplier) Stats() applier.Stats       { return applier.Stats{} }
 func (a *noopDistributedApplier) GetTargets() []applier.Target {
 	return nil
 }

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -329,6 +329,10 @@ func (d *delayedCallbackApplier) Start(ctx context.Context) error {
 	return d.realApplier.Start(ctx)
 }
 
+func (d *delayedCallbackApplier) Stats() applier.Stats {
+	return d.realApplier.Stats()
+}
+
 func (d *delayedCallbackApplier) Apply(ctx context.Context, chunk *table.Chunk, rows [][]any, callback applier.ApplyCallback) error {
 	// Wrap the callback to add delay
 	wrappedCallback := func(affectedRows int64, err error) {


### PR DESCRIPTION
## Summary
Adds an applier-side `Stats()` snapshot so a write-limited copy pipeline is diagnosable at runtime. Today the copier's dynamic chunker feedback measures end-to-end chunk time (read + queue wait + write), so a saturated applier presents as a read-side/chunker problem — the chunker shrinks chunks while the true bottleneck is invisible.

## What
- New `Stats()` on the `Applier` interface, implemented by `SingleTargetApplier` and `ShardedApplier`, reporting queue depth/capacity, pending work, active write workers, and rolling p50/p90 queue-wait vs write-time (128-entry timing ring, matching the default buffer capacity).
- Queue-wait is stamped before the buffered send, deliberately including send-side backpressure; write time is measured dequeue-to-completion, so the two cleanly separate "waiting for a worker" from "doing the write".
- Sharded stats aggregate capacity/depth/workers across shards with one shared timing ring.

## Why
During a load-test migration on a large table, throughput collapsed ~4x below target with the chunker pinned near its floor. Post-analysis showed the apparent source-side bottleneck was most plausibly the applier write path (write-threads at default 4), but nothing in the status output could confirm it: worker count is now reported (#953) but queue occupancy and wait-vs-write split are not. With this snapshot, a write-limited pipeline shows up unambiguously as queue pegged at capacity and queue-wait ≫ write time.

A follow-up PR will surface these fields in the migration/move status lines and metrics.

```
before — chunker feedback blends read + queue-wait + write

┌─────────┐   end-to-end chunk latency (read + queue + write, blended)
│ chunker │◀─────────────────────────────────────────────────────────┐
└────┬────┘                                                          │
     │ shrinks chunks                                                │
     ▼                                                               │
┌────────┐     ┌───────────────┐     ┌───────────────┐               │
│ reader │────▶│ applier queue │────▶│ write workers │───────────────┘
└────────┘     └───────────────┘     └───────────────┘
                saturation here is invisible — presents as a
                chunker/read-side problem
```

```
after — applier exposes its own pipeline snapshot

┌────────┐     ┌───────────────┐     ┌───────────────┐
│ reader │────▶│ applier queue │────▶│ write workers │
└────────┘     └───────┬───────┘     └───────┬───────┘
                       │                     │
                       ▼                     ▼
               ┌─────────────────────────────────────────┐
               │ Stats(): queue depth/capacity, pending, │
               │ active workers, queue-wait p50/p90,     │
               │ write-time p50/p90                      │
               └─────────────────────────────────────────┘
                write-limited pipeline is unambiguous:
                queue pegged at capacity, queue-wait ≫ write-time
```

