### PR TITLE
copier: runtime read-worker scaling seam (SetReadWorkers)

### DIFF
--- a/pkg/copier/README.md
+++ b/pkg/copier/README.md
@@ -240,7 +240,7 @@ Both copier implementations use goroutines for parallel chunk processing:
 - Stops on first error
 
 **Buffered:**
-- Fixed number of reader goroutines (equal to concurrency)
+- A pool of reader goroutines, starting at `concurrency` and resizable at runtime via `SetReadWorkers`
 - Each reader goroutine reads chunks and sends rows to the applier
 - The applier has its own internal parallelism for writing
 - Callbacks notify readers when writes complete

--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -307,6 +307,15 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 		default:
 		}
 
+		// Re-check health after BlockWait: a reader can sit blocked in the
+		// throttler for a long time, and the copy may have been cancelled or
+		// invalidated while it waited. Exit here rather than claiming one
+		// more chunk against a dead copy.
+		if !c.isHealthy(ctx) {
+			c.logger.Debug("readWorker unhealthy after BlockWait, exiting")
+			return nil
+		}
+
 		c.logger.Debug("readWorker calling chunker.Next()")
 		chunk, err := c.chunker.Next()
 		if err != nil {

--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -17,7 +17,6 @@ import (
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/throttler"
 	"github.com/block/spirit/pkg/utils"
-	"golang.org/x/sync/errgroup"
 )
 
 // The buffered copier implements a producer/consumer pattern
@@ -44,6 +43,23 @@ type buffered struct {
 	metricsSink      metrics.Sink
 	copierEtaHistory *copierEtaHistory
 	autoscale        AutoscaleConfig
+
+	// Read-worker pool management, symmetric with the applier's write-worker
+	// pool (SetWriteWorkers/ActiveWriteWorkers). concurrency above is the
+	// initial reader count; the *live* count can change at runtime via
+	// SetReadWorkers. Unlike write workers, readers also exit naturally when
+	// the chunker is exhausted, so instead of a WaitGroup (whose Add would
+	// race Wait once the count hits zero) the pool is a mutex-guarded count
+	// with a condition variable: Run waits for liveReaders to reach zero and
+	// closes scaling under the same mutex, so no reader can be spawned after
+	// the drain has been observed.
+	readScaleMu       sync.Mutex         // guards the fields below and spawn/park
+	readersDone       *sync.Cond         // signalled on every reader exit; created in Run
+	readerCtx         context.Context    // ctx readers run under; set in Run
+	readerCancel      context.CancelFunc // cancels readerCtx; used to abort siblings on reader error
+	readerQuits       []chan struct{}    // one quit channel per live reader — closing one parks (exits) that reader
+	liveReaders       int                // current live reader count
+	readScalingClosed bool               // set true when the pool has drained, to block new spawns
 }
 
 // Assert that buffered implements the Copier interface
@@ -180,17 +196,41 @@ func (c *buffered) Run(ctx context.Context) error {
 		go as.run(ctx)
 	}
 
-	// Start read workers
-	g, errGrpCtx := errgroup.WithContext(ctx)
-	c.logger.Debug("starting read workers", "count", c.concurrency)
-	for range c.concurrency {
-		g.Go(func() error {
-			return c.readWorker(errGrpCtx)
-		})
+	// Start the read-worker pool. It starts at c.concurrency and can be
+	// resized at runtime via SetReadWorkers. readerCtx replaces the old
+	// errgroup context: a reader that fails cancels it so sibling readers
+	// abort their in-flight reads promptly.
+	readerCtx, readerCancel := context.WithCancel(ctx)
+	defer readerCancel()
+	c.readScaleMu.Lock()
+	if c.readersDone == nil {
+		c.readersDone = sync.NewCond(&c.readScaleMu)
 	}
+	c.readerCtx = readerCtx
+	c.readerCancel = readerCancel
+	c.readerQuits = nil
+	c.liveReaders = 0
+	c.readScalingClosed = false
+	c.readScaleMu.Unlock()
+	c.logger.Debug("starting read workers", "count", c.concurrency)
+	c.SetReadWorkers(c.concurrency)
 
-	// Wait for all read workers to finish
-	err := g.Wait()
+	// Wait for the reader pool to drain (chunker exhausted, error, or ctx
+	// cancelled). Observing zero and closing scaling happen under the same
+	// mutex, so a concurrent SetReadWorkers cannot spawn a reader after the
+	// drain has been observed.
+	c.readScaleMu.Lock()
+	for c.liveReaders > 0 {
+		c.readersDone.Wait()
+	}
+	c.readScalingClosed = true
+	c.readerQuits = nil
+	c.readScaleMu.Unlock()
+
+	// Reader errors are recorded via setInvalid (first error wins) rather
+	// than returned through an errgroup, so pick them up here. They take
+	// precedence over applier.Wait/Stop errors below, as before.
+	err := c.getFirstErr()
 
 	// Wait for the applier to finish processing all pending work
 	// This ensures all callbacks have been invoked before we return
@@ -206,11 +246,10 @@ func (c *buffered) Run(ctx context.Context) error {
 
 	// A failure inside an async applier callback (e.g. a chunklet the target
 	// rejected with a warning) is reported to the callback in the applier's own
-	// goroutine — it never flows through errGrp or applier.Wait, both of which
-	// return nil in that case. Surface the first captured error so callers get
-	// the real root cause instead of a generic "copy failed" message (or, worse,
-	// a nil error that looks like success). Read/apply errors that already came
-	// back through errGrp take precedence and leave this untouched.
+	// goroutine, which may run after the reader pool drained — too late for the
+	// getFirstErr read above — and applier.Wait returns nil in that case.
+	// Re-check so callers get the real root cause instead of a generic "copy
+	// failed" message (or, worse, a nil error that looks like success).
 	if err == nil {
 		err = c.getFirstErr()
 	}
@@ -245,12 +284,23 @@ func (c *buffered) autoscalerIfEnabled() *autoScaler {
 	return newAutoScaler(gradual, scaler, c.autoscale.StartThreads, c.autoscale.MaxThreads, c.logger, c.metricsSink)
 }
 
-// readWorker reads chunks and sends them to the applier
-func (c *buffered) readWorker(ctx context.Context) error {
+// readWorker reads chunks and sends them to the applier. It exits when the
+// chunker is exhausted, the copy is invalidated, or its quit channel is closed
+// (scale-down via SetReadWorkers). The quit check sits right after BlockWait —
+// the spot where an idle reader parks — so a parked reader exits as soon as
+// the throttler releases it, without claiming another chunk.
+func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 	c.logger.Debug("readWorker started", "isRead", c.chunker.IsRead())
 
 	for !c.chunker.IsRead() && c.isHealthy(ctx) {
 		c.throttler.BlockWait(ctx)
+
+		select {
+		case <-quit:
+			c.logger.Debug("readWorker parked (scale-down), exiting")
+			return nil
+		default:
+		}
 
 		c.logger.Debug("readWorker calling chunker.Next()")
 		chunk, err := c.chunker.Next()
@@ -343,6 +393,90 @@ func (c *buffered) readWorker(ctx context.Context) error {
 
 	c.logger.Debug("readWorker exiting main loop")
 	return nil
+}
+
+// SetReadWorkers reconciles the live read-worker count to n, spawning new
+// readers or parking existing ones as needed. It is the read-side counterpart
+// of SingleTargetApplier.SetWriteWorkers: idempotent, safe to call repeatedly,
+// and n is clamped to a minimum of 1 so the copy always makes progress. Calls
+// before Run has started the pool or after it has drained are no-ops.
+//
+// Parking is cooperative: closing a reader's quit channel makes it exit right
+// after its next BlockWait returns, so a chunk already claimed is always read
+// and submitted to the applier — no chunk is ever lost.
+func (c *buffered) SetReadWorkers(n int) {
+	if n < 1 {
+		n = 1
+	}
+	c.readScaleMu.Lock()
+	defer c.readScaleMu.Unlock()
+
+	// No-op before Run has recorded the reader context or once the pool has
+	// drained. In both states we must not spawn: before Run a nil readerCtx
+	// would panic the reader, and post-drain spawns would race Run's
+	// drain-wait, which has already observed zero.
+	if c.readerCtx == nil || c.readScalingClosed {
+		return
+	}
+
+	cur := len(c.readerQuits)
+	switch {
+	case n > cur:
+		for range n - cur {
+			c.spawnReadWorkerLocked()
+		}
+		c.logger.Info("scaled read workers up", "from", cur, "to", n)
+	case n < cur:
+		// Park the most-recently-added readers by closing their quit channels.
+		for i := cur - 1; i >= n; i-- {
+			close(c.readerQuits[i])
+		}
+		c.readerQuits = c.readerQuits[:n]
+		c.logger.Info("scaled read workers down", "from", cur, "to", n)
+	}
+}
+
+// ActiveReadWorkers returns the current number of live read workers.
+func (c *buffered) ActiveReadWorkers() int {
+	c.readScaleMu.Lock()
+	defer c.readScaleMu.Unlock()
+	return c.liveReaders
+}
+
+// spawnReadWorkerLocked starts one read worker. Callers must hold readScaleMu.
+func (c *buffered) spawnReadWorkerLocked() {
+	quit := make(chan struct{})
+	c.readerQuits = append(c.readerQuits, quit)
+	c.liveReaders++
+	ctx := c.readerCtx
+	cancel := c.readerCancel
+	go func() {
+		defer c.readerExited(quit)
+		if err := c.readWorker(ctx, quit); err != nil {
+			// The error itself was already recorded by setInvalid inside
+			// readWorker; cancelling the shared reader context aborts sibling
+			// readers' in-flight reads promptly (errgroup parity).
+			cancel()
+		}
+	}()
+}
+
+// readerExited is the bookkeeping counterpart of spawnReadWorkerLocked, run as
+// every reader's exit path. It removes the reader's quit channel from the pool
+// (present only when the reader exited naturally — a parked reader's entry was
+// already trimmed by SetReadWorkers), decrements the live count, and wakes
+// Run's drain-wait.
+func (c *buffered) readerExited(quit chan struct{}) {
+	c.readScaleMu.Lock()
+	defer c.readScaleMu.Unlock()
+	for i, q := range c.readerQuits {
+		if q == quit {
+			c.readerQuits = append(c.readerQuits[:i], c.readerQuits[i+1:]...)
+			break
+		}
+	}
+	c.liveReaders--
+	c.readersDone.Broadcast()
 }
 
 // setInvalid marks the copy as failed and records the first error that caused

--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -174,6 +174,11 @@ func (c *buffered) StartTime() time.Time {
 	return c.startTime
 }
 
+// Run copies all rows from the source to the target table, blocking until
+// the copy completes or fails. Run must not be called more than once per
+// copier instance: it resets the read-worker pool state that SetReadWorkers
+// reconciles against, so a second concurrent Run would corrupt the first's
+// pool accounting.
 func (c *buffered) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -404,6 +409,15 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 // Parking is cooperative: closing a reader's quit channel makes it exit right
 // after its next BlockWait returns, so a chunk already claimed is always read
 // and submitted to the applier — no chunk is ever lost.
+//
+// Parking latency differs from the write pool: write workers observe quit
+// inside their blocking select and park immediately, but a parked reader
+// stays live (and counted by ActiveReadWorkers) until its in-flight
+// BlockWait returns — up to the throttler's full block duration (~60s for
+// the replica throttler). Scaling down and back up within that window
+// briefly overlaps parked readers with their replacements: the overlap is
+// bounded by the previous pool size, self-drains, and parked readers do no
+// chunk work.
 func (c *buffered) SetReadWorkers(n int) {
 	if n < 1 {
 		n = 1
@@ -436,7 +450,10 @@ func (c *buffered) SetReadWorkers(n int) {
 	}
 }
 
-// ActiveReadWorkers returns the current number of live read workers.
+// ActiveReadWorkers returns the current number of live read workers. This
+// includes readers parked by SetReadWorkers that are still waiting for their
+// in-flight BlockWait to return (see SetReadWorkers), so it can briefly
+// exceed the requested worker count after a scale-down.
 func (c *buffered) ActiveReadWorkers() int {
 	c.readScaleMu.Lock()
 	defer c.readScaleMu.Unlock()

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -512,10 +512,23 @@ func TestBufferedCopierReadWorkerScaling(t *testing.T) {
 		runErr <- b.Run(t.Context())
 	}()
 
-	// The initial pool comes up at Concurrency and parks at the gate.
+	// The initial pool comes up at Concurrency and parks at the gate. Drain
+	// runErr while polling so an early Run failure surfaces as its real error
+	// instead of an opaque Eventually timeout.
+	var earlyRunErr error
+	runReturnedEarly := false
 	require.Eventually(t, func() bool {
+		select {
+		case earlyRunErr = <-runErr:
+			runReturnedEarly = true
+			return true // fail fast below; Run should still be copying
+		default:
+		}
 		return b.ActiveReadWorkers() == 4
 	}, 10*time.Second, 10*time.Millisecond)
+	require.NoError(t, earlyRunErr)
+	require.False(t, runReturnedEarly, "Run returned before the gate released the copy")
+	require.Equal(t, 4, b.ActiveReadWorkers())
 
 	// Scale up: spawning is synchronous, the new readers park at the gate too.
 	b.SetReadWorkers(6)

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -432,3 +432,129 @@ func TestBufferedCopierGeometry(t *testing.T) {
 		"SELECT BIT_XOR(CRC32(CONCAT(id, name, ST_AsText(location)))) FROM geomdst").Scan(&checksumDst))
 	require.Equal(t, checksumSrc, checksumDst, "geometry data checksum mismatch after buffered copy")
 }
+
+// gateThrottler gives tests deterministic control over where read workers
+// park. BlockWait blocks until either one token is received on allow (waking
+// exactly one reader for one loop iteration) or open is closed (the gate is
+// permanently open and BlockWait returns immediately from then on).
+type gateThrottler struct {
+	allow chan struct{}
+	open  chan struct{}
+}
+
+func (g *gateThrottler) Open(_ context.Context) error      { return nil }
+func (g *gateThrottler) Close() error                      { return nil }
+func (g *gateThrottler) IsThrottled() bool                 { return false }
+func (g *gateThrottler) UpdateLag(_ context.Context) error { return nil }
+func (g *gateThrottler) BlockWait(ctx context.Context) {
+	select {
+	case <-g.allow:
+	case <-g.open:
+	case <-ctx.Done():
+	}
+}
+
+// TestBufferedCopierReadWorkerScaling exercises SetReadWorkers /
+// ActiveReadWorkers: the runtime read-side counterpart of the applier's
+// SetWriteWorkers. Readers idle inside throttler.BlockWait, so the gate
+// throttler holds them parked while we scale the pool and releases them
+// one loop iteration at a time to observe parking deterministically.
+func TestBufferedCopierReadWorkerScaling(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS readscalesrc, readscaledst")
+	testutils.RunSQL(t, "CREATE TABLE readscalesrc (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, pad VARBINARY(1024) NOT NULL)")
+	testutils.RunSQL(t, "CREATE TABLE readscaledst (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, pad VARBINARY(1024) NOT NULL)")
+
+	// Seed ~16k rows of ~1KiB each by doubling, so with a small chunk byte
+	// budget the copy has hundreds of chunks — the token phase below consumes
+	// a handful and must not exhaust the chunker.
+	testutils.RunSQL(t, "INSERT INTO readscalesrc (pad) VALUES (RANDOM_BYTES(1024))")
+	for range 14 {
+		testutils.RunSQL(t, "INSERT INTO readscalesrc (pad) SELECT RANDOM_BYTES(1024) FROM readscalesrc")
+	}
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "readscalesrc")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "readscaledst")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	gate := &gateThrottler{
+		allow: make(chan struct{}),
+		open:  make(chan struct{}),
+	}
+	cfg := NewCopierDefaultConfig()
+	cfg.Concurrency = 4
+	cfg.Throttler = gate
+	cfg.Applier, err = applier.NewSingleTargetApplier(applier.Target{DB: db}, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{
+		NewTable:         t2,
+		TargetChunkTime:  cfg.TargetChunkTime,
+		TargetChunkBytes: 64 * 1024, // keep chunks small so the copy has many
+		Logger:           cfg.Logger,
+	})
+	require.NoError(t, err)
+	require.NoError(t, chunker.Open())
+
+	copier, err := NewCopier(db, chunker, cfg)
+	require.NoError(t, err)
+	b := copier.(*buffered)
+
+	// Before Run the pool does not exist: the setter is a no-op.
+	b.SetReadWorkers(8)
+	require.Equal(t, 0, b.ActiveReadWorkers())
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- b.Run(t.Context())
+	}()
+
+	// The initial pool comes up at Concurrency and parks at the gate.
+	require.Eventually(t, func() bool {
+		return b.ActiveReadWorkers() == 4
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Scale up: spawning is synchronous, the new readers park at the gate too.
+	b.SetReadWorkers(6)
+	require.Equal(t, 6, b.ActiveReadWorkers())
+
+	// Scale down to 0, which clamps to 1: five quit channels close, but a
+	// parked reader only observes quit once BlockWait releases it. Feed one
+	// token at a time; each wakes one reader — a parked one exits without
+	// claiming a chunk, the survivor copies one chunk and re-parks.
+	b.SetReadWorkers(0)
+	require.Eventually(t, func() bool {
+		select {
+		case gate.allow <- struct{}{}:
+		default:
+		}
+		return b.ActiveReadWorkers() == 1
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Scale back up mid-copy.
+	b.SetReadWorkers(3)
+	require.Equal(t, 3, b.ActiveReadWorkers())
+
+	// Open the gate permanently and let the copy finish.
+	close(gate.open)
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Minute):
+		t.Fatal("copy did not complete in time")
+	}
+
+	// The pool has drained and scaling is closed: the setter is a no-op again.
+	require.Equal(t, 0, b.ActiveReadWorkers())
+	b.SetReadWorkers(5)
+	require.Equal(t, 0, b.ActiveReadWorkers())
+
+	// All rows made it across.
+	var srcRows, dstRows int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM readscalesrc").Scan(&srcRows))
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM readscaledst").Scan(&dstRows))
+	require.Equal(t, srcRows, dstRows)
+}

--- a/pkg/copier/buffered_test.go
+++ b/pkg/copier/buffered_test.go
@@ -482,7 +482,10 @@ func TestBufferedCopierReadWorkerScaling(t *testing.T) {
 	require.NoError(t, t2.SetInfo(t.Context()))
 
 	gate := &gateThrottler{
-		allow: make(chan struct{}),
+		// allow is buffered so the test's non-blocking token sends don't
+		// depend on a reader being mid-receive at that exact instant (the
+		// send site has a default case, so at most one token is in flight).
+		allow: make(chan struct{}, 1),
 		open:  make(chan struct{}),
 	}
 	cfg := NewCopierDefaultConfig()


### PR DESCRIPTION
## Summary

Adds a resizable read-worker pool to the buffered copier: `SetReadWorkers(int)` / `ActiveReadWorkers()`, the read-side counterpart of the applier's existing `SetWriteWorkers`/`ActiveWriteWorkers` seam (introduced in #953; untouched here). Mechanism only, no behavior change on any reachable production path — the pool still starts at `--threads` and nothing calls the setter yet (one edge case changes: `Concurrency=0`, which `NewCopier` does not reject, previously spawned zero readers so `Run` returned nil having copied nothing; the pool's min-1 clamp now runs one reader and actually copies); a follow-up PR teaches the autoscaler (#831) to drive reads and writes together, arbitrated by the applier pipeline stats added in #1081.

## What

- `pkg/copier/buffered.go`: the fixed-size errgroup of readers becomes a mutex-guarded pool with per-reader quit channels. Scale-up spawns readers; scale-down parks the most-recently-added ones (LIFO), clamped to a minimum of 1. Calls before `Run` or after the pool drains are no-ops.
- Parking is cooperative and lossless: the quit check sits right after `throttler.BlockWait` returns — the spot where an idle reader parks — so a parked reader exits as soon as the throttler releases it without claiming a fresh chunk, and a reader mid-chunk always finishes and submits it.
- Error semantics preserved: a failed reader records the first error (`setInvalid`) and cancels the shared reader context so siblings abort in-flight reads promptly, matching the old errgroup cancellation.
- Test: `TestBufferedCopierReadWorkerScaling` uses a token-gate throttler to park readers deterministically and exercises scale-up, clamp, scale-down parking, mid-copy re-scale, and the before/after no-ops; passes with `-race`.

## Why

Readers exit naturally when the chunker drains (write workers never exit on their own), so a straight copy of the write pool's `WaitGroup` would let a concurrent spawn's `Add` race `Wait` at zero. Instead `Run` waits on a condition variable for the live count to reach zero and closes scaling under the same mutex, making the drain observation and the spawn cutoff atomic.

## Before / after

```
Before                              After
┌─────────────────────────────┐     ┌─────────────────────────────────────┐
│ Run                         │     │ Run                                 │
│                             │     │                                     │
│  errgroup, N = --threads    │     │  SetReadWorkers(--threads)          │
│  (fixed for the whole copy) │     │   ┌───────────────────────────────┐ │
│                             │     │   │ pool: 1 quit chan per reader  │ │
│  g.Wait()                   │     │   │  scale-up   → spawn reader    │ │
└─────────────────────────────┘     │   │  scale-down → close quit,     │ │
                                    │   │    LIFO; parked reader exits  │ │
                                    │   │    after BlockWait, never     │ │
                                    │   │    dropping a claimed chunk   │ │
                                    │   └───────────────────────────────┘ │
                                    │                                     │
                                    │  drain-wait: liveReaders == 0,      │
                                    │  then close scaling (same mutex)    │
                                    └─────────────────────────────────────┘
```


