### PR TITLE
checksum: narrow a mismatching chunk before recopying it

### DIFF
--- a/pkg/checksum/README.md
+++ b/pkg/checksum/README.md
@@ -62,6 +62,28 @@ The actual implementation includes additional handling:
 
 The CRC32 + XOR aggregate technique for table checksumming was pioneered by **pt-table-checksum** from Percona Toolkit, which established this as a reliable method for verifying data consistency in MySQL. This same approach has since been adopted by other database tools, including TiDB's data migration and verification utilities, demonstrating its effectiveness for distributed database scenarios.
 
+## Repairing a mismatch
+
+When a chunk fails verification and `FixDifferences` is on, the checker recopies the chunk's key range: `DELETE` then `REPLACE INTO ... SELECT` for the single-server case, or `DELETE` on every target followed by a re-apply through the applier for the distributed case.
+
+Chunks are sized by how long they take to *read* while checksumming, which says nothing about how long they take to rewrite. Recopying a whole XL chunk to fix a handful of rows is a large write burst, a long lock hold, and a wide window in which the target range is deleted but not yet rewritten. So the repair is narrowed first (`subdivide.go`):
+
+1. Cut the chunk's key range into `csRepairSplitParts` contiguous pieces (`table.Chunk.Split`, using `ORDER BY key LIMIT 1 OFFSET n` boundary lookups). The first and last inherit the original's bounds — inclusivity and unboundedness included — and each interior cut is an exclusive upper bound on one piece and an inclusive lower bound on the next.
+2. Re-checksum each piece **inside the same snapshot transaction that observed the mismatch**, and keep only the pieces that differ.
+3. Recurse on each differing piece, stopping at `csRepairMaxDepth` rounds or once a piece holds fewer than `csRepairMinSplitRows` rows — below that, recopying is cheaper than analysing.
+
+Step 2 is sound because `BIT_XOR` is associative and the row counts are additive: over an exact partition read in one snapshot, the pieces must reproduce the whole-range result, so a mismatching range must contain a mismatching piece. Reading a piece from a *different* snapshot would break that — a piece could look clean because a concurrent write happened to fix it, and the repair would be skipped on the strength of an observation that never applied to the chunk being fixed.
+
+That argument needs the pieces to partition the range exactly, and `Split` cannot promise it for every key type: MySQL orders `ENUM` by declaration ordinal but compares it against a string literal lexically, a case-insensitive collation orders by weight rather than by bytes, and a `NULL` key value satisfies neither `>=` nor `<`. So exactness is *checked* rather than assumed — the pieces' row counts, read in the same snapshot as the parent's, must sum to the parent's on both sides. A gap (which would let a differing row escape repair) or an overlap (which would delete and rewrite rows twice) shows up as a shortfall or an excess, and the chunk is repaired whole instead.
+
+Everything else that makes narrowing unusable also falls back to repairing the whole range, because declining to fix a known difference is never an option: a range with too few distinct key values to cut, a failed boundary query, pieces that all verify clean, and pieces that *all* differ. The last is the systematic case — a lossy `ALTER`, a wrong column mapping, a truncated target — where narrowing has bought nothing, and one statement pair is cheaper and shorter-lived than one per piece.
+
+A verification *failure*, by contrast, is propagated: it means the snapshot is no longer usable, so the pass should fail and be retried rather than repair on stale information. `differencesFound` is incremented before narrowing begins, so a chunk left unrepaired this way cannot be reported as a pass.
+
+The repair's timeout (`fixChunkTimeout`) and its detachment from the caller's cancellation are owned once per chunk and shared by all its narrowed repairs. The narrowed repairs together rewrite no more than the single repair they replace, so one budget covers them — and giving each its own would multiply the span during which a fix ignores cancellation by the number of pieces.
+
+In the distributed case the boundaries are cut from a single source shard, since offsets into one shard's rows are the only row-position information a single query can give. A chunk's key range is spread across shards by the vindex, so no shard's distribution describes the whole range and the pieces come out unevenly balanced. The shard is chosen per range rather than once per chunk: a sub-range's rows can sit almost entirely on a different shard than its parent's did, and cutting it with a shard that holds nothing in it would find no boundaries at all and silently give up on narrowing.
+
 ## Pacing and scaling
 
 `SingleChecker` and `DistributedChecker` pace themselves against the same throttler the copier uses. Two things are separate here:

--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -158,75 +158,32 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 
 	c.logger.Debug("checksumming chunk", "chunk", chunk.String())
 
-	// Build the checksum query fragments. The same WHERE clause applies to
-	// both sources and targets since all schemas are identical, but the
-	// column expressions are side-dependent: JSON columns round-trip through
-	// text on the source and render strictly on the target (see
-	// table.castExpr). Move/sync writes are text-mediated — the applier
-	// writes rendered text that the target re-parses — so the same
-	// text-image contract as the single-server checksum applies here. This
-	// does assume source and target servers parse JSON text identically; if
-	// a future server version changed parse behavior (e.g. fixed the double
-	// misrounding bugs), a cross-version move of affected values would fail
-	// the checksum safely rather than pass silently.
-	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
-	if err != nil {
-		return err
-	}
-	whereClause := chunk.String()
-
-	// Query ALL sources and aggregate results.
-	// BIT_XOR is associative/commutative, so XOR-ing per-source checksums
-	// produces the same result as checksumming all rows in one table.
-	// The count is simply summed.
-	var sourceChecksum int64
-	var sourceCount uint64
+	// Acquire every source and target snapshot up front and hold them for the
+	// whole chunk. Beyond the checksum itself, the repair path re-reads
+	// sub-ranges through these same transactions, which is what makes narrowing
+	// sound (see narrowRepair).
+	srcTrxs := make([]*sql.Tx, len(c.sourcePools))
 	for i := range c.sourcePools {
 		srcTrx, err := c.sourcePools[i].trxPool.Get()
 		if err != nil {
 			return fmt.Errorf("failed to get transaction for source %d: %w", i, err)
 		}
 		defer c.sourcePools[i].trxPool.Put(srcTrx)
-
-		sourceQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-			sourceChecksumCols,
-			chunk.Table.QuotedTableName,
-			whereClause,
-		)
-		var cs int64
-		var cnt uint64
-		if err := srcTrx.QueryRowContext(ctx, sourceQuery).Scan(&cs, &cnt); err != nil {
-			return fmt.Errorf("failed to query source %d: %w", i, err)
-		}
-		sourceChecksum ^= cs
-		sourceCount += cnt
-		c.logger.Debug("source checksum", "sourceID", i, "checksum", cs, "count", cnt)
+		srcTrxs[i] = srcTrx
 	}
-
-	// Query ALL targets and aggregate results.
-	// Same aggregation logic: XOR checksums, sum counts.
-	var targetChecksum int64
-	var targetCount uint64
+	tgtTrxs := make([]*sql.Tx, len(c.targetTrxPools))
 	for i, targetTrxPool := range c.targetTrxPools {
 		targetTrx, err := targetTrxPool.Get()
 		if err != nil {
 			return fmt.Errorf("failed to get transaction for target %d: %w", i, err)
 		}
 		defer targetTrxPool.Put(targetTrx)
+		tgtTrxs[i] = targetTrx
+	}
 
-		targetQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-			targetChecksumCols,
-			chunk.Table.QuotedTableName,
-			whereClause,
-		)
-		var cs int64
-		var cnt uint64
-		if err := targetTrx.QueryRowContext(ctx, targetQuery).Scan(&cs, &cnt); err != nil {
-			return fmt.Errorf("failed to query target %d: %w", i, err)
-		}
-		targetChecksum ^= cs
-		targetCount += cnt
-		c.logger.Debug("target checksum", "targetID", i, "checksum", cs, "count", cnt)
+	sourceChecksum, targetChecksum, sourceCount, targetCount, perSourceCount, err := c.checksumRange(ctx, srcTrxs, tgtTrxs, chunk)
+	if err != nil {
+		return err
 	}
 
 	c.logger.Debug("aggregated checksums",
@@ -266,14 +223,132 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		if !c.fixDifferences {
 			return errors.New("checksum mismatch")
 		}
-		// Since we can fix differences, replace the chunk.
-		if err := c.replaceChunk(ctx, chunk); err != nil {
+		// Since we can fix differences, replace the chunk — narrowed to the
+		// sub-ranges that actually differ, so a mismatch of a few rows does not
+		// delete-and-reapply an XL chunk on every target.
+		counts := rangeCounts{
+			sourceRows: sourceCount,
+			targetRows: targetCount,
+			splitter:   widestSource(srcTrxs, perSourceCount),
+		}
+		if err := c.narrowAndReplaceChunk(ctx, srcTrxs, tgtTrxs, chunk, counts); err != nil {
 			return err
 		}
 	}
 	// When we give feedback, we need to say how many rows were in the chunk.
 	c.chunker.Feedback(chunk, time.Since(startTime), targetCount)
 	return nil
+}
+
+// checksumRange checksums a key range across every source and every target,
+// inside the supplied snapshot transactions.
+//
+// BIT_XOR is associative/commutative, so XOR-ing per-shard checksums produces
+// the same result as checksumming all rows in one table; the counts are simply
+// summed. perSourceCount is returned alongside so the repair path can pick a
+// representative shard to cut split boundaries from.
+//
+// The same WHERE clause applies to both sources and targets since all schemas
+// are identical, but the column expressions are side-dependent: JSON columns
+// round-trip through text on the source and render strictly on the target (see
+// table.castExpr). Move/sync writes are text-mediated — the applier writes
+// rendered text that the target re-parses — so the same text-image contract as
+// the single-server checksum applies here. This does assume source and target
+// servers parse JSON text identically; if a future server version changed parse
+// behavior (e.g. fixed the double misrounding bugs), a cross-version move of
+// affected values would fail the checksum safely rather than pass silently.
+func (c *DistributedChecker) checksumRange(ctx context.Context, srcTrxs, tgtTrxs []*sql.Tx, chunk *table.Chunk) (sourceChecksum, targetChecksum int64, sourceCount, targetCount uint64, perSourceCount []uint64, err error) {
+	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
+	if err != nil {
+		return 0, 0, 0, 0, nil, err
+	}
+	whereClause := chunk.String()
+
+	perSourceCount = make([]uint64, len(srcTrxs))
+	for i, srcTrx := range srcTrxs {
+		sourceQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
+			sourceChecksumCols,
+			chunk.Table.QuotedTableName,
+			whereClause,
+		)
+		var cs int64
+		var cnt uint64
+		if err := srcTrx.QueryRowContext(ctx, sourceQuery).Scan(&cs, &cnt); err != nil {
+			return 0, 0, 0, 0, nil, fmt.Errorf("failed to query source %d: %w", i, err)
+		}
+		sourceChecksum ^= cs
+		sourceCount += cnt
+		perSourceCount[i] = cnt
+		c.logger.Debug("source checksum", "sourceID", i, "checksum", cs, "count", cnt)
+	}
+
+	for i, targetTrx := range tgtTrxs {
+		targetQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
+			targetChecksumCols,
+			chunk.Table.QuotedTableName,
+			whereClause,
+		)
+		var cs int64
+		var cnt uint64
+		if err := targetTrx.QueryRowContext(ctx, targetQuery).Scan(&cs, &cnt); err != nil {
+			return 0, 0, 0, 0, nil, fmt.Errorf("failed to query target %d: %w", i, err)
+		}
+		targetChecksum ^= cs
+		targetCount += cnt
+		c.logger.Debug("target checksum", "targetID", i, "checksum", cs, "count", cnt)
+	}
+	return sourceChecksum, targetChecksum, sourceCount, targetCount, perSourceCount, nil
+}
+
+// narrowAndReplaceChunk recopies a mismatching chunk, first narrowing it to the
+// differing sub-ranges.
+//
+// Split boundaries are cut from a single source shard, since offsets into one
+// shard's rows are the only row-position information a single query can give.
+// A chunk's key range is spread across shards by the vindex, so no shard's
+// distribution describes the whole range and the pieces come out unevenly
+// balanced. They are still an exact partition of the key *range*, which is what
+// narrowing needs — see narrowRepair, which validates that against the row
+// counts. The shard is chosen per range rather than once for the chunk: a
+// sub-range's rows can sit almost entirely on a different shard than its
+// parent's did, and cutting it with a shard that holds nothing in it would find
+// no boundaries at all and silently give up on narrowing.
+func (c *DistributedChecker) narrowAndReplaceChunk(ctx context.Context, srcTrxs, tgtTrxs []*sql.Tx, chunk *table.Chunk, counts rangeCounts) error {
+	verify := func(ctx context.Context, sub *table.Chunk) (rangeCounts, error) {
+		srcCRC, tgtCRC, srcCount, tgtCount, perSourceCount, err := c.checksumRange(ctx, srcTrxs, tgtTrxs, sub)
+		if err != nil {
+			return rangeCounts{}, err
+		}
+		return rangeCounts{
+			sourceRows: srcCount,
+			targetRows: tgtCount,
+			mismatched: compareChunk(srcCRC, tgtCRC, srcCount, tgtCount).mismatched(),
+			splitter:   widestSource(srcTrxs, perSourceCount),
+		}, nil
+	}
+	// One fix window for the whole chunk — see SingleChecker.narrowAndReplaceChunk.
+	fixCtx, fixCancel := context.WithTimeout(context.WithoutCancel(ctx), fixChunkTimeout)
+	defer fixCancel()
+	repair := func(_ context.Context, sub *table.Chunk) error {
+		return c.replaceChunk(fixCtx, sub)
+	}
+	return narrowRepair(ctx, chunk, counts, verify, repair, c.logger)
+}
+
+// widestSource returns the transaction for the shard holding the most rows of a
+// range, or nil if no shard holds any — in which case there are no boundaries to
+// cut and the range has to be repaired whole.
+func widestSource(srcTrxs []*sql.Tx, perSourceCount []uint64) table.Splitter {
+	widest, most := -1, uint64(0)
+	for i, n := range perSourceCount {
+		if i < len(srcTrxs) && n > most {
+			widest, most = i, n
+		}
+	}
+	if widest < 0 {
+		return nil
+	}
+	return srcTrxs[widest]
 }
 
 // GetProgress returns rows verified so far and the total to verify, proxied
@@ -287,7 +362,11 @@ func (c *DistributedChecker) GetProgress() status.ChecksumProgress {
 // In the distributed case, we first delete the entire chunk range from all targets,
 // then use Apply to recopy the data from the source. This handles both missing rows
 // and extra rows on the destination.
-func (c *DistributedChecker) replaceChunk(ctx context.Context, chunk *table.Chunk) error {
+//
+// fixCtx must already carry the repair's timeout and be detached from the
+// caller's cancellation (see narrowAndReplaceChunk, which owns one such context
+// per chunk and reuses it across the narrowed sub-ranges).
+func (c *DistributedChecker) replaceChunk(fixCtx context.Context, chunk *table.Chunk) error {
 	c.logger.Warn("recopying chunk via DELETE + Apply", "chunk", chunk.String())
 
 	// We further prevent the chance of deadlocks from the recopying process by only re-copying one chunk at a time.
@@ -299,10 +378,8 @@ func (c *DistributedChecker) replaceChunk(ctx context.Context, chunk *table.Chun
 	// parent ctx is cancelled between or during these steps, the target side
 	// would be left with rows DELETEd but not yet reapplied. The
 	// continuous-checksum loop's cancellation on sentinel drop hits this race,
-	// so we run the fix under a context that ignores the parent's
-	// cancellation. The bounded timeout still protects against a hung apply.
-	fixCtx, fixCancel := context.WithTimeout(context.WithoutCancel(ctx), fixChunkTimeout)
-	defer fixCancel()
+	// which is why fixCtx ignores the parent's cancellation. Its bounded timeout
+	// still protects against a hung apply.
 
 	// Step 1: Delete all rows in the chunk range from all targets
 	// This ensures we remove any extra rows that shouldn't be there.

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -128,27 +128,7 @@ func (c *SingleChecker) ChecksumChunk(ctx context.Context, trxPool *dbconn.TrxPo
 	}
 	defer trxPool.Put(trx)
 	c.logger.Debug("checksumming chunk", "chunk", chunk.String())
-	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
-	if err != nil {
-		return err
-	}
-	source := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-		sourceChecksumCols,
-		chunk.Table.QuotedTableName,
-		chunk.String(),
-	)
-	target := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
-		targetChecksumCols,
-		chunk.NewTable.QuotedTableName,
-		chunk.String(),
-	)
-	var sourceChecksum, targetChecksum int64
-	var sourceCount, targetCount uint64
-	err = trx.QueryRowContext(ctx, source).Scan(&sourceChecksum, &sourceCount)
-	if err != nil {
-		return err
-	}
-	err = trx.QueryRowContext(ctx, target).Scan(&targetChecksum, &targetCount)
+	sourceChecksum, targetChecksum, sourceCount, targetCount, err := c.checksumRange(ctx, trx, chunk)
 	if err != nil {
 		return err
 	}
@@ -179,14 +159,72 @@ func (c *SingleChecker) ChecksumChunk(ctx context.Context, trxPool *dbconn.TrxPo
 		if !c.fixDifferences {
 			return errors.New("checksum mismatch")
 		}
-		// Since we can fix differences, replace the chunk.
-		if err = c.replaceChunk(ctx, chunk); err != nil {
+		// Since we can fix differences, replace the chunk — narrowed to the
+		// sub-ranges that actually differ, so a mismatch of a few rows does not
+		// rewrite an XL chunk.
+		if err = c.narrowAndReplaceChunk(ctx, trx, chunk, sourceCount, targetCount); err != nil {
 			return err
 		}
 	}
 	// When we give feedback, we need to say how many rows were in the chunk.
 	c.chunker.Feedback(chunk, time.Since(startTime), targetCount)
 	return nil
+}
+
+// checksumRange runs the source and target checksum queries for a key range
+// inside the given snapshot transaction.
+func (c *SingleChecker) checksumRange(ctx context.Context, trx *sql.Tx, chunk *table.Chunk) (sourceChecksum, targetChecksum int64, sourceCount, targetCount uint64, err error) {
+	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	source := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
+		sourceChecksumCols,
+		chunk.Table.QuotedTableName,
+		chunk.String(),
+	)
+	target := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
+		targetChecksumCols,
+		chunk.NewTable.QuotedTableName,
+		chunk.String(),
+	)
+	if err := trx.QueryRowContext(ctx, source).Scan(&sourceChecksum, &sourceCount); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if err := trx.QueryRowContext(ctx, target).Scan(&targetChecksum, &targetCount); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	return sourceChecksum, targetChecksum, sourceCount, targetCount, nil
+}
+
+// narrowAndReplaceChunk recopies a mismatching chunk, first narrowing it to the
+// differing sub-ranges. The narrowing reads through trx — the same snapshot the
+// mismatch was observed in — see narrowRepair.
+func (c *SingleChecker) narrowAndReplaceChunk(ctx context.Context, trx *sql.Tx, chunk *table.Chunk, sourceCount, targetCount uint64) error {
+	verify := func(ctx context.Context, sub *table.Chunk) (rangeCounts, error) {
+		srcCRC, tgtCRC, srcCount, tgtCount, err := c.checksumRange(ctx, trx, sub)
+		if err != nil {
+			return rangeCounts{}, err
+		}
+		return rangeCounts{
+			sourceRows: srcCount,
+			targetRows: tgtCount,
+			mismatched: compareChunk(srcCRC, tgtCRC, srcCount, tgtCount).mismatched(),
+			splitter:   trx,
+		}, nil
+	}
+	// One fix window for the whole chunk, not one per sub-range. The narrowed
+	// repairs together rewrite no more than the single repair they replace, so
+	// the same budget covers them; giving each its own would multiply the span
+	// during which the fix ignores the parent's cancellation by the number of
+	// pieces.
+	fixCtx, fixCancel := context.WithTimeout(context.WithoutCancel(ctx), fixChunkTimeout)
+	defer fixCancel()
+	repair := func(_ context.Context, sub *table.Chunk) error {
+		return c.replaceChunk(fixCtx, sub)
+	}
+	counts := rangeCounts{sourceRows: sourceCount, targetRows: targetCount, splitter: trx}
+	return narrowRepair(ctx, chunk, counts, verify, repair, c.logger)
 }
 
 // GetProgress returns rows verified so far and the total to verify, proxied
@@ -274,12 +312,11 @@ func (c *SingleChecker) inspectDifferences(ctx context.Context, trx *sql.Tx, chu
 
 // replaceChunk recopies the data from table to newTable for a given chunk.
 // For cross-database operations, this reads the data from the source and writes it to the target.
-// Note that the chunk is dynamically sized based on the target-time that it took
-// to *read* data in the checksum. This could be substantially longer than the time
-// that it takes to copy the data. Maybe in future we could consider splitting
-// the chunk here, but this is expected to be a very rare situation, so a small
-// stall from an XL sized chunk is considered acceptable.
-func (c *SingleChecker) replaceChunk(ctx context.Context, chunk *table.Chunk) error {
+//
+// fixCtx must already carry the repair's timeout and be detached from the
+// caller's cancellation (see narrowAndReplaceChunk, which owns one such context
+// per chunk and reuses it across the narrowed sub-ranges).
+func (c *SingleChecker) replaceChunk(fixCtx context.Context, chunk *table.Chunk) error {
 	c.logger.Warn("recopying chunk", "chunk", chunk.String())
 
 	// We further prevent the chance of deadlocks from the recopying process by only re-copying one chunk at a time.
@@ -372,11 +409,9 @@ func (c *SingleChecker) replaceChunk(ctx context.Context, chunk *table.Chunk) er
 	// deadlock pattern documented above). If the parent ctx is cancelled
 	// between them, the target chunk would be left with rows DELETEd but not
 	// yet REPLACEd. The continuous-checksum loop's cancellation on sentinel
-	// drop hits this race, so we run both statements under a context that
-	// ignores the parent's cancellation. The bounded timeout still protects
-	// against a hung transaction.
-	fixCtx, fixCancel := context.WithTimeout(context.WithoutCancel(ctx), fixChunkTimeout)
-	defer fixCancel()
+	// drop hits this race, which is why fixCtx ignores the parent's
+	// cancellation. Its bounded timeout still protects against a hung
+	// transaction.
 	if _, err := dbconn.RetryableTransaction(fixCtx, c.db, dbconn.ErrorOnDupKey, c.dbConfig, deleteStmt); err != nil {
 		return fmt.Errorf("failed to delete existing rows: %w", err)
 	}

--- a/pkg/checksum/subdivide.go
+++ b/pkg/checksum/subdivide.go
@@ -1,0 +1,201 @@
+package checksum
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/block/spirit/pkg/table"
+)
+
+const (
+	// csRepairSplitParts is how many pieces a mismatching chunk is cut into per
+	// narrowing round. Each piece costs one boundary lookup plus one checksum
+	// comparison, so the round costs roughly one extra scan of the range no
+	// matter how this is set; a larger value simply buys a finer result from
+	// that same scan. 8 keeps the boundary OFFSET queries cheap while cutting a
+	// worst-case chunk down by two orders of magnitude over csRepairMaxDepth
+	// rounds.
+	csRepairSplitParts = 8
+
+	// csRepairMinSplitRows is the range size below which narrowing is not worth
+	// its own cost: recopying this many rows is a short, bounded stall, and the
+	// narrowing scan would be a comparable amount of work for no benefit.
+	csRepairMinSplitRows = 2000
+
+	// csRepairMaxDepth bounds the recursion. Two rounds take the largest chunk
+	// the dynamic sizer will produce (table.MaxDynamicRowSize, 100k rows) down
+	// to ~1.5k rows, which is already below csRepairMinSplitRows. The bound
+	// exists so that a pathological key distribution cannot turn one mismatch
+	// into an unbounded tree of queries.
+	csRepairMaxDepth = 2
+)
+
+// rangeCounts is what verifying one key range reports back.
+type rangeCounts struct {
+	// sourceRows and targetRows are the row counts the comparison read on each
+	// side. Both are needed, not just the larger: they are what the caller sums
+	// to prove the sub-ranges partition their parent exactly.
+	sourceRows, targetRows uint64
+	// mismatched is true when source and target disagree over this range.
+	mismatched bool
+	// splitter is the connection whose row distribution should be used to cut
+	// this range up, and must belong to the snapshot the counts were read in.
+	// For a sharded source it is the shard holding the most of this range, which
+	// is why each range carries its own rather than inheriting the parent's: a
+	// range's rows can live mostly on a different shard than its parent's did.
+	// A nil splitter means the range cannot be cut and must be repaired whole.
+	splitter table.Splitter
+}
+
+// rows is the range's size for the purpose of deciding whether to narrow it: the
+// larger side, so that a wholly-missing target still narrows.
+func (r rangeCounts) rows() uint64 {
+	return max(r.sourceRows, r.targetRows)
+}
+
+// rangeVerifier re-compares source and target over a sub-range.
+//
+// It MUST run in the same snapshot that observed the original mismatch. That is
+// what makes narrowing sound: BIT_XOR is associative and the counts are additive,
+// so over an exact partition of the range the sub-results must reproduce the
+// whole-range result. Read from a different snapshot, a sub-range could appear
+// clean because a concurrent write happened to fix it, and the repair would be
+// skipped on the strength of an observation that never applied to the chunk we
+// were asked to fix.
+type rangeVerifier func(ctx context.Context, chunk *table.Chunk) (rangeCounts, error)
+
+// rangeRepairer recopies a range from source to target. It must be idempotent
+// and safe to call on a sub-range of a chunk, which both checkers' chunk-replace
+// methods are: they work purely from chunk.String().
+type rangeRepairer func(ctx context.Context, chunk *table.Chunk) error
+
+// narrowRepair repairs a chunk whose checksum did not match, first narrowing it
+// to the sub-ranges that actually differ.
+//
+// Chunks are sized by how long they take to *read* during checksumming, which
+// says nothing about how long they take to recopy — a repair DELETEs and then
+// re-writes every row in the range. As checksum chunks grow (they are sized for
+// read-ahead, not for latency), recopying a whole chunk to fix a handful of rows
+// becomes a large write burst, a long lock hold and a wide window in which the
+// target range is deleted but not yet rewritten. Narrowing first turns that into
+// a few small repairs.
+//
+// Narrowing is best-effort in one direction only. Anything that makes it
+// unusable — a key range that cannot be cut, a boundary query that fails, a
+// subdivision whose row counts do not add up, a set of pieces that all differ
+// (or none of which do) — falls back to repairing the whole range, because
+// leaving a known difference in place is not an option. Verification *failures*
+// are not swallowed: those mean the snapshot itself is gone, so the pass should
+// fail and be retried rather than repair on stale information. The narrow window
+// where Split succeeds and verification is then cancelled leaves the difference
+// unrepaired, which is a change from the unconditional repair this replaces; it
+// is safe because differencesFound has already been incremented by the caller,
+// so the run cannot report a pass.
+func narrowRepair(
+	ctx context.Context,
+	chunk *table.Chunk,
+	counts rangeCounts,
+	verify rangeVerifier,
+	repair rangeRepairer,
+	logger *slog.Logger,
+) error {
+	return narrowRepairAtDepth(ctx, chunk, counts, verify, repair, logger, 0)
+}
+
+func narrowRepairAtDepth(
+	ctx context.Context,
+	chunk *table.Chunk,
+	counts rangeCounts,
+	verify rangeVerifier,
+	repair rangeRepairer,
+	logger *slog.Logger,
+	depth int,
+) error {
+	if counts.rows() < csRepairMinSplitRows || depth >= csRepairMaxDepth || counts.splitter == nil {
+		return repair(ctx, chunk)
+	}
+	subs, err := chunk.Split(ctx, counts.splitter, csRepairSplitParts)
+	if err != nil {
+		logger.Warn("could not subdivide chunk for repair, recopying it whole",
+			"chunk", chunk.String(), "error", err)
+		return repair(ctx, chunk)
+	}
+	if len(subs) < 2 {
+		// Too few distinct key values in the range to cut it up.
+		return repair(ctx, chunk)
+	}
+
+	// Verify every sub-range before repairing any of them. Repairing as we go
+	// would mean a mid-loop verification error left the chunk partially fixed
+	// *and* stopped us from learning about the rest of it; this way the fallbacks
+	// below still have the whole picture.
+	results := make([]rangeCounts, len(subs))
+	var sourceRows, targetRows uint64
+	differing := 0
+	for i, sub := range subs {
+		r, err := verify(ctx, sub)
+		if err != nil {
+			return err
+		}
+		results[i] = r
+		sourceRows += r.sourceRows
+		targetRows += r.targetRows
+		if r.mismatched {
+			differing++
+		}
+	}
+
+	// Everything below rests on the sub-ranges partitioning the parent exactly,
+	// and table.Chunk.Split cannot promise that for every key type — a key whose
+	// collation order differs from its byte order, or a NULL key value, produces
+	// an overlap or a gap. Rather than reason about types, check it: the counts
+	// were read in the same snapshot as the parent's, so over an exact partition
+	// they must add up on both sides. A gap would let a differing row escape
+	// repair entirely, so a mismatch here has to mean the whole chunk.
+	if sourceRows != counts.sourceRows || targetRows != counts.targetRows {
+		logger.Warn("subdividing a chunk did not partition it exactly, recopying it whole",
+			"chunk", chunk.String(), "parts", len(subs),
+			"sourceRows", sourceRows, "expectedSourceRows", counts.sourceRows,
+			"targetRows", targetRows, "expectedTargetRows", counts.targetRows)
+		return repair(ctx, chunk)
+	}
+
+	// The whole range mismatched, so at least one sub-range must: the sub-ranges
+	// partition it exactly, BIT_XOR is associative and the counts are additive.
+	// If that does not hold, something we believe about the range is wrong, so
+	// fall back to the repair we would have done anyway rather than silently
+	// decline to fix a known difference.
+	if differing == 0 {
+		logger.Warn("subdividing a mismatching chunk found no differing sub-range, recopying it whole",
+			"chunk", chunk.String(), "parts", len(subs))
+		return repair(ctx, chunk)
+	}
+
+	// Every piece differs, so narrowing bought nothing: the same rows will be
+	// rewritten either way. Doing it as one statement pair rather than one per
+	// piece is the cheaper and shorter-lived option, and it keeps the systematic
+	// cases (a lossy ALTER, a wrong column mapping, a truncated target) from
+	// fanning a single chunk out into dozens of transactions.
+	if differing == len(subs) {
+		logger.Warn("every sub-range of a mismatching chunk differs, recopying it whole",
+			"chunk", chunk.String(), "parts", len(subs), "rows", counts.rows())
+		return repair(ctx, chunk)
+	}
+
+	logger.Warn("narrowed chunk repair",
+		"chunk", chunk.String(),
+		"rows", counts.rows(),
+		"parts", len(subs),
+		"differing", differing,
+		"depth", depth)
+
+	for i, sub := range subs {
+		if !results[i].mismatched {
+			continue
+		}
+		if err := narrowRepairAtDepth(ctx, sub, results[i], verify, repair, logger, depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/checksum/subdivide_test.go
+++ b/pkg/checksum/subdivide_test.go
@@ -1,0 +1,538 @@
+package checksum
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// narrowFixtureRows is chosen so that two rounds of narrowing are reachable:
+// 19600 / 8 = 2450 rows per first-round piece, which is still above
+// csRepairMinSplitRows, so a differing piece is cut again.
+const narrowFixtureRows = 19600
+
+// narrowFixture builds a source table of narrowFixtureRows rows (ids 1..N) and
+// returns a chunk covering all of it. The recursive CTE is kept shallow and
+// cross-joined because cte_max_recursion_depth defaults to 1000.
+func narrowFixture(t *testing.T) (*sql.DB, *table.Chunk) {
+	t.Helper()
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS narrowsub_t1, narrowsub_t2")
+	testutils.RunSQL(t, "CREATE TABLE narrowsub_t1 (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL)")
+	testutils.RunSQL(t, "CREATE TABLE narrowsub_t2 (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL)")
+	testutils.RunSQL(t, `INSERT INTO narrowsub_t1 (id, pad)
+		WITH RECURSIVE s(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM s WHERE i < 139)
+		SELECT x.i*140 + y.i + 1, 0 FROM s x, s y`)
+	testutils.RunSQL(t, "INSERT INTO narrowsub_t2 SELECT * FROM narrowsub_t1")
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+
+	t1 := table.NewTableInfo(db, "test", "narrowsub_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "narrowsub_t2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	var n int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM narrowsub_t1").Scan(&n))
+	require.Equal(t, narrowFixtureRows, n)
+
+	return db, &table.Chunk{
+		Key:           t1.KeyColumns,
+		Table:         t1,
+		NewTable:      t2,
+		ColumnMapping: table.NewColumnMapping(t1, t2, nil),
+	}
+}
+
+// rowsIn counts source rows inside a chunk's range.
+func rowsIn(t *testing.T, db *sql.DB, c *table.Chunk) uint64 {
+	t.Helper()
+	var n uint64
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM narrowsub_t1 WHERE "+c.String()).Scan(&n))
+	return n
+}
+
+// wholeCounts describes the fixture chunk as its parent verification would.
+func wholeCounts(db *sql.DB) rangeCounts {
+	return rangeCounts{sourceRows: narrowFixtureRows, targetRows: narrowFixtureRows, splitter: db}
+}
+
+// verifierForIDs returns a rangeVerifier that reports a range as differing when
+// it contains any of the given ids — i.e. it stands in for a real source/target
+// comparison, without needing corrupted data.
+func verifierForIDs(t *testing.T, db *sql.DB, ids ...int) rangeVerifier {
+	t.Helper()
+	return func(ctx context.Context, sub *table.Chunk) (rangeCounts, error) {
+		rows := rowsIn(t, db, sub)
+		counts := rangeCounts{sourceRows: rows, targetRows: rows, splitter: db}
+		for _, id := range ids {
+			var hit int
+			q := fmt.Sprintf("SELECT COUNT(*) FROM narrowsub_t1 WHERE id = %d AND (%s)", id, sub.String())
+			if err := db.QueryRowContext(ctx, q).Scan(&hit); err != nil {
+				return rangeCounts{}, err
+			}
+			if hit > 0 {
+				counts.mismatched = true
+				break
+			}
+		}
+		return counts, nil
+	}
+}
+
+func recordingRepairer(out *[]*table.Chunk) rangeRepairer {
+	return func(_ context.Context, c *table.Chunk) error {
+		*out = append(*out, c)
+		return nil
+	}
+}
+
+func TestNarrowRepairNarrowsToTheDifferingRange(t *testing.T) {
+	db, whole := narrowFixture(t)
+	var repaired []*table.Chunk
+
+	require.NoError(t, narrowRepair(t.Context(), whole, wholeCounts(db),
+		verifierForIDs(t, db, 7777), recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+	require.Len(t, repaired, 1, "one differing row means exactly one range to repair")
+	// Two rounds of 8 leaves ~1/64th of the chunk. The point of the exercise is
+	// that a single bad row does not rewrite 19600 rows.
+	got := rowsIn(t, db, repaired[0])
+	assert.Positive(t, got)
+	assert.Less(t, got, uint64(csRepairMinSplitRows),
+		"the narrowed range should be smaller than the point at which narrowing stops")
+
+	// And it has to be the *right* range.
+	var hit int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM narrowsub_t1 WHERE id = 7777 AND ("+repaired[0].String()+")").Scan(&hit))
+	assert.Equal(t, 1, hit, "the repaired range must contain the differing row")
+}
+
+func TestNarrowRepairHandlesSeveralDifferingRanges(t *testing.T) {
+	db, whole := narrowFixture(t)
+	var repaired []*table.Chunk
+
+	// Three rows spread across the range: first piece, middle, last piece.
+	require.NoError(t, narrowRepair(t.Context(), whole, wholeCounts(db),
+		verifierForIDs(t, db, 5, 9800, narrowFixtureRows), recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+	require.Len(t, repaired, 3)
+	total := uint64(0)
+	for _, c := range repaired {
+		total += rowsIn(t, db, c)
+	}
+	assert.Less(t, total, uint64(3*csRepairMinSplitRows))
+
+	// The repaired ranges must not overlap, or the same rows would be deleted
+	// and rewritten more than once.
+	for i := range repaired {
+		for j := i + 1; j < len(repaired); j++ {
+			var both int
+			q := fmt.Sprintf("SELECT COUNT(*) FROM narrowsub_t1 WHERE (%s) AND (%s)",
+				repaired[i].String(), repaired[j].String())
+			require.NoError(t, db.QueryRowContext(t.Context(), q).Scan(&both))
+			assert.Zero(t, both, "repaired ranges %d and %d overlap", i, j)
+		}
+	}
+}
+
+func TestNarrowRepairSkipsSmallChunks(t *testing.T) {
+	db, whole := narrowFixture(t)
+	var repaired []*table.Chunk
+
+	// A chunk this size is cheaper to recopy than to analyse.
+	small := rangeCounts{sourceRows: csRepairMinSplitRows - 1, targetRows: csRepairMinSplitRows - 1, splitter: db}
+	require.NoError(t, narrowRepair(t.Context(), whole, small,
+		func(context.Context, *table.Chunk) (rangeCounts, error) {
+			t.Fatal("a chunk below the threshold must not be verified piecewise")
+			return rangeCounts{}, nil
+		}, recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+	require.Len(t, repaired, 1)
+	assert.Same(t, whole, repaired[0], "the whole chunk is repaired unchanged")
+}
+
+// TestNarrowRepairFallsBackWhenNoSubRangeDiffers covers the case that should be
+// impossible: the whole range mismatched, so an exact partition of it must
+// contain a mismatching piece. If the invariant is ever violated we must still
+// perform the repair rather than quietly decline to fix a known difference.
+func TestNarrowRepairFallsBackWhenNoSubRangeDiffers(t *testing.T) {
+	db, whole := narrowFixture(t)
+	var repaired []*table.Chunk
+
+	require.NoError(t, narrowRepair(t.Context(), whole, wholeCounts(db),
+		func(_ context.Context, sub *table.Chunk) (rangeCounts, error) {
+			rows := rowsIn(t, db, sub)
+			return rangeCounts{sourceRows: rows, targetRows: rows, splitter: db}, nil
+		}, recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+	require.Len(t, repaired, 1)
+	assert.Same(t, whole, repaired[0])
+}
+
+func TestNarrowRepairFallsBackWhenSplitFails(t *testing.T) {
+	db, whole := narrowFixture(t)
+	// A condition that cannot be evaluated makes the boundary queries fail.
+	whole.AdditionalConditions = "no_such_column = 1"
+	var repaired []*table.Chunk
+
+	require.NoError(t, narrowRepair(t.Context(), whole, wholeCounts(db),
+		func(context.Context, *table.Chunk) (rangeCounts, error) {
+			t.Fatal("verification cannot run if the range could not be split")
+			return rangeCounts{}, nil
+		}, recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+	require.Len(t, repaired, 1)
+	assert.Same(t, whole, repaired[0], "an unsplittable range is repaired whole")
+}
+
+// TestNarrowRepairPropagatesVerifyError asserts a verification failure is not
+// swallowed: it means the snapshot we were reasoning about is gone, so the pass
+// must fail and be retried rather than repair on stale information.
+func TestNarrowRepairPropagatesVerifyError(t *testing.T) {
+	db, whole := narrowFixture(t)
+	sentinel := errors.New("snapshot gone")
+	var repaired []*table.Chunk
+
+	err := narrowRepair(t.Context(), whole, wholeCounts(db),
+		func(context.Context, *table.Chunk) (rangeCounts, error) {
+			return rangeCounts{}, sentinel
+		}, recordingRepairer(&repaired), slog.New(slog.DiscardHandler))
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Empty(t, repaired, "nothing should be recopied on an unusable snapshot")
+}
+
+// TestNarrowAndReplaceChunkRepairsOnlyWhatDiffers drives the real comparison and
+// the real recopy against real data.
+//
+// The probe is a target-only column (as an "add column" migration would have):
+// it is invisible to the checksum, which compares intersecting columns only, but
+// replaceChunk resets it to its default on every row it rewrites. Counting the
+// rows whose marker was cleared tells us exactly how much of the chunk was
+// recopied to fix one bad row.
+func TestNarrowAndReplaceChunkRepairsOnlyWhatDiffers(t *testing.T) {
+	const badID = 7777
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS narrowe2e_t1, _narrowe2e_t1_new")
+	testutils.RunSQL(t, "CREATE TABLE narrowe2e_t1 (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL)")
+	testutils.RunSQL(t, "CREATE TABLE _narrowe2e_t1_new (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL, marker INT NOT NULL DEFAULT 0)")
+	testutils.RunSQL(t, `INSERT INTO narrowe2e_t1 (id, pad)
+		WITH RECURSIVE s(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM s WHERE i < 139)
+		SELECT x.i*140 + y.i + 1, x.i FROM s x, s y`)
+	testutils.RunSQL(t, "INSERT INTO _narrowe2e_t1_new (id, pad, marker) SELECT id, pad, 1 FROM narrowe2e_t1")
+	testutils.RunSQL(t, fmt.Sprintf("UPDATE _narrowe2e_t1_new SET pad = pad + 1000 WHERE id = %d", badID))
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "narrowe2e_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_narrowe2e_t1_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	checker := &SingleChecker{
+		db:             db,
+		dbConfig:       dbconn.NewDBConfig(),
+		logger:         slog.New(slog.DiscardHandler),
+		fixDifferences: true,
+	}
+	chunk := &table.Chunk{
+		Key:           t1.KeyColumns,
+		Table:         t1,
+		NewTable:      t2,
+		ColumnMapping: table.NewColumnMapping(t1, t2, nil),
+	}
+
+	// A REPEATABLE READ snapshot stands in for the one a checksum worker holds
+	// from the transaction pool.
+	trx, err := db.BeginTx(t.Context(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	require.NoError(t, err)
+	defer func() { _ = trx.Rollback() }()
+
+	require.NoError(t, checker.narrowAndReplaceChunk(t.Context(), trx, chunk, narrowFixtureRows, narrowFixtureRows))
+
+	// The difference is gone.
+	var diffs int
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM narrowe2e_t1 a
+		JOIN _narrowe2e_t1_new b USING (id) WHERE a.pad <> b.pad`).Scan(&diffs))
+	assert.Zero(t, diffs, "the repair must reconcile the differing row")
+	var srcRows, tgtRows int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM narrowe2e_t1").Scan(&srcRows))
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM _narrowe2e_t1_new").Scan(&tgtRows))
+	assert.Equal(t, srcRows, tgtRows)
+
+	// ...and it was fixed by rewriting a small slice of the chunk, not all of it.
+	var rewritten int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM _narrowe2e_t1_new WHERE marker = 0").Scan(&rewritten))
+	assert.Positive(t, rewritten, "something must have been rewritten")
+	assert.Less(t, rewritten, csRepairMinSplitRows,
+		"narrowing should have kept the recopy well under the whole %d-row chunk", narrowFixtureRows)
+
+	var badRowRewritten int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM _narrowe2e_t1_new WHERE id = %d AND marker = 0", badID)).Scan(&badRowRewritten))
+	assert.Equal(t, 1, badRowRewritten, "the differing row must be one of the rewritten ones")
+}
+
+// TestDistributedNarrowAndReplaceChunkRepairsOnlyWhatDiffers is the N:M analog
+// of the test above. The repair path differs completely — DELETE on every target
+// followed by a re-apply through the applier — so it gets its own coverage. The
+// marker column is the same probe: the applier writes the source's non-generated
+// columns only, so a rewritten row loses its marker.
+func TestDistributedNarrowAndReplaceChunkRepairsOnlyWhatDiffers(t *testing.T) {
+	const badID = 7777
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	newDBName, _ := testutils.CreateUniqueTestDatabase(t)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS narrowdist_t1")
+	testutils.RunSQL(t, "CREATE TABLE narrowdist_t1 (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL)")
+	testutils.RunSQL(t, `INSERT INTO narrowdist_t1 (id, pad)
+		WITH RECURSIVE s(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM s WHERE i < 139)
+		SELECT x.i*140 + y.i + 1, x.i FROM s x, s y`)
+	testutils.RunSQL(t, "CREATE TABLE "+newDBName+".narrowdist_t1 (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL, marker INT NOT NULL DEFAULT 0)")
+	testutils.RunSQL(t, "INSERT INTO "+newDBName+".narrowdist_t1 (id, pad, marker) SELECT id, pad, 1 FROM test.narrowdist_t1")
+	testutils.RunSQL(t, fmt.Sprintf("UPDATE %s.narrowdist_t1 SET pad = pad + 1000 WHERE id = %d", newDBName, badID))
+
+	destCfg := cfg.Clone()
+	destCfg.DBName = newDBName
+	src, err := dbconn.New(cfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(src)
+	dest, err := dbconn.New(destCfg.FormatDSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(dest)
+
+	t1 := table.NewTableInfo(src, "test", "narrowdist_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(dest, newDBName, "narrowdist_t1")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	app, err := applier.NewSingleTargetApplier(
+		applier.Target{DB: dest, KeyRange: "0", Config: destCfg}, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(src, cfg.Addr, cfg.User, cfg.Passwd, app, change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.FixDifferences = true
+	config.Applier = app
+	config.Logger = slog.New(slog.DiscardHandler)
+	checker, err := NewChecker([]*sql.DB{src}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+	dc, ok := checker.(*DistributedChecker)
+	require.True(t, ok)
+	// Run() would build these; we are driving one chunk directly so that the
+	// chunker's own sizing does not decide whether narrowing is reachable.
+	dc.sourcePools = []sourcePool{{db: src}}
+	// Run() also starts the applier's workers; the recopy's Apply calls queue
+	// forever without them.
+	require.NoError(t, app.Start(t.Context()))
+	defer func() { _ = app.Stop() }()
+
+	chunk := &table.Chunk{
+		Key:           t1.KeyColumns,
+		Table:         t1,
+		NewTable:      t2,
+		ColumnMapping: table.NewColumnMapping(t1, t2, nil),
+	}
+	srcTrx, err := src.BeginTx(t.Context(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	require.NoError(t, err)
+	defer func() { _ = srcTrx.Rollback() }()
+	tgtTrx, err := dest.BeginTx(t.Context(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	require.NoError(t, err)
+	defer func() { _ = tgtTrx.Rollback() }()
+
+	require.NoError(t, dc.narrowAndReplaceChunk(t.Context(), []*sql.Tx{srcTrx}, []*sql.Tx{tgtTrx}, chunk,
+		rangeCounts{sourceRows: narrowFixtureRows, targetRows: narrowFixtureRows, splitter: srcTrx}))
+
+	var diffs int
+	require.NoError(t, dest.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM test.narrowdist_t1 a
+		JOIN narrowdist_t1 b USING (id) WHERE a.pad <> b.pad`).Scan(&diffs))
+	assert.Zero(t, diffs, "the repair must reconcile the differing row")
+	var tgtRows int
+	require.NoError(t, dest.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM narrowdist_t1").Scan(&tgtRows))
+	assert.Equal(t, narrowFixtureRows, tgtRows, "no rows may be lost by the delete-then-reapply")
+
+	var rewritten int
+	require.NoError(t, dest.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM narrowdist_t1 WHERE marker = 0").Scan(&rewritten))
+	assert.Positive(t, rewritten)
+	assert.Less(t, rewritten, csRepairMinSplitRows,
+		"narrowing should have kept the re-apply well under the whole %d-row chunk", narrowFixtureRows)
+}
+
+// TestNarrowRepairFallsBackWhenEverySubRangeDiffers covers systematic corruption
+// — a lossy ALTER, a wrong column mapping, a truncated target. Every piece needs
+// rewriting, so narrowing has bought nothing, and fanning the chunk out into one
+// repair per piece would only multiply the transaction count and the span of the
+// fix's uncancellable window.
+func TestNarrowRepairFallsBackWhenEverySubRangeDiffers(t *testing.T) {
+	db, whole := narrowFixture(t)
+	var repaired []*table.Chunk
+
+	require.NoError(t, narrowRepair(t.Context(), whole, wholeCounts(db),
+		func(_ context.Context, sub *table.Chunk) (rangeCounts, error) {
+			rows := rowsIn(t, db, sub)
+			return rangeCounts{sourceRows: rows, targetRows: rows, mismatched: true, splitter: db}, nil
+		}, recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+	require.Len(t, repaired, 1, "an all-differing chunk is recopied in one go")
+	assert.Same(t, whole, repaired[0])
+}
+
+// TestNarrowRepairFallsBackWhenCountsDoNotAddUp is the guard against a
+// subdivision that is not an exact partition. table.Chunk.Split cannot promise
+// exactness for every key type — a collation whose order differs from byte order,
+// or a NULL key value, yields an overlap or a gap — and a gap would let a
+// differing row escape repair entirely. The row counts, read in the same snapshot
+// as the parent's, are the check.
+func TestNarrowRepairFallsBackWhenCountsDoNotAddUp(t *testing.T) {
+	db, whole := narrowFixture(t)
+
+	for _, tc := range []struct {
+		name  string
+		short bool // report fewer rows (a gap) rather than more (an overlap)
+	}{
+		{"gap", true},
+		{"overlap", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var repaired []*table.Chunk
+			first := true
+			require.NoError(t, narrowRepair(t.Context(), whole, wholeCounts(db),
+				func(_ context.Context, sub *table.Chunk) (rangeCounts, error) {
+					rows := rowsIn(t, db, sub)
+					// Perturb one piece so the totals cannot reconcile.
+					if first {
+						first = false
+						if tc.short {
+							rows--
+						} else {
+							rows++
+						}
+					}
+					return rangeCounts{sourceRows: rows, targetRows: rows, mismatched: true, splitter: db}, nil
+				}, recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+			require.Len(t, repaired, 1)
+			assert.Same(t, whole, repaired[0], "an inexact partition must not be trusted")
+		})
+	}
+}
+
+// TestNarrowRepairFallsBackWithoutASplitter covers the distributed case where no
+// source shard holds any of the range: there are no boundaries to cut from.
+func TestNarrowRepairFallsBackWithoutASplitter(t *testing.T) {
+	_, whole := narrowFixture(t)
+	var repaired []*table.Chunk
+
+	counts := rangeCounts{sourceRows: 0, targetRows: narrowFixtureRows, splitter: nil}
+	require.NoError(t, narrowRepair(t.Context(), whole, counts,
+		func(context.Context, *table.Chunk) (rangeCounts, error) {
+			t.Fatal("without a splitter there is nothing to verify piecewise")
+			return rangeCounts{}, nil
+		}, recordingRepairer(&repaired), slog.New(slog.DiscardHandler)))
+
+	require.Len(t, repaired, 1)
+	assert.Same(t, whole, repaired[0])
+}
+
+func TestWidestSource(t *testing.T) {
+	a, b, c := &sql.Tx{}, &sql.Tx{}, &sql.Tx{}
+	trxs := []*sql.Tx{a, b, c}
+
+	assert.Equal(t, table.Splitter(b), widestSource(trxs, []uint64{10, 500, 20}))
+	assert.Equal(t, table.Splitter(a), widestSource(trxs, []uint64{500, 500, 20}), "ties take the first shard")
+	assert.Nil(t, widestSource(trxs, []uint64{0, 0, 0}), "no shard holds the range")
+	assert.Nil(t, widestSource(nil, nil))
+	assert.Nil(t, widestSource(trxs, nil))
+	// A count slice longer than the transaction slice must not index out of range.
+	assert.Equal(t, table.Splitter(a), widestSource([]*sql.Tx{a}, []uint64{5, 999}))
+}
+
+// TestNarrowAndReplaceChunkUsesTheMismatchSnapshot is the test that fails if the
+// sub-range verification is moved off the snapshot transaction.
+//
+// The setup makes live data and snapshot data disagree: the mismatch is observed
+// in the snapshot, then repaired behind its back. A verifier reading live data
+// would find every sub-range clean, conclude the partition was inexact or the
+// mismatch imaginary, and fall back to recopying the whole chunk. Reading the
+// snapshot, it still sees the difference and narrows to it.
+func TestNarrowAndReplaceChunkUsesTheMismatchSnapshot(t *testing.T) {
+	const badID = 7777
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS narrowsnap_t1, _narrowsnap_t1_new")
+	testutils.RunSQL(t, "CREATE TABLE narrowsnap_t1 (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL)")
+	testutils.RunSQL(t, "CREATE TABLE _narrowsnap_t1_new (id INT NOT NULL PRIMARY KEY, pad INT NOT NULL, marker INT NOT NULL DEFAULT 0)")
+	testutils.RunSQL(t, `INSERT INTO narrowsnap_t1 (id, pad)
+		WITH RECURSIVE s(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM s WHERE i < 139)
+		SELECT x.i*140 + y.i + 1, x.i FROM s x, s y`)
+	testutils.RunSQL(t, "INSERT INTO _narrowsnap_t1_new (id, pad, marker) SELECT id, pad, 1 FROM narrowsnap_t1")
+	testutils.RunSQL(t, fmt.Sprintf("UPDATE _narrowsnap_t1_new SET pad = pad + 1000 WHERE id = %d", badID))
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	t1 := table.NewTableInfo(db, "test", "narrowsnap_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_narrowsnap_t1_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	checker := &SingleChecker{
+		db:             db,
+		dbConfig:       dbconn.NewDBConfig(),
+		logger:         slog.New(slog.DiscardHandler),
+		fixDifferences: true,
+	}
+	chunk := &table.Chunk{
+		Key:           t1.KeyColumns,
+		Table:         t1,
+		NewTable:      t2,
+		ColumnMapping: table.NewColumnMapping(t1, t2, nil),
+	}
+
+	trx, err := db.BeginTx(t.Context(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	require.NoError(t, err)
+	defer func() { _ = trx.Rollback() }()
+
+	// Observe the mismatch, which also pins the snapshot.
+	srcCRC, tgtCRC, srcCount, tgtCount, err := checker.checksumRange(t.Context(), trx, chunk)
+	require.NoError(t, err)
+	require.True(t, compareChunk(srcCRC, tgtCRC, srcCount, tgtCount).mismatched())
+
+	// Now make the live rows agree, invisibly to the snapshot.
+	testutils.RunSQL(t, fmt.Sprintf(
+		"UPDATE _narrowsnap_t1_new SET pad = pad - 1000 WHERE id = %d", badID))
+
+	require.NoError(t, checker.narrowAndReplaceChunk(t.Context(), trx, chunk, srcCount, tgtCount))
+
+	var rewritten int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM _narrowsnap_t1_new WHERE marker = 0").Scan(&rewritten))
+	assert.Positive(t, rewritten, "the snapshot still shows a difference, so something must be rewritten")
+	assert.Less(t, rewritten, csRepairMinSplitRows,
+		"verification must read the snapshot; reading live data would find every sub-range clean and recopy the whole chunk")
+}

--- a/pkg/table/chunk_split.go
+++ b/pkg/table/chunk_split.go
@@ -1,0 +1,241 @@
+package table
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+)
+
+// Splitter is the query surface Chunk.Split needs. Both *sql.DB and *sql.Tx
+// satisfy it.
+//
+// Callers that split a chunk in order to decide something about its contents
+// should pass the *transaction* they made that observation in, not the pool:
+// boundaries cut from a different snapshot than the one that found a
+// discrepancy would not line up with it.
+type Splitter interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// Split divides the chunk's key range into up to parts contiguous sub-chunks of
+// roughly equal row count, and returns them in key order.
+//
+// The first sub-chunk inherits the original's lower bound and the last its upper
+// bound — including whether those are inclusive — so an unbounded end stays
+// unbounded. Interior split points appear as an exclusive upper bound on one
+// sub-chunk and an inclusive lower bound on the next, which is the same
+// convention the chunkers use and is what makes the partition exact for
+// composite keys as well as single-column ones. AdditionalConditions, Key,
+// Table, NewTable and ColumnMapping are carried across unchanged; ChunkSize and
+// ActualBytes are not, since they describe the original chunk's sizing rather
+// than its range.
+//
+// # Exactness
+//
+// The sub-chunks are an exact partition of the original — union equal to the
+// original range, no overlaps — provided the key's comparison order matches the
+// order the boundaries were read in. Boundaries come from ORDER BY, while the
+// range predicates use >= and <, and MySQL does not always agree with itself
+// about those two:
+//
+//   - ENUM sorts by declaration ordinal but compares against a string literal
+//     lexically, so 'zebra' can sort before 'mango' and still compare after it.
+//   - A case- or accent-insensitive collation orders strings by collation weight
+//     while Datum comparison (used for the monotonicity check below) compares
+//     bytes.
+//   - A NULL key value satisfies neither >= nor <, so it belongs to no
+//     sub-chunk. In practice chunk keys are PRIMARY KEY columns and cannot be
+//     NULL, and the chunkers' own bounds already exclude NULL-keyed rows.
+//
+// Cuts that are not strictly increasing under Datum comparison are dropped,
+// which removes the ENUM case and every ordinal-versus-lexical case where byte
+// order is the truth. It cannot cover the collation cases, so a caller that
+// depends on exactness must verify it — for example by checking that the
+// sub-chunks' row counts sum to the original's, as checksum.narrowRepair does,
+// and treating a shortfall or excess as "operate on the whole chunk".
+//
+// Returns nil (not an error) when the range cannot usefully be divided: parts
+// is less than 2, or the range holds too few rows to yield more than one piece.
+// Callers should treat a nil result as "operate on the whole chunk".
+//
+// Split finds boundaries the same way the composite chunker does, with
+// ORDER BY ... LIMIT 1 OFFSET n against the source table, so it costs one query
+// per interior boundary and the OFFSET scan cost that implies. It is intended
+// for the rare path (narrowing a discrepancy), not for steady-state chunking.
+func (c *Chunk) Split(ctx context.Context, q Splitter, parts int) ([]*Chunk, error) {
+	if parts < 2 {
+		return nil, nil
+	}
+	rows, err := c.countRows(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	// Fewer rows than pieces means at least one piece would be empty, and a
+	// single row cannot be divided at all.
+	if rows < 2 {
+		return nil, nil
+	}
+	if uint64(parts) > rows {
+		parts = int(rows)
+	}
+
+	// Interior boundaries only: parts pieces need parts-1 cuts.
+	stride := rows / uint64(parts)
+	if stride == 0 {
+		return nil, nil
+	}
+	// The smallest key in the range. Every cut has to be strictly greater than
+	// this, or the first sub-chunk would be empty — which happens when the key
+	// has ties and the whole first stride shares the minimum value. Split does
+	// not require a unique key, so this is reachable.
+	prev, err := c.boundaryAtOffset(ctx, q, 0)
+	if err != nil {
+		return nil, err
+	}
+	var cuts [][]Datum
+	for i := 1; i < parts; i++ {
+		offset := stride * uint64(i)
+		if offset >= rows {
+			break
+		}
+		datums, err := c.boundaryAtOffset(ctx, q, offset)
+		if err != nil {
+			return nil, err
+		}
+		// No row at this offset (concurrent change, or an AdditionalConditions
+		// filter we cannot predict): stop cutting and use what we have.
+		if datums == nil {
+			break
+		}
+		// Each cut must be strictly greater than the one before it (and than the
+		// range minimum). A repeated value would produce an empty sub-chunk or one
+		// whose inclusive lower bound equals its exclusive upper bound; a value
+		// that went *backwards* would make two sub-chunks overlap. Both happen for
+		// real: ties on a non-unique key give equal cuts, and a key whose sort
+		// order differs from its comparison order (ENUM) gives decreasing ones.
+		// Skipping the cut merges it into the previous piece, which is still
+		// contiguous.
+		if prev != nil && !datumsIncreasing(prev, datums) {
+			continue
+		}
+		prev = datums
+		cuts = append(cuts, datums)
+	}
+	if len(cuts) == 0 {
+		return nil, nil
+	}
+
+	subs := make([]*Chunk, 0, len(cuts)+1)
+	for i := range len(cuts) + 1 {
+		sub := &Chunk{
+			Key:                  c.Key,
+			AdditionalConditions: c.AdditionalConditions,
+			Table:                c.Table,
+			NewTable:             c.NewTable,
+			ColumnMapping:        c.ColumnMapping,
+		}
+		if i == 0 {
+			sub.LowerBound = c.LowerBound
+		} else {
+			sub.LowerBound = &Boundary{Value: cuts[i-1], Inclusive: true}
+		}
+		if i == len(cuts) {
+			sub.UpperBound = c.UpperBound
+		} else {
+			sub.UpperBound = &Boundary{Value: cuts[i], Inclusive: false}
+		}
+		subs = append(subs, sub)
+	}
+	return subs, nil
+}
+
+// countRows returns how many source rows fall in the chunk's range. Used to
+// decide the number of pieces, so that a range far smaller than parts is not
+// cut into empty slivers.
+func (c *Chunk) countRows(ctx context.Context, q Splitter) (uint64, error) {
+	query := "SELECT COUNT(*) FROM " + c.Table.QuotedTableName + " WHERE " + c.String()
+	var n uint64
+	if err := q.QueryRowContext(ctx, query).Scan(&n); err != nil {
+		return 0, fmt.Errorf("failed to count rows for chunk split: %w", err)
+	}
+	return n, nil
+}
+
+// boundaryAtOffset returns the key values of the row at the given offset within
+// the chunk's range, ordered by the chunk key, or nil if there is no such row.
+func (c *Chunk) boundaryAtOffset(ctx context.Context, q Splitter, offset uint64) ([]Datum, error) {
+	quotedKeys := QuoteColumns(c.Key)
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s ORDER BY %s LIMIT 1 OFFSET %d",
+		quotedKeys,
+		c.Table.QuotedTableName,
+		c.String(),
+		quotedKeys,
+		offset,
+	)
+	rows, err := q.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find split boundary: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	columnNames, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	raw := make([]sql.RawBytes, len(columnNames))
+	ptrs := make([]any, len(columnNames))
+	for i := range columnNames {
+		ptrs[i] = &raw[i]
+	}
+	if !rows.Next() {
+		return nil, rows.Err()
+	}
+	if err := rows.Scan(ptrs...); err != nil {
+		return nil, err
+	}
+	// Scanned as raw bytes, so convert to the column's datum type — the same
+	// conversion chunkerComposite.nextQueryToDatums performs.
+	datums := make([]Datum, 0, len(columnNames))
+	for i, name := range columnNames {
+		val := reflect.ValueOf(raw[i]).Interface().(sql.RawBytes)
+		tp, err := c.Table.datumTp(name)
+		if err != nil {
+			return nil, fmt.Errorf("looking up type for column %s: %w", name, err)
+		}
+		d, err := NewDatum(string(val), tp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create datum for column %s: %w", name, err)
+		}
+		datums = append(datums, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return datums, nil
+}
+
+// datumsIncreasing reports whether key tuple b sorts strictly after a, comparing
+// lexicographically across the key columns the way a composite range predicate
+// does.
+//
+// A datum pair that cannot be compared (mismatched or unsupported types) is
+// treated as increasing: refusing every cut would disable splitting outright,
+// whereas an out-of-order cut only costs the caller's exactness check, which is
+// the backstop for exactly this case.
+func datumsIncreasing(a, b []Datum) bool {
+	if len(a) != len(b) {
+		return true
+	}
+	for i := range a {
+		cmp, err := b[i].compare(a[i])
+		if err != nil {
+			return true
+		}
+		if cmp != 0 {
+			return cmp > 0
+		}
+	}
+	return false // identical tuples
+}

--- a/pkg/table/chunk_split_test.go
+++ b/pkg/table/chunk_split_test.go
@@ -1,0 +1,228 @@
+package table
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// splitFixture creates a table with rows 1..n and returns its TableInfo.
+func splitFixture(t *testing.T, name string, n int) *TableInfo {
+	t.Helper()
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS "+name)
+	testutils.RunSQL(t, "CREATE TABLE "+name+" (id INT NOT NULL PRIMARY KEY, pad VARCHAR(10))")
+	if n > 0 {
+		testutils.RunSQL(t, fmt.Sprintf(
+			"INSERT INTO %s (id, pad) WITH RECURSIVE s(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i < %d) SELECT i, 'x' FROM s",
+			name, n))
+	}
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	ti := NewTableInfo(db, "test", name)
+	require.NoError(t, ti.SetInfo(t.Context()))
+	return ti
+}
+
+// countIn returns how many rows of ti fall inside the chunk's range, which is
+// how the tests verify a partition covers exactly what it should.
+func countIn(t *testing.T, ti *TableInfo, c *Chunk) int {
+	t.Helper()
+	var n int
+	require.NoError(t, ti.db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM "+ti.QuotedTableName+" WHERE "+c.String()).Scan(&n))
+	return n
+}
+
+func TestChunkSplitPartitionsExactly(t *testing.T) {
+	ti := splitFixture(t, "csplit1", 1000)
+	whole := &Chunk{Key: []string{"id"}, Table: ti, NewTable: ti}
+	require.Equal(t, 1000, countIn(t, ti, whole))
+
+	subs, err := whole.Split(t.Context(), ti.db, 4)
+	require.NoError(t, err)
+	require.Len(t, subs, 4)
+
+	// The union must be exactly the original, with no double-counting: if the
+	// interior boundaries were both inclusive, or both exclusive, this total
+	// would come out over or under 1000.
+	total := 0
+	for _, s := range subs {
+		n := countIn(t, ti, s)
+		assert.Positive(t, n, "no sub-chunk may be empty")
+		total += n
+	}
+	assert.Equal(t, 1000, total, "sub-chunks must partition the range exactly")
+
+	// Unbounded ends stay unbounded, so the partition still covers rows outside
+	// any boundary the caller never set.
+	assert.Nil(t, subs[0].LowerBound, "first sub-chunk inherits the open lower bound")
+	assert.Nil(t, subs[len(subs)-1].UpperBound, "last sub-chunk inherits the open upper bound")
+}
+
+func TestChunkSplitPreservesBoundsAndConditions(t *testing.T) {
+	ti := splitFixture(t, "csplit2", 500)
+	lo, err := NewDatum(100, signedType)
+	require.NoError(t, err)
+	hi, err := NewDatum(300, signedType)
+	require.NoError(t, err)
+	// [100, 300) with an extra filter, i.e. the shape a real chunk has.
+	whole := &Chunk{
+		Key:                  []string{"id"},
+		Table:                ti,
+		NewTable:             ti,
+		LowerBound:           &Boundary{Value: []Datum{lo}, Inclusive: true},
+		UpperBound:           &Boundary{Value: []Datum{hi}, Inclusive: false},
+		AdditionalConditions: "id % 2 = 0",
+	}
+	before := countIn(t, ti, whole)
+	require.Equal(t, 100, before, "even ids in [100,300)")
+
+	subs, err := whole.Split(t.Context(), ti.db, 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, subs)
+
+	total := 0
+	for _, s := range subs {
+		assert.Equal(t, "id % 2 = 0", s.AdditionalConditions, "the filter must ride along")
+		assert.Equal(t, whole.Key, s.Key)
+		assert.Equal(t, ti, s.Table)
+		assert.Equal(t, ti, s.NewTable)
+		total += countIn(t, ti, s)
+	}
+	assert.Equal(t, before, total, "splitting must not change what the range covers")
+
+	// The outer edges are the original's, inclusivity included — otherwise a
+	// repair driven off these sub-chunks would miss or overreach a boundary row.
+	assert.Equal(t, whole.LowerBound, subs[0].LowerBound)
+	assert.Equal(t, whole.UpperBound, subs[len(subs)-1].UpperBound)
+}
+
+func TestChunkSplitCompositeKey(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS csplit3")
+	testutils.RunSQL(t, "CREATE TABLE csplit3 (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a, b))")
+	testutils.RunSQL(t, `INSERT INTO csplit3 (a, b)
+		WITH RECURSIVE s(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i < 40)
+		SELECT x.i, y.i FROM s x, s y`)
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	ti := NewTableInfo(db, "test", "csplit3")
+	require.NoError(t, ti.SetInfo(t.Context()))
+
+	whole := &Chunk{Key: []string{"a", "b"}, Table: ti, NewTable: ti}
+	require.Equal(t, 1600, countIn(t, ti, whole))
+
+	subs, err := whole.Split(t.Context(), ti.db, 8)
+	require.NoError(t, err)
+	require.Len(t, subs, 8)
+
+	// Composite keys are where an inclusive/exclusive slip is easiest to make,
+	// because the comparison expands into nested OR terms rather than a simple
+	// range test.
+	total := 0
+	for i, s := range subs {
+		if i > 0 {
+			require.Len(t, s.LowerBound.Value, 2, "interior cuts bound both key parts")
+		}
+		total += countIn(t, ti, s)
+	}
+	assert.Equal(t, 1600, total)
+}
+
+func TestChunkSplitRefusesWhenNotUseful(t *testing.T) {
+	ti := splitFixture(t, "csplit4", 3)
+	whole := &Chunk{Key: []string{"id"}, Table: ti, NewTable: ti}
+
+	for _, parts := range []int{0, 1} {
+		subs, err := whole.Split(t.Context(), ti.db, parts)
+		require.NoError(t, err)
+		assert.Nil(t, subs, "parts=%d is not a split", parts)
+	}
+
+	// More pieces requested than rows available: clamped rather than returning
+	// empty slivers.
+	subs, err := whole.Split(t.Context(), ti.db, 50)
+	require.NoError(t, err)
+	require.Len(t, subs, 3, "3 rows can only be cut into 3 pieces")
+	for _, s := range subs {
+		assert.Positive(t, countIn(t, ti, s))
+	}
+
+	// A single row cannot be divided, and an empty range has nothing to divide.
+	single := splitFixture(t, "csplit5", 1)
+	subs, err = (&Chunk{Key: []string{"id"}, Table: single, NewTable: single}).Split(t.Context(), single.db, 4)
+	require.NoError(t, err)
+	assert.Nil(t, subs)
+
+	empty := splitFixture(t, "csplit6", 0)
+	subs, err = (&Chunk{Key: []string{"id"}, Table: empty, NewTable: empty}).Split(t.Context(), empty.db, 4)
+	require.NoError(t, err)
+	assert.Nil(t, subs)
+}
+
+func TestChunkSplitHandlesKeyTies(t *testing.T) {
+	// Split does not require a unique key. With heavy ties, consecutive offsets
+	// can land on the same key value; emitting both as cuts would create an
+	// empty sub-chunk and, worse, a sub-chunk whose lower bound equals its
+	// exclusive upper bound.
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS csplit7")
+	testutils.RunSQL(t, "CREATE TABLE csplit7 (id INT NOT NULL PRIMARY KEY, grp INT NOT NULL, KEY (grp))")
+	testutils.RunSQL(t, `INSERT INTO csplit7 (id, grp)
+		WITH RECURSIVE s(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i < 100)
+		SELECT i, i % 3 FROM s`)
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	ti := NewTableInfo(db, "test", "csplit7")
+	require.NoError(t, ti.SetInfo(t.Context()))
+
+	// Chunking on grp, which has only 3 distinct values across 100 rows.
+	whole := &Chunk{Key: []string{"grp"}, Table: ti, NewTable: ti}
+	subs, err := whole.Split(t.Context(), ti.db, 10)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(subs), 3, "cannot cut a 3-valued key into more than 3 pieces")
+
+	total := 0
+	for _, s := range subs {
+		n := countIn(t, ti, s)
+		assert.Positive(t, n, "a tie must not yield an empty sub-chunk")
+		total += n
+	}
+	assert.Equal(t, 100, total, "ties must still partition exactly")
+}
+
+// TestChunkSplitEnumKeyStaysExact covers a key whose sort order is not its
+// comparison order. MySQL orders ENUM by declaration ordinal but compares it
+// against a string literal lexically, so boundaries read in ORDER BY order can
+// come back *decreasing* in the order the range predicates use — which would
+// make two sub-chunks overlap and get the same rows deleted and rewritten twice.
+func TestChunkSplitEnumKeyStaysExact(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS csplit8")
+	// Declaration order is deliberately not lexicographic.
+	testutils.RunSQL(t, "CREATE TABLE csplit8 (e ENUM('apple','zebra','mango') NOT NULL PRIMARY KEY)")
+	testutils.RunSQL(t, "INSERT INTO csplit8 (e) VALUES ('apple'), ('zebra'), ('mango')")
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	ti := NewTableInfo(db, "test", "csplit8")
+	require.NoError(t, ti.SetInfo(t.Context()))
+
+	whole := &Chunk{Key: []string{"e"}, Table: ti, NewTable: ti}
+	require.Equal(t, 3, countIn(t, ti, whole))
+
+	subs, err := whole.Split(t.Context(), ti.db, 3)
+	require.NoError(t, err)
+
+	total := 0
+	for _, s := range subs {
+		n := countIn(t, ti, s)
+		assert.Positive(t, n, "no sub-chunk may be empty")
+		total += n
+	}
+	assert.Equal(t, 3, total, "a decreasing cut must be dropped, not emitted as an overlap")
+}


### PR DESCRIPTION
> **Stacked on #1087** — this targets the `checksum-autoscale` branch, so the diff shows only this PR's own change. Retarget to `main` once #1087 merges.

This is PR 2 of 3 in the checksum-autoscaling series. PR 1 (#1087) made the checksum phase throttler-aware and scalable, and started measuring chunk read times. PR 3 will use that measurement to grow checksum chunks toward ~10s of read time. This PR is the prerequisite for that: it makes a mismatch repair proportional to the mismatch rather than to the chunk.

## Why

A checksum chunk is sized by how long it takes to *read*. That says nothing about how long it takes to rewrite — and on a mismatch we `DELETE` and re-write the chunk's entire key range. `replaceChunk`'s own comment has flagged this for a while:

> Note that the chunk is dynamically sized based on the target-time that it took to *read* data in the checksum. This could be substantially longer than the time that it takes to copy the data. Maybe in future we could consider splitting the chunk here, but this is expected to be a very rare situation, so a small stall from an XL sized chunk is considered acceptable.

Once chunks are sized for read-ahead rather than for latency, "a small stall from an XL sized chunk" stops being small: fixing a handful of rows becomes a large write burst, a long lock hold, and a wide window in which the target range is deleted but not yet rewritten (the `DELETE` and `REPLACE` are deliberately separate transactions, to avoid a documented deadlock on a unique secondary index).

## What

On mismatch, cut the range into 8, re-checksum each piece inside the same snapshot that observed the mismatch, and repair only the pieces that differ — recursing twice, or until a piece is under 2000 rows. On a 19,600-row chunk with one bad row that rewrites **306 rows instead of 19,600**.

New: `table.Chunk.Split` (the range arithmetic, in `pkg/table` because `datumTp` and `expandRowConstructorComparison` are unexported and both checkers need it) and `checksum.narrowRepair` (the depth-bounded driver). Both checkers gained a `checksumRange` helper so the whole-chunk and sub-range comparisons are the same code.

## Why skipping a clean piece is safe

`BIT_XOR` is associative and the row counts are additive, so over an exact partition read in one snapshot the pieces must reproduce the whole-range result — meaning a mismatching range must contain a mismatching piece.

Both halves of that matter, and both are enforced:

- **Same snapshot.** A piece read from a different snapshot could look clean because a concurrent write happened to fix it, and the repair would be skipped on the strength of an observation that never applied to the chunk being fixed. There is a test that fails if either checker is moved off the snapshot transaction.
- **Exact partition.** `Split` cannot promise this for every key type, so it is *checked* rather than assumed: the pieces' row counts must sum to the parent's on both sides. MySQL orders `ENUM` by declaration ordinal but compares it against a string literal lexically; a case-insensitive collation orders by weight rather than bytes; a `NULL` key value satisfies neither `>=` nor `<`. A gap would let a differing row escape repair entirely, so a shortfall or excess means recopy the whole chunk.

## Fallbacks

Everything that makes narrowing unusable falls back to repairing the whole range, because declining to fix a known difference is not an option: too few distinct key values to cut, a failed boundary query, no piece differing, and — importantly — *every* piece differing. That last one is the systematic case (a lossy `ALTER`, a wrong column mapping, a truncated target) where narrowing buys nothing; without it, one chunk fanned out into 64 repairs and 128 transactions for the same write volume.

Relatedly, `fixChunkTimeout` and its detachment from the caller's cancellation are now owned once per chunk and shared across its narrowed repairs. The narrowed repairs together rewrite no more than the single repair they replace, so one budget covers them — and giving each its own would multiply the span in which a fix ignores cancellation by the number of pieces.

A verification *failure* is propagated rather than swallowed: it means the snapshot is gone, so the pass should fail and be retried. `differencesFound` is incremented before narrowing starts, so a chunk left unrepaired this way cannot be reported as a pass.

## Sharded sources

Boundaries come from one shard, since offsets into one shard's rows are the only row-position information a single query gives. The shard is chosen **per range**, not once per chunk: a sub-range's rows can sit almost entirely on a different shard than its parent's did, and cutting it with a shard that holds nothing in it would find no boundaries and silently give up on narrowing.

## Testing

`pkg/table` and `pkg/checksum` pass, both under `-race`; `golangci-lint` clean.

The strongest assertion uses a target-only `marker` column — the shape an "add column" migration has. It is invisible to the checksum, which compares intersecting columns only, but the repair resets it on every row it rewrites, so counting cleared markers measures exactly how much of the chunk was recopied. Covered for both the single-server (`REPLACE INTO ... SELECT`) and distributed (`DELETE` + applier re-apply) repair paths.

Also covered: exact partitioning for single-column, composite, bounded, unbounded and filtered ranges; key ties on a non-unique key; the `ENUM` ordinal-vs-lexical case; the count-validation fallback in both the gap and overlap directions; the all-differ and none-differ fallbacks; per-range shard selection; and verification-error propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
