### PR TITLE
checksum: size chunks for the checksum, not for the copier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ scripts/      → Build and run helper scripts
 
 ### Key design decisions
 
-- **Dynamic chunking**: chunk size auto-adjusts against a target based on the 90th percentile of the last 10 chunks, rather than a fixed row count. The default buffered copier targets an in-memory *byte budget* (`--target-chunk-size`, default `table.DefaultTargetChunkBytes` = 16 MiB); the checksum and legacy `--unbuffered` copier target a *chunk time* (`--target-chunk-time`, default 500ms for migrate).
+- **Dynamic chunking**: chunk size auto-adjusts against a target based on the 90th percentile of the last 10 chunks, rather than a fixed row count. The default buffered copier targets an in-memory *byte budget* (`--target-chunk-size`, default `table.DefaultTargetChunkBytes` = 16 MiB); the legacy `--unbuffered` copier and the continuous checksum target a *chunk time* (`--target-chunk-time`, default 500ms for migrate). The cutover checksum targets its own much larger chunk time (`--checksum-target-chunk-time`, default `checksum.DefaultTargetChunkTime` = 10s) and starts at the row ceiling rather than ramping up to it (`checksum.ChunkStartRows`), because growth is capped per feedback window and the ramp is longer than many whole tables — see `pkg/checksum/README.md`.
 - **Change row map**: binlog changes are deduplicated in a map before flushing, so a row updated 10 times is only copied once.
 - **High watermark optimization**: binlog changes above the copier's current position are discarded (only for auto-increment PKs).
 - **Checkpoint/resume**: progress is saved periodically; interrupted migrations resume automatically with ~1 minute of lost progress.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The following are some of the optimizations that make Spirit faster than gh-ost:
 Rather than accept a fixed chunk size (such as 1000 rows), Spirit dynamically adjusts the chunk size against a target. This is both safer for very wide tables with a lot of indexes and faster for smaller tables. The target depends on the copier:
 
 - The **default buffered copier** reads full rows into memory, so it sizes each chunk against an in-memory **byte budget** (`--target-chunk-size`, default 16 MiB). Time is a poor signal here — the buffered copier's measured chunk time includes waiting behind the write queue, which inflates under load independently of chunk size — whereas a byte budget is a stable property of the data and keeps chunks large enough to engage InnoDB/Aurora read-ahead.
-- The **checksum** and the legacy `--unbuffered` copier size each chunk against a **target time** (such as 500ms), configured via [`--target-chunk-time`](docs/migrate.md#target-chunk-time).
+- The legacy `--unbuffered` copier sizes each chunk against a **target time** (such as 500ms), configured via [`--target-chunk-time`](docs/migrate.md#target-chunk-time).
+- The **checksum** also targets a time, but its own much larger one ([`--checksum-target-chunk-time`](docs/migrate.md#checksum-target-chunk-time), default 10s). A copy chunk's duration bounds a write transaction's lifetime; a checksum chunk's bounds a server-side aggregate inside a snapshot that is held for the whole pass either way, and only one row per chunk crosses the wire. In practice the chunker's 100,000-row ceiling is what decides a checksum chunk's size, and the time target is the safety valve for tables where even that is too much work per chunk.
 
 500ms is quite "high" for traditional MySQL environments, but remember _Spirit does not support read-replicas_. This helps it copy chunks as efficiently as possible.
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -15,6 +15,7 @@ spirit migrate --host mydb:3306 --username root --password secret \
 
 - [alter](#alter)
 - [checkpoint-max-age](#checkpoint-max-age)
+- [checksum-target-chunk-time](#checksum-target-chunk-time)
 - [checksum-yield-timeout](#checksum-yield-timeout)
 - [conf](#conf)
 - [database](#database)
@@ -80,6 +81,17 @@ Operationally, this means:
 - Do not upgrade or downgrade the Spirit binary while a migration is in progress.
 - If you must change Spirit versions, let the in-flight migration finish first, or accept the lost progress and start fresh with the new version.
 - For long-running migrations that span planned binary upgrades, plan to drain the migration before the upgrade window.
+
+### checksum-target-chunk-time
+
+- Type: Duration
+- Default value: `10s`
+
+The target time to spend *reading* each chunk of the checksum. This is the checksum's equivalent of [target-chunk-time](#target-chunk-time), and it is much larger for a reason: the two are bounding different things.
+
+A copy chunk's duration is the lifetime of a write transaction, so its target is a latency budget — it decides how long a row lock is held (with [`--unbuffered`](#unbuffered)) and how far behind a replica appears. A checksum chunk's duration bounds neither. The checksum aggregates `BIT_XOR(CRC32(...))` on the server and returns **one row per chunk** however many rows the chunk covers, and it does so inside a `REPEATABLE READ` snapshot that is held for the whole pass regardless. Longer chunks are therefore close to free, and length is what keeps a scan sequential long enough for InnoDB linear read-ahead — and Aurora's batched prefetch — to stay engaged.
+
+On a healthy server this is not the value that decides the chunk size: the dynamic chunker's `100,000`-row ceiling does, and that is intended. The row cap is a bound that can be reasoned about, whereas a binding *time* target lets chunk size follow load. This flag is the safety valve for the case the row cap cannot see: rows so wide, or storage so slow, that even 100,000 rows is too much work for one chunk. Lower it if a table's `checksum chunk size distribution` log line shows chunk durations you are not comfortable with; the row-capped count in that line tells you which of the two bounds is currently in effect.
 
 ### checksum-yield-timeout
 
@@ -362,7 +374,9 @@ The table that the schema change will be performed on.
 - Range: `100ms-5s`
 - Typical safe values: `100ms-1s`
 
-The target time for each chunk of the **checksum** and the legacy [`--unbuffered`](#unbuffered) copier. Note that the chunk size is specified as a _target time_ and not a _target rows_. This is helpful because rows can be inconsistent when you consider some tables may have a lot of columns or secondary indexes, or copy tasks may slow down as the workload becomes IO bound.
+The target time for each chunk of the legacy [`--unbuffered`](#unbuffered) copier and of the continuous checksum that runs *during* the copy. Note that the chunk size is specified as a _target time_ and not a _target rows_. This is helpful because rows can be inconsistent when you consider some tables may have a lot of columns or secondary indexes, or copy tasks may slow down as the workload becomes IO bound.
+
+> **The cutover checksum does not use `--target-chunk-time`.** It has its own, much larger target ([`--checksum-target-chunk-time`](#checksum-target-chunk-time)), because a checksum chunk's duration bounds a server-side read rather than a write transaction. The continuous checksum stays on this flag: it shares the copy phase with the copier, so it is held to the copier's budget.
 
 > **The default buffered copier does not use `--target-chunk-time`.** It reads full rows into memory, so it sizes each copy chunk against an in-memory _byte budget_ ([`--target-chunk-size`](#target-chunk-size)) instead. Time is a poor signal for the buffered copier: its measured chunk time includes the wait behind the write queue, which inflates under load independently of chunk size and would collapse the chunk size to the row floor. A byte budget is a stable property of the data and keeps chunks large enough to engage InnoDB/Aurora read-ahead. The budget defaults to 16 MiB and can be tuned with [`--target-chunk-size`](#target-chunk-size).
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -154,9 +154,9 @@ A Go MySQL DSN for the source database. All tables in this database will be copi
 ### target-chunk-time
 
 - Type: Duration
-- Default value: `5s`
+- Default value: `10s`
 
-The target time for each **checksum** chunk. The copy phase always uses the buffered copier, which sizes its chunks against an in-memory byte budget rather than a target time, so this flag does not affect the copy. See the [migrate documentation](migrate.md#target-chunk-time) for a detailed explanation of how chunk timing (and the buffered copier's byte budget) works.
+The target time to spend *reading* each **checksum** chunk. The copy phase always uses the buffered copier, which sizes its chunks against an in-memory byte budget rather than a target time, so this flag does not affect the copy. Because move's only consumer of this flag is the checksum, it is the counterpart of migrate's [`--checksum-target-chunk-time`](migrate.md#checksum-target-chunk-time) rather than of its `--target-chunk-time` — see that section for why a checksum chunk's target is so much larger than a copy chunk's, and why the chunker's `100,000`-row ceiling usually decides the chunk size before this value does.
 
 ### target-chunk-size
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -97,6 +97,11 @@ than a target time, so this flag does not affect the copy. See the [migrate
 documentation](migrate.md#target-chunk-time) for how chunk timing (and the
 buffered copier's byte budget) works.
 
+Sync's only checksum is the *continuous* one, which runs alongside the copy and
+is therefore held to a copy-phase budget. It is not the cutover checksum that
+migrate sizes with
+[`--checksum-target-chunk-time`](migrate.md#checksum-target-chunk-time).
+
 ### target-chunk-size
 
 - Type: Integer (bytes)

--- a/pkg/checksum/README.md
+++ b/pkg/checksum/README.md
@@ -62,6 +62,32 @@ The actual implementation includes additional handling:
 
 The CRC32 + XOR aggregate technique for table checksumming was pioneered by **pt-table-checksum** from Percona Toolkit, which established this as a reliable method for verifying data consistency in MySQL. This same approach has since been adopted by other database tools, including TiDB's data migration and verification utilities, demonstrating its effectiveness for distributed database scenarios.
 
+## Chunk size
+
+The checksum sizes chunks with the same dynamic sizer as the copier, but not with the same calibration, because a chunk's duration bounds different things in the two phases. A copy chunk's time is a write transaction's lifetime, so it is a latency budget. A checksum chunk's time is a read inside a snapshot that is held for the whole pass either way, and only one row crosses the wire per chunk however many rows it covers. Longer chunks are therefore nearly free, and length is what keeps a scan sequential long enough to engage InnoDB linear read-ahead and Aurora's batched prefetch.
+
+Two things are set differently:
+
+- **The target time** is `--checksum-target-chunk-time` (10s), not the copier's `--target-chunk-time` (500ms). See `DefaultTargetChunkTime`.
+- **The starting size** is `table.MaxDynamicRowSize`, not `table.StartingChunkSize`. See `ChunkStartRows`.
+
+The starting size is the one that mattered in practice. The sizer converges upward slowly on purpose — growth is capped at `table.MaxDynamicStepFactor` per feedback window, and a window is 10 chunks — so climbing from 1000 rows to the row cap takes roughly 130 chunks. That is more chunks than many whole tables have, which meant the checksum could spend an entire pass converging and never once use the size it had measured as correct. Starting at the cap inverts the asymmetry, and shrinking is what the sizer is good at: it shrinks with no per-step cap, and panic-shrinks on any single chunk exceeding `DynamicPanicFactor` × the target. Overshooting costs one slow chunk; undershooting cost the whole pass.
+
+On a healthy server neither setting decides the chunk size — `table.MaxDynamicRowSize` (100k rows) does, and that is intended. The row cap is a bound that can be reasoned about: it is what bounds a repair, and what `inspectDifferences` holds in memory when a chunk mismatches. A binding *time* target, by contrast, would let chunk size follow load. The target's job is to be the safety valve for what the row cap cannot see — rows so wide, or storage so slow, that even 100k rows is too much work for one chunk. At the copier's 500ms that valve trips on ordinary tables and shrinks chunks precisely when read-ahead matters most.
+
+Measured on a 1M-row, 6-column table (194 MB against a 128 MB buffer pool), before and after this calibration:
+
+| | chunks | rows p50 | duration p90 | at the row cap |
+| --- | --- | --- | --- | --- |
+| copier's calibration | 126 | 5,062 | 30ms | 0/126 |
+| checksum's calibration | 12 | 100,000 | 162ms | 10/12 |
+
+Per-row cost at p50 is unchanged on local SSD (~1.6µs either way) — read-ahead has little left to win when the storage is this fast, and the read-ahead argument is a claim about network-attached storage that a local box cannot demonstrate. What the numbers do show is the sizing reaching its bound in two chunks instead of never, and p90 per-row cost falling with it (5.9µs → 1.6µs) as per-chunk overhead is amortised over 20× the rows.
+
+Two costs come with the larger chunks, both bounded by the row cap. A throttle decision only takes effect between chunks (`BlockWait` is called before dispatch and chunks in flight are never abandoned), so back-off latency now tracks a chunk's duration rather than a copier's 500ms budget. And a table with fewer than `threads` × 100k rows produces fewer chunks than there are workers, so the checksum of a small table is less parallel than it was — which is affordable precisely because it is a small table.
+
+One more consequence worth knowing: on a table with an auto-increment key, starting at the row cap means the optimistic chunker's gap-prefetch switch (`maybeSwitchToPrefetch`) now fires on the first feedback window rather than never. That is a net gain — in prefetch mode a chunk holds exactly `chunkSize` *rows* rather than `chunkSize` *key values*, so chunks stay uniform across a key space pitted with deletes — at the cost of one index-only `OFFSET` query per chunk.
+
 ## Repairing a mismatch
 
 When a chunk fails verification and `FixDifferences` is on, the checker recopies the chunk's key range: `DELETE` then `REPLACE INTO ... SELECT` for the single-server case, or `DELETE` on every target followed by a re-apply through the applier for the distributed case.
@@ -110,7 +136,7 @@ One constraint shapes all of this: the `REPEATABLE READ` transaction pool **cann
 
 `ContinuousChecker` is not covered by any of this: it manages its own pacing through `MinPassInterval` and its retry queue, and takes no table lock or snapshot pool.
 
-Each pass logs a `checksum chunk size distribution` line (chunk count, duration p50/p90/max, row p50/max, and how many chunks hit `table.MaxDynamicRowSize`). The row-capped count is the useful one: the checksum aggregates server-side and returns one row per chunk, so its chunks are far cheaper than the copier's, and if most are pinned at the row ceiling then that — not `--target-chunk-time` — is what bounds them.
+Each pass logs a `checksum chunk size distribution` line (chunk count, duration p50/p90/max, row p50/max, and how many chunks hit `table.MaxDynamicRowSize`). The row-capped count is the useful one: it is what answered the sizing question above, and with the checksum's own calibration it should now read close to all of them. A pass where it reads *low* is a pass where the time target is binding instead — meaning that table's rows are wide enough, or its storage slow enough, to be worth looking at.
 
 ## Continuous checksum
 

--- a/pkg/checksum/checksum.go
+++ b/pkg/checksum/checksum.go
@@ -44,6 +44,45 @@ var (
 	fixChunkTimeout = 10 * time.Minute
 )
 
+// DefaultTargetChunkTime is the read time the checksum aims for per chunk.
+//
+// It is much larger than the copier's target because it is bounding a different
+// thing. A copy chunk's time is a write transaction's lifetime, so it is a
+// latency budget. A checksum chunk is a read-only aggregate inside a snapshot
+// that is already held for the whole pass, and only one row per chunk crosses
+// the wire no matter how many rows it covers — so a longer chunk buys longer
+// sequential scans (which is what engages InnoDB linear read-ahead and Aurora's
+// batched prefetch) at no cost in lock or memory terms.
+//
+// In practice this is not the binding constraint on a healthy server:
+// table.MaxDynamicRowSize caps a chunk at 100k rows, and 100k rows of a typical
+// table is well under 10s of read. That is deliberate — the row cap is a bound
+// we can reason about (it is what bounds a repair, and what
+// SingleChecker.inspectDifferences holds in memory on a mismatch), whereas a
+// time target that binds would let chunk size follow load. The target's job is
+// to be the safety valve for the case the cap cannot see: rows so wide, or
+// storage so slow, that even 100k rows is too much work for one chunk. At the
+// copier's 500ms that valve trips on perfectly healthy tables and shrinks chunks
+// precisely when read-ahead matters most.
+const DefaultTargetChunkTime = 10 * time.Second
+
+// ChunkStartRows is the row count a checksum chunker starts at, as opposed to
+// the copier's much smaller table.StartingChunkSize.
+//
+// The dynamic sizer converges upward slowly on purpose: growth is capped at
+// table.MaxDynamicStepFactor per feedback window, and a window is 10 chunks. From
+// 1000 rows that is ~130 chunks to reach table.MaxDynamicRowSize — more chunks
+// than many whole tables have, so the checksum could spend an entire pass
+// converging and never once use the chunk size it had measured as correct. (A
+// 1M-row table measured 126 chunks, ending at 25k rows, with p90 chunk time at
+// 6% of the 500ms target and not one chunk reaching the row cap.)
+//
+// Starting at the cap inverts that, and the asymmetry justifies it: the sizer
+// shrinks without any per-step cap and panic-shrinks on a single chunk that
+// exceeds DynamicPanicFactor × the target, so overshooting costs one slow chunk,
+// while undershooting costs the whole pass.
+const ChunkStartRows = table.MaxDynamicRowSize
+
 // chunkMismatch describes why a chunk's source and target disagreed. It is
 // returned by compareChunk so the caller can log a debuggable reason while
 // treating any mismatch (checksum OR row count) identically — same retry,
@@ -185,7 +224,7 @@ type CheckerConfig struct {
 func NewCheckerDefaultConfig() *CheckerConfig {
 	return &CheckerConfig{
 		Concurrency:     4,
-		TargetChunkTime: 1000 * time.Millisecond,
+		TargetChunkTime: DefaultTargetChunkTime,
 		DBConfig:        dbconn.NewDBConfig(),
 		Logger:          slog.Default(),
 		FixDifferences:  false,

--- a/pkg/migration/checksum_chunk_size_test.go
+++ b/pkg/migration/checksum_chunk_size_test.go
@@ -1,0 +1,97 @@
+package migration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/checksum"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChecksumChunkerIsSizedSeparatelyFromTheCopier pins the wiring that gives
+// the checksum its own chunk-sizing profile.
+//
+// The two phases share a chunker implementation but not its calibration: a copy
+// chunk's duration bounds a write transaction, a checksum chunk's bounds a
+// server-side aggregate inside a snapshot that is already held. Before this was
+// separated, the checksum inherited the copier's 500ms target and 1000-row start
+// and — because growth is capped per feedback window — spent whole passes ramping
+// without ever reaching the size it had measured as correct.
+func TestChecksumChunkerIsSizedSeparatelyFromTheCopier(t *testing.T) {
+	tableName := "chunksize_profile"
+	dropStmt := fmt.Sprintf("DROP TABLE IF EXISTS %s, %s, %s",
+		tableName, utils.NewTableName(tableName), utils.CheckpointTableName(tableName))
+	testutils.RunSQL(t, dropStmt)
+	t.Cleanup(func() { testutils.RunSQL(t, dropStmt) })
+	testutils.RunSQL(t, "CREATE TABLE "+tableName+" (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, pad VARCHAR(10))")
+	testutils.RunSQL(t, "INSERT INTO "+tableName+" (pad) VALUES ('a'), ('b'), ('c')")
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	r, err := NewRunner(&Migration{
+		Host:         cfg.Addr,
+		Username:     cfg.User,
+		Password:     &cfg.Passwd,
+		Database:     cfg.DBName,
+		Threads:      1,
+		WriteThreads: 1,
+		Table:        tableName,
+		Alter:        "ENGINE=InnoDB",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(r) })
+
+	// A programmatically-constructed Migration leaves the Kong defaults at zero,
+	// so normalizeOptions is what has to fill this in — otherwise a library caller
+	// would get a zero target and the chunker's own fallback.
+	assert.Equal(t, checksum.DefaultTargetChunkTime, r.migration.ChecksumTargetChunkTime)
+	assert.NotEqual(t, r.migration.TargetChunkTime, r.migration.ChecksumTargetChunkTime,
+		"the checksum must not be sharing the copier's target")
+
+	dbCfg := dbconn.NewDBConfig()
+	r.db, err = dbconn.New(testutils.DSN(), dbCfg)
+	require.NoError(t, err)
+	r.dbConfig = dbCfg
+	r.changes[0].table = table.NewTableInfo(r.db, r.migration.Database, r.migration.Table)
+	require.NoError(t, r.changes[0].table.SetInfo(t.Context()))
+	require.NoError(t, r.changes[0].dropOldTable(t.Context()))
+	require.NoError(t, r.changes[0].createNewTable(t.Context()))
+	require.NoError(t, r.changes[0].alterNewTable(t.Context()))
+	require.NoError(t, r.initChunkers())
+
+	require.NoError(t, r.copyChunker.Open())
+	require.NoError(t, r.checksumChunker.Open())
+
+	copyChunk, err := r.copyChunker.Next()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(table.StartingChunkSize), copyChunk.ChunkSize,
+		"the copy phase keeps its conservative ramp")
+
+	checksumChunk, err := r.checksumChunker.Next()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(checksum.ChunkStartRows), checksumChunk.ChunkSize,
+		"the checksum starts at the row cap instead of ramping up to it")
+}
+
+// TestChecksumTargetChunkTimeValidation covers the flag's own bounds. It is a
+// duration read straight from the command line, and a negative value would make
+// every chunk look late and pin the chunk size at the row floor.
+func TestChecksumTargetChunkTimeValidation(t *testing.T) {
+	pw := ""
+	m := &Migration{
+		Password:                &pw,
+		Table:                   "t",
+		Alter:                   "ENGINE=InnoDB",
+		ChecksumTargetChunkTime: -1 * time.Second,
+	}
+	err := m.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--checksum-target-chunk-time")
+}

--- a/pkg/migration/checksum_invalidation_test.go
+++ b/pkg/migration/checksum_invalidation_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/checksum"
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/table"
@@ -337,9 +338,14 @@ func TestContinuousChecksumDivergenceClearsCheckpointWatermark(t *testing.T) {
 // chunker can carve out multiple chunks: the composite chunker won't report a
 // low-watermark until at least one fully-processed chunk has had Feedback,
 // which in practice requires more than one chunk on the runway.
+//
+// The runway is sized against the *checksum* chunker, which starts at the row
+// cap rather than ramping up from the copier's 1000 rows (see
+// checksum.ChunkStartRows). A few thousand rows is one whole checksum chunk, so
+// the table would be read out before a watermark ever appeared.
 func advanceRunnerToChecksumWatermarks(t *testing.T, r *Runner) {
 	t.Helper()
-	seedRows(t, r.db, r.migration.Table, 4096)
+	seedRows(t, r.db, r.migration.Table, 3*checksum.ChunkStartRows)
 	require.NoError(t, r.changes[0].table.SetInfo(t.Context()))
 	require.NoError(t, r.initChunkers())
 	require.NoError(t, r.copyChunker.Open())

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -42,13 +42,23 @@ type Migration struct {
 	// cap is fixed at 2x that (deliberately not configurable for now, to keep
 	// the experimental surface small). See issue #831.
 	EnableExperimentalAutoscaling bool `name:"enable-experimental-autoscaling" help:"EXPERIMENTAL: dynamically scale write threads between the starting value and 2x that, based on throttler feedback" optional:"" default:"false"`
-	// TargetChunkTime sizes chunks for the time-based signal: the checksum
-	// (server-side CRC) and the legacy --unbuffered copier. The default buffered
-	// copier ignores it and sizes chunks by an in-memory byte budget
+	// TargetChunkTime sizes chunks for the time-based signal: the legacy
+	// --unbuffered copier and the continuous (during-copy) checksum. The default
+	// buffered copier ignores it and sizes chunks by an in-memory byte budget
 	// (table.DefaultTargetChunkBytes), because its fed-back time measures
 	// read + applier-queue-wait + write/commit — a signal that is
 	// size-independent under backpressure and collapses the chunk size.
-	TargetChunkTime time.Duration `name:"target-chunk-time" help:"Target time per chunk for the checksum and the legacy --unbuffered copier. The default buffered copier ignores it and sizes chunks by memory." optional:"" default:"500ms"`
+	//
+	// The cutover checksum has its own, much larger target
+	// (ChecksumTargetChunkTime). It is the one phase where the chunk time bounds
+	// nothing but a read: the continuous checksum shares the copy phase with the
+	// copier and is deliberately left on the copier's budget.
+	TargetChunkTime time.Duration `name:"target-chunk-time" help:"Target time per chunk for the legacy --unbuffered copier and the during-copy continuous checksum. The default buffered copier ignores it and sizes chunks by memory; the cutover checksum uses --checksum-target-chunk-time." optional:"" default:"500ms"`
+	// ChecksumTargetChunkTime is the target read time for one chunk of the
+	// cutover checksum. See checksum.DefaultTargetChunkTime for why it is so much
+	// larger than TargetChunkTime, and why table.MaxDynamicRowSize rather than
+	// this value is what usually decides checksum chunk size.
+	ChecksumTargetChunkTime time.Duration `name:"checksum-target-chunk-time" help:"Target read time per checksum chunk. Larger than the copier's target because a checksum chunk aggregates server-side and holds no write transaction; in practice a chunk is usually capped by rows before it reaches this." optional:"" default:"10s"`
 	// TargetChunkSize is the in-memory byte budget the default buffered copier
 	// sizes each copy chunk against (the memory signal; see
 	// table.DefaultTargetChunkBytes and pkg/table/README.md). It has no effect
@@ -121,6 +131,9 @@ func (m *Migration) Validate() error {
 	if m.TargetChunkTime < 0 {
 		return fmt.Errorf("--target-chunk-time must be non-negative, got %s", m.TargetChunkTime)
 	}
+	if m.ChecksumTargetChunkTime < 0 {
+		return fmt.Errorf("--checksum-target-chunk-time must be non-negative, got %s", m.ChecksumTargetChunkTime)
+	}
 	if m.ReplicaMaxLag < 0 {
 		return fmt.Errorf("--replica-max-lag must be non-negative, got %s", m.ReplicaMaxLag)
 	}
@@ -153,6 +166,11 @@ func (m *Migration) Run() error {
 func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, err error) {
 	if m.TargetChunkTime == 0 {
 		m.TargetChunkTime = table.ChunkerDefaultTarget
+	}
+	// Zero means "not set" for callers that construct a Migration programmatically
+	// (tests, library users) rather than through Kong.
+	if m.ChecksumTargetChunkTime == 0 {
+		m.ChecksumTargetChunkTime = checksum.DefaultTargetChunkTime
 	}
 	if m.TargetChunkSize == 0 {
 		m.TargetChunkSize = table.DefaultTargetChunkBytes

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -852,7 +852,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 
 	r.checker, err = checksum.NewChecker([]*sql.DB{r.db}, r.checksumChunker, []change.Source{r.replClient}, &checksum.CheckerConfig{
 		Concurrency:     r.migration.Threads,
-		TargetChunkTime: r.migration.TargetChunkTime,
+		TargetChunkTime: r.migration.ChecksumTargetChunkTime,
 		DBConfig:        r.dbConfig,
 		Logger:          r.logger,
 		FixDifferences:  true,
@@ -1543,7 +1543,13 @@ func (r *Runner) initChunkers() error {
 		if err != nil {
 			return err
 		}
-		checksumChunker, err := table.NewChunker(change.table, chunkerCfg)
+		// The checksum's chunks are sized against their own, much larger target,
+		// and start at the row cap rather than ramping up to it. See
+		// checksum.DefaultTargetChunkTime and checksum.ChunkStartRows.
+		checksumChunkerCfg := chunkerCfg
+		checksumChunkerCfg.TargetChunkTime = r.migration.ChecksumTargetChunkTime
+		checksumChunkerCfg.StartingChunkSize = checksum.ChunkStartRows
+		checksumChunker, err := table.NewChunker(change.table, checksumChunkerCfg)
 		if err != nil {
 			return err
 		}

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -11,9 +11,13 @@ import (
 )
 
 type Move struct {
-	SourceDSN       string        `name:"source-dsn" help:"Where to copy the tables from." default:"spirit:spirit@tcp(127.0.0.1:3306)/src"`
-	TargetDSN       string        `name:"target-dsn" help:"Where to copy the tables to." default:"spirit:spirit@tcp(127.0.0.1:3306)/dest"`
-	TargetChunkTime time.Duration `name:"target-chunk-time" help:"Target time for each checksum chunk. The copy phase is sized by an in-memory byte budget and does not use this." default:"5s"`
+	SourceDSN string `name:"source-dsn" help:"Where to copy the tables from." default:"spirit:spirit@tcp(127.0.0.1:3306)/src"`
+	TargetDSN string `name:"target-dsn" help:"Where to copy the tables to." default:"spirit:spirit@tcp(127.0.0.1:3306)/dest"`
+	// TargetChunkTime is the checksum's target read time per chunk. The Kong
+	// default must stay equal to checksum.DefaultTargetChunkTime, which documents
+	// why it is this large and why table.MaxDynamicRowSize usually decides chunk
+	// size before it does.
+	TargetChunkTime time.Duration `name:"target-chunk-time" help:"Target read time for each checksum chunk. The copy phase is sized by an in-memory byte budget and does not use this." default:"10s"`
 	// TargetChunkSize is the in-memory byte budget the buffered copier sizes each
 	// copy chunk against (see table.DefaultTargetChunkBytes). Move always uses the
 	// buffered copier. A zero value means "use the default" (NewRunner fills it

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -173,6 +173,9 @@ func NewRunner(m *Move) (*Runner, error) {
 	if m.TargetChunkSize == 0 {
 		m.TargetChunkSize = table.DefaultTargetChunkBytes
 	}
+	if m.TargetChunkTime == 0 {
+		m.TargetChunkTime = checksum.DefaultTargetChunkTime
+	}
 	r := &Runner{
 		move:   m,
 		logger: slog.Default(),
@@ -364,7 +367,8 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 			// Move always uses the buffered copier, which reads rows into client
 			// memory; size the copy chunker by an in-memory byte budget rather than
 			// copy time, whose signal collapses under write-side backpressure. The
-			// checksum runs server-side and keeps the time signal.
+			// checksum runs server-side and keeps the time signal, and starts at the
+			// row cap rather than ramping up to it (see checksum.ChunkStartRows).
 			copyChunkerCfg := chunkerCfg
 			copyChunkerCfg.TargetChunkBytes = r.move.TargetChunkSize
 			copyChunker, err := table.NewChunker(tbl, copyChunkerCfg)
@@ -374,7 +378,9 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 			if err := r.sources[i].replClient.AddSubscription(tbl, nil, copyChunker); err != nil {
 				return err
 			}
-			checksumChunker, err := table.NewChunker(tbl, chunkerCfg)
+			checksumChunkerCfg := chunkerCfg
+			checksumChunkerCfg.StartingChunkSize = checksum.ChunkStartRows
+			checksumChunker, err := table.NewChunker(tbl, checksumChunkerCfg)
 			if err != nil {
 				return err
 			}
@@ -885,7 +891,8 @@ func (r *Runner) newCopy(ctx context.Context) error {
 			// Move always uses the buffered copier, which reads rows into client
 			// memory; size the copy chunker by an in-memory byte budget rather than
 			// copy time, whose signal collapses under write-side backpressure. The
-			// checksum runs server-side and keeps the time signal.
+			// checksum runs server-side and keeps the time signal, and starts at the
+			// row cap rather than ramping up to it (see checksum.ChunkStartRows).
 			copyChunkerCfg := chunkerCfg
 			copyChunkerCfg.TargetChunkBytes = r.move.TargetChunkSize
 			copyChunker, err := table.NewChunker(tbl, copyChunkerCfg)
@@ -895,7 +902,9 @@ func (r *Runner) newCopy(ctx context.Context) error {
 			if err := r.sources[i].replClient.AddSubscription(tbl, nil, copyChunker); err != nil {
 				return err
 			}
-			checksumChunker, err := table.NewChunker(tbl, chunkerCfg)
+			checksumChunkerCfg := chunkerCfg
+			checksumChunkerCfg.StartingChunkSize = checksum.ChunkStartRows
+			checksumChunker, err := table.NewChunker(tbl, checksumChunkerCfg)
 			if err != nil {
 				return err
 			}

--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -100,6 +100,20 @@ type ChunkerConfig struct {
 	// ColumnMapping describes the column relationship between source and target tables,
 	// including any renames. If nil, a default mapping with no renames is created.
 	ColumnMapping *ColumnMapping
+	// StartingChunkSize overrides the row count the chunker starts — and resets
+	// — at. Zero means the StartingChunkSize constant.
+	//
+	// The constant is deliberately conservative because for a copier the first
+	// chunks are write transactions, so overshooting costs a long lock hold. A
+	// read-only consumer has the opposite asymmetry: overshooting costs one slow
+	// read (and the panic shrink reacts to it within a single chunk), while
+	// undershooting costs the whole pass, because growth is capped at
+	// MaxDynamicStepFactor per feedback window and a window is 10 chunks. Ramping
+	// from 1000 rows to MaxDynamicRowSize needs ~130 chunks — more than many
+	// tables have, so such a consumer can spend its entire life converging and
+	// never reach the size it measured as correct. Those consumers (the checksum)
+	// start at the ceiling and let the sizer shrink instead.
+	StartingChunkSize uint64
 	// Key and Where are used for composite chunkers to specify a non-primary key index.
 	// When Key is set, the composite chunker is always used regardless of whether the
 	// table has an auto-increment primary key.
@@ -134,7 +148,7 @@ func NewChunker(t *TableInfo, config ChunkerConfig) (MappedChunker, error) {
 			Ti:                t,
 			NewTi:             newTable,
 			columnMapping:     config.ColumnMapping,
-			dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: config.TargetChunkTime, TargetChunkBytes: config.TargetChunkBytes},
+			dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: config.TargetChunkTime, TargetChunkBytes: config.TargetChunkBytes, startSize: config.StartingChunkSize},
 			watermarkTracker:  watermarkTracker{lowerBoundWatermarkMap: make(map[string]*Chunk)},
 			logger:            config.Logger,
 		}, nil
@@ -145,7 +159,7 @@ func NewChunker(t *TableInfo, config ChunkerConfig) (MappedChunker, error) {
 		columnMapping:     config.ColumnMapping,
 		keyName:           config.Key,
 		where:             config.Where,
-		dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: config.TargetChunkTime},
+		dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: config.TargetChunkTime, startSize: config.StartingChunkSize},
 		watermarkTracker:  watermarkTracker{lowerBoundWatermarkMap: make(map[string]*Chunk)},
 		logger:            config.Logger,
 	}, nil

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -319,7 +319,7 @@ func (t *chunkerComposite) Reset() error {
 	// Reset all state to initial values
 	t.chunkPtrs = []Datum{} // reset to empty slice (first chunk)
 	t.finalChunkSent = false
-	t.chunkSize = StartingChunkSize
+	t.chunkSize = t.startingChunkSize()
 	t.watermark = nil
 	t.lowerBoundWatermarkMap = make(map[string]*Chunk, 0)
 	t.inflightChunks = 0
@@ -410,7 +410,7 @@ func (t *chunkerComposite) open() (err error) {
 		t.keyName = "PRIMARY"
 	}
 	t.finalChunkSent = false
-	t.chunkSize = StartingChunkSize
+	t.chunkSize = t.startingChunkSize()
 	t.inflightChunks = 0
 	t.checkpointHighPtr = Datum{} // reset checkpoint high pointer
 

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -44,8 +44,11 @@ var _ MappedChunker = &chunkerOptimistic{}
 
 // nextChunkByPrefetching uses prefetching instead of feedback to determine the chunk size.
 // It is used when the chunker detects that there are very large gaps in the sequence.
-// When this mode is enabled, the chunkSize is "reset" to 1000 rows, so we know that
-// t.chunkSize is reliable. It is also expanded again based on feedback.
+// When this mode is enabled, the chunkSize is "reset" to the chunker's starting size,
+// so we know that t.chunkSize is reliable. It is also expanded again based on feedback.
+//
+// In this mode a chunk holds exactly t.chunkSize rows rather than t.chunkSize key
+// values, because the upper bound is found by offsetting into the index.
 func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
 	key := QuoteColumns(t.Ti.KeyColumns[:1])
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s > ? ORDER BY %s LIMIT 1 OFFSET %d",
@@ -83,7 +86,7 @@ func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
 				"min-val", minVal,
 				"max-val", maxVal,
 				"max-dynamic-row-size", MaxDynamicRowSize)
-			t.chunkSize = StartingChunkSize // reset
+			t.chunkSize = t.startingChunkSize() // reset
 			t.chunkPrefetchingEnabled = false
 		}
 
@@ -335,7 +338,7 @@ func (t *chunkerOptimistic) Reset() error {
 	t.chunkPtr = NewNilDatum(t.Ti.keyDatums[0])
 	t.checkpointHighPtr = NewNilDatum(t.Ti.keyDatums[0]) // reset checkpoint high pointer
 	t.finalChunkSent = false
-	t.chunkSize = StartingChunkSize
+	t.chunkSize = t.startingChunkSize()
 	t.watermark = nil
 	t.lowerBoundWatermarkMap = make(map[string]*Chunk, 0)
 	t.inflightChunks = 0
@@ -433,7 +436,7 @@ func (t *chunkerOptimistic) maybeSwitchToPrefetchBytes(newTarget uint64, p90Byte
 // the mutex.
 func (t *chunkerOptimistic) switchToPrefetch() {
 	t.logger.Warn("switching to prefetch algorithm")
-	t.chunkSize = StartingChunkSize // reset
+	t.chunkSize = t.startingChunkSize() // reset
 	t.chunkPrefetchingEnabled = true
 }
 
@@ -468,7 +471,7 @@ func (t *chunkerOptimistic) open() (err error) {
 	t.isOpen = true
 	t.chunkPtr = NewNilDatum(t.Ti.keyDatums[0])
 	t.finalChunkSent = false
-	t.chunkSize = StartingChunkSize
+	t.chunkSize = t.startingChunkSize()
 	t.inflightChunks = 0
 
 	// Initialize progress tracking

--- a/pkg/table/dynamic_chunk_sizer.go
+++ b/pkg/table/dynamic_chunk_sizer.go
@@ -29,6 +29,11 @@ type dynamicChunkSizer struct {
 	TargetChunkBytes uint64
 	chunkByteInfo    []uint64
 
+	// startSize is the row count the chunker starts and resets at. Zero means
+	// the StartingChunkSize constant. See ChunkerConfig.StartingChunkSize for
+	// why a read-only consumer wants a different value than a copier does.
+	startSize uint64
+
 	disableDynamicChunker bool // only used by the test suite
 	// pinnedAtFloor records that we have already warned about the chunk size
 	// being stuck at MinDynamicRowSize. It suppresses the per-chunk
@@ -36,6 +41,21 @@ type dynamicChunkSizer struct {
 	// and is re-armed by updateChunkerTarget once the chunk size climbs back
 	// above the floor. See panicShrink.
 	pinnedAtFloor bool
+}
+
+// startingChunkSize is the row count to start — or reset — at. Callers use it
+// rather than the StartingChunkSize constant so that a chunker configured with
+// its own starting size keeps it across Open, Reset and the optimistic
+// chunker's algorithm switches.
+//
+// The configured value is clamped to the dynamic bounds, but deliberately not
+// through boundaryCheckTargetChunkSize: that caps growth relative to the current
+// chunk size, which is zero (or already shrunk) at the points this is called.
+func (d *dynamicChunkSizer) startingChunkSize() uint64 {
+	if d.startSize == 0 {
+		return StartingChunkSize
+	}
+	return min(max(d.startSize, MinDynamicRowSize), MaxDynamicRowSize)
 }
 
 // panicShrink reacts to a chunk whose processing time blew past the panic

--- a/pkg/table/starting_chunk_size_test.go
+++ b/pkg/table/starting_chunk_size_test.go
@@ -1,0 +1,94 @@
+package table
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startSizeFixture creates a densely-populated table with an auto-increment
+// primary key (so NewChunker picks the optimistic chunker) plus a second table
+// with a composite key, and returns both.
+func startSizeFixture(t *testing.T) (autoInc, composite *TableInfo) {
+	t.Helper()
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS startsize_autoinc, startsize_composite")
+	testutils.RunSQL(t, "CREATE TABLE startsize_autoinc (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, pad VARCHAR(10))")
+	testutils.RunSQL(t, "CREATE TABLE startsize_composite (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a, b))")
+	testutils.RunSQL(t, `INSERT INTO startsize_autoinc (pad)
+		WITH RECURSIVE s(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i < 500) SELECT 'x' FROM s`)
+	testutils.RunSQL(t, `INSERT INTO startsize_composite (a, b)
+		WITH RECURSIVE s(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i < 30) SELECT x.i, y.i FROM s x, s y`)
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	autoInc = NewTableInfo(db, "test", "startsize_autoinc")
+	require.NoError(t, autoInc.SetInfo(t.Context()))
+	composite = NewTableInfo(db, "test", "startsize_composite")
+	require.NoError(t, composite.SetInfo(t.Context()))
+	return autoInc, composite
+}
+
+// TestStartingChunkSizeIsUsedByBothChunkers covers the config knob that lets a
+// read-only consumer (the checksum) skip the ramp the copier needs. Both chunker
+// implementations have to honour it, and it has to survive Reset — otherwise a
+// checksum retry would start over at the copier's size.
+func TestStartingChunkSizeIsUsedByBothChunkers(t *testing.T) {
+	autoInc, composite := startSizeFixture(t)
+
+	for _, tc := range []struct {
+		name string
+		ti   *TableInfo
+	}{
+		{"optimistic", autoInc},
+		{"composite", composite},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			def, err := NewChunker(tc.ti, ChunkerConfig{})
+			require.NoError(t, err)
+			require.NoError(t, def.Open())
+			first, err := def.Next()
+			require.NoError(t, err)
+			assert.Equal(t, uint64(StartingChunkSize), first.ChunkSize,
+				"an unset StartingChunkSize must keep the existing default")
+
+			c, err := NewChunker(tc.ti, ChunkerConfig{StartingChunkSize: 40000})
+			require.NoError(t, err)
+			require.NoError(t, c.Open())
+			first, err = c.Next()
+			require.NoError(t, err)
+			assert.Equal(t, uint64(40000), first.ChunkSize, "the first chunk must already be at the configured size")
+
+			// A checksum that hits its yield timeout or a retryable error resets and
+			// re-reads the table; resetting to the copier's 1000 rows would put the
+			// ramp back in the way.
+			require.NoError(t, c.Reset())
+			first, err = c.Next()
+			require.NoError(t, err)
+			assert.Equal(t, uint64(40000), first.ChunkSize, "Reset must not drop back to the default")
+		})
+	}
+}
+
+// TestStartingChunkSizeIsClamped guards the bounds. The value reaches the sizer
+// from a config struct, so it cannot be assumed sane; and it deliberately does
+// not go through boundaryCheckTargetChunkSize, whose growth cap is relative to
+// the current chunk size and would clamp any starting value to the row floor.
+func TestStartingChunkSizeIsClamped(t *testing.T) {
+	d := dynamicChunkSizer{}
+	assert.Equal(t, uint64(StartingChunkSize), d.startingChunkSize(), "zero means the default")
+
+	d.startSize = MaxDynamicRowSize * 10
+	assert.Equal(t, uint64(MaxDynamicRowSize), d.startingChunkSize())
+
+	d.startSize = 1
+	assert.Equal(t, uint64(MinDynamicRowSize), d.startingChunkSize())
+
+	d.startSize = MaxDynamicRowSize
+	assert.Equal(t, uint64(MaxDynamicRowSize), d.startingChunkSize(),
+		"starting at the ceiling is the checksum's configuration and must survive clamping")
+}


### PR DESCRIPTION
> **Stacked on #1089** — this targets the `checksum-repair-subdivide` branch, so the diff shows only this PR's own change. Retarget once #1089 merges.

This is PR 3 of 3 in the checksum-autoscaling series. PR 1 (#1087) made the checksum throttler-aware and scalable, and added a per-pass measurement of chunk read times specifically to answer one question: *which ceiling is actually binding on checksum chunk size?* PR 2 (#1089) made a mismatch repair proportional to the mismatch rather than to the chunk, so that growing chunks does not grow the repair. This PR reads the measurement and acts on it.

## What the measurement said

A 1M-row, 6-column table (194 MB against a 128 MB buffer pool), `--threads 4`:

```
checksum chunk size distribution chunks=126 target=500ms duration-p50=8ms
  duration-p90=30ms duration-max=44ms rows-p50=5062 rows-max=25624 row-capped=0/126
```

Neither ceiling was binding. The p90 chunk was using **6% of its time budget**, and **not one chunk in 126** reached the row cap. The chunk size ended the pass at 25,624 rows, still climbing.

That is not a tuning problem, it is a convergence problem. The sizer's growth is capped at `MaxDynamicStepFactor` (1.5×) per feedback window, and a window is 10 chunks — so climbing from `StartingChunkSize` (1000 rows) to `MaxDynamicRowSize` (100k) takes roughly **130 chunks**. This table had 126. The checksum spent its entire life converging and never once used the chunk size it had measured as correct. Any table under a few million rows behaves the same way, and raising the time target alone makes it *worse*, not better: a bigger target means a longer climb.

## What this changes

The checksum gets its own two settings, because a chunk's duration bounds different things in the two phases. A copy chunk's time is a write transaction's lifetime — a latency budget that decides how long a row lock is held and how far a replica appears behind. A checksum chunk's time bounds neither: the CRC is aggregated server-side so exactly one row per chunk crosses the wire, and it runs inside a `REPEATABLE READ` snapshot that is held for the whole pass either way.

- **Starting size** — `checksum.ChunkStartRows` (the row cap) instead of `table.StartingChunkSize`. New `ChunkerConfig.StartingChunkSize`, honoured by both chunker implementations and across `Reset` and the optimistic chunker's algorithm switches. This is the change that mattered.
- **Target time** — `--checksum-target-chunk-time` (10s) instead of the copier's `--target-chunk-time` (500ms). For `move`, whose `--target-chunk-time` is already documented as checksum-only, the default moves 5s → 10s instead of adding a flag.

Starting at the cap is safe because the sizer's asymmetry runs the other way from the copier's: it shrinks with **no** per-step cap, and panic-shrinks on any single chunk exceeding `DynamicPanicFactor` × the target. Overshooting costs one slow chunk. Undershooting cost the whole pass.

Same table, after:

| | chunks | rows p50 | duration p90 | at the row cap |
| --- | --- | --- | --- | --- |
| before | 126 | 5,062 | 30ms | 0/126 |
| after | 12 | 100,000 | 162ms | 10/12 |

## What I am *not* claiming

Per-row cost at p50 is unchanged on this box (~1.6µs either way). Read-ahead has little left to win when the storage is a local SSD, and "larger chunks engage InnoDB linear read-ahead and Aurora's batched prefetch" is a claim about network-attached storage that a laptop cannot demonstrate. What the numbers do show is p90 per-row cost falling with the chunk count (5.9µs → 1.6µs) as per-chunk overhead amortises over 20× the rows, and the sizing reaching its bound in two chunks instead of never.

I also did **not** raise `MaxDynamicRowSize`, so this does not deliver literal 10s chunks — at 100k rows the cap binds first, and 10s becomes a safety valve rather than a goal. That is deliberate. The row cap is a bound that can be reasoned about: it is what bounds a repair (PR 2), and what `inspectDifferences` holds in memory on a mismatch. A binding *time* target would instead let chunk size follow load. Raising the cap is a separate decision, and it is now a decision with data behind it — `row-capped` reads 10/12 rather than 0/126, so the instrument PR 1 added will say when the cap is costing something.

## Costs, both bounded by the row cap

- **Throttle latency.** A throttle decision takes effect between chunks (`BlockWait` before dispatch; chunks in flight are never abandoned), so back-off now tracks a chunk's duration rather than 500ms.
- **Small-table parallelism.** A table with fewer than `threads` × 100k rows yields fewer chunks than there are workers. Affordable precisely because it is a small table.
- **Gap prefetch fires sooner.** On an auto-increment key, being at the row cap from chunk one means `maybeSwitchToPrefetch` now fires on the first feedback window rather than never. That is a net gain — in prefetch mode a chunk holds exactly `chunkSize` *rows* rather than `chunkSize` *key values*, so chunks stay uniform across a key space pitted with deletes — at the cost of one index-only `OFFSET` query per chunk.

The continuous (during-copy) checksum is deliberately left on the copier's budget: it shares the copy phase, so it is held to copy-phase latency. `--target-chunk-time`'s help text and the docs now say so, since it no longer covers the cutover checksum.

## Testing

`pkg/table`, `pkg/checksum`, `pkg/copier` and `pkg/migration` pass, `pkg/table` and `pkg/checksum` also under `-race`; `golangci-lint` clean.

New tests cover the starting size on both chunker implementations (including that it survives `Reset`, and that it is clamped to the dynamic bounds without going through the growth-capping path), and the runner wiring that gives the checksum a different profile from the copier — which is the thing a future refactor is most likely to undo silently.

One existing test needed its fixture resized: `advanceRunnerToChecksumWatermarks` seeded 4096 rows to get "more than one chunk on the runway", which is now less than one checksum chunk. It now sizes the runway against `checksum.ChunkStartRows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
