### PR TITLE
move: support the reverse window for sharded (N:M) moves

### DIFF
--- a/pkg/applier/keyrange.go
+++ b/pkg/applier/keyrange.go
@@ -15,6 +15,31 @@ type keyRange struct {
 	unbounded bool   // open upper range ("80-"): contains everything >= start
 }
 
+// keyRangeHexDigits is the number of hex digits in a 64-bit keyspace id. A
+// bound is a PREFIX of that id, so it may be shorter (right-padded with zeros)
+// but never longer.
+const keyRangeHexDigits = 16
+
+var keyRangeHexRe = regexp.MustCompile(`^[0-9a-f]+$`)
+
+// parseKeyRangeBound parses one side of a key range: a hex prefix of the 64-bit
+// keyspace id, right-padded with zeros to a full id. side is "start" or "end",
+// used only for the error message.
+func parseKeyRangeBound(side, bound string) (uint64, error) {
+	if !keyRangeHexRe.MatchString(bound) {
+		return 0, fmt.Errorf("invalid %s key range: %s (expected hex characters [0-9a-f])", side, bound)
+	}
+	if len(bound) > keyRangeHexDigits {
+		return 0, fmt.Errorf("invalid %s key range: %s (at most %d hex characters, it is a prefix of a 64-bit keyspace id)", side, bound, keyRangeHexDigits)
+	}
+	padded := bound + strings.Repeat("0", keyRangeHexDigits-len(bound))
+	v, err := strconv.ParseUint(padded, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s key range: %s: %w", side, bound, err)
+	}
+	return v, nil
+}
+
 // parseKeyRange parses a Vitess-style key range string into a keyRange struct.
 // Examples: "-80" -> [0, 0x80...], "80-" -> [0x80..., 0xff...], "80-c0" -> [0x80..., 0xc0...]
 func parseKeyRange(kr string) (keyRange, error) {
@@ -32,18 +57,9 @@ func parseKeyRange(kr string) (keyRange, error) {
 	var err error
 
 	// Parse start
-	if parts[0] == "" {
-		start = 0
-	} else {
-		// Validate hex format [0-9a-f]+
-		if !regexp.MustCompile(`^[0-9a-f]+$`).MatchString(parts[0]) {
-			return keyRange{}, fmt.Errorf("invalid start key range: %s (expected hex characters [0-9a-f])", parts[0])
-		}
-		// Pad to 16 hex chars (64 bits) and parse
-		padded := parts[0] + strings.Repeat("0", 16-len(parts[0]))
-		start, err = strconv.ParseUint(padded, 16, 64)
-		if err != nil {
-			return keyRange{}, fmt.Errorf("invalid start key range: %s: %w", parts[0], err)
+	if parts[0] != "" {
+		if start, err = parseKeyRangeBound("start", parts[0]); err != nil {
+			return keyRange{}, err
 		}
 	}
 
@@ -55,15 +71,14 @@ func parseKeyRange(kr string) (keyRange, error) {
 	if parts[1] == "" {
 		return keyRange{start: start, unbounded: true}, nil
 	}
-	// Validate hex format [0-9a-f]+
-	if !regexp.MustCompile(`^[0-9a-f]+$`).MatchString(parts[1]) {
-		return keyRange{}, fmt.Errorf("invalid end key range: %s (expected hex characters [0-9a-f])", parts[1])
+	if end, err = parseKeyRangeBound("end", parts[1]); err != nil {
+		return keyRange{}, err
 	}
-	// Pad to 16 hex chars (64 bits) and parse
-	padded := parts[1] + strings.Repeat("0", 16-len(parts[1]))
-	end, err = strconv.ParseUint(padded, 16, 64)
-	if err != nil {
-		return keyRange{}, fmt.Errorf("invalid end key range: %s: %w", parts[1], err)
+	// A bounded range is [start, end): end <= start describes no keyspace id at
+	// all, so every row hashing into it would be stranded with "no shard found"
+	// at apply time. Reject it here instead.
+	if end <= start {
+		return keyRange{}, fmt.Errorf("invalid key range: %s (end must be greater than start; use %q for an open-ended range)", kr, parts[0]+"-")
 	}
 	return keyRange{start: start, end: end}, nil
 }

--- a/pkg/applier/keyrange.go
+++ b/pkg/applier/keyrange.go
@@ -69,6 +69,30 @@ func (kr keyRange) contains(hash uint64) bool {
 	return hash >= kr.start && hash < kr.end
 }
 
+// ValidateKeyRanges parses each Vitess-style key range and checks that no two
+// overlap — the same rules NewShardedApplier enforces at construction. It
+// exists so callers can fail fast on a bad shard layout before doing any work
+// (e.g. move validates reverse-window source key ranges before the copy, since
+// the sharded reverse applier is only constructed after the forward cutover).
+func ValidateKeyRanges(ranges []string) error {
+	parsed := make([]keyRange, len(ranges))
+	for i, r := range ranges {
+		kr, err := parseKeyRange(r)
+		if err != nil {
+			return fmt.Errorf("key range %d (%q): %w", i, r, err)
+		}
+		parsed[i] = kr
+	}
+	for i := range parsed {
+		for j := i + 1; j < len(parsed); j++ {
+			if parsed[i].overlaps(parsed[j]) {
+				return fmt.Errorf("key ranges overlap: %q and %q", ranges[i], ranges[j])
+			}
+		}
+	}
+	return nil
+}
+
 // overlaps checks if two key ranges overlap
 func (kr keyRange) overlaps(other keyRange) bool {
 	// Two ranges [a, b) and [c, d) overlap if:

--- a/pkg/applier/keyrange.go
+++ b/pkg/applier/keyrange.go
@@ -10,8 +10,9 @@ import (
 
 // keyRange represents a parsed Vitess-style key range
 type keyRange struct {
-	start uint64 // inclusive
-	end   uint64 // exclusive
+	start     uint64 // inclusive
+	end       uint64 // exclusive; only meaningful when !unbounded
+	unbounded bool   // open upper range ("80-"): contains everything >= start
 }
 
 // parseKeyRange parses a Vitess-style key range string into a keyRange struct.
@@ -46,27 +47,38 @@ func parseKeyRange(kr string) (keyRange, error) {
 		}
 	}
 
-	// Parse end
+	// Parse end. An empty end means the range has NO upper bound — Vitess
+	// key ranges are byte prefixes, so "80-" contains every keyspace id
+	// >= 0x80..., INCLUDING 0xffffffffffffffff. Representing it as
+	// end=MaxUint64 with an exclusive compare would wrongly exclude a hash
+	// of exactly MaxUint64, leaving that row with no shard at all.
 	if parts[1] == "" {
-		end = ^uint64(0) // max uint64
-	} else {
-		// Validate hex format [0-9a-f]+
-		if !regexp.MustCompile(`^[0-9a-f]+$`).MatchString(parts[1]) {
-			return keyRange{}, fmt.Errorf("invalid end key range: %s (expected hex characters [0-9a-f])", parts[1])
-		}
-		// Pad to 16 hex chars (64 bits) and parse
-		padded := parts[1] + strings.Repeat("0", 16-len(parts[1]))
-		end, err = strconv.ParseUint(padded, 16, 64)
-		if err != nil {
-			return keyRange{}, fmt.Errorf("invalid end key range: %s: %w", parts[1], err)
-		}
+		return keyRange{start: start, unbounded: true}, nil
+	}
+	// Validate hex format [0-9a-f]+
+	if !regexp.MustCompile(`^[0-9a-f]+$`).MatchString(parts[1]) {
+		return keyRange{}, fmt.Errorf("invalid end key range: %s (expected hex characters [0-9a-f])", parts[1])
+	}
+	// Pad to 16 hex chars (64 bits) and parse
+	padded := parts[1] + strings.Repeat("0", 16-len(parts[1]))
+	end, err = strconv.ParseUint(padded, 16, 64)
+	if err != nil {
+		return keyRange{}, fmt.Errorf("invalid end key range: %s: %w", parts[1], err)
 	}
 	return keyRange{start: start, end: end}, nil
 }
 
 // contains checks if a hash value falls within this key range
 func (kr keyRange) contains(hash uint64) bool {
-	return hash >= kr.start && hash < kr.end
+	return hash >= kr.start && (kr.unbounded || hash < kr.end)
+}
+
+// String renders the parsed range for logs and errors.
+func (kr keyRange) String() string {
+	if kr.unbounded {
+		return fmt.Sprintf("[0x%016x, unbounded)", kr.start)
+	}
+	return fmt.Sprintf("[0x%016x, 0x%016x)", kr.start, kr.end)
 }
 
 // ValidateKeyRanges parses each Vitess-style key range and checks that no two
@@ -95,10 +107,11 @@ func ValidateKeyRanges(ranges []string) error {
 
 // overlaps checks if two key ranges overlap
 func (kr keyRange) overlaps(other keyRange) bool {
-	// Two ranges [a, b) and [c, d) overlap if:
-	// - a < d AND c < b
-	// This is because:
+	// Two ranges [a, b) and [c, d) overlap if a < d AND c < b:
 	// - If a >= d, then the first range starts at or after the second range ends (no overlap)
 	// - If c >= b, then the second range starts at or after the first range ends (no overlap)
-	return kr.start < other.end && other.start < kr.end
+	// An unbounded range has no end, so the "< end" side of its check is
+	// vacuously true — two unbounded ranges always overlap.
+	return (other.unbounded || kr.start < other.end) &&
+		(kr.unbounded || other.start < kr.end)
 }

--- a/pkg/applier/keyrange_test.go
+++ b/pkg/applier/keyrange_test.go
@@ -6,11 +6,12 @@ import (
 
 func TestParseKeyRange(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantErr   bool
-		wantStart uint64
-		wantEnd   uint64
+		name          string
+		input         string
+		wantErr       bool
+		wantStart     uint64
+		wantEnd       uint64
+		wantUnbounded bool
 	}{
 		{
 			name:      "valid range -80",
@@ -20,11 +21,11 @@ func TestParseKeyRange(t *testing.T) {
 			wantEnd:   0x8000000000000000,
 		},
 		{
-			name:      "valid range 80-",
-			input:     "80-",
-			wantErr:   false,
-			wantStart: 0x8000000000000000,
-			wantEnd:   0xffffffffffffffff,
+			name:          "valid range 80-",
+			input:         "80-",
+			wantErr:       false,
+			wantStart:     0x8000000000000000,
+			wantUnbounded: true,
 		},
 		{
 			name:      "valid range 40-80",
@@ -89,6 +90,9 @@ func TestParseKeyRange(t *testing.T) {
 				if got.end != tt.wantEnd {
 					t.Errorf("parseKeyRange(%q).end = 0x%016x, want 0x%016x", tt.input, got.end, tt.wantEnd)
 				}
+				if got.unbounded != tt.wantUnbounded {
+					t.Errorf("parseKeyRange(%q).unbounded = %v, want %v", tt.input, got.unbounded, tt.wantUnbounded)
+				}
 			}
 		})
 	}
@@ -123,6 +127,34 @@ func TestKeyRangeContains(t *testing.T) {
 			name:     "hash at end boundary (exclusive)",
 			keyRange: "-80",
 			hash:     0x8000000000000000,
+			want:     false,
+		},
+		{
+			// Regression: an open-ended range has NO upper bound. Vitess's
+			// byte-wise KeyRangeContains places keyspace id ff...ff in "80-";
+			// modeling the open end as end=MaxUint64 with an exclusive
+			// compare wrongly left this hash with no shard at all.
+			name:     "max hash belongs to the open-ended range",
+			keyRange: "80-",
+			hash:     0xffffffffffffffff,
+			want:     true,
+		},
+		{
+			name:     "max hash belongs to the full range",
+			keyRange: "-",
+			hash:     0xffffffffffffffff,
+			want:     true,
+		},
+		{
+			name:     "zero hash belongs to the full range",
+			keyRange: "-",
+			hash:     0x0000000000000000,
+			want:     true,
+		},
+		{
+			name:     "max hash not in a bounded range",
+			keyRange: "80-c0",
+			hash:     0xffffffffffffffff,
 			want:     false,
 		},
 	}
@@ -164,6 +196,24 @@ func TestKeyRangeOverlaps(t *testing.T) {
 			name:   "contained range",
 			range1: "40-c0",
 			range2: "60-80",
+			want:   true,
+		},
+		{
+			name:   "two open-ended ranges overlap",
+			range1: "80-",
+			range2: "c0-",
+			want:   true,
+		},
+		{
+			name:   "bounded range below an open-ended range does not overlap",
+			range1: "-80",
+			range2: "80-",
+			want:   false,
+		},
+		{
+			name:   "bounded range crossing into an open-ended range overlaps",
+			range1: "40-c0",
+			range2: "80-",
 			want:   true,
 		},
 	}

--- a/pkg/applier/keyrange_test.go
+++ b/pkg/applier/keyrange_test.go
@@ -74,6 +74,36 @@ func TestParseKeyRange(t *testing.T) {
 			input:   "80",
 			wantErr: true,
 		},
+		{
+			name:      "full 16-hex-digit bounds",
+			input:     "4000000000000000-8000000000000000",
+			wantErr:   false,
+			wantStart: 0x4000000000000000,
+			wantEnd:   0x8000000000000000,
+		},
+		{
+			// A bound is a prefix of a 64-bit keyspace id; anything longer used
+			// to panic in the zero-padding (strings.Repeat with a negative count).
+			name:    "start longer than 16 hex digits",
+			input:   "80000000000000000-",
+			wantErr: true,
+		},
+		{
+			name:    "end longer than 16 hex digits",
+			input:   "-80000000000000000",
+			wantErr: true,
+		},
+		{
+			// [0xc0.., 0x80..) is empty: rows hashing there would have no shard.
+			name:    "end before start",
+			input:   "c0-80",
+			wantErr: true,
+		},
+		{
+			name:    "end equal to start",
+			input:   "80-80",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -107,6 +107,12 @@ func NewShardedApplier(targets []Target, cfg *ApplierConfig) (*ShardedApplier, e
 	}
 	shards := make([]*shardTarget, len(targets))
 	for i, target := range targets {
+		// A nil connection is only discovered when a row routes to this shard,
+		// which may be long after construction (and never in a test that only
+		// exercises other shards) — fail here instead.
+		if target.DB == nil {
+			return nil, fmt.Errorf("shard %d: target DB must be non-nil", i)
+		}
 		// Parse the key range
 		kr, err := parseKeyRange(target.KeyRange)
 		if err != nil {

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -733,12 +733,17 @@ func (a *ShardedApplier) resolveShardLocks(locks []*dbconn.TableLock) (map[int]*
 // the deletes to all shards. The vindex value is considered immutable, and we will
 // error if it changes on an update.
 //
-// Note: the sharded applier does not allow any transformations!
-// The targetTable argument is intentionally ignored.
-// This also means that table names between source and target must be the same.
-func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.TableInfo, keys [][]any, locks []*dbconn.TableLock) (int64, error) {
+// Note: the sharded applier supports renaming the table (targetTable, nil =>
+// same name as sourceTable) but no column transformations. The rename exists
+// for the reverse feed of a sharded-source move, which writes back to the
+// source's retired `_old` tables.
+func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys [][]any, locks []*dbconn.TableLock) (int64, error) {
 	if len(keys) == 0 {
 		return 0, nil
+	}
+	// For move operations, targetTable may be nil - use sourceTable for both
+	if targetTable == nil {
+		targetTable = sourceTable
 	}
 	// Resolve which lock belongs to which shard before executing anything,
 	// so a missing lock fails loudly instead of partially applying.
@@ -762,7 +767,7 @@ func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.T
 	// Use just the table name, not the fully qualified name, because
 	// the database connection (shard.writeDB) already determines which database to write to
 	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (%s)",
-		sourceTable.QuotedTableName,
+		targetTable.QuotedTableName,
 		table.QuoteColumns(sourceTable.KeyColumns),
 		inClause,
 	)
@@ -843,9 +848,12 @@ func (a *ShardedApplier) DeleteKeys(ctx context.Context, sourceTable, _ *table.T
 // This is likely not too big of a limitation, as Vitess itself recommends that vindex columns be immutable.
 // If it turns out to be a problem, we can revisit tracking by other columns later.
 //
-// Note: the sharded applier does not allow any transformations!
-// The targetTable argument is intentionally ignored.
-// This also means that table names between source and target must be the same.
+// Note: the sharded applier supports renaming the table (mapping's target,
+// which defaults to the source when no NewTable is set) but no column
+// transformations. The rename exists for the reverse feed of a sharded-source
+// move, which writes back to the source's retired `_old` tables. The sharding
+// column and hash always come from the mapping's SOURCE table — the watched
+// table whose row images we are routing.
 func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []LogicalRow, locks []*dbconn.TableLock) (int64, error) {
 	if len(rows) == 0 {
 		return 0, nil
@@ -874,6 +882,7 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 	// (since RowImage from binlog contains ALL columns, including generated ones)
 	shardingOrdinal := slices.Index(sourceTable.Columns, sourceTable.ShardingColumn)
 	sourceOrdinal := mapping.SourceOrdinalIndices()
+	sourceColumnNames, _ := mapping.ColumnsSlice()
 	if shardingOrdinal == -1 {
 		return 0, fmt.Errorf("sharding column %s not found in columns", sourceTable.ShardingColumn)
 	}
@@ -921,8 +930,11 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 	results := make(chan result, shardsToCopy)
 	defer close(results)
 
-	// Build column list for the upsert statement
-	columnList := table.QuoteColumns(sourceTable.NonGeneratedColumns)
+	// Build the column list for the upsert statement from the mapping so a
+	// renamed target (e.g. the reverse feed's `_old` tables) uses its own
+	// column list. With no rename the mapping's target IS the source table,
+	// so this is identical to the previous NonGeneratedColumns list.
+	_, columnList := mapping.Columns()
 
 	for shardID, rows := range shardRows {
 		if len(rows) == 0 {
@@ -940,7 +952,7 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 						return
 					}
 					value := logicalRow.RowImage[colIdx]
-					col := sourceTable.NonGeneratedColumns[i]
+					col := sourceColumnNames[i]
 					columnType, ok := sourceTable.GetColumnMySQLType(col)
 					if !ok {
 						results <- result{err: fmt.Errorf("column %s not found in table info", col)}
@@ -965,14 +977,14 @@ func (a *ShardedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMa
 			// implications. Just the table name here — the per-shard DB
 			// connection already determines which database to write to.
 			upsertStmt := fmt.Sprintf("REPLACE INTO %s (%s) VALUES %s",
-				sourceTable.QuotedTableName,
+				mapping.TargetTable().QuotedTableName,
 				columnList,
 				strings.Join(valuesClauses, ", "),
 			)
 			a.logger.Debug("executing upsert on shard",
 				"shardID", sid,
 				"rowCount", len(valuesClauses),
-				"table", sourceTable.TableName,
+				"table", mapping.TargetTable().TableName,
 			)
 			var affected int64
 			var err error

--- a/pkg/applier/sharded.go
+++ b/pkg/applier/sharded.go
@@ -129,9 +129,9 @@ func NewShardedApplier(targets []Target, cfg *ApplierConfig) (*ShardedApplier, e
 	for i := range shards {
 		for j := i + 1; j < len(shards); j++ {
 			if shards[i].keyRange.overlaps(shards[j].keyRange) {
-				return nil, fmt.Errorf("key ranges overlap: shard %d (%s: [0x%016x, 0x%016x)) and shard %d (%s: [0x%016x, 0x%016x))",
-					i, targets[i].KeyRange, shards[i].keyRange.start, shards[i].keyRange.end,
-					j, targets[j].KeyRange, shards[j].keyRange.start, shards[j].keyRange.end)
+				return nil, fmt.Errorf("key ranges overlap: shard %d (%s: %s) and shard %d (%s: %s)",
+					i, targets[i].KeyRange, shards[i].keyRange,
+					j, targets[j].KeyRange, shards[j].keyRange)
 			}
 		}
 	}
@@ -141,8 +141,7 @@ func NewShardedApplier(targets []Target, cfg *ApplierConfig) (*ShardedApplier, e
 		cfg.Logger.Info("parsed key range for shard",
 			"shardID", i,
 			"keyRange", targets[i].KeyRange,
-			"start", fmt.Sprintf("0x%016x", shard.keyRange.start),
-			"end", fmt.Sprintf("0x%016x", shard.keyRange.end))
+			"parsed", shard.keyRange.String())
 	}
 
 	return &ShardedApplier{

--- a/pkg/applier/sharded_test.go
+++ b/pkg/applier/sharded_test.go
@@ -1157,3 +1157,134 @@ func TestShardedApplierCallbackPanicDecrements(t *testing.T) {
 	defer cancel()
 	require.NoError(t, a.Wait(ctx))
 }
+
+// TestShardedApplierRenamedTarget covers the rename support used by the
+// reverse feed of a sharded-source move: the watched table is the (former
+// move target's) real table, but writes land on the former source shards'
+// retired `_old` tables. Upserts must go to the mapping's target name and
+// still route by the SOURCE table's sharding metadata; DeleteKeys must
+// broadcast to the explicit target name, and a nil targetTable must keep
+// the forward-move behavior (same name as the source).
+func TestShardedApplierRenamedTarget(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sharded_renamed_watched")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sharded_renamed_shard1")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS sharded_renamed_shard2")
+	testutils.RunSQL(t, "CREATE DATABASE sharded_renamed_watched")
+	testutils.RunSQL(t, "CREATE DATABASE sharded_renamed_shard1")
+	testutils.RunSQL(t, "CREATE DATABASE sharded_renamed_shard2")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	watched := base.Clone()
+	watched.DBName = "sharded_renamed_watched"
+	watchedDB, err := sql.Open("mysql", watched.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(watchedDB)
+
+	shard1 := base.Clone()
+	shard1.DBName = "sharded_renamed_shard1"
+	shard1DB, err := sql.Open("mysql", shard1.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(shard1DB)
+
+	shard2 := base.Clone()
+	shard2.DBName = "sharded_renamed_shard2"
+	shard2DB, err := sql.Open("mysql", shard2.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(shard2DB)
+
+	const createT1 = `CREATE TABLE t1 (
+		id INT PRIMARY KEY,
+		user_id INT NOT NULL,
+		name VARCHAR(100)
+	)`
+	const createT1Old = `CREATE TABLE t1_old (
+		id INT PRIMARY KEY,
+		user_id INT NOT NULL,
+		name VARCHAR(100)
+	)`
+
+	ctx := t.Context()
+	_, err = watchedDB.ExecContext(ctx, createT1)
+	require.NoError(t, err)
+	// The shards deliberately have ONLY t1_old at first: if a write ignored the
+	// mapping's target name and used the source name, it would fail loudly.
+	for _, db := range []*sql.DB{shard1DB, shard2DB} {
+		_, err = db.ExecContext(ctx, createT1Old)
+		require.NoError(t, err)
+	}
+
+	// The watched table carries the sharding metadata used for routing.
+	sourceTable := table.NewTableInfo(watchedDB, watched.DBName, "t1")
+	require.NoError(t, sourceTable.SetInfo(ctx))
+	sourceTable.ShardingColumn = "user_id"
+	sourceTable.HashFunc = testutils.EvenOddHasher
+
+	// One shared _old TableInfo: QuotedTableName is unqualified, so each
+	// shard's own connection determines the database it lands in.
+	oldTable := table.NewTableInfo(shard1DB, shard1.DBName, "t1_old")
+	require.NoError(t, oldTable.SetInfo(ctx))
+
+	applier, err := NewShardedApplier([]Target{
+		{DB: shard1DB, KeyRange: "-80"}, // even user_ids
+		{DB: shard2DB, KeyRange: "80-"}, // odd user_ids
+	}, NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	renamed := table.NewColumnMapping(sourceTable, oldTable, nil)
+	rows := []LogicalRow{
+		{RowImage: []any{int64(1), int64(101), "odd-one"}},
+		{RowImage: []any{int64(2), int64(102), "even-two"}},
+		{RowImage: []any{int64(3), int64(103), "odd-three"}},
+	}
+	affected, err := applier.UpsertRows(ctx, renamed, rows, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), affected)
+
+	rowNames := func(db *sql.DB, tableName string) map[int64]string {
+		out := make(map[int64]string)
+		res, qerr := db.QueryContext(ctx, "SELECT id, name FROM "+tableName+" ORDER BY id")
+		require.NoError(t, qerr)
+		defer utils.CloseAndLog(res)
+		for res.Next() {
+			var id int64
+			var name string
+			require.NoError(t, res.Scan(&id, &name))
+			out[id] = name
+		}
+		require.NoError(t, res.Err())
+		return out
+	}
+
+	// Rows routed by the source's sharding metadata, written to t1_old.
+	require.Equal(t, map[int64]string{2: "even-two"}, rowNames(shard1DB, "t1_old"))
+	require.Equal(t, map[int64]string{1: "odd-one", 3: "odd-three"}, rowNames(shard2DB, "t1_old"))
+
+	// DeleteKeys with an explicit renamed target broadcasts to t1_old.
+	affected, err = applier.DeleteKeys(ctx, sourceTable, oldTable, [][]any{{int64(1)}, {int64(2)}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), affected)
+	require.Empty(t, rowNames(shard1DB, "t1_old"))
+	require.Equal(t, map[int64]string{3: "odd-three"}, rowNames(shard2DB, "t1_old"))
+
+	// nil targetTable (the forward-move path) still writes to the source's own
+	// name. Create t1 on the shards now and run the same flow un-renamed.
+	for _, db := range []*sql.DB{shard1DB, shard2DB} {
+		_, err = db.ExecContext(ctx, createT1)
+		require.NoError(t, err)
+	}
+	forward := table.NewColumnMapping(sourceTable, nil, nil)
+	affected, err = applier.UpsertRows(ctx, forward, rows, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), affected)
+	require.Equal(t, map[int64]string{2: "even-two"}, rowNames(shard1DB, "t1"))
+	require.Equal(t, map[int64]string{1: "odd-one", 3: "odd-three"}, rowNames(shard2DB, "t1"))
+
+	affected, err = applier.DeleteKeys(ctx, sourceTable, nil, [][]any{{int64(3)}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+	require.Equal(t, map[int64]string{1: "odd-one"}, rowNames(shard2DB, "t1"))
+	// The renamed tables are untouched by the un-renamed flow.
+	require.Equal(t, map[int64]string{3: "odd-three"}, rowNames(shard2DB, "t1_old"))
+}

--- a/pkg/applier/sharded_test.go
+++ b/pkg/applier/sharded_test.go
@@ -1158,6 +1158,14 @@ func TestShardedApplierCallbackPanicDecrements(t *testing.T) {
 	require.NoError(t, a.Wait(ctx))
 }
 
+// A nil shard connection is otherwise only discovered when a row happens to
+// route to that shard — possibly long after construction, as a nil-pointer
+// panic in the write path.
+func TestShardedApplierRejectsNilTargetDB(t *testing.T) {
+	_, err := NewShardedApplier([]Target{{DB: nil, KeyRange: "-80"}}, NewApplierDefaultConfig())
+	require.ErrorContains(t, err, "shard 0: target DB must be non-nil")
+}
+
 // TestShardedApplierRenamedTarget covers the rename support used by the
 // reverse feed of a sharded-source move: the watched table is the (former
 // move target's) real table, but writes land on the former source shards'

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -1643,7 +1643,10 @@ func (r *Runner) DumpCheckpoint(ctx context.Context) error {
 		Statement:         r.migration.Statement,
 		OriginalTableName: originalTableName,
 	}); err != nil {
-		return status.ErrCouldNotWriteCheckpoint
+		// Keep the cause: the WatchTask dumper distinguishes a benign
+		// canceled-mid-write (it is being stopped) from a genuinely broken
+		// checkpoint table, which is fatal.
+		return fmt.Errorf("%w: %w", status.ErrCouldNotWriteCheckpoint, err)
 	}
 	return nil
 }

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -36,9 +36,11 @@ type Move struct {
 	// the window the source's now-retired _old tables are kept current from the
 	// targets; an operator rolls back by creating the _spirit_move_revert table on
 	// the first target (see revertmarker.go), otherwise the window elapses and the
-	// move finalizes forward. Requires an unsharded (single) source — see the
-	// guard in Runner.Run. The data plane is ReverseFeed (reversefeed.go); the
-	// post-cutover driver is reverseWindow (reversewindow.go).
+	// move finalizes forward. A sharded (multi-DSN) source additionally requires
+	// ReverseShardingProvider and SourceKeyRanges so the reverse feed can route
+	// rows back to the correct source shard — see the guard in Runner.Run. The
+	// data plane is ReverseFeed (reversefeed.go); the post-cutover driver is
+	// reverseWindow (reversewindow.go).
 	ReverseWindow time.Duration `name:"reverse-window" help:"After cutover, reverse the move (change-only) and keep it alive for this long to allow rollback. 0 disables (normal cutover)." default:"0"`
 
 	// EnableExperimentalGTID switches the change source from binlog file+position to MySQL GTIDs.
@@ -61,8 +63,25 @@ type Move struct {
 	// table schemas. If empty, SourceDSN is used as the single source.
 	SourceDSNs []string `kong:"-"`
 
+	// SourceKeyRanges optionally specifies each source shard's Vitess-style key
+	// range ("-80", "80-", ...), parallel to SourceDSNs (SourceKeyRanges[i] is
+	// SourceDSNs[i]'s range). Required, together with ReverseShardingProvider,
+	// when ReverseWindow > 0 and the source is sharded (len(SourceDSNs) > 1):
+	// the reverse feed routes rows flowing back from the targets to the source
+	// shard whose range contains the row's hash. Unused otherwise.
+	SourceKeyRanges []string `kong:"-"`
+
 	ShardingProvider table.ShardingMetadataProvider `kong:"-"`
-	Targets          []applier.Target               `kong:"-"`
+
+	// ReverseShardingProvider provides the SOURCE keyspace's sharding metadata
+	// (vindex column + hash) for the reverse feed of a reverse-window move with
+	// a sharded source. It is consulted for each moved table when the window
+	// opens; a table without metadata is a hard error there, because reverse
+	// writes could not be routed to a source shard. Note the asymmetry with
+	// ShardingProvider, which describes the TARGET keyspace for the forward copy.
+	ReverseShardingProvider table.ShardingMetadataProvider `kong:"-"`
+
+	Targets []applier.Target `kong:"-"`
 }
 
 // Validate is called by Kong after parsing to check for invalid flag values.

--- a/pkg/move/reversefeed.go
+++ b/pkg/move/reversefeed.go
@@ -55,13 +55,25 @@ type ReverseSource struct {
 // ReverseFeedConfig configures a ReverseFeed.
 type ReverseFeedConfig struct {
 	Sources []ReverseSource
-	// Target is the U side (single, unsharded). Target.DB's default database
-	// MUST be U's schema (see ReverseSource.DB).
+	// Target is the U side when the former move source was a single database.
+	// Target.DB's default database MUST be U's schema (see ReverseSource.DB).
+	// Mutually exclusive with Targets.
 	Target applier.Target
+	// Targets is the U side when the former move source was SHARDED: one entry
+	// per former source shard, each with its Vitess-style key range set. Rows
+	// are routed by the WATCHED table's sharding metadata, so every
+	// ReverseSource table must have ShardingColumn and HashFunc set (the source
+	// keyspace's vindex) — NewReverseFeed fails otherwise. Each Targets[i].DB's
+	// default database MUST be that shard's schema (see ReverseSource.DB).
+	// Mutually exclusive with Target.
+	Targets []applier.Target
 	// TargetTables maps each watched (reverse-source) table NAME to the U-side
-	// TableInfo it is written to, built on Target.DB. It is a map, not a slice,
-	// because the names can differ: after a forward cutover the source tables are
-	// renamed to their _old form, so a watched "t1" is written to "t1_old".
+	// TableInfo it is written to, built on Target.DB (with Targets, on any one
+	// shard: the schemas are identical and the name is unqualified, so each
+	// shard's own connection determines where the write lands). It is a map,
+	// not a slice, because the names can differ: after a forward cutover the
+	// source tables are renamed to their _old form, so a watched "t1" is
+	// written to "t1_old".
 	TargetTables map[string]*table.TableInfo
 
 	Logger        *slog.Logger
@@ -100,11 +112,26 @@ func NewReverseFeed(cfg ReverseFeedConfig) (_ *ReverseFeed, err error) {
 	if len(cfg.Sources) == 0 {
 		return nil, errors.New("reverse feed: at least one source is required")
 	}
-	if cfg.Target.DB == nil {
+	if len(cfg.Targets) > 0 && cfg.Target.DB != nil {
+		return nil, errors.New("reverse feed: Target and Targets are mutually exclusive")
+	}
+	if len(cfg.Targets) == 0 && cfg.Target.DB == nil {
 		return nil, errors.New("reverse feed: target DB must be non-nil")
 	}
 	if len(cfg.TargetTables) == 0 {
 		return nil, errors.New("reverse feed: at least one target table is required")
+	}
+	if len(cfg.Targets) > 0 {
+		// Sharded reverse target: routing decisions come from the watched
+		// tables' sharding metadata, so its absence would strand every row —
+		// fail here rather than fatally at first apply.
+		for si, src := range cfg.Sources {
+			for _, t := range src.Tables {
+				if t.ShardingColumn == "" || t.HashFunc == nil {
+					return nil, fmt.Errorf("reverse feed: source %d table %q has no sharding metadata; a sharded reverse target requires ShardingColumn and HashFunc on every watched table", si, t.TableName)
+				}
+			}
+		}
 	}
 
 	logger := cfg.Logger
@@ -124,12 +151,20 @@ func NewReverseFeed(cfg ReverseFeedConfig) (_ *ReverseFeed, err error) {
 		threads = 4
 	}
 
-	// One applier writing to U, shared across all source feeds.
-	appl, err := applier.NewSingleTargetApplier(cfg.Target, &applier.ApplierConfig{
+	// One applier writing to U, shared across all source feeds. With a sharded
+	// U (Targets), the applier routes each row to the shard whose key range
+	// contains its hash — the exact mirror of the forward move's fan-out.
+	applCfg := &applier.ApplierConfig{
 		DBConfig: dbCfg,
 		Logger:   logger,
 		Threads:  threads,
-	})
+	}
+	var appl applier.Applier
+	if len(cfg.Targets) > 0 {
+		appl, err = applier.NewShardedApplier(cfg.Targets, applCfg)
+	} else {
+		appl, err = applier.NewSingleTargetApplier(cfg.Target, applCfg)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("reverse feed: create applier: %w", err)
 	}

--- a/pkg/move/reversefeed.go
+++ b/pkg/move/reversefeed.go
@@ -122,6 +122,11 @@ func NewReverseFeed(cfg ReverseFeedConfig) (_ *ReverseFeed, err error) {
 		return nil, errors.New("reverse feed: at least one target table is required")
 	}
 	if len(cfg.Targets) > 0 {
+		for ti := range cfg.Targets {
+			if cfg.Targets[ti].DB == nil {
+				return nil, fmt.Errorf("reverse feed: target %d DB must be non-nil", ti)
+			}
+		}
 		// Sharded reverse target: routing decisions come from the watched
 		// tables' sharding metadata, so its absence would strand every row —
 		// fail here rather than fatally at first apply.

--- a/pkg/move/reversefeed_test.go
+++ b/pkg/move/reversefeed_test.go
@@ -200,3 +200,138 @@ func TestReverseFeedStartCleanupOnPartialFailure(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "start source 1", "the second source must be the one that fails")
 }
+
+// --- Sharded (M:N) reverse feed ---
+//
+// Layout for the sharded variant: poc_rfnm_u0 / poc_rfnm_u1 = the former
+// SOURCE shards (reverse targets), holding their post-cutover retired t1_old
+// tables split by id parity (EvenOddHasher: even → "-80" → u0, odd → "80-" →
+// u1). poc_rfnm_s0 / poc_rfnm_s1 = the former move targets (reverse sources),
+// watched under their real t1 names, with the source keyspace's sharding
+// metadata attached — the reverse feed routes each row back to the source
+// shard whose key range contains its hash.
+
+// setupFanOut builds the post-forward-cutover state of a 2:2 move.
+func setupFanOut(t *testing.T) {
+	t.Helper()
+	for _, s := range []string{"poc_rfnm_u0", "poc_rfnm_u1"} {
+		testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+s)
+		testutils.RunSQL(t, "CREATE DATABASE "+s)
+		testutils.RunSQL(t, "CREATE TABLE "+s+".t1_old (id BIGINT NOT NULL PRIMARY KEY, val VARCHAR(255))")
+	}
+	for _, s := range []string{"poc_rfnm_s0", "poc_rfnm_s1"} {
+		testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+s)
+		testutils.RunSQL(t, "CREATE DATABASE "+s)
+		testutils.RunSQL(t, "CREATE TABLE "+s+".t1 (id BIGINT NOT NULL PRIMARY KEY, val VARCHAR(255))")
+	}
+	// Source shards split by id parity; the former targets split by id range
+	// (any distribution works — the feed only cares where rows land, not where
+	// they come from).
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_u0.t1_old VALUES (2,'two'),(4,'four'),(6,'six')")
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_u1.t1_old VALUES (1,'one'),(3,'three'),(5,'five')")
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s0.t1 VALUES (1,'one'),(2,'two'),(3,'three')")
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s1.t1 VALUES (4,'four'),(5,'five'),(6,'six')")
+}
+
+// newFanOutFeed wires the sharded reverse feed s0,s1 → u0 ("-80"), u1 ("80-").
+func newFanOutFeed(t *testing.T) (*ReverseFeed, *sql.DB) {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	u0DB := openSchemaConn(t, "poc_rfnm_u0")
+	u1DB := openSchemaConn(t, "poc_rfnm_u1")
+	// One shared _old mapping TableInfo: the name is unqualified, so each
+	// shard's own connection determines the database written to.
+	oldTbl := reverseTableInfo(t, u0DB, "poc_rfnm_u0", "t1_old")
+
+	mkSource := func(schema string) ReverseSource {
+		sDB := openSchemaConn(t, schema)
+		wt := reverseTableInfo(t, sDB, schema, "t1")
+		wt.ShardingColumn = "id"
+		wt.HashFunc = testutils.EvenOddHasher
+		return ReverseSource{
+			DB:       sDB,
+			Addr:     cfg.Addr,
+			User:     cfg.User,
+			Password: cfg.Passwd,
+			Tables:   []*table.TableInfo{wt},
+		}
+	}
+
+	feed, err := NewReverseFeed(ReverseFeedConfig{
+		Sources: []ReverseSource{mkSource("poc_rfnm_s0"), mkSource("poc_rfnm_s1")},
+		Targets: []applier.Target{
+			{DB: u0DB, KeyRange: "-80"},
+			{DB: u1DB, KeyRange: "80-"},
+		},
+		TargetTables: map[string]*table.TableInfo{"t1": oldTbl},
+	})
+	require.NoError(t, err)
+	return feed, u0DB
+}
+
+// TestReverseFeedFanOutRoutesByShard: writes on BOTH former targets flow back
+// to the source SHARD owning each row (by the source vindex), into its t1_old
+// table. This is the M:N reverse the 1:N fan-in tests above cannot cover.
+func TestReverseFeedFanOutRoutesByShard(t *testing.T) {
+	setupFanOut(t)
+	feed, ctl := newFanOutFeed(t)
+	defer feed.Close()
+	require.NoError(t, feed.Start(t.Context()))
+
+	// "App writes" landing on each former target after cutover.
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s0.t1 VALUES (7,'seven')") // odd  → u1
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s1.t1 VALUES (8,'eight')") // even → u0
+	testutils.RunSQL(t, "UPDATE poc_rfnm_s0.t1 SET val='TWO' WHERE id=2") // even → u0
+	testutils.RunSQL(t, "DELETE FROM poc_rfnm_s1.t1 WHERE id=5")          // broadcast delete
+
+	require.NoError(t, feed.Flush(t.Context()))
+
+	require.Equal(t,
+		[]string{"2=TWO", "4=four", "6=six", "8=eight"},
+		dumpRows(t, ctl, "SELECT id,val FROM poc_rfnm_u0.t1_old ORDER BY id"),
+		"u0 must hold exactly the even rows")
+	require.Equal(t,
+		[]string{"1=one", "3=three", "7=seven"},
+		dumpRows(t, ctl, "SELECT id,val FROM poc_rfnm_u1.t1_old ORDER BY id"),
+		"u1 must hold exactly the odd rows")
+	union := dumpRows(t, ctl, "SELECT id,val FROM poc_rfnm_s0.t1 UNION ALL SELECT id,val FROM poc_rfnm_s1.t1 ORDER BY id")
+	got := dumpRows(t, ctl, "SELECT id,val FROM poc_rfnm_u0.t1_old UNION ALL SELECT id,val FROM poc_rfnm_u1.t1_old ORDER BY id")
+	require.Equal(t, union, got, "the source shards' union must equal the former targets' union")
+}
+
+// TestReverseFeedShardedConfigValidation: the sharded target form fails fast on
+// a config that could not route (both target forms set, or watched tables
+// without sharding metadata).
+func TestReverseFeedShardedConfigValidation(t *testing.T) {
+	setupFanOut(t)
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	u0DB := openSchemaConn(t, "poc_rfnm_u0")
+	u1DB := openSchemaConn(t, "poc_rfnm_u1")
+	oldTbl := reverseTableInfo(t, u0DB, "poc_rfnm_u0", "t1_old")
+	sDB := openSchemaConn(t, "poc_rfnm_s0")
+	bare := reverseTableInfo(t, sDB, "poc_rfnm_s0", "t1") // no sharding metadata
+	src := ReverseSource{
+		DB: sDB, Addr: cfg.Addr, User: cfg.User, Password: cfg.Passwd,
+		Tables: []*table.TableInfo{bare},
+	}
+	targets := []applier.Target{{DB: u0DB, KeyRange: "-80"}, {DB: u1DB, KeyRange: "80-"}}
+
+	_, err = NewReverseFeed(ReverseFeedConfig{
+		Sources:      []ReverseSource{src},
+		Target:       applier.Target{DB: u0DB},
+		Targets:      targets,
+		TargetTables: map[string]*table.TableInfo{"t1": oldTbl},
+	})
+	require.ErrorContains(t, err, "mutually exclusive")
+
+	_, err = NewReverseFeed(ReverseFeedConfig{
+		Sources:      []ReverseSource{src},
+		Targets:      targets,
+		TargetTables: map[string]*table.TableInfo{"t1": oldTbl},
+	})
+	require.ErrorContains(t, err, "no sharding metadata")
+}

--- a/pkg/move/reversefeed_test.go
+++ b/pkg/move/reversefeed_test.go
@@ -334,4 +334,13 @@ func TestReverseFeedShardedConfigValidation(t *testing.T) {
 		TargetTables: map[string]*table.TableInfo{"t1": oldTbl},
 	})
 	require.ErrorContains(t, err, "no sharding metadata")
+
+	// A nil shard connection would otherwise only surface when a row happened
+	// to route to that shard, mid-window.
+	_, err = NewReverseFeed(ReverseFeedConfig{
+		Sources:      []ReverseSource{src},
+		Targets:      []applier.Target{{DB: u0DB, KeyRange: "-80"}, {DB: nil, KeyRange: "80-"}},
+		TargetTables: map[string]*table.TableInfo{"t1": oldTbl},
+	})
+	require.ErrorContains(t, err, "target 1 DB must be non-nil")
 }

--- a/pkg/move/reversefeed_test.go
+++ b/pkg/move/reversefeed_test.go
@@ -281,8 +281,8 @@ func TestReverseFeedFanOutRoutesByShard(t *testing.T) {
 	require.NoError(t, feed.Start(t.Context()))
 
 	// "App writes" landing on each former target after cutover.
-	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s0.t1 VALUES (7,'seven')") // odd  → u1
-	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s1.t1 VALUES (8,'eight')") // even → u0
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s0.t1 VALUES (7,'seven')")  // odd  → u1
+	testutils.RunSQL(t, "INSERT INTO poc_rfnm_s1.t1 VALUES (8,'eight')")  // even → u0
 	testutils.RunSQL(t, "UPDATE poc_rfnm_s0.t1 SET val='TWO' WHERE id=2") // even → u0
 	testutils.RunSQL(t, "DELETE FROM poc_rfnm_s1.t1 WHERE id=5")          // broadcast delete
 

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -150,11 +150,19 @@ func (w *reverseWindow) run(ctx context.Context) error {
 
 // buildFeed constructs the reverse feed: reverse sources are the former targets
 // (watched under their real names); the reverse target is the source, written
-// to its _old tables (the forward cutover renamed source real → _old).
+// to its _old tables (the forward cutover renamed source real → _old). With a
+// sharded source (an N:M move), the reverse target is the set of source shards
+// and each row is routed by the SOURCE keyspace's sharding metadata, which is
+// attached to the watched tables here.
 func (w *reverseWindow) buildFeed(ctx context.Context) error {
 	r := w.r
-	src := &r.sources[0] // single source (guarded in Run)
+	src := &r.sources[0] // canonical source: table names and the _old TableInfos
+	sharded := len(r.sources) > 1
 
+	// The _old mapping TableInfos are built on sources[0]. Their names are
+	// unqualified, so with a sharded source the same mapping serves every
+	// shard — each shard's own connection determines the database written to
+	// (the shards' schemas are identical by the move's own invariant).
 	targetTables := make(map[string]*table.TableInfo, len(src.tables))
 	for _, t := range src.tables {
 		oldName := check.CutoverOldName(t.TableName)
@@ -183,6 +191,21 @@ func (w *reverseWindow) buildFeed(ctx context.Context) error {
 			if err := wt.SetInfo(ctx); err != nil {
 				return fmt.Errorf("reverse window: load target table %q on shard %d: %w", t.TableName, i, err)
 			}
+			if sharded {
+				// Reverse rows are routed to a source shard by the SOURCE
+				// keyspace's vindex. No metadata for a moved table means its
+				// rows cannot be routed — fail loudly rather than let the
+				// window open with an unroutable feed.
+				col, hashFn, err := r.move.ReverseShardingProvider.GetShardingMetadata(tgt.Config.DBName, t.TableName)
+				if err != nil {
+					return fmt.Errorf("reverse window: sharding metadata for table %q: %w", t.TableName, err)
+				}
+				if col == "" || hashFn == nil {
+					return fmt.Errorf("reverse window: no sharding metadata for table %q; a sharded source requires every moved table to have a sharding key to route reverse writes", t.TableName)
+				}
+				wt.ShardingColumn = col
+				wt.HashFunc = hashFn
+			}
 			watched = append(watched, wt)
 		}
 		w.watched[i] = watched
@@ -196,15 +219,29 @@ func (w *reverseWindow) buildFeed(ctx context.Context) error {
 		})
 	}
 
-	feed, err := NewReverseFeed(ReverseFeedConfig{
+	cfg := ReverseFeedConfig{
 		Sources:      sources,
-		Target:       applier.Target{DB: src.db},
 		TargetTables: targetTables,
 		Logger:       r.logger,
 		DBConfig:     r.dbConfig,
 		Threads:      r.move.WriteThreads,
 		GTID:         r.move.EnableExperimentalGTID,
-	})
+	}
+	if sharded {
+		revTargets := make([]applier.Target, len(r.sources))
+		for i := range r.sources {
+			revTargets[i] = applier.Target{
+				DB:       r.sources[i].db,
+				Config:   r.sources[i].config,
+				KeyRange: r.sources[i].keyRange,
+			}
+		}
+		cfg.Targets = revTargets
+	} else {
+		cfg.Target = applier.Target{DB: src.db}
+	}
+
+	feed, err := NewReverseFeed(cfg)
 	if err != nil {
 		return err
 	}
@@ -233,10 +270,10 @@ func (w *reverseWindow) completeForward(ctx context.Context) error {
 
 // reverseCutover rolls the move back to the source. It mirrors the forward
 // cutover with roles swapped, plus one asymmetry: the source tables sit under
-// their _old names and must be un-retired before traffic returns to them.
+// their _old names (on every source shard) and must be un-retired before
+// traffic returns to them.
 func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 	r := w.r
-	src := &r.sources[0]
 
 	// Record that we are rolling back (best-effort; for a future resume).
 	if err := r.checkpointTbl().Write(ctx, checkpoint.Record{Phase: phaseReverting, CutoverAt: r.cutoverAt}); err != nil {
@@ -277,11 +314,15 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 	w.feed.Close()
 
 	// 3. Un-retire the source: rename its _old tables back to their real names
-	//    so it can serve again. The feed is stopped, so nothing writes them.
-	for _, t := range src.tables {
-		oldName := check.CutoverOldName(t.TableName)
-		if err := dbconn.Exec(ctx, src.db, "RENAME TABLE %n TO %n", oldName, t.TableName); err != nil {
-			return fmt.Errorf("reverse cutover: un-retire source table %q: %w", t.TableName, err)
+	//    (on every source shard) so it can serve again. The feed is stopped, so
+	//    nothing writes them.
+	for si := range r.sources {
+		s := &r.sources[si]
+		for _, t := range r.sourceTables {
+			oldName := check.CutoverOldName(t.TableName)
+			if err := dbconn.Exec(ctx, s.db, "RENAME TABLE %n TO %n", oldName, t.TableName); err != nil {
+				return fmt.Errorf("reverse cutover: un-retire source %d table %q: %w", si, t.TableName, err)
+			}
 		}
 	}
 
@@ -297,7 +338,7 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 	//    cutover's source rename. _revert (not _old) marks these as revert
 	//    artifacts, so a later move can safely drop them.
 	for i := range r.targets {
-		for _, t := range src.tables {
+		for _, t := range r.sourceTables {
 			revertName := check.RevertRetiredName(t.TableName)
 			stmt := sqlescape.MustEscapeSQL("RENAME TABLE %n TO %n", t.TableName, revertName)
 			if err := locks[i].ExecUnderLock(ctx, stmt); err != nil {

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -173,6 +173,31 @@ func (w *reverseWindow) buildFeed(ctx context.Context) error {
 		targetTables[t.TableName] = oldTbl
 	}
 
+	// Reverse rows are routed to a source shard by the SOURCE keyspace's vindex,
+	// so the provider is asked about the source schema (the canonical
+	// sources[0]) — NOT the target shard whose binlog carries the row. The
+	// answer is per-table, not per-shard, so resolve it once here. No metadata
+	// for a moved table means its rows cannot be routed — fail loudly rather
+	// than let the window open with an unroutable feed.
+	type shardingMeta struct {
+		column string
+		hash   table.HashFunc
+	}
+	var sharding map[string]shardingMeta
+	if sharded {
+		sharding = make(map[string]shardingMeta, len(src.tables))
+		for _, t := range src.tables {
+			col, hashFn, err := r.move.ReverseShardingProvider.GetShardingMetadata(src.config.DBName, t.TableName)
+			if err != nil {
+				return fmt.Errorf("reverse window: sharding metadata for table %q: %w", t.TableName, err)
+			}
+			if col == "" || hashFn == nil {
+				return fmt.Errorf("reverse window: no sharding metadata for table %q; a sharded source requires every moved table to have a sharding key to route reverse writes", t.TableName)
+			}
+			sharding[t.TableName] = shardingMeta{column: col, hash: hashFn}
+		}
+	}
+
 	sources := make([]ReverseSource, 0, len(r.targets))
 	w.watched = make([][]*table.TableInfo, len(r.targets))
 	for i := range r.targets {
@@ -192,19 +217,8 @@ func (w *reverseWindow) buildFeed(ctx context.Context) error {
 				return fmt.Errorf("reverse window: load target table %q on shard %d: %w", t.TableName, i, err)
 			}
 			if sharded {
-				// Reverse rows are routed to a source shard by the SOURCE
-				// keyspace's vindex. No metadata for a moved table means its
-				// rows cannot be routed — fail loudly rather than let the
-				// window open with an unroutable feed.
-				col, hashFn, err := r.move.ReverseShardingProvider.GetShardingMetadata(tgt.Config.DBName, t.TableName)
-				if err != nil {
-					return fmt.Errorf("reverse window: sharding metadata for table %q: %w", t.TableName, err)
-				}
-				if col == "" || hashFn == nil {
-					return fmt.Errorf("reverse window: no sharding metadata for table %q; a sharded source requires every moved table to have a sharding key to route reverse writes", t.TableName)
-				}
-				wt.ShardingColumn = col
-				wt.HashFunc = hashFn
+				wt.ShardingColumn = sharding[t.TableName].column
+				wt.HashFunc = sharding[t.TableName].hash
 			}
 			watched = append(watched, wt)
 		}

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -1,9 +1,11 @@
 package move
 
 // End-to-end tests for the reverse-window move driven through the real Runner
-// (forward copy + cutover + reverse window + terminal action). 1 source → 1
-// target keeps the harness simple; the N:1 reverse feed itself is covered by
-// reversefeed_test.go. Uses the :8033 test MySQL (binlog=ROW).
+// (forward copy + cutover + reverse window + terminal action). The 1:1 tests
+// keep the harness simple; the *NM tests cover the sharded-source (2:2) form,
+// where the reverse feed routes rows back per source shard. The feed data
+// plane itself is covered by reversefeed_test.go. Uses the :8033 test MySQL
+// (binlog=ROW).
 
 import (
 	"context"
@@ -11,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/go-sql-driver/mysql"
@@ -337,4 +341,249 @@ func TestMoveReverseWindowRefusesStaleRevertMarker(t *testing.T) {
 	err = runner.Run(t.Context())
 	require.Error(t, err, "move must refuse to start when a revert marker is present")
 	require.Contains(t, err.Error(), "revert marker")
+}
+
+// TestMoveReverseWindowShardedSourceGuards: a reverse-window move with a
+// sharded (multi-DSN) source must fail fast — before any connection is opened
+// or copy starts — unless the reverse routing inputs are complete and valid.
+func TestMoveReverseWindowShardedSourceGuards(t *testing.T) {
+	newShardedMove := func() *Move {
+		return &Move{
+			SourceDSNs:      []string{"u:p@tcp(127.0.0.1:3306)/a", "u:p@tcp(127.0.0.1:3306)/b"},
+			TargetChunkTime: time.Second,
+			Threads:         1,
+			WriteThreads:    1,
+			ReverseWindow:   time.Second,
+		}
+	}
+	provider := &testShardingProvider{shardingColumn: "id", hashFunc: testutils.EvenOddHasher}
+
+	m := newShardedMove()
+	runner, err := NewRunner(m)
+	require.NoError(t, err)
+	require.ErrorContains(t, runner.Run(t.Context()), "ReverseShardingProvider")
+	utils.CloseAndLog(runner)
+
+	m = newShardedMove()
+	m.ReverseShardingProvider = provider
+	m.SourceKeyRanges = []string{"-80"} // one range for two sources
+	runner, err = NewRunner(m)
+	require.NoError(t, err)
+	require.ErrorContains(t, runner.Run(t.Context()), "one SourceKeyRanges entry per source DSN")
+	utils.CloseAndLog(runner)
+
+	m = newShardedMove()
+	m.ReverseShardingProvider = provider
+	m.SourceKeyRanges = []string{"-80", "-90"} // overlapping
+	runner, err = NewRunner(m)
+	require.NoError(t, err)
+	require.ErrorContains(t, runner.Run(t.Context()), "key ranges are invalid")
+	utils.CloseAndLog(runner)
+}
+
+// nmReverseFixture is the harness for reverse-window moves with a SHARDED
+// source (2 source shards → 2 target shards, both split by id parity:
+// EvenOddHasher maps even ids to "-80" and odd ids to "80-").
+type nmReverseFixture struct {
+	srcEvenName, srcOddName string // source shards: evens = "-80", odds = "80-"
+	tgtEvenName, tgtOddName string
+	sourceDSNs              []string
+	sourceKeyRanges         []string
+	ctl                     *sql.DB
+	checkpointDBName        string // the sorted targets[0], where the marker goes
+}
+
+func setupNMReverseFixture(t *testing.T) *nmReverseFixture {
+	t.Helper()
+	f := &nmReverseFixture{}
+	f.srcEvenName, _ = testutils.CreateUniqueTestDatabase(t)
+	f.srcOddName, _ = testutils.CreateUniqueTestDatabase(t)
+	f.tgtEvenName, _ = testutils.CreateUniqueTestDatabase(t)
+	f.tgtOddName, _ = testutils.CreateUniqueTestDatabase(t)
+
+	for _, dbName := range []string{f.srcEvenName, f.srcOddName} {
+		testutils.RunSQLInDatabase(t, dbName, `CREATE TABLE users (
+			id BIGINT NOT NULL PRIMARY KEY,
+			val VARCHAR(255) NOT NULL
+		)`)
+	}
+	testutils.RunSQLInDatabase(t, f.srcEvenName, "INSERT INTO users VALUES (2,'two'),(4,'four')")
+	testutils.RunSQLInDatabase(t, f.srcOddName, "INSERT INTO users VALUES (1,'one'),(3,'three')")
+
+	f.sourceDSNs = []string{
+		testutils.DSNForDatabase(f.srcEvenName),
+		testutils.DSNForDatabase(f.srcOddName),
+	}
+	f.sourceKeyRanges = []string{"-80", "80-"}
+
+	ctl, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(ctl) })
+	f.ctl = ctl
+	return f
+}
+
+// newRunner builds a runner for the fixture's 2:2 move. Target DB handles are
+// opened fresh per call (Runner.Close closes them), with the parity split
+// mirrored on the target side.
+func (f *nmReverseFixture) newRunner(t *testing.T, window time.Duration) *Runner {
+	t.Helper()
+	dbConfig := dbconn.NewDBConfig()
+	targets := make([]applier.Target, 0, 2)
+	for _, tc := range []struct {
+		name, keyRange string
+	}{{f.tgtEvenName, "-80"}, {f.tgtOddName, "80-"}} {
+		db, err := dbconn.New(testutils.DSNForDatabase(tc.name), dbConfig)
+		require.NoError(t, err)
+		cfg, err := mysql.ParseDSN(testutils.DSNForDatabase(tc.name))
+		require.NoError(t, err)
+		targets = append(targets, applier.Target{DB: db, Config: cfg, KeyRange: tc.keyRange})
+	}
+	// The checkpoint (and the revert marker) live on the sorted targets[0].
+	first := targets[0]
+	if targetKey(targets[1]) < targetKey(first) {
+		first = targets[1]
+	}
+	f.checkpointDBName = first.Config.DBName
+
+	provider := &testShardingProvider{shardingColumn: "id", hashFunc: testutils.EvenOddHasher}
+	m := &Move{
+		SourceDSNs:              f.sourceDSNs,
+		SourceKeyRanges:         f.sourceKeyRanges,
+		Targets:                 targets,
+		SourceTables:            []string{"users"},
+		ShardingProvider:        provider,
+		ReverseShardingProvider: provider,
+		TargetChunkTime:         time.Second,
+		Threads:                 1,
+		WriteThreads:            1,
+		ReverseWindow:           window,
+	}
+	runner, err := NewRunner(m)
+	require.NoError(t, err)
+	return runner
+}
+
+func (f *nmReverseFixture) rows(t *testing.T, dbName string) map[int64]string {
+	t.Helper()
+	out := make(map[int64]string)
+	rows, err := f.ctl.QueryContext(t.Context(), "SELECT id, val FROM "+dbName+".users")
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+	for rows.Next() {
+		var id int64
+		var val string
+		require.NoError(t, rows.Scan(&id, &val))
+		out[id] = val
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// TestMoveReverseWindowRevertNM: a revert of a 2:2 (sharded source → sharded
+// target) move routes every row — including writes made on the targets during
+// the window — back to the source shard owning it, un-retires ALL source
+// shards, and retires ALL targets.
+func TestMoveReverseWindowRevertNM(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	f := setupNMReverseFixture(t)
+	runner := f.newRunner(t, 30*time.Second) // long; the revert ends it early
+	defer utils.CloseAndLog(runner)
+
+	var reverseCutoverCalled bool
+	runner.SetCutover(func(context.Context) error { return nil })
+	runner.SetReverseCutover(func(context.Context) error { reverseCutoverCalled = true; return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Run(context.Background()) }()
+
+	waitForReverseWindow(t, f.ctl, f.checkpointDBName)
+	// Window-time app writes, placed on the target shard that serves each row.
+	testutils.RunSQL(t, "INSERT INTO "+f.tgtEvenName+".users VALUES (8,'eight')")
+	testutils.RunSQL(t, "INSERT INTO "+f.tgtOddName+".users VALUES (9,'nine')")
+	testutils.RunSQL(t, "UPDATE "+f.tgtEvenName+".users SET val='two-updated' WHERE id=2")
+	testutils.RunSQL(t, "DELETE FROM "+f.tgtOddName+".users WHERE id=1")
+	testutils.RunSQL(t, "CREATE TABLE "+f.checkpointDBName+"."+revertMarkerName+" (id INT)")
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("timed out waiting for the N:M reverse cutover to complete")
+	}
+	require.True(t, reverseCutoverCalled, "reverse cutover func must run on revert")
+
+	// Every source shard un-retired and holding exactly its own rows, with the
+	// window's writes routed back by the source vindex.
+	require.Equal(t, map[int64]string{2: "two-updated", 4: "four", 8: "eight"}, f.rows(t, f.srcEvenName),
+		"even rows (incl. window-time insert/update) must land on the even source shard")
+	require.Equal(t, map[int64]string{3: "three", 9: "nine"}, f.rows(t, f.srcOddName),
+		"odd rows must land on the odd source shard, with the window-time delete applied")
+	for _, src := range []string{f.srcEvenName, f.srcOddName} {
+		require.True(t, tableExists(t, f.ctl, src, "users"), "source %s must be un-retired", src)
+		require.False(t, tableExists(t, f.ctl, src, "users_old"), "source %s _old must be gone", src)
+	}
+	// Every target retired to _revert.
+	for _, tgt := range []string{f.tgtEvenName, f.tgtOddName} {
+		require.True(t, tableExists(t, f.ctl, tgt, "users_revert"), "target %s must be retired to _revert", tgt)
+		require.False(t, tableExists(t, f.ctl, tgt, "users"), "target %s real table must be gone", tgt)
+	}
+	require.False(t, tableExists(t, f.ctl, f.checkpointDBName, checkpointTableName), "checkpoint should be dropped")
+}
+
+// TestMoveReverseWindowNMResumesAfterKill: killing a 2:2 move mid-window and
+// re-running it resumes the window (rebuilding per-shard state for ALL sources)
+// and can still roll back with correct per-shard routing.
+func TestMoveReverseWindowNMResumesAfterKill(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	f := setupNMReverseFixture(t)
+
+	run1 := f.newRunner(t, 30*time.Second)
+	run1.SetCutover(func(context.Context) error { return nil })
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	run1Done := make(chan struct{})
+	go func() { _ = run1.Run(ctx1); close(run1Done) }()
+
+	waitForReverseWindow(t, f.ctl, f.checkpointDBName)
+	// Wait for the source retire to land on BOTH source shards before killing,
+	// so run 2 resumes from the fully-cutover state.
+	waitForTable(t, f.ctl, f.srcEvenName, "users_old")
+	waitForTable(t, f.ctl, f.srcOddName, "users_old")
+	cancel1()
+	<-run1Done
+	utils.CloseAndLog(run1)
+
+	require.True(t, tableExists(t, f.ctl, f.checkpointDBName, checkpointTableName), "checkpoint must survive the kill")
+
+	run2 := f.newRunner(t, 30*time.Second)
+	defer utils.CloseAndLog(run2)
+	run2.SetCutover(func(context.Context) error {
+		t.Error("resume must NOT run the forward cutover again (it re-copied instead of resuming)")
+		return nil
+	})
+	var reverseCutoverCalled bool
+	run2.SetReverseCutover(func(context.Context) error { reverseCutoverCalled = true; return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- run2.Run(context.Background()) }()
+
+	waitForReverseWindow(t, f.ctl, f.checkpointDBName)
+	// A write made while the resumed window is live, then the revert.
+	testutils.RunSQL(t, "INSERT INTO "+f.tgtOddName+".users VALUES (11,'eleven')")
+	testutils.RunSQL(t, "CREATE TABLE "+f.checkpointDBName+"."+revertMarkerName+" (id INT)")
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("timed out waiting for the resumed N:M window to roll back")
+	}
+	require.True(t, reverseCutoverCalled, "resumed window must be able to roll back")
+
+	require.Equal(t, map[int64]string{2: "two", 4: "four"}, f.rows(t, f.srcEvenName))
+	require.Equal(t, map[int64]string{1: "one", 3: "three", 11: "eleven"}, f.rows(t, f.srcOddName),
+		"a window-time write after resume must still route to the owning source shard")
+	for _, tgt := range []string{f.tgtEvenName, f.tgtOddName} {
+		require.True(t, tableExists(t, f.ctl, tgt, "users_revert"), "target %s retired to _revert", tgt)
+	}
 }

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/go-sql-driver/mysql"
@@ -541,16 +542,25 @@ func TestMoveReverseWindowNMResumesAfterKill(t *testing.T) {
 	run1 := f.newRunner(t, 30*time.Second)
 	run1.SetCutover(func(context.Context) error { return nil })
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	run1Done := make(chan struct{})
-	go func() { _ = run1.Run(ctx1); close(run1Done) }()
+	run1Err := make(chan error, 1)
+	go func() { run1Err <- run1.Run(ctx1) }()
 
 	waitForReverseWindow(t, f.ctl, f.checkpointDBName)
 	// Wait for the source retire to land on BOTH source shards before killing,
 	// so run 2 resumes from the fully-cutover state.
 	waitForTable(t, f.ctl, f.srcEvenName, "users_old")
 	waitForTable(t, f.ctl, f.srcOddName, "users_old")
+	// The checkpoint phase and the renames land during cutover, before the
+	// window loop starts; wait for the runner to report ReverseWindow so the
+	// kill hits the loop itself and surfaces as a clean context.Canceled.
+	require.Eventually(t, func() bool {
+		return run1.Progress().CurrentState == status.ReverseWindow
+	}, 30*time.Second, 50*time.Millisecond, "run 1 must reach the reverse-window state")
 	cancel1()
-	<-run1Done
+	// The only acceptable outcome of the kill is our own cancellation — any
+	// other error means run 1 died on its own and the "resume" below would be
+	// testing recovery from the wrong state.
+	require.ErrorIs(t, <-run1Err, context.Canceled, "run 1 must die from the kill, not an earlier failure")
 	utils.CloseAndLog(run1)
 
 	require.True(t, tableExists(t, f.ctl, f.checkpointDBName, checkpointTableName), "checkpoint must survive the kill")

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1982,7 +1982,10 @@ func (r *Runner) DumpCheckpoint(ctx context.Context) error {
 		ChecksumWatermark: checksumWatermark,
 		Position:          string(positionsJSON),
 	}); err != nil {
-		return status.ErrCouldNotWriteCheckpoint
+		// Keep the cause: the WatchTask dumper distinguishes a benign
+		// canceled-mid-write (it is being stopped) from a genuinely broken
+		// checkpoint table, which is fatal.
+		return fmt.Errorf("%w: %w", status.ErrCouldNotWriteCheckpoint, err)
 	}
 	return nil
 }

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -59,6 +59,11 @@ type sourceInfo struct {
 	dsn        string
 	replClient change.Source
 	tables     []*table.TableInfo // this source's TableInfo objects (bound to this source's db)
+	// keyRange is this source shard's Vitess-style key range (from
+	// Move.SourceKeyRanges, attached before the sources are sorted so it stays
+	// with its DSN). Only set — and only needed — for a reverse-window move
+	// with a sharded source, where the reverse feed routes rows back by range.
+	keyRange string
 }
 
 // sourceKey returns a stable identifier for a source, used for checkpoint
@@ -798,15 +803,19 @@ func (r *Runner) resumeReverseWindow(ctx context.Context, rec checkpoint.Record)
 	if len(logical) == 0 {
 		return fmt.Errorf("resume reverse window: found no retired (_old) source tables to resume from")
 	}
-	src := &r.sources[0] // reverse-window is single-source (guarded at cutover)
-	src.tables = make([]*table.TableInfo, 0, len(logical))
-	for _, name := range logical {
-		// Only the name is read downstream (buildFeed derives the _old source
-		// and real target TableInfos itself), so no SetInfo — the logical table
-		// no longer exists on the source under this name.
-		src.tables = append(src.tables, table.NewTableInfo(src.db, src.config.DBName, name))
+	// Rebuild every source's table list (all source shards hold the same
+	// logical tables; sources[0] was the canonical one the names came from).
+	for si := range r.sources {
+		src := &r.sources[si]
+		src.tables = make([]*table.TableInfo, 0, len(logical))
+		for _, name := range logical {
+			// Only the name is read downstream (buildFeed derives the _old source
+			// and real target TableInfos itself), so no SetInfo — the logical table
+			// no longer exists on the source under this name.
+			src.tables = append(src.tables, table.NewTableInfo(src.db, src.config.DBName, name))
+		}
 	}
-	r.sourceTables = src.tables
+	r.sourceTables = r.sources[0].tables
 
 	return newReverseWindow(r).run(ctx)
 }
@@ -974,10 +983,21 @@ func (r *Runner) Run(ctx context.Context) error {
 	)
 
 	if r.move.ReverseWindow > 0 && len(r.move.SourceDSNs) > 1 {
-		// Reverse-window is only defined for an unsharded source (1 source →
-		// M targets ⇒ an M:1 reverse). A sharded source would need an M:N
-		// reverse with a reverse sharding provider, which is out of scope.
-		return fmt.Errorf("--reverse-window requires an unsharded (single) source, got %d source shards", len(r.move.SourceDSNs))
+		// A sharded source reverses as an M:N feed: rows flowing back from the
+		// targets are routed to the source shard whose key range contains the
+		// row's hash. That routing needs the source shard layout and the source
+		// keyspace's sharding metadata, so both are required up front — failing
+		// here, before any copy, rather than after the forward cutover when the
+		// reverse feed is actually built.
+		if r.move.ReverseShardingProvider == nil {
+			return fmt.Errorf("--reverse-window with a sharded source (%d source shards) requires a ReverseShardingProvider to route reverse writes", len(r.move.SourceDSNs))
+		}
+		if len(r.move.SourceKeyRanges) != len(r.move.SourceDSNs) {
+			return fmt.Errorf("--reverse-window with a sharded source requires one SourceKeyRanges entry per source DSN, got %d ranges for %d sources", len(r.move.SourceKeyRanges), len(r.move.SourceDSNs))
+		}
+		if err := applier.ValidateKeyRanges(r.move.SourceKeyRanges); err != nil {
+			return fmt.Errorf("--reverse-window source key ranges are invalid: %w", err)
+		}
 	}
 
 	var err error
@@ -1005,6 +1025,12 @@ func (r *Runner) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to parse source DSN %d: %w", i, err)
 		}
 		r.sources[i] = sourceInfo{db: db, config: cfg, dsn: dsn}
+		// Attach this shard's key range BEFORE the sort below, so it stays
+		// with its DSN (SourceKeyRanges is parallel to the caller's SourceDSNs
+		// order, not the sorted order).
+		if i < len(r.move.SourceKeyRanges) {
+			r.sources[i].keyRange = r.move.SourceKeyRanges[i]
+		}
 	}
 	// Sort sources by sourceKey (addr/dbname) for deterministic ordering.
 	// sources[0] is the canonical source we read the table list and SHOW

--- a/pkg/status/task.go
+++ b/pkg/status/task.go
@@ -72,8 +72,13 @@ func continuallyDumpCheckpoint(ctx context.Context, task Task, logger *slog.Logg
 					logger.Warn("could not write checkpoint yet, watermark not ready")
 					continue
 				}
-				// If the error is context canceled, that's fine too.
-				if errors.Is(err, context.Canceled) {
+				// If our context was canceled while the dump was in flight, the
+				// task is stopping us on purpose (e.g. the reverse-window flow
+				// stops the dumper right before cutover). The killed write can
+				// surface as any driver error, not necessarily context.Canceled,
+				// so check the context itself — going fatal here would Cancel()
+				// the very task that is shutting us down cleanly.
+				if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 					return
 				}
 				if task.Progress().CurrentState >= CutOver {

--- a/pkg/status/task_test.go
+++ b/pkg/status/task_test.go
@@ -254,3 +254,37 @@ func TestContinuallyDumpCheckpointErrorDuringCutover(t *testing.T) {
 		t.Fatal("a checkpoint error after reaching CutOver must not cancel the task")
 	}
 }
+
+// TestContinuallyDumpCheckpointCanceledMidDump reproduces the
+// stop-while-writing race: the loop's context is canceled while a dump is
+// in flight (the reverse-window flow stops the dumper right before
+// cutover), and the killed write surfaces as an arbitrary driver error —
+// NOT context.Canceled. The loop must recognize its own context is done
+// and exit quietly instead of fatally cancelling the task it belongs to.
+func TestContinuallyDumpCheckpointCanceledMidDump(t *testing.T) {
+	setTestIntervals(t, time.Hour, 2*time.Millisecond)
+	task := newFakeTask(CopyRows)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	// The dump itself observes the stop signal mid-write: the caller
+	// cancels, then the interrupted write returns a non-context error.
+	task.dumpErr = func() error {
+		cancel()
+		return errors.New("invalid connection")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		continuallyDumpCheckpoint(ctx, task, slog.Default())
+	}()
+
+	waitSignal(t, done, "checkpoint loop exit after canceled-mid-dump error")
+	if task.cancelled() {
+		t.Fatal("a dump error caused by our own cancellation must not cancel the task")
+	}
+	if n := task.checkpointCount.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 checkpoint attempt, got %d", n)
+	}
+}


### PR DESCRIPTION
## What

Removes the `--reverse-window requires an unsharded source` restriction: a move from a **sharded** source (N shards → M shards) can now hold a rollback window after cutover and revert with no data loss. Follow-up to #1051, which shipped the reverse window for unsharded (1:N) sources only.

## How it works

The N:M reverse is itself an M:N sharded feed. Each former **target** shard's binlog is watched, and every row flowing back is routed to the **source** shard whose key range contains `hash(shardingColumn)` — computed with the *source* keyspace's sharding metadata, attached to the watched former-target tables. This is the exact mirror of the forward fan-out, where `ShardingProvider` describes the target keyspace.

Two commits, in dependency order:

### 1. `applier`: sharded applier honors the mapping's target table name

The `ShardedApplier` previously ignored the mapping's target side — upserts and deletes always used the source table's name and columns. Fine for forward moves (names match), but the reverse feed must write to the source shards' retired `<table>_old` tables — a renamed target.

- `UpsertRows` writes to `mapping.TargetTable().QuotedTableName` with the mapping's target column list; `DeleteKeys` accepts a target table (nil ⇒ source, matching `SingleTargetApplier`).
- Routing is unchanged: the sharding column/hash still come from the mapping's **source** table (the watched table whose row images are being routed).
- No behavior change for forward moves — subscriptions pass a nil new-table, so the target defaults to the source. Also fixes a latent inconsistency where the column list came from all `NonGeneratedColumns` while values were built from the mapping intersection; both are mapping-derived now.
- New exported `applier.ValidateKeyRanges` (same parse/overlap rules the applier enforces at construction) so callers can fail fast.

### 2. `move`: sharded (N:M) reverse window

- `Move` gains `ReverseShardingProvider` and `SourceKeyRanges` (parallel to `SourceDSNs`; both `kong:"-"` — programmatic callers such as Strata supply them). Required when `ReverseWindow > 0` with multiple sources, validated at `Run` start — **before any copy** — so a misconfigured reversible move fails immediately rather than after the forward cutover.
- Each source's key range is attached to its `sourceInfo` **before** the deterministic source sort, so it stays with its DSN.
- `ReverseFeedConfig` gains `Targets` (mutually exclusive with `Target`): the former source shards, applied through a shared `ShardedApplier`. Watched tables must carry `ShardingColumn`/`HashFunc`, checked at construction so a bad feed fails before the window opens, not fatally at first apply.
- `reverseWindow.buildFeed` attaches the reverse provider's metadata to each watched table and builds one `applier.Target{DB, Config, KeyRange}` per source shard. The shared `_old` mapping `TableInfo`s are unqualified, so each shard's own connection lands writes in the right database.
- `reverseCutover` un-retires `_old` → real on **every** source shard; `resumeReverseWindow` rebuilds per-source table lists for all sources.

Unsharded (1:N) reverse windows are untouched — a single source still uses the `SingleTargetApplier` path with no provider or key ranges.

## Testing

All against the test MySQL with `-race`:

- `TestShardedApplierRenamedTarget` — shards start with **only** `t1_old`, so an un-renamed write fails loudly; asserts parity routing into `t1_old`, broadcast delete, and the unchanged nil-target forward path.
- `TestReverseFeedFanOutRoutesByShard` / `TestReverseFeedShardedConfigValidation` — sharded feed routes rows back by hash per shard; construction-time validation.
- `TestMoveReverseWindowShardedSourceGuards` — the three fast-fail cases (no MySQL needed).
- `TestMoveReverseWindowRevertNM` — full 2:2 runner: forward move → cutover → window-time insert/update/delete → revert marker → asserts **exact per-shard row maps** on the un-retired sources, including the window writes.
- `TestMoveReverseWindowNMResumesAfterKill` — kill mid-window, resume, revert; same per-shard assertions.
- Full `pkg/applier` + `pkg/move` suites pass.

Downstream, a Strata e2e (sharded→sharded move through the real CLI, revert, per-shard vindex-correct rollback verified through the proxy) runs green against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)