### PR TITLE
applier: expose Stats() in status lines and metrics gauges

### DIFF
--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/table"
 	"github.com/go-sql-driver/mysql"
 )
@@ -165,6 +166,10 @@ type ApplierConfig struct {
 	ChunkletMaxSize int
 	Logger          *slog.Logger
 	DBConfig        *dbconn.DBConfig
+	// MetricsSink, when non-nil, makes the applier periodically report its
+	// Stats() snapshot as gauges (see pkg/metrics applier_* names). Nil
+	// disables emission entirely — no goroutine is started.
+	MetricsSink metrics.Sink
 }
 
 // NewApplierDefaultConfig returns a default config for the applier.

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/table"
 )
 
@@ -26,10 +27,11 @@ import (
 type ShardedApplier struct {
 	sync.Mutex
 
-	shards   []*shardTarget
-	targets  []Target // Original target configurations
-	dbConfig *dbconn.DBConfig
-	logger   *slog.Logger
+	shards      []*shardTarget
+	targets     []Target // Original target configurations
+	dbConfig    *dbconn.DBConfig
+	logger      *slog.Logger
+	metricsSink metrics.Sink // nil disables the stats emitter
 
 	// Pending work tracking (shared across all shards).
 	//
@@ -148,6 +150,7 @@ func NewShardedApplier(targets []Target, cfg *ApplierConfig) (*ShardedApplier, e
 		targets:     targets,
 		dbConfig:    cfg.DBConfig,
 		logger:      cfg.Logger,
+		metricsSink: cfg.MetricsSink,
 		pendingWork: make(map[int64]*pendingWork),
 	}, nil
 }
@@ -201,6 +204,14 @@ func (a *ShardedApplier) Start(ctx context.Context) error {
 	// Start a single feedback coordinator for all shards
 	a.wg.Add(1)
 	go a.feedbackCoordinator(workerCtx)
+
+	// Report pipeline gauges (aggregated across shards) for the applier's
+	// lifetime. Exits on Stop()'s context cancellation; joined via a.wg.
+	if a.metricsSink != nil {
+		a.wg.Go(func() {
+			emitStatsLoop(workerCtx, a, a.metricsSink, a.logger)
+		})
+	}
 
 	return nil
 }

--- a/pkg/applier/single_target.go
+++ b/pkg/applier/single_target.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/table"
 )
 
@@ -20,9 +21,10 @@ import (
 type SingleTargetApplier struct {
 	sync.Mutex
 
-	target   Target
-	dbConfig *dbconn.DBConfig
-	logger   *slog.Logger
+	target      Target
+	dbConfig    *dbconn.DBConfig
+	logger      *slog.Logger
+	metricsSink metrics.Sink // nil disables the stats emitter
 
 	// Internal chunklet processing
 	chunkletBuffer      chan chunklet
@@ -65,7 +67,7 @@ type SingleTargetApplier struct {
 
 	// Context management
 	cancelFunc context.CancelFunc
-	wg         sync.WaitGroup // tracks the feedbackCoordinator goroutine only
+	wg         sync.WaitGroup // tracks the feedbackCoordinator and stats-emitter goroutines
 
 	// State management to make Start/Stop idempotent
 	started bool
@@ -105,6 +107,7 @@ func NewSingleTargetApplier(target Target, cfg *ApplierConfig) (*SingleTargetApp
 		target:              target,
 		dbConfig:            cfg.DBConfig,
 		logger:              cfg.Logger,
+		metricsSink:         cfg.MetricsSink,
 		chunkletBuffer:      make(chan chunklet, defaultBufferSize),
 		chunkletCompletions: make(chan chunkletCompletion, defaultBufferSize),
 		pendingWork:         make(map[int64]*pendingWork),
@@ -161,6 +164,14 @@ func (a *SingleTargetApplier) Start(ctx context.Context) error {
 	// drained.
 	a.wg.Add(1)
 	go a.feedbackCoordinator(workerCtx)
+
+	// Report pipeline gauges for the applier's lifetime. Exits on Stop()'s
+	// context cancellation; joined via a.wg like the coordinator.
+	if a.metricsSink != nil {
+		a.wg.Go(func() {
+			emitStatsLoop(workerCtx, a, a.metricsSink, a.logger)
+		})
+	}
 
 	// Spawn the initial worker pool. SetWriteWorkers only takes scaleMu, so
 	// calling it while holding the main lock is safe (no lock nesting on the

--- a/pkg/applier/stats.go
+++ b/pkg/applier/stats.go
@@ -1,6 +1,7 @@
 package applier
 
 import (
+	"fmt"
 	"slices"
 	"sync"
 	"time"
@@ -40,6 +41,32 @@ type Stats struct {
 	QueueWaitP90 time.Duration
 	WriteTimeP50 time.Duration
 	WriteTimeP90 time.Duration
+}
+
+// String renders the snapshot in the kebab-case key=value style used by the
+// runner status lines, so migrate and move report identical fields. Durations
+// are rounded to the millisecond — finer precision is noise at status cadence.
+func (s Stats) String() string {
+	return fmt.Sprintf("applier-queue=%d/%d applier-pending=%d applier-workers=%d applier-queue-wait-p50=%v applier-queue-wait-p90=%v applier-write-p50=%v applier-write-p90=%v",
+		s.QueueDepth,
+		s.QueueCap,
+		s.PendingWork,
+		s.ActiveWorkers,
+		s.QueueWaitP50.Round(time.Millisecond),
+		s.QueueWaitP90.Round(time.Millisecond),
+		s.WriteTimeP50.Round(time.Millisecond),
+		s.WriteTimeP90.Round(time.Millisecond),
+	)
+}
+
+// StatusSuffix renders a's Stats() for appending to a runner status line: a
+// leading space plus Stats().String(), or "" when a is nil. Runner Status()
+// can be called before the applier is constructed, so this must be nil-safe.
+func StatusSuffix(a Applier) string {
+	if a == nil {
+		return ""
+	}
+	return " " + a.Stats().String()
 }
 
 // chunkletTiming is one completed chunklet's queue-wait and write durations.

--- a/pkg/applier/stats_emitter.go
+++ b/pkg/applier/stats_emitter.go
@@ -1,0 +1,61 @@
+package applier
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/block/spirit/pkg/metrics"
+)
+
+// statsEmitTick is how often an applier reports its pipeline gauges. It
+// matches the autoscaler's cadence (copier acTick) so the write-thread count
+// and the pipeline occupancy it acts on are sampled at the same rate. A var
+// so tests can shorten it.
+var statsEmitTick = 5 * time.Second
+
+// statsProvider is the narrow slice of Applier the emitter needs.
+type statsProvider interface {
+	Stats() Stats
+}
+
+// emitStatsLoop periodically sends the applier's Stats() snapshot to the sink
+// as gauges until ctx is cancelled. Each concrete applier starts one of these
+// from Start() when a MetricsSink is configured — the loop lives exactly as
+// long as the pipeline it measures, covering both the copy and binlog-apply
+// phases.
+func emitStatsLoop(ctx context.Context, a statsProvider, sink metrics.Sink, logger *slog.Logger) {
+	ticker := time.NewTicker(statsEmitTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			emitStats(ctx, a, sink, logger)
+		}
+	}
+}
+
+// emitStats sends one gauge snapshot. Failures are logged at Debug and
+// dropped — metrics must never affect the migration.
+func emitStats(ctx context.Context, a statsProvider, sink metrics.Sink, logger *slog.Logger) {
+	s := a.Stats()
+	m := &metrics.Metrics{
+		Values: []metrics.MetricValue{
+			{Name: metrics.ApplierQueueDepthMetricName, Type: metrics.GAUGE, Value: float64(s.QueueDepth)},
+			{Name: metrics.ApplierQueueCapacityMetricName, Type: metrics.GAUGE, Value: float64(s.QueueCap)},
+			{Name: metrics.ApplierPendingWorkMetricName, Type: metrics.GAUGE, Value: float64(s.PendingWork)},
+			{Name: metrics.ApplierActiveWorkersMetricName, Type: metrics.GAUGE, Value: float64(s.ActiveWorkers)},
+			{Name: metrics.ApplierQueueWaitP50MetricName, Type: metrics.GAUGE, Value: float64(s.QueueWaitP50.Milliseconds())},
+			{Name: metrics.ApplierQueueWaitP90MetricName, Type: metrics.GAUGE, Value: float64(s.QueueWaitP90.Milliseconds())},
+			{Name: metrics.ApplierWriteTimeP50MetricName, Type: metrics.GAUGE, Value: float64(s.WriteTimeP50.Milliseconds())},
+			{Name: metrics.ApplierWriteTimeP90MetricName, Type: metrics.GAUGE, Value: float64(s.WriteTimeP90.Milliseconds())},
+		},
+	}
+	sendCtx, cancel := context.WithTimeout(ctx, metrics.SinkTimeout)
+	defer cancel()
+	if err := sink.Send(sendCtx, m); err != nil {
+		logger.Debug("applier stats metrics send failed", "error", err)
+	}
+}

--- a/pkg/applier/stats_emitter_test.go
+++ b/pkg/applier/stats_emitter_test.go
@@ -1,0 +1,211 @@
+package applier
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/metrics"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// captureSink records every Metrics batch it receives.
+type captureSink struct {
+	mu    sync.Mutex
+	sends []*metrics.Metrics
+}
+
+func (s *captureSink) Send(_ context.Context, m *metrics.Metrics) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sends = append(s.sends, m)
+	return nil
+}
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.sends)
+}
+
+func (s *captureSink) last() *metrics.Metrics {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.sends) == 0 {
+		return nil
+	}
+	return s.sends[len(s.sends)-1]
+}
+
+// errorSink always fails; emitStats must swallow the error.
+type errorSink struct{}
+
+func (s *errorSink) Send(context.Context, *metrics.Metrics) error {
+	return errors.New("sink unavailable")
+}
+
+// stubStats is a fixed-snapshot statsProvider.
+type stubStats struct{ s Stats }
+
+func (p stubStats) Stats() Stats { return p.s }
+
+// shortenStatsTick shortens the global emit cadence for the duration of the
+// test. Tests using it must not run in parallel — statsEmitTick is package
+// state.
+func shortenStatsTick(t *testing.T) {
+	t.Helper()
+	old := statsEmitTick
+	statsEmitTick = 10 * time.Millisecond
+	t.Cleanup(func() { statsEmitTick = old })
+}
+
+// TestEmitStatsGauges pins the metric names, the GAUGE type, and the
+// duration→milliseconds conversion for one snapshot.
+func TestEmitStatsGauges(t *testing.T) {
+	sink := &captureSink{}
+	p := stubStats{Stats{
+		QueueDepth:    3,
+		QueueCap:      128,
+		PendingWork:   7,
+		ActiveWorkers: 4,
+		QueueWaitP50:  1800 * time.Millisecond,
+		QueueWaitP90:  4200 * time.Millisecond,
+		WriteTimeP50:  95 * time.Millisecond,
+		WriteTimeP90:  210 * time.Millisecond,
+	}}
+	emitStats(t.Context(), p, sink, slog.Default())
+	require.Equal(t, 1, sink.count())
+
+	got := map[string]float64{}
+	for _, v := range sink.last().Values {
+		require.Equal(t, metrics.GAUGE, v.Type, "metric %s must be a gauge", v.Name)
+		got[v.Name] = v.Value
+	}
+	require.Equal(t, map[string]float64{
+		metrics.ApplierQueueDepthMetricName:    3,
+		metrics.ApplierQueueCapacityMetricName: 128,
+		metrics.ApplierPendingWorkMetricName:   7,
+		metrics.ApplierActiveWorkersMetricName: 4,
+		metrics.ApplierQueueWaitP50MetricName:  1800,
+		metrics.ApplierQueueWaitP90MetricName:  4200,
+		metrics.ApplierWriteTimeP50MetricName:  95,
+		metrics.ApplierWriteTimeP90MetricName:  210,
+	}, got)
+}
+
+// TestEmitStatsSinkErrorSwallowed verifies a failing sink never propagates —
+// metrics must not affect the migration.
+func TestEmitStatsSinkErrorSwallowed(t *testing.T) {
+	emitStats(t.Context(), stubStats{}, &errorSink{}, slog.Default())
+}
+
+// TestEmitStatsLoopLifecycle verifies the loop emits on its tick and exits on
+// context cancellation.
+func TestEmitStatsLoopLifecycle(t *testing.T) {
+	shortenStatsTick(t)
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		emitStatsLoop(ctx, stubStats{}, sink, slog.Default())
+	}()
+
+	require.Eventually(t, func() bool { return sink.count() >= 2 },
+		5*time.Second, 5*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("emitStatsLoop did not exit after context cancellation")
+	}
+}
+
+// TestSingleTargetApplierEmitsStats verifies the applier starts the emitter
+// when a MetricsSink is configured and joins it on Stop.
+func TestSingleTargetApplierEmitsStats(t *testing.T) {
+	shortenStatsTick(t)
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	db, err := sql.Open("mysql", base.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	sink := &captureSink{}
+	cfg := NewApplierDefaultConfig()
+	cfg.MetricsSink = sink
+	a, err := NewSingleTargetApplier(Target{DB: db, Config: base, KeyRange: "0"}, cfg)
+	require.NoError(t, err)
+	require.NoError(t, a.Start(t.Context()))
+
+	require.Eventually(t, func() bool { return sink.count() >= 1 },
+		5*time.Second, 5*time.Millisecond)
+
+	// Stop joins the emitter goroutine via a.wg, so after Stop returns the
+	// send count must be stable.
+	require.NoError(t, a.Stop())
+	n := sink.count()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, n, sink.count(), "emitter still sending after Stop")
+}
+
+// TestShardedApplierEmitsStats is the ShardedApplier counterpart: one
+// aggregated emitter, started with the applier and joined on Stop.
+func TestShardedApplierEmitsStats(t *testing.T) {
+	shortenStatsTick(t)
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	db1, err := sql.Open("mysql", base.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db1)
+	db2, err := sql.Open("mysql", base.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db2)
+
+	sink := &captureSink{}
+	cfg := NewApplierDefaultConfig()
+	cfg.MetricsSink = sink
+	a, err := NewShardedApplier([]Target{
+		{DB: db1, KeyRange: "-80"},
+		{DB: db2, KeyRange: "80-"},
+	}, cfg)
+	require.NoError(t, err)
+	require.NoError(t, a.Start(t.Context()))
+
+	require.Eventually(t, func() bool { return sink.count() >= 1 },
+		5*time.Second, 5*time.Millisecond)
+
+	require.NoError(t, a.Stop())
+	n := sink.count()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, n, sink.count(), "emitter still sending after Stop")
+}
+
+// TestNilSinkStartsNoEmitter verifies a nil MetricsSink keeps today's
+// behavior: Start/Stop work and no emitter goroutine runs.
+func TestNilSinkStartsNoEmitter(t *testing.T) {
+	shortenStatsTick(t)
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	db, err := sql.Open("mysql", base.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	a, err := NewSingleTargetApplier(Target{DB: db, Config: base, KeyRange: "0"}, NewApplierDefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, a.Start(t.Context()))
+	time.Sleep(30 * time.Millisecond) // several ticks' worth
+	require.NoError(t, a.Stop())
+}

--- a/pkg/applier/stats_test.go
+++ b/pkg/applier/stats_test.go
@@ -72,6 +72,44 @@ func TestTimingRingWraps(t *testing.T) {
 	require.Equal(t, time.Millisecond, wt90)
 }
 
+// TestStatsString pins the exact status-line rendering, including the
+// zero-value form (durations render as 0s) and millisecond rounding — a
+// change to either should be deliberate, since operators grep these fields.
+func TestStatsString(t *testing.T) {
+	s := Stats{
+		QueueDepth:    48,
+		QueueCap:      128,
+		PendingWork:   53,
+		ActiveWorkers: 4,
+		QueueWaitP50:  1800 * time.Millisecond,
+		QueueWaitP90:  4200 * time.Millisecond,
+		WriteTimeP50:  95 * time.Millisecond,
+		WriteTimeP90:  210 * time.Millisecond,
+	}
+	require.Equal(t,
+		"applier-queue=48/128 applier-pending=53 applier-workers=4 "+
+			"applier-queue-wait-p50=1.8s applier-queue-wait-p90=4.2s "+
+			"applier-write-p50=95ms applier-write-p90=210ms",
+		s.String())
+
+	require.Equal(t,
+		"applier-queue=0/0 applier-pending=0 applier-workers=0 "+
+			"applier-queue-wait-p50=0s applier-queue-wait-p90=0s "+
+			"applier-write-p50=0s applier-write-p90=0s",
+		Stats{}.String())
+
+	// Sub-millisecond noise rounds away.
+	require.Contains(t,
+		Stats{WriteTimeP50: 1499 * time.Microsecond}.String(),
+		"applier-write-p50=1ms")
+}
+
+// TestStatusSuffixNil verifies the runner-facing helper is nil-safe: Status()
+// can be requested before the applier is constructed.
+func TestStatusSuffixNil(t *testing.T) {
+	require.Empty(t, StatusSuffix(nil))
+}
+
 // TestSingleTargetApplierStatsFresh verifies the zero-value snapshot of a
 // constructed-but-not-started applier.
 func TestSingleTargetApplierStatsFresh(t *testing.T) {
@@ -91,6 +129,9 @@ func TestSingleTargetApplierStatsFresh(t *testing.T) {
 	require.Zero(t, stats.ActiveWorkers)
 	require.Zero(t, stats.QueueWaitP90)
 	require.Zero(t, stats.WriteTimeP90)
+
+	// StatusSuffix on a live applier: a leading space plus String().
+	require.Equal(t, " "+a.Stats().String(), StatusSuffix(a))
 }
 
 // TestSingleTargetApplierStatsQueueDepth verifies that chunklets enqueued

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,6 +24,19 @@ const (
 	// continuous load signal (0..>1) the autoscaler controls on.
 	WriteThreadsMetricName         = "write_threads"
 	ThrottlerUtilizationMetricName = "throttler_utilization"
+
+	// Applier pipeline gauges (see pkg/applier Stats). Together they
+	// distinguish a read-limited copy pipeline (queue near empty, workers
+	// idle) from a write-limited one (queue pegged at capacity with
+	// queue-wait far above write time).
+	ApplierQueueDepthMetricName    = "applier_queue_depth"
+	ApplierQueueCapacityMetricName = "applier_queue_capacity"
+	ApplierPendingWorkMetricName   = "applier_pending_work"
+	ApplierActiveWorkersMetricName = "applier_active_workers"
+	ApplierQueueWaitP50MetricName  = "applier_queue_wait_ms_p50"
+	ApplierQueueWaitP90MetricName  = "applier_queue_wait_ms_p90"
+	ApplierWriteTimeP50MetricName  = "applier_write_time_ms_p50"
+	ApplierWriteTimeP90MetricName  = "applier_write_time_ms_p90"
 )
 
 // Metrics are collection of MetricValues.

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -162,6 +162,9 @@ func TestCheckpoint(t *testing.T) {
 	require.Equal(t, "copyRows", r.status.Get().String())
 
 	require.Contains(t, r.Status(), `migration status: state=copyRows copy-progress=0/11040 0.00% binlog-deltas=0`)
+	// The status line also reports the applier pipeline snapshot.
+	require.Contains(t, r.Status(), `applier-queue=`)
+	require.Contains(t, r.Status(), `applier-queue-wait-p90=`)
 
 	// first chunk.
 	chunk1, err := r.copyChunker.Next()

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -78,6 +78,11 @@ type Runner struct {
 	copyChunker  table.Chunker // the chunker for copying
 	copyDuration time.Duration // how long the copy took
 
+	// applier is the shared write layer used by both the copier (buffered
+	// copy) and the replication client (binlog deltas). Kept on the runner
+	// so Status() can report its pipeline snapshot.
+	applier applier.Applier
+
 	checker         checksum.Checker
 	checksumChunker table.Chunker // the chunker for checksum
 
@@ -756,14 +761,16 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	appl, err := applier.NewSingleTargetApplier(
 		applier.Target{DB: r.db},
 		&applier.ApplierConfig{
-			Logger:   r.logger,
-			DBConfig: r.dbConfig,
-			Threads:  r.migration.WriteThreads,
+			Logger:      r.logger,
+			DBConfig:    r.dbConfig,
+			Threads:     r.migration.WriteThreads,
+			MetricsSink: r.metricsSink,
 		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create applier: %w", err)
 	}
+	r.applier = appl
 
 	// Create copier with the prepared chunker
 	r.copier, err = copier.NewCopier(r.db, r.copyChunker, &copier.CopierConfig{
@@ -1641,7 +1648,7 @@ func (r *Runner) Status() string {
 	switch state { //nolint: exhaustive
 	case status.CopyRows:
 		// Status for copy rows
-		return fmt.Sprintf("migration status: state=%s copy-progress=%s binlog-deltas=%v total-time=%s copier-time=%s copier-remaining-time=%v copier-is-throttled=%v conns-in-use=%d",
+		return fmt.Sprintf("migration status: state=%s copy-progress=%s binlog-deltas=%v total-time=%s copier-time=%s copier-remaining-time=%v copier-is-throttled=%v conns-in-use=%d%s",
 			r.status.Get().String(),
 			r.copier.GetProgress(),
 			r.replClient.GetDeltaLen(),
@@ -1650,6 +1657,7 @@ func (r *Runner) Status() string {
 			r.copier.GetETA(),
 			r.copier.GetThrottler().IsThrottled(),
 			r.db.Stats().InUse,
+			applier.StatusSuffix(r.applier),
 		)
 	case status.WaitingOnSentinelTable:
 		return fmt.Sprintf("migration status: state=%s sentinel-table=%s.%s total-time=%s sentinel-wait-time=%s sentinel-max-wait-time=%s conns-in-use=%d",
@@ -1664,11 +1672,12 @@ func (r *Runner) Status() string {
 	case status.ApplyChangeset, status.PostChecksum:
 		// We've finished copying rows, and we are now trying to reduce the number of binlog deltas before
 		// proceeding to the checksum and then the final cutover.
-		return fmt.Sprintf("migration status: state=%s binlog-deltas=%v total-time=%s conns-in-use=%d",
+		return fmt.Sprintf("migration status: state=%s binlog-deltas=%v total-time=%s conns-in-use=%d%s",
 			r.status.Get().String(),
 			r.replClient.GetDeltaLen(),
 			time.Since(r.startTime).Round(time.Second),
 			r.db.Stats().InUse,
+			applier.StatusSuffix(r.applier),
 		)
 	case status.Checksum:
 		return fmt.Sprintf("migration status: state=%s checksum-progress=%s binlog-deltas=%v total-time=%s checksum-time=%s conns-in-use=%d",

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1362,7 +1362,7 @@ func (r *Runner) Status() string {
 	switch state { //nolint:exhaustive
 	case status.CopyRows:
 		// Status for copy rows
-		return fmt.Sprintf("migration status: state=%s copy-progress=%s binlog-deltas=%v total-time=%s copier-time=%s copier-remaining-time=%v copier-is-throttled=%v",
+		return fmt.Sprintf("migration status: state=%s copy-progress=%s binlog-deltas=%v total-time=%s copier-time=%s copier-remaining-time=%v copier-is-throttled=%v%s",
 			r.status.Get().String(),
 			r.copier.GetProgress(),
 			r.getDeltaLenAll(),
@@ -1370,6 +1370,7 @@ func (r *Runner) Status() string {
 			time.Since(r.copier.StartTime()).Round(time.Second),
 			r.copier.GetETA(),
 			r.copier.GetThrottler().IsThrottled(),
+			applier.StatusSuffix(r.applier),
 		)
 	case status.WaitingOnSentinelTable:
 		return fmt.Sprintf("migration status: state=%s total-time=%s sentinel-wait-time=%s sentinel-max-wait-time=%s",
@@ -1381,10 +1382,11 @@ func (r *Runner) Status() string {
 	case status.ApplyChangeset, status.PostChecksum:
 		// We've finished copying rows, and we are now trying to reduce the number of binlog deltas before
 		// proceeding to the checksum and then the final cutover.
-		return fmt.Sprintf("migration status: state=%s binlog-deltas=%v total-time=%s",
+		return fmt.Sprintf("migration status: state=%s binlog-deltas=%v total-time=%s%s",
 			r.status.Get().String(),
 			r.getDeltaLenAll(),
 			time.Since(r.startTime).Round(time.Second),
+			applier.StatusSuffix(r.applier),
 		)
 	case status.Checksum:
 		// This could take a while if it's a large table.


### PR DESCRIPTION
## Summary
PR 2 of 2 for applier pipeline observability (stacked on #1081). #1081 added the `Stats()` snapshot; this PR surfaces it in the periodic status lines of `migrate` and `move`, and as metrics gauges.

## What
- Status lines (copyRows and applyChangeset/postChecksum) gain: `applier-queue=<depth>/<cap> applier-pending=<n> applier-workers=<n> applier-queue-wait-p50/p90 applier-write-p50/p90`
- Eight new gauges (`applier_queue_depth`, `applier_queue_capacity`, `applier_pending_work`, `applier_active_workers`, `applier_queue_wait_ms_p50/p90`, `applier_write_time_ms_p50/p90`) emitted every 5s — same cadence as the copier autoscaler
- `ApplierConfig.MetricsSink` (nil = no emitter goroutine); wired from the migration runner's existing sink. Move gets status fields only — it has no metrics-sink plumbing today.

## Why
During a recent long-running migration we could see the chunker collapse but had no visibility into whether the applier pipeline was the bottleneck (queue full, writes slow) or starved (queue empty). These fields answer that question at a glance during an incident, without a debugger.

## Before / after
before:
```
... copier-is-throttled=false conns-in-use=6
```
after:
```
... copier-is-throttled=false conns-in-use=6 applier-queue=48/128 applier-pending=53 applier-workers=4 applier-queue-wait-p50=1.8s applier-queue-wait-p90=4.2s applier-write-p50=95ms applier-write-p90=210ms
queue pegged at capacity + queue-wait >> write time  → write-limited
queue near empty + workers idle                      → read-limited
```