### PR TITLE
autoscale: unify the shared controller mechanism under pkg/autoscale

### DIFF
--- a/pkg/applier/stats_emitter.go
+++ b/pkg/applier/stats_emitter.go
@@ -9,7 +9,7 @@ import (
 )
 
 // statsEmitTick is how often an applier reports its pipeline gauges. It
-// matches the autoscaler's cadence (copier acTick) so the write-thread count
+// matches the autoscalers' cadence (autoscale.Tick) so the write-thread count
 // and the pipeline occupancy it acts on are sampled at the same rate. A var
 // so tests can shorten it.
 var statsEmitTick = 5 * time.Second

--- a/pkg/applier/stats_emitter.go
+++ b/pkg/applier/stats_emitter.go
@@ -5,14 +5,16 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/block/spirit/pkg/autoscale"
 	"github.com/block/spirit/pkg/metrics"
 )
 
-// statsEmitTick is how often an applier reports its pipeline gauges. It
-// matches the autoscalers' cadence (autoscale.Tick) so the write-thread count
-// and the pipeline occupancy it acts on are sampled at the same rate. A var
-// so tests can shorten it.
-var statsEmitTick = 5 * time.Second
+// statsEmitTick is how often an applier reports its pipeline gauges. Matching
+// the autoscalers' cadence is the whole point — the copier's controller
+// arbitrates between its read and write pools on the queue occupancy reported
+// here, so the two must be sampled at the same rate — hence it is derived from
+// autoscale.Tick rather than restating 5s. A var so tests can shorten it.
+var statsEmitTick = autoscale.Tick
 
 // statsProvider is the narrow slice of Applier the emitter needs.
 type statsProvider interface {

--- a/pkg/autoscale/README.md
+++ b/pkg/autoscale/README.md
@@ -1,0 +1,48 @@
+# Autoscale
+
+The `autoscale` package holds the primitives shared by Spirit's phase-level thread-count controllers. Two phases currently scale their worker pools at runtime — the copier's read/write pools ([issue #831](https://github.com/block/spirit/issues/831)) and the checksum's reader pool ([#1087](https://github.com/block/spirit/pull/1087)) — and both apply the same control law to different pools. Defining that law once means the two cannot silently drift apart.
+
+Autoscaling is experimental and opt-in via `--enable-experimental-autoscaling`. Nothing here runs unless it is set.
+
+## The zone law
+
+Each tick, a controller classifies the throttler's continuous utilization signal (0 = idle, 1.0 = exactly where the binary hard-stop flips) with `Classify`:
+
+| Utilization | `Action` | Move |
+| --- | --- | --- |
+| `< LowWatermark` (0.4) | `Grow` | +1 thread |
+| `[LowWatermark, HighWatermark)` | `Hold` | nothing |
+| `[HighWatermark, PanicThreshold)` (0.7–1.0) | `Shed` | −1 thread |
+| `>= PanicThreshold` (1.0) | `Halve` | halve the pool |
+
+The shape is "gentle in the normal regime, abrupt only in emergencies". The full derivation — why additive steps rather than classic AIMD, why the dead band has hysteresis, and why the resting point depends on which side the band is approached from — lives on `copier.autoScaler`, where it was first worked out. This package holds only the mechanism.
+
+`MinVCPUs` (4) is part of the law rather than of any phase: the signal's denominator is the instance vCPU count, so below it one thread is half or a third of the whole scale and no dead band is wide enough to rest in. The migration runner enforces it once at setup by disabling autoscaling for the whole migration.
+
+## What the controllers share
+
+- **`Gate`** turns one tick's signals (`Inputs`) into a `Plan`. It owns the precedence between the zones, a caller-supplied veto, and the cooldown bookkeeping — the part most likely to drift if each phase kept its own copy, and the hardest to notice when it does. Precedence, highest first: `Halve`, then the veto, then `Shed`, `Grow`, and recovery inside the dead band.
+
+  `Decide` is pure; the caller reports back with `Applied` or `Idle`. That split exists because a controller may legitimately decline a permitted plan — the copier does not grow a balanced pipeline — and must not burn a cooldown for a move it never made.
+
+  Increases and decreases hold independent cooldowns. A decrease also arms the increase cooldown (so a shed is not immediately undone by a signal that has not yet reflected the cut), but not the reverse: a fresh overload must be answerable at once, even right after the increase that likely caused it.
+
+- **`Ceiling`** resolves a scalable pool's upper bound: the start value when scaling is off, twice it when on. The migration runner sizes the connection pool from the same number the phases cap themselves with, so a scaled-up pool never starves on connections.
+
+- **`RunTicker`** and **`Emit`** are the loop and the best-effort gauge send every controller repeats. A controller must never stall or fail a migration because a metrics sink is unavailable, so `Emit` bounds the send and logs failures at Debug.
+
+- **`Limiter`** is a concurrency gate whose limit can change while work is in flight. `errgroup.SetLimit` cannot: the errgroup contract forbids changing the limit while any goroutine in the group is active, so a phase that wants to be resized mid-pass needs its own gate. Shrinking never interrupts in-flight work — for the checksum a cancelled chunk is wasted I/O that has to be redone — the reduction is absorbed by subsequent releases instead.
+
+## What stays with each phase
+
+Everything genuinely phase-specific: how big a step is, which pool it lands on, and what may veto one.
+
+- **Copier** ([`pkg/copier`](../copier/README.md)) has two pools fed by one signal, so utilization alone cannot say which to grow. The applier queue between them arbitrates: starved → readers are the bottleneck, full → writers are. A balanced pipeline holds. The write side additionally refuses to grow when the redo-aware Aurora signal has no commit-latency backstop (`throttler.ResolveMaxWriteThreads`).
+- **Checksum** ([`pkg/checksum`](../checksum/README.md)) has one pool and no arbitration, plus a veto the utilization signal cannot see: the change feed's post-flush residual. A feed losing ground means the checksum's reads are winning a race against writes that actually have to finish, so a worker is shed — on stock MySQL as well as Aurora, where there is no continuous signal at all.
+
+## See Also
+
+- [pkg/throttler](../throttler/README.md) — the source of the continuous signal (`GradualThrottler`) and of the binary hard-stop underneath all of this
+- [pkg/copier](../copier/README.md) — the write/read autoscaler and the law's derivation
+- [pkg/checksum](../checksum/README.md) — the checksum controller and its backlog veto
+- [docs/migrate.md](../../docs/migrate.md) — operator-facing documentation for `--enable-experimental-autoscaling`

--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -1,17 +1,28 @@
 // Package autoscale holds the primitives shared by spirit's phase-level
 // thread-count controllers.
 //
-// Two things live here because more than one phase needs them and neither
-// belongs to a single phase's package:
+// Everything here is needed by more than one phase and belongs to none of them:
 //
-//   - The utilization zone law (the watermark/cooldown constants and
-//     Classify). The copier's write/read autoscaler and the checksum
-//     controller apply the same law to different pools; defining the
-//     thresholds once means they cannot silently drift apart.
+//   - The utilization zone law: the watermark/cooldown constants, Classify, and
+//     MinVCPUs (the instance size below which the signal is too coarse for the
+//     law to work at all). The copier's write/read autoscaler and the checksum
+//     controller apply the same law to different pools; defining the thresholds
+//     once means they cannot silently drift apart.
+//   - Gate (in controller.go), which turns one tick's signals into a Plan. It
+//     owns the precedence between the zones, a caller-supplied veto, and the
+//     cooldown bookkeeping — the part most likely to drift if each phase kept its
+//     own copy, and the hardest to notice when it does.
+//   - The plumbing every controller repeats: Ceiling for a scalable pool's upper
+//     bound, RunTicker for the tick loop, Emit for best-effort gauges.
 //   - Limiter, a concurrency gate whose limit can change while work is in
 //     flight. errgroup.SetLimit cannot: the errgroup contract forbids
 //     modifying the limit while any goroutine in the group is active, so a
 //     phase that wants to be resized mid-pass needs its own gate.
+//
+// What stays with each phase is what is genuinely phase-specific: how big a step
+// is, which pool it lands on, and what may veto one. The copier apportions a
+// step between its read and write pools using the applier queue; the checksum has
+// one pool and a change-feed backlog veto.
 //
 // The law's rationale — why additive steps with a multiplicative panic
 // backoff, and why the dead band has hysteresis — is documented at length on
@@ -43,6 +54,19 @@ const (
 	// it may fire again, giving the change time to register in the signal.
 	// Increases and decreases hold independent cooldowns.
 	CooldownTicks = 2
+	// MinVCPUs is the smallest instance size (in vCPUs) on which a controller is
+	// allowed to engage at all. It is a property of the law above rather than of
+	// any one phase: the utilization signal's denominator is the vCPU count, so
+	// below this one thread is half or a third of the whole scale and no dead band
+	// is wide enough to rest in — the controller can only oscillate. Observed in
+	// staging on r6g.large (2 vCPUs): the write-thread count ping-ponged 1↔2
+	// indefinitely (issue #831). At 4+ vCPUs the worst-case per-thread step (0.25)
+	// fits inside the dead band.
+	//
+	// The migration runner enforces it once, at setup, by disabling autoscaling
+	// for the whole migration; the controllers themselves never see a small
+	// instance.
+	MinVCPUs = 4
 )
 
 // Tick is how often a controller should re-evaluate. Aligned with the

--- a/pkg/autoscale/autoscale_test.go
+++ b/pkg/autoscale/autoscale_test.go
@@ -32,6 +32,17 @@ func TestClassifyZones(t *testing.T) {
 	}
 }
 
+// TestMinVCPUsFitsTheDeadBand pins the relationship MinVCPUs exists for: on the
+// smallest instance the law engages on, one thread's worth of utilization
+// (1/vCPUs) must fit inside the dead band, or a single +1 vaults across it and
+// ping-pongs with the -1 path (the r6g.large oscillation in issue #831). If a
+// watermark moves, this says whether MinVCPUs has to move with it.
+func TestMinVCPUsFitsTheDeadBand(t *testing.T) {
+	step := 1.0 / float64(MinVCPUs)
+	assert.Less(t, step, HighWatermark-LowWatermark,
+		"one thread's utilization step must be narrower than the dead band")
+}
+
 func TestCeilDiv(t *testing.T) {
 	// The point of ceil is that halving never lands on zero, and 3 backs off
 	// to 2 rather than 1.

--- a/pkg/autoscale/controller.go
+++ b/pkg/autoscale/controller.go
@@ -1,0 +1,200 @@
+package autoscale
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/block/spirit/pkg/metrics"
+)
+
+// Ceiling resolves the upper bound of a scalable pool: the start value when
+// scaling is disabled (so the pool cannot move), twice it when enabled.
+//
+// It is here rather than in either phase because the migration runner sizes the
+// connection pool from the same number the phases cap themselves with — threads
+// scaled above the connection budget would just queue on the sql.DB pool,
+// buying no parallelism — and three copies of "2 ×" invite drift. Callers with
+// an extra rule of their own wrap this rather than reimplementing it (see
+// throttler.ResolveMaxWriteThreads, which additionally refuses to grow the write
+// pool when the redo-aware signal has no commit-latency backstop).
+//
+// The floor of 1 matters for pool sizing: a zero or negative start would
+// otherwise under-budget the connection pool for a phase that always runs at
+// least one worker.
+func Ceiling(start int, enabled bool) int {
+	start = max(start, 1)
+	if !enabled {
+		return start
+	}
+	return 2 * start
+}
+
+// RunTicker drives fn every interval until ctx is cancelled. Controllers keep
+// their tick step as a separate method so tests can drive it directly without
+// real time; this is only the loop around it.
+func RunTicker(ctx context.Context, interval time.Duration, fn func(context.Context)) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fn(ctx)
+		}
+	}
+}
+
+// Emit sends one tick's gauges, or does nothing when sink is nil. The send is
+// bounded by metrics.SinkTimeout and a failure is logged at Debug: a controller
+// must never stall or fail a migration because a metrics sink is unavailable.
+//
+// Callers compose their own value list, because which gauges are meaningful
+// differs per phase — notably, a phase with no continuous signal omits
+// utilization rather than reporting a hard zero, which on a dashboard would read
+// as "completely idle" instead of "not measured".
+func Emit(ctx context.Context, sink metrics.Sink, logger *slog.Logger, values ...metrics.MetricValue) {
+	if sink == nil {
+		return
+	}
+	sendCtx, cancel := context.WithTimeout(ctx, metrics.SinkTimeout)
+	defer cancel()
+	if err := sink.Send(sendCtx, &metrics.Metrics{Values: values}); err != nil {
+		logger.Debug("autoscaler metrics send failed", "error", err)
+	}
+}
+
+// Plan is what a controller is permitted to do on one tick: the zone law's
+// verdict after cooldowns and any caller-supplied veto have been applied.
+//
+// It says what kind of move is allowed, not how big it is or which pool it lands
+// on. Those stay with the controller: the copier apportions a step between its
+// read and write pools using the applier queue, while the checksum has a single
+// pool and no arbitration to do.
+type Plan int
+
+const (
+	// PlanNone means nothing may change this tick — the dead band, or a
+	// cooldown still running, or growth suppressed with nothing to shed.
+	PlanNone Plan = iota
+	// PlanHalve is the multiplicative backoff of the panic zone.
+	PlanHalve
+	// PlanShed is the additive decrease of the soft-overload zone.
+	PlanShed
+	// PlanShedVeto is an additive decrease demanded by the caller's veto rather
+	// than by utilization. It is distinguished from PlanShed so the controller
+	// can log the real reason, and so a controller that must record having paid
+	// for the veto can tell the two apart.
+	PlanShedVeto
+	// PlanGrow is the additive increase of the headroom zone.
+	PlanGrow
+	// PlanRecover is an additive increase back toward the configured start
+	// value, offered inside the dead band. It exists for phases that shed for a
+	// reason unrelated to utilization and would otherwise sit on the reduced
+	// count for the rest of the run — a signal saying "no longer overloaded" is
+	// enough to undo such a shed, whereas going *past* the operator's configured
+	// count requires positive headroom (PlanGrow).
+	PlanRecover
+)
+
+// Inputs is one tick's worth of signals for Gate.Decide.
+type Inputs struct {
+	// Zone is the utilization verdict, from Classify. A controller with no
+	// continuous signal passes Hold, which leaves recovery available but rules
+	// out growth.
+	Zone Action
+	// Veto, when set, sheds a thread and outranks the zone law's Shed, Grow and
+	// Hold — but not Halve. It is for pressure the utilization signal cannot
+	// see: the checksum's change-feed backlog is a hard prerequisite for
+	// finishing a migration while contributing almost nothing to server load.
+	Veto bool
+	// GrowthBlocked suppresses PlanGrow and PlanRecover without shedding
+	// anything. Two cases need it: a veto that has already been paid for this
+	// window (otherwise the intervening ticks would grow straight back into the
+	// shed and the two signals would cancel out), and a veto signal that has
+	// gone stale, where freezing is right but shedding on no evidence is not.
+	GrowthBlocked bool
+	// CanRecover enables PlanRecover — typically "the live count is below the
+	// configured start".
+	CanRecover bool
+}
+
+// Gate owns the cooldown bookkeeping every controller needs and turns Inputs
+// into a Plan. It is a value type; the zero value is ready to use.
+//
+// Increases and decreases hold independent cooldowns. That asymmetry is
+// load-bearing: a fresh overload must be able to shed immediately even right
+// after an increase — which likely caused it — while consecutive decreases still
+// space themselves out far enough for the signal to reflect the previous cut.
+type Gate struct {
+	up, down int
+}
+
+// Decide resolves one tick. It is pure: the caller records the outcome with
+// Applied or Idle, because whether a permitted plan was actually carried out is
+// the controller's business (the copier declines to grow a balanced pipeline
+// even when the zone law allows it, and must not burn a cooldown for a move it
+// did not make).
+//
+// Precedence, highest first:
+//
+//  1. Halve. Both this and a veto shed, and this sheds faster, so it has to come
+//     first — otherwise a tick spent inside the veto's cooldown would consume the
+//     panic response and downgrade the backoff to one thread per cooldown at
+//     exactly the moment the server is most overloaded.
+//  2. The veto, which therefore outranks Shed, Grow and Hold. Utilization can
+//     show plenty of headroom while a caller-visible prerequisite falls behind.
+//  3. The zone law: Shed, then Grow, then recovery inside the dead band.
+func (g *Gate) Decide(in Inputs) Plan {
+	switch {
+	case in.Zone == Halve:
+		// Gated on the down cooldown only, so the first breach is never delayed
+		// by a recent increase's cooldown.
+		if g.down == 0 {
+			return PlanHalve
+		}
+	case in.Veto:
+		if g.down == 0 {
+			return PlanShedVeto
+		}
+	case in.Zone == Shed:
+		if g.down == 0 {
+			return PlanShed
+		}
+	case in.Zone == Grow:
+		if !in.GrowthBlocked && g.up == 0 {
+			return PlanGrow
+		}
+	default: // Hold, which doubles as the recovery path.
+		if in.CanRecover && !in.GrowthBlocked && g.up == 0 {
+			return PlanRecover
+		}
+	}
+	return PlanNone
+}
+
+// Applied arms the cooldowns for a plan the controller carried out. Any decrease
+// arms the up cooldown too, so a shed is not immediately undone by a growth
+// signal that has not yet had time to reflect the cut.
+func (g *Gate) Applied(p Plan) {
+	switch p {
+	case PlanHalve, PlanShed, PlanShedVeto:
+		g.down = CooldownTicks
+		g.up = CooldownTicks
+	case PlanGrow, PlanRecover:
+		g.up = CooldownTicks
+	case PlanNone:
+	}
+}
+
+// Idle records a tick on which nothing changed — the dead band, a declined
+// plan, or a cooldown still running — and decays the cooldowns toward zero.
+func (g *Gate) Idle() {
+	if g.up > 0 {
+		g.up--
+	}
+	if g.down > 0 {
+		g.down--
+	}
+}

--- a/pkg/autoscale/controller_test.go
+++ b/pkg/autoscale/controller_test.go
@@ -1,0 +1,200 @@
+package autoscale
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestCeiling(t *testing.T) {
+	// Disabled means the pool cannot move; enabled doubles.
+	assert.Equal(t, 4, Ceiling(4, false))
+	assert.Equal(t, 8, Ceiling(4, true))
+	// The floor of 1 keeps a zero/negative start from under-budgeting the
+	// connection pool for a phase that always runs at least one worker.
+	assert.Equal(t, 1, Ceiling(0, false))
+	assert.Equal(t, 2, Ceiling(0, true))
+	assert.Equal(t, 1, Ceiling(-3, false))
+}
+
+// TestGateZoneActions pins the plan each zone yields from a rested gate.
+func TestGateZoneActions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Inputs
+		want Plan
+	}{
+		{"panic halves", Inputs{Zone: Halve}, PlanHalve},
+		{"soft overload sheds", Inputs{Zone: Shed}, PlanShed},
+		{"headroom grows", Inputs{Zone: Grow}, PlanGrow},
+		{"dead band holds", Inputs{Zone: Hold}, PlanNone},
+		{"dead band recovers when below start", Inputs{Zone: Hold, CanRecover: true}, PlanRecover},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var g Gate
+			assert.Equal(t, tc.want, g.Decide(tc.in))
+		})
+	}
+}
+
+// TestGateVetoPrecedence pins the ordering that makes the veto useful without
+// letting it weaken the panic response: it outranks Shed, Grow and Hold, but
+// Halve outranks it.
+func TestGateVetoPrecedence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Inputs
+		want Plan
+	}{
+		{"veto beats headroom", Inputs{Zone: Grow, Veto: true}, PlanShedVeto},
+		{"veto beats the dead band", Inputs{Zone: Hold, Veto: true}, PlanShedVeto},
+		{"veto beats recovery", Inputs{Zone: Hold, Veto: true, CanRecover: true}, PlanShedVeto},
+		{"veto subsumes shed", Inputs{Zone: Shed, Veto: true}, PlanShedVeto},
+		{"panic beats the veto", Inputs{Zone: Halve, Veto: true}, PlanHalve},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var g Gate
+			assert.Equal(t, tc.want, g.Decide(tc.in))
+		})
+	}
+}
+
+// TestGateGrowthBlockedSuppressesIncreasesOnly is the "already paid, or stale"
+// case: increases stop, but nothing is shed on no evidence, and a real overload
+// still sheds.
+func TestGateGrowthBlockedSuppressesIncreasesOnly(t *testing.T) {
+	var g Gate
+	assert.Equal(t, PlanNone, g.Decide(Inputs{Zone: Grow, GrowthBlocked: true}))
+	assert.Equal(t, PlanNone, g.Decide(Inputs{Zone: Hold, GrowthBlocked: true, CanRecover: true}))
+	assert.Equal(t, PlanShed, g.Decide(Inputs{Zone: Shed, GrowthBlocked: true}))
+	assert.Equal(t, PlanHalve, g.Decide(Inputs{Zone: Halve, GrowthBlocked: true}))
+	// GrowthBlocked is about growth; it must not neuter an active veto.
+	assert.Equal(t, PlanShedVeto, g.Decide(Inputs{Zone: Grow, Veto: true, GrowthBlocked: true}))
+}
+
+// TestGateCooldownSpacesRepeatedMoves walks the cooldown decay: a carried-out
+// plan blocks the same direction for CooldownTicks idle ticks and is permitted
+// again on the next one.
+func TestGateCooldownSpacesRepeatedMoves(t *testing.T) {
+	var g Gate
+	require.Equal(t, PlanGrow, g.Decide(Inputs{Zone: Grow}))
+	g.Applied(PlanGrow)
+
+	for i := range CooldownTicks {
+		require.Equal(t, PlanNone, g.Decide(Inputs{Zone: Grow}), "tick %d should still be cooling down", i)
+		g.Idle()
+	}
+	assert.Equal(t, PlanGrow, g.Decide(Inputs{Zone: Grow}), "growth should be permitted once the cooldown decays")
+}
+
+// TestGateDecreaseAlsoArmsTheUpCooldown pins the asymmetry documented on Gate:
+// a shed blocks growth too (so it isn't immediately undone by a signal that has
+// not yet reflected the cut), while a growth does NOT block shedding (a fresh
+// overload — likely caused by that growth — must be answerable at once).
+func TestGateDecreaseAlsoArmsTheUpCooldown(t *testing.T) {
+	var g Gate
+	g.Applied(PlanShed)
+	assert.Equal(t, PlanNone, g.Decide(Inputs{Zone: Grow}), "a shed must block growth")
+	assert.Equal(t, PlanNone, g.Decide(Inputs{Zone: Hold, CanRecover: true}), "a shed must block recovery")
+
+	var g2 Gate
+	g2.Applied(PlanGrow)
+	assert.Equal(t, PlanShed, g2.Decide(Inputs{Zone: Shed}), "a growth must not delay shedding")
+	assert.Equal(t, PlanHalve, g2.Decide(Inputs{Zone: Halve}), "a growth must not delay the panic response")
+	assert.Equal(t, PlanShedVeto, g2.Decide(Inputs{Zone: Grow, Veto: true}), "a growth must not delay the veto")
+}
+
+// TestGateDeclinedPlanKeepsCooldownUnspent is the reason Decide is pure: the
+// copier legitimately declines a permitted PlanGrow when the pipeline is
+// balanced, and must not burn a cooldown for a move it never made.
+func TestGateDeclinedPlanKeepsCooldownUnspent(t *testing.T) {
+	var g Gate
+	require.Equal(t, PlanGrow, g.Decide(Inputs{Zone: Grow}))
+	g.Idle() // declined
+	assert.Equal(t, PlanGrow, g.Decide(Inputs{Zone: Grow}), "a declined plan must leave the cooldown unspent")
+}
+
+// TestGateIdleDoesNotUnderflow guards the counters against going negative on a
+// long quiet stretch, which would make a later Applied's cooldown ineffective.
+func TestGateIdleDoesNotUnderflow(t *testing.T) {
+	var g Gate
+	for range 20 {
+		g.Idle()
+	}
+	assert.Equal(t, Gate{}, g)
+	g.Applied(PlanShed)
+	assert.Equal(t, PlanNone, g.Decide(Inputs{Zone: Shed}))
+}
+
+func TestRunTickerCallsUntilCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		RunTicker(ctx, time.Millisecond, func(context.Context) { calls.Add(1) })
+	}()
+
+	require.Eventually(t, func() bool { return calls.Load() >= 3 }, 2*time.Second, time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunTicker did not return after cancellation")
+	}
+	// No tick may land after the loop returns — a controller mutating pool sizes
+	// on a cancelled context would race the phase's teardown.
+	settled := calls.Load()
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, settled, calls.Load())
+}
+
+type recordingSink struct {
+	sent atomic.Int64
+	err  error
+	last atomic.Pointer[metrics.Metrics]
+}
+
+func (s *recordingSink) Send(_ context.Context, m *metrics.Metrics) error {
+	s.sent.Add(1)
+	s.last.Store(m)
+	return s.err
+}
+
+func TestEmitSendsValues(t *testing.T) {
+	sink := &recordingSink{}
+	Emit(context.Background(), sink, discardLogger(),
+		metrics.MetricValue{Name: "threads", Type: metrics.GAUGE, Value: 4})
+
+	require.Equal(t, int64(1), sink.sent.Load())
+	require.Len(t, sink.last.Load().Values, 1)
+	assert.Equal(t, "threads", sink.last.Load().Values[0].Name)
+}
+
+func TestEmitNilSinkIsANoop(t *testing.T) {
+	// Metrics are optional; a phase with no sink configured must not panic.
+	Emit(context.Background(), nil, discardLogger(),
+		metrics.MetricValue{Name: "threads", Type: metrics.GAUGE, Value: 4})
+}
+
+func TestEmitSwallowsSinkErrors(t *testing.T) {
+	// An unavailable sink must never stall or fail a migration.
+	sink := &recordingSink{err: errors.New("sink down")}
+	Emit(context.Background(), sink, discardLogger(),
+		metrics.MetricValue{Name: "threads", Type: metrics.GAUGE, Value: 4})
+	assert.Equal(t, int64(1), sink.sent.Load())
+}

--- a/pkg/checksum/autoscaler.go
+++ b/pkg/checksum/autoscaler.go
@@ -3,7 +3,6 @@ package checksum
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"github.com/block/spirit/pkg/autoscale"
 	"github.com/block/spirit/pkg/metrics"
@@ -111,11 +110,9 @@ type checksumScaler struct {
 
 	min, start, max int
 	current         int
-	// upCooldown gates increases; downCooldown gates decreases. Separate so a
-	// fresh overload can shed immediately even right after an increase (which
-	// likely caused it), while consecutive sheds are still spaced out enough
-	// for the signal to reflect the previous cut.
-	upCooldown, downCooldown int
+	// gate holds the cooldown state and resolves the zone law (plus the backlog
+	// veto) into the move this tick may make. See autoscale.Gate.
+	gate autoscale.Gate
 	// Residual-tracking state, all owned by observeBacklog. lastFlushes is the
 	// flush counter at the most recent evaluation, so a residual is compared only
 	// once per flush; prevResidual the previous flush's residual, or -1 before any
@@ -176,44 +173,25 @@ func newChecksumScaler(t throttler.Throttler, limiter *autoscale.Limiter, backlo
 // run drives the control loop until ctx is cancelled. Callers start it per
 // pass, so a yield/resume cycle gets a fresh controller at start.
 func (s *checksumScaler) run(ctx context.Context) {
-	ticker := time.NewTicker(csTick)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			s.tick(ctx)
-		}
-	}
+	autoscale.RunTicker(ctx, csTick, s.tick)
 }
 
 // tick performs a single control step. Split out so tests can drive it
 // directly without real time.
 //
-// Precedence, highest first:
+// The precedence — panic zone, then the backlog veto, then the zone law, with
+// recovery inside the dead band — lives in autoscale.Gate, which the copier's
+// controller shares. What is specific to the checksum is the veto itself and
+// the fact that there is one pool to move rather than two:
 //
-//  1. The utilization panic zone. Both this and the backlog veto shed, and
-//     this sheds faster (multiplicatively), so it has to be evaluated first:
-//     if the veto were checked ahead of it, a tick spent inside the veto's
-//     cooldown would consume the panic response and downgrade backoff to -1
-//     per cooldown at exactly the moment the server is most overloaded.
-//  2. The backlog veto, which therefore outranks Grow, Hold and Shed.
-//     Utilization can show plenty of headroom while the feed still falls
-//     behind, because the feed's writes are a small share of server load but a
-//     hard prerequisite for finishing the migration.
-//  3. The utilization zone law.
-//
-// The Hold case doubles as the recovery path. Without it a transient backlog
-// would permanently cost throughput for the rest of the pass: on stock MySQL
-// there is no other way back up at all, and on Aurora the dead band would sit
-// on the reduced count indefinitely. Recovery stops at the configured start —
-// growing beyond what the operator asked for requires a positive headroom
-// signal, not merely the absence of a negative one.
-//
-// Both increase paths additionally require the backlog signal to be live rather
-// than merely quiet (see backlogStale), so a feed whose flushes have stopped
-// completing freezes the count instead of letting it climb.
+//   - The Grow and recovery paths additionally require the backlog signal to be
+//     live rather than merely quiet (see backlogStale), so a feed whose flushes
+//     have stopped completing freezes the count instead of letting it climb.
+//   - Recovery stops at the configured start. Growing beyond what the operator
+//     asked for requires a positive headroom signal, not merely the absence of a
+//     negative one. Without recovery at all, a transient backlog would cost
+//     throughput for the rest of the pass: on stock MySQL there is no other way
+//     back up, and on Aurora the dead band would sit on the reduced count.
 func (s *checksumScaler) tick(ctx context.Context) {
 	util := 0.0
 	zone := autoscale.Hold
@@ -221,76 +199,46 @@ func (s *checksumScaler) tick(ctx context.Context) {
 		util = s.gradual.Utilization()
 		zone = autoscale.Classify(util)
 	}
-	backlogVeto := s.observeBacklog()
-	// Growth needs a *live* absence of backlog pressure, not merely the absence
-	// of a verdict. See backlogStale.
-	growthBlocked := s.backlogLosing || s.backlogStale()
+	plan := s.gate.Decide(autoscale.Inputs{
+		Zone: zone,
+		Veto: s.observeBacklog(),
+		// Growth needs a *live* absence of backlog pressure, not merely the
+		// absence of a verdict: the veto is one-shot per flush, so without this
+		// the remaining ticks of a losing window would grow straight back into
+		// the shed and the two signals would cancel out. backlogStale covers the
+		// other case, a verdict computed from data that stopped arriving.
+		GrowthBlocked: s.backlogLosing || s.backlogStale(),
+		CanRecover:    s.current < s.start,
+	})
 
-	acted := false
-	switch {
-	case zone == autoscale.Halve:
-		// The hard stop is typically already firing on raw samples in this
-		// zone, so the pass is being paused anyway; halving is about resuming
-		// gently. Gated on the down cooldown only, so the first breach is
-		// never delayed by a recent increase's cooldown.
-		if s.downCooldown == 0 {
-			s.set(autoscale.CeilDiv(s.current, 2), "utilization at panic threshold")
-			s.shedCooldowns()
-			acted = true
-		}
-	case backlogVeto:
-		// The feed is losing ground. Shed one worker to hand read capacity
-		// back to it. This is the only shedding lever on stock MySQL.
-		if s.downCooldown == 0 {
-			s.set(s.current-1, "change-feed backlog not draining")
-			s.shedForFlush = true
-			s.shedCooldowns()
-			acted = true
-		}
-	case zone == autoscale.Shed:
-		if s.downCooldown == 0 {
-			s.set(s.current-1, "utilization above high watermark")
-			s.shedCooldowns()
-			acted = true
-		}
-	case zone == autoscale.Grow:
-		// Also gated on backlogLosing. The veto above is deliberately one-shot
-		// per window, so without this the other ticks of a losing window would
-		// grow straight back into the shed and the two signals would cancel out.
-		if !growthBlocked && s.upCooldown == 0 {
-			s.set(s.current+1, "utilization below low watermark")
-			s.upCooldown = autoscale.CooldownTicks
-			acted = true
-		}
-	default: // Hold, or no continuous signal at all.
-		// Gated on backlogLosing for the same reason, not on the one-shot veto:
-		// the veto clears as soon as it is acted on, so recovering on its absence
-		// would hand the worker straight back while the feed is still behind.
-		if !growthBlocked && s.current < s.start && s.upCooldown == 0 {
-			s.set(s.current+1, "recovering toward configured thread count")
-			s.upCooldown = autoscale.CooldownTicks
-			acted = true
-		}
+	acted := true
+	switch plan {
+	case autoscale.PlanHalve:
+		// The hard stop is typically already firing on raw samples in this zone,
+		// so the pass is being paused anyway; halving is about resuming gently.
+		s.set(autoscale.CeilDiv(s.current, 2), "utilization at panic threshold")
+	case autoscale.PlanShedVeto:
+		// The feed is losing ground. Shed one worker to hand read capacity back
+		// to it. This is the only shedding lever on stock MySQL. Recording the
+		// shed here is what caps one flush at one worker however many ticks pass
+		// before the next flush.
+		s.set(s.current-1, "change-feed backlog not draining")
+		s.shedForFlush = true
+	case autoscale.PlanShed:
+		s.set(s.current-1, "utilization above high watermark")
+	case autoscale.PlanGrow:
+		s.set(s.current+1, "utilization below low watermark")
+	case autoscale.PlanRecover:
+		s.set(s.current+1, "recovering toward configured thread count")
+	case autoscale.PlanNone:
+		acted = false
 	}
-
-	if !acted {
-		// Nothing to do, or waiting out a cooldown after a recent change.
-		if s.upCooldown > 0 {
-			s.upCooldown--
-		}
-		if s.downCooldown > 0 {
-			s.downCooldown--
-		}
+	if acted {
+		s.gate.Applied(plan)
+	} else {
+		s.gate.Idle()
 	}
 	s.emit(ctx, util)
-}
-
-// shedCooldowns is applied after any decrease. It sets the up cooldown too, so
-// a shed is not immediately undone by a growth signal that has not yet had time
-// to reflect the cut.
-func (s *checksumScaler) shedCooldowns() {
-	s.downCooldown = autoscale.CooldownTicks
-	s.upCooldown = autoscale.CooldownTicks
 }
 
 // observeBacklog samples the change feed and reports whether the veto is in
@@ -404,24 +352,15 @@ func (s *checksumScaler) set(target int, reason string) {
 
 // emit reports the live thread count and observed utilization every tick.
 func (s *checksumScaler) emit(ctx context.Context, util float64) {
-	if s.metricsSink == nil {
-		return
-	}
-	m := &metrics.Metrics{
-		Values: []metrics.MetricValue{
-			{Name: metrics.ChecksumThreadsMetricName, Type: metrics.GAUGE, Value: float64(s.current)},
-		},
+	values := []metrics.MetricValue{
+		{Name: metrics.ChecksumThreadsMetricName, Type: metrics.GAUGE, Value: float64(s.current)},
 	}
 	// Utilization is only meaningful when a continuous signal exists; emitting
 	// a hard zero on stock MySQL would read as "completely idle" on dashboards
 	// rather than "not measured".
 	if s.gradual != nil {
-		m.Values = append(m.Values,
+		values = append(values,
 			metrics.MetricValue{Name: metrics.ThrottlerUtilizationMetricName, Type: metrics.GAUGE, Value: util})
 	}
-	sendCtx, cancel := context.WithTimeout(ctx, metrics.SinkTimeout)
-	defer cancel()
-	if err := s.metricsSink.Send(sendCtx, m); err != nil {
-		s.logger.Debug("checksum autoscaler metrics send failed", "error", err)
-	}
+	autoscale.Emit(ctx, s.metricsSink, s.logger, values...)
 }

--- a/pkg/copier/README.md
+++ b/pkg/copier/README.md
@@ -368,4 +368,5 @@ See `pkg/throttler` for details on throttler implementations.
 - [pkg/table](../table/README.md) - Chunking strategies and progress tracking
 - [pkg/applier](../applier/README.md) - Buffered copier's write layer
 - [pkg/throttler](../throttler/README.md) - Rate limiting and system protection
+- [pkg/autoscale](../autoscale/README.md) - The zone law, cooldown gate and resizable limiter shared with the checksum controller
 - [DBLog Paper](https://netflixtechblog.com/dblog-a-generic-change-data-capture-framework-69351fb9099b) - Inspiration for buffered copier

--- a/pkg/copier/autoscaler.go
+++ b/pkg/copier/autoscaler.go
@@ -247,6 +247,12 @@ func (a *autoScaler) tick(ctx context.Context) {
 	// here is apportioning the permitted move between the two pools. The copier
 	// supplies no veto — the queue is an arbiter, not a signal of its own, and it
 	// decides *where* a step lands rather than whether one is allowed.
+	//
+	// It supplies no CanRecover either, so PlanShedVeto and PlanRecover cannot
+	// occur today. They are still folded into the shed and grow arms below rather
+	// than given a no-op arm of their own: a future veto or recovery signal wired
+	// into the Inputs above should then take effect, not silently do nothing while
+	// the Gate believes the copier declined it.
 	plan := a.gate.Decide(autoscale.Inputs{Zone: autoscale.Classify(util)})
 
 	acted := true
@@ -264,7 +270,7 @@ func (a *autoScaler) tick(ctx context.Context) {
 		if a.reader != nil {
 			a.setRead(autoscale.CeilDiv(a.readCurrent, 2))
 		}
-	case autoscale.PlanShed:
+	case autoscale.PlanShed, autoscale.PlanShedVeto:
 		// Additive decrease, the mirror image of the increase path. Shedding one
 		// thread at a time avoids the halve-and-reclimb sawtooth on a signal our
 		// own workers largely produce. A starved queue means idle writers — the
@@ -279,7 +285,7 @@ func (a *autoScaler) tick(ctx context.Context) {
 		} else {
 			a.setWrite(a.current - 1)
 		}
-	case autoscale.PlanGrow:
+	case autoscale.PlanGrow, autoscale.PlanRecover:
 		// Additive increase on the pool the queue says is the bottleneck.
 		// Balanced (or unconfirmed) holds: growing either side of a balanced
 		// pipeline just moves the queue off its equilibrium without more
@@ -293,11 +299,6 @@ func (a *autoScaler) tick(ctx context.Context) {
 		default: // queueBalanced
 			acted = false
 		}
-	case autoscale.PlanRecover, autoscale.PlanShedVeto:
-		// Neither applies to the copier: it has no veto signal, and it never
-		// sheds for a reason outside the zone law, so there is nothing to recover
-		// from. Both are unreachable given the Inputs above.
-		acted = false
 	case autoscale.PlanNone:
 		acted = false
 	}

--- a/pkg/copier/autoscaler.go
+++ b/pkg/copier/autoscaler.go
@@ -32,53 +32,37 @@ import (
 //     cooldown-spaced steps let the controller track the trend instead of
 //     chasing the noise.
 //
-// Zones, evaluated each tick against the (smoothed) utilization:
+// Zones, evaluated each tick against the (smoothed) utilization by
+// autoscale.Classify:
 //
-//	util < acLowWatermark                  add one thread (cooldown-gated)
-//	[acLowWatermark, acHighWatermark)      hold
-//	[acHighWatermark, acPanicThreshold)    shed one thread (cooldown-gated)
-//	util >= acPanicThreshold               halve (first breach immediate)
+//	util < autoscale.LowWatermark                        add one thread (cooldown-gated)
+//	[autoscale.LowWatermark, autoscale.HighWatermark)    hold
+//	[autoscale.HighWatermark, autoscale.PanicThreshold)  shed one thread (cooldown-gated)
+//	util >= autoscale.PanicThreshold                     halve (first breach immediate)
+//
+// The dead band must be wider than the utilization step of a single thread (at
+// most 1/vCPUs, and >= 0.25 only when vCPUs < autoscale.MinVCPUs, where the
+// runner disables autoscaling entirely) — otherwise one +1 can vault across the
+// band and ping-pong with the -1 path.
 //
 // The band has hysteresis, so the resting point depends on which side it is
 // approached from. The auto-sized start (the vCPU count) sits above the band,
-// so on an idle server the controller sheds down and parks just under
-// acHighWatermark — the first edge it meets — and holds there; it does not
-// continue down to acLowWatermark (that is the floor it would climb up to had
-// it started below the band). Parking near 70% of vCPUs leaves headroom for
+// so on an idle server the controller sheds down and parks just under the high
+// watermark — the first edge it meets — and holds there; it does not continue
+// down to the low watermark (that is the floor it would climb up to had it
+// started below the band). Parking near 70% of vCPUs leaves headroom for
 // the primary OLTP workload, and leaving copy throughput on the table is fine.
 // Responsiveness to genuine overload is not traded away: that is the
 // BlockWait hard-stop's job, which none of this touches.
-// The thresholds themselves live in pkg/autoscale, because the checksum
-// controller applies the same law to its own pool and two copies of these
-// numbers would drift. The rationale above is the derivation; pkg/autoscale
-// holds only the values.
-const (
-	// acLowWatermark is the effective setpoint: below it there is headroom,
-	// so we may add a thread (subject to cooldown).
-	acLowWatermark = autoscale.LowWatermark
-	// acHighWatermark starts the additive back-off. The dead band between the
-	// watermarks must be wider than the utilization step of a single thread
-	// (at most 1/vCPUs, and >= 0.25 only when vCPUs < MinAutoscaleVCPUs,
-	// where the runner disables autoscaling entirely) — otherwise one +1 can
-	// vault across the band and ping-pong with the -1 path.
-	acHighWatermark = autoscale.HighWatermark
-	// acPanicThreshold is where back-off turns multiplicative. At 1.0 the
-	// smoothed signal has reached vCPUs — sustained load just below the point
-	// where the raw per-sample hard-stop trips (it fires on running > vCPUs +
-	// selfMonitoringHeadroom). By the time the average climbs here the hard-stop
-	// is typically firing on the raw samples, so the copy is already being
-	// paused; halving sheds enough that the resume is gentle. This compares the gradual
-	// (smoothed) utilization, NOT IsThrottled() — on a
-	// multi-throttler that would include binary children like replica lag,
-	// and halving on those is unguided (they already pause the copy, which
-	// makes the worker count moot while tripped).
-	acPanicThreshold = autoscale.PanicThreshold
-	// acCooldownTicks is how many ticks a direction holds after a change before
-	// it may fire again: a change at tick T allows the next at tick T+3, i.e.
-	// 15s apart at acTick, giving the change time to register in the signal
-	// first. Increases and decreases hold independent cooldowns — see tick().
-	acCooldownTicks = autoscale.CooldownTicks
-)
+//
+// The thresholds, the zone classification, and the cooldown bookkeeping all live
+// in pkg/autoscale, because the checksum controller applies the same law to its
+// own pool and two copies would drift. The rationale above is the derivation;
+// pkg/autoscale holds the mechanism. Note in particular that the panic zone
+// compares the *gradual* (smoothed) utilization and never IsThrottled(): on a
+// multi-throttler the latter would include binary children like replica lag,
+// and halving on those is unguided — they already pause the copy, which makes
+// the worker count moot while tripped.
 
 // Queue-arbitration tunables. When read scaling is engaged (see
 // enableReadScaling), utilization alone cannot decide which pool to grow:
@@ -108,9 +92,9 @@ const (
 	// chunklets essentially the moment they arrive.
 	acQueueWaitEpsilon = time.Millisecond
 	// acQueueStatePersistTicks is how many consecutive ticks a queue state
-	// must hold before it arbitrates. Matches acCooldownTicks so the
+	// must hold before it arbitrates. Matches autoscale.CooldownTicks so the
 	// anti-flap window and the action spacing describe the same timescale.
-	acQueueStatePersistTicks = 2
+	acQueueStatePersistTicks = autoscale.CooldownTicks
 )
 
 // queueState classifies the applier queue for arbitration. The zero value is
@@ -131,22 +115,13 @@ const (
 var acTick = autoscale.Tick
 
 // ResolveMaxReadThreads resolves the upper bound the read-worker pool may
-// scale to: the read-side mirror of throttler.ResolveMaxWriteThreads. When
-// autoscaling is disabled the cap equals start, so the pool cannot move; when
-// enabled it is fixed at 2 × start, for symmetry with the write scaler.
-// Exported so the migration runner sizes the connection pool from the same
-// formula the copier caps the pool with — readers scaled above the connection
-// budget would just queue on the sql.DB pool, silently buying no extra
-// parallelism.
+// scale to: the read-side mirror of throttler.ResolveMaxWriteThreads, and like
+// it a thin naming of autoscale.Ceiling. Exported so the migration runner sizes
+// the connection pool from the same formula the copier caps the pool with —
+// readers scaled above the connection budget would just queue on the sql.DB
+// pool, silently buying no extra parallelism.
 func ResolveMaxReadThreads(start int, autoscaleEnabled bool) int {
-	// The reader pool never runs below one worker (SetReadWorkers and
-	// enableReadScaling both clamp to 1), so the cap honors the same floor —
-	// a zero/invalid start would otherwise under-budget the connection pool.
-	start = max(start, 1)
-	if !autoscaleEnabled {
-		return start
-	}
-	return 2 * start
+	return autoscale.Ceiling(start, autoscaleEnabled)
 }
 
 // writeScaler is the optional capability the autoscaler drives. The
@@ -178,20 +153,17 @@ type statsProvider interface {
 // utilization parked in the [low, high) dead-band so the hard-stop is rarely
 // hit.
 type autoScaler struct {
-	throttler          throttler.GradualThrottler
-	scaler             writeScaler
-	min, max           int
-	current            int
-	low, high, panicAt float64
-	// upCooldown gates increases; downCooldown gates decreases. They are
-	// separate so a fresh overload can halve immediately even right after an
-	// increase (which likely caused it), while consecutive halvings are still
-	// spaced out enough for the signal to reflect the previous cut.
-	// When read scaling is engaged the cooldowns are shared across both
-	// pools — one action per tick, whichever side it lands on.
-	upCooldown, downCooldown int
-	logger                   *slog.Logger
-	metricsSink              metrics.Sink
+	throttler throttler.GradualThrottler
+	scaler    writeScaler
+	min, max  int
+	current   int
+	// gate holds the cooldown state and resolves the zone law into the move this
+	// tick may make (see autoscale.Gate). When read scaling is engaged the
+	// cooldowns are shared across both pools — one action per tick, whichever
+	// side it lands on.
+	gate        autoscale.Gate
+	logger      *slog.Logger
+	metricsSink metrics.Sink
 
 	// Read-side state, populated by enableReadScaling; reader == nil means
 	// the write-only law from #953 (no arbitration, no read pool).
@@ -220,9 +192,6 @@ func newAutoScaler(t throttler.GradualThrottler, s writeScaler, start, maxThread
 		min:         1,
 		max:         maxThreads,
 		current:     start,
-		low:         acLowWatermark,
-		high:        acHighWatermark,
-		panicAt:     acPanicThreshold,
 		logger:      logger,
 		metricsSink: sink,
 	}
@@ -250,16 +219,7 @@ func (a *autoScaler) enableReadScaling(r readScaler, stats statsProvider, start,
 
 // run drives the control loop until ctx is cancelled.
 func (a *autoScaler) run(ctx context.Context) {
-	ticker := time.NewTicker(acTick)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			a.tick(ctx)
-		}
-	}
+	autoscale.RunTicker(ctx, acTick, a.tick)
 }
 
 // tick performs a single control step. Split out so tests can drive it directly
@@ -283,84 +243,70 @@ func (a *autoScaler) run(ctx context.Context) {
 func (a *autoScaler) tick(ctx context.Context) {
 	util := a.throttler.Utilization()
 	queue := a.observeQueue()
+	// The zone law and the cooldown gating are autoscale.Gate's; what remains
+	// here is apportioning the permitted move between the two pools. The copier
+	// supplies no veto — the queue is an arbiter, not a signal of its own, and it
+	// decides *where* a step lands rather than whether one is allowed.
+	plan := a.gate.Decide(autoscale.Inputs{Zone: autoscale.Classify(util)})
 
-	acted := false
-	switch {
-	case util >= a.panicAt:
-		// Panic: multiplicative backoff, at most once per cooldown window.
-		// The first breach halves immediately — it is never delayed by an
-		// increase's cooldown, since the increase likely caused the overload.
-		// Consecutive halvings wait out the window: the signal updates on the
-		// same ~5s cadence we tick on, so reacting to every tick would halve
-		// repeatedly on one stale window. The BlockWait hard-stop engages in
-		// this zone too, so the copy is already paused — the halve is about
-		// resuming gently, not about stopping the bleeding. Both pools halve:
-		// at panic there is no time to apportion blame, and the queue reading
-		// is unreliable anyway while the hard-stop pauses the pipeline.
-		if a.downCooldown == 0 {
-			a.setWrite(ceilDiv(a.current, 2))
-			if a.reader != nil {
-				a.setRead(ceilDiv(a.readCurrent, 2))
-			}
-			a.downCooldown = acCooldownTicks
-			a.upCooldown = acCooldownTicks
-			acted = true
+	acted := true
+	switch plan {
+	case autoscale.PlanHalve:
+		// Multiplicative backoff, at most once per cooldown window. Consecutive
+		// halvings wait out the window: the signal updates on the same ~5s
+		// cadence we tick on, so reacting to every tick would halve repeatedly on
+		// one stale window. The BlockWait hard-stop engages in this zone too, so
+		// the copy is already paused — the halve is about resuming gently, not
+		// about stopping the bleeding. Both pools halve: at panic there is no time
+		// to apportion blame, and the queue reading is unreliable anyway while the
+		// hard-stop pauses the pipeline.
+		a.setWrite(autoscale.CeilDiv(a.current, 2))
+		if a.reader != nil {
+			a.setRead(autoscale.CeilDiv(a.readCurrent, 2))
 		}
-	case util >= a.high:
-		// Soft overload: additive decrease, the mirror image of the increase
-		// path. Like the panic path it is gated only by the down cooldown, so
-		// the first shed is never delayed by a recent increase's cooldown.
-		// Shedding one thread at a time avoids the halve-and-reclimb sawtooth
-		// on a signal our own workers largely produce. A starved queue means
-		// idle writers — the load is coming from the read side, so shed there;
-		// anything else sheds a writer (the write-only default). The read side
-		// is only blamed while it can actually shed (readCurrent > readMin):
-		// at the reader floor the blame falls through to the writer, so this
-		// zone always removes a real thread rather than clamping into a
-		// phantom no-op that still burns the cooldowns.
-		if a.downCooldown == 0 {
-			if a.reader != nil && queue == queueStarved && a.readCurrent > a.readMin {
-				a.setRead(a.readCurrent - 1)
-			} else {
-				a.setWrite(a.current - 1)
-			}
-			a.downCooldown = acCooldownTicks
-			a.upCooldown = acCooldownTicks
-			acted = true
-		}
-	case util < a.low && a.upCooldown == 0:
-		// Cautious, cooldown-gated additive increase — on the pool the queue
-		// says is the bottleneck. Balanced (or unconfirmed) holds: growing
-		// either side of a balanced pipeline just moves the queue off its
-		// equilibrium without more throughput to show for it.
-		if a.reader == nil {
-			a.setWrite(a.current + 1)
-			a.upCooldown = acCooldownTicks
-			acted = true
+	case autoscale.PlanShed:
+		// Additive decrease, the mirror image of the increase path. Shedding one
+		// thread at a time avoids the halve-and-reclimb sawtooth on a signal our
+		// own workers largely produce. A starved queue means idle writers — the
+		// load is coming from the read side, so shed there; anything else sheds a
+		// writer (the write-only default). The read side is only blamed while it
+		// can actually shed (readCurrent > readMin): at the reader floor the blame
+		// falls through to the writer, so this zone always removes a real thread
+		// rather than clamping into a phantom no-op that still burns the
+		// cooldowns.
+		if a.reader != nil && queue == queueStarved && a.readCurrent > a.readMin {
+			a.setRead(a.readCurrent - 1)
 		} else {
-			switch queue {
-			case queueStarved:
-				a.setRead(a.readCurrent + 1)
-				a.upCooldown = acCooldownTicks
-				acted = true
-			case queueFull:
-				a.setWrite(a.current + 1)
-				a.upCooldown = acCooldownTicks
-				acted = true
-			case queueBalanced:
-				// hold
-			}
+			a.setWrite(a.current - 1)
 		}
+	case autoscale.PlanGrow:
+		// Additive increase on the pool the queue says is the bottleneck.
+		// Balanced (or unconfirmed) holds: growing either side of a balanced
+		// pipeline just moves the queue off its equilibrium without more
+		// throughput to show for it. Declining here leaves the cooldown unspent,
+		// which is why the Gate is told what happened rather than assuming.
+		switch {
+		case a.reader == nil, queue == queueFull:
+			a.setWrite(a.current + 1)
+		case queue == queueStarved:
+			a.setRead(a.readCurrent + 1)
+		default: // queueBalanced
+			acted = false
+		}
+	case autoscale.PlanRecover, autoscale.PlanShedVeto:
+		// Neither applies to the copier: it has no veto signal, and it never
+		// sheds for a reason outside the zone law, so there is nothing to recover
+		// from. Both are unreachable given the Inputs above.
+		acted = false
+	case autoscale.PlanNone:
+		acted = false
 	}
-	if !acted {
+	if acted {
+		a.gate.Applied(plan)
+	} else {
 		// Dead-band, balanced hold, or waiting out a cooldown after a recent
 		// change.
-		if a.upCooldown > 0 {
-			a.upCooldown--
-		}
-		if a.downCooldown > 0 {
-			a.downCooldown--
-		}
+		a.gate.Idle()
 	}
 
 	a.emit(ctx, util)
@@ -449,28 +395,13 @@ func (a *autoScaler) setRead(target int) {
 
 // emit reports the current thread counts and observed utilization every tick.
 func (a *autoScaler) emit(ctx context.Context, util float64) {
-	if a.metricsSink == nil {
-		return
-	}
-	m := &metrics.Metrics{
-		Values: []metrics.MetricValue{
-			{Name: metrics.WriteThreadsMetricName, Type: metrics.GAUGE, Value: float64(a.current)},
-			{Name: metrics.ThrottlerUtilizationMetricName, Type: metrics.GAUGE, Value: util},
-		},
+	values := []metrics.MetricValue{
+		{Name: metrics.WriteThreadsMetricName, Type: metrics.GAUGE, Value: float64(a.current)},
+		{Name: metrics.ThrottlerUtilizationMetricName, Type: metrics.GAUGE, Value: util},
 	}
 	if a.reader != nil {
-		m.Values = append(m.Values,
+		values = append(values,
 			metrics.MetricValue{Name: metrics.ReadThreadsMetricName, Type: metrics.GAUGE, Value: float64(a.readCurrent)})
 	}
-	sendCtx, cancel := context.WithTimeout(ctx, metrics.SinkTimeout)
-	defer cancel()
-	if err := a.metricsSink.Send(sendCtx, m); err != nil {
-		a.logger.Debug("autoscaler metrics send failed", "error", err)
-	}
-}
-
-// ceilDiv returns ceil(n/d) for positive integers — used for the multiplicative
-// halving so that, e.g., 3 backs off to 2 rather than 1.
-func ceilDiv(n, d int) int {
-	return (n + d - 1) / d
+	autoscale.Emit(ctx, a.metricsSink, a.logger, values...)
 }

--- a/pkg/copier/autoscaler_test.go
+++ b/pkg/copier/autoscaler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/autoscale"
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/table"
@@ -232,12 +233,12 @@ func TestAutoScaler_DeadBandBoundaries(t *testing.T) {
 		util float64
 		want int // expected current after one tick, starting from 4
 	}{
-		{"just below low increases", acLowWatermark - eps, 5},
-		{"exactly low holds", acLowWatermark, 4},
-		{"just below high holds", acHighWatermark - eps, 4},
-		{"exactly high sheds one", acHighWatermark, 3},
-		{"just below panic sheds one", acPanicThreshold - eps, 3},
-		{"exactly panic halves", acPanicThreshold, 2},
+		{"just below low increases", autoscale.LowWatermark - eps, 5},
+		{"exactly low holds", autoscale.LowWatermark, 4},
+		{"just below high holds", autoscale.HighWatermark - eps, 4},
+		{"exactly high sheds one", autoscale.HighWatermark, 3},
+		{"just below panic sheds one", autoscale.PanicThreshold - eps, 3},
+		{"exactly panic halves", autoscale.PanicThreshold, 2},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -256,9 +257,9 @@ func TestAutoScaler_DeadBandBoundaries(t *testing.T) {
 // than ramping it to the cap or shrinking it to 1. If either side moves and
 // breaks the relationship, this fails loudly.
 func TestAutoScaler_StaleHoldValueParksInDeadBand(t *testing.T) {
-	require.GreaterOrEqual(t, throttler.StaleUtilizationHold, acLowWatermark,
+	require.GreaterOrEqual(t, throttler.StaleUtilizationHold, autoscale.LowWatermark,
 		"stale hold below the low watermark would scale up blind on a dead signal")
-	require.Less(t, throttler.StaleUtilizationHold, acHighWatermark,
+	require.Less(t, throttler.StaleUtilizationHold, autoscale.HighWatermark,
 		"stale hold at/above the high watermark would halve on a dead signal")
 
 	as, _, ut := newTestScaler(4, 16)
@@ -298,14 +299,6 @@ func TestAutoScaler_ConvergesOnSelfInducedSignal(t *testing.T) {
 		"controller must converge once and then hold steady on a self-induced signal")
 	require.Equal(t, 4, as.current,
 		"steady state parks just above the low watermark: 4 threads / 8 vCPUs = 0.5")
-}
-
-func TestCeilDiv(t *testing.T) {
-	require.Equal(t, 1, ceilDiv(1, 2))
-	require.Equal(t, 1, ceilDiv(2, 2))
-	require.Equal(t, 2, ceilDiv(3, 2))
-	require.Equal(t, 2, ceilDiv(4, 2))
-	require.Equal(t, 3, ceilDiv(5, 2))
 }
 
 // TestResolveMaxReadThreads pins the pool-size formula the migration runner
@@ -719,7 +712,7 @@ func TestAutoScalerIntegrationEngaged(t *testing.T) {
 	// their prompt exit-on-park is pinned by the PR 1 pool tests — so the
 	// observable assertion here is on the write pool.
 	gated.setUtil(1.2)
-	require.Eventually(t, func() bool { return app.ActiveWriteWorkers() <= ceilDiv(start, 2) },
+	require.Eventually(t, func() bool { return app.ActiveWriteWorkers() <= autoscale.CeilDiv(start, 2) },
 		10*time.Second, 5*time.Millisecond,
 		"autoscaler should halve the live write-worker pool at the panic threshold")
 

--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/autoscale"
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/metrics"
 	"github.com/block/spirit/pkg/status"
@@ -285,7 +286,7 @@ func (c *buffered) autoscalerIfEnabled() *autoScaler {
 	}
 	c.logger.Info("starting experimental autoscaler: write-thread scaling engaged",
 		"start", c.autoscale.StartThreads, "max", c.autoscale.MaxThreads,
-		"low_watermark", acLowWatermark, "high_watermark", acHighWatermark)
+		"low_watermark", autoscale.LowWatermark, "high_watermark", autoscale.HighWatermark)
 	as := newAutoScaler(gradual, scaler, c.autoscale.StartThreads, c.autoscale.MaxThreads, c.logger, c.metricsSink)
 	// Read scaling engages whenever the write side does: the copier's own
 	// reader pool is runtime-resizable (SetReadWorkers) and every applier

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/autoscale"
 	"github.com/block/spirit/pkg/buildinfo"
 	"github.com/block/spirit/pkg/change"
 	"github.com/block/spirit/pkg/checkpoint"
@@ -711,11 +712,11 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	// Autoscaling drives the buffered copier's applier worker pool; the legacy
 	// unbuffered copier has no such pool, so the combination downgrades to a
 	// fixed thread count with a warning rather than silently doing nothing.
-	autoscale := r.migration.EnableExperimentalAutoscaling
-	if autoscale && r.migration.Unbuffered {
+	autoscaleEnabled := r.migration.EnableExperimentalAutoscaling
+	if autoscaleEnabled && r.migration.Unbuffered {
 		r.logger.Warn("--enable-experimental-autoscaling has no effect with --unbuffered; write threads stay fixed",
 			"write_threads", r.migration.WriteThreads)
-		autoscale = false
+		autoscaleEnabled = false
 	}
 	// redoAware tracks whether the Aurora threads throttler will run its
 	// redo-aware perf_schema signal (which excludes redo-log waiters). It gates
@@ -726,24 +727,24 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	// (and logs it) when the throttler is built; this is an independent probe of
 	// the same source in the same setup phase, used only to size maxWrite here.
 	redoAware := false
-	// On Aurora instances below MinAutoscaleVCPUs the utilization signal is too
+	// On Aurora instances below autoscale.MinVCPUs the utilization signal is too
 	// coarse to control on — one thread is half or more of the dead band — so
 	// the controller could only oscillate; run a fixed pool instead. Aurora is
 	// the one place the autoscaler can engage at all (it needs the continuous
 	// signal only the Aurora throttlers provide); an IsAurora probe failure is
 	// benign here, matching AuroraSetup.Build, since without Aurora the
 	// autoscaler stays dormant regardless and the copier logs its own downgrade.
-	if autoscale {
+	if autoscaleEnabled {
 		if isAurora, err := throttler.IsAurora(ctx, r.db); err == nil && isAurora {
 			vCPUs, err := throttler.AuroraVCPUs(ctx, r.db)
 			if err != nil {
 				return err
 			}
-			if vCPUs < throttler.MinAutoscaleVCPUs {
+			if vCPUs < autoscale.MinVCPUs {
 				r.logger.Warn("autoscaling disabled: instance is too small for the utilization signal to guide scaling; write threads stay fixed",
-					"vcpus", vCPUs, "min_vcpus", throttler.MinAutoscaleVCPUs,
+					"vcpus", vCPUs, "min_vcpus", autoscale.MinVCPUs,
 					"write_threads", r.migration.WriteThreads)
-				autoscale = false
+				autoscaleEnabled = false
 			} else {
 				redoAware = throttler.CanReadRedoAwareThreads(ctx, r.db) == nil
 			}
@@ -756,14 +757,14 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	// autoscaler can shed but not oversubscribe the redo log unguarded (see
 	// ResolveMaxWriteThreads).
 	commitLatencyEnabled := r.migration.MaxCommitLatency > 0
-	maxWrite := throttler.ResolveMaxWriteThreads(r.migration.WriteThreads, autoscale, redoAware, commitLatencyEnabled)
+	maxWrite := throttler.ResolveMaxWriteThreads(r.migration.WriteThreads, autoscaleEnabled, redoAware, commitLatencyEnabled)
 	// The read side mirrors it: when autoscaling engages, the copier may grow
 	// its read-worker pool up to copier.ResolveMaxReadThreads (2x Threads; see
 	// autoscalerIfEnabled), so size for that ceiling too — readers scaled
 	// above the pool budget would just queue on the sql.DB pool, silently
 	// buying no extra parallelism. Same formula as the copier's cap, by
 	// construction.
-	maxRead := copier.ResolveMaxReadThreads(r.migration.Threads, autoscale)
+	maxRead := copier.ResolveMaxReadThreads(r.migration.Threads, autoscaleEnabled)
 	// Finalize the pool now that WriteThreads (and its autoscale ceiling) is
 	// known: maxRead + maxWrite + controlPlaneConns() + checksumOffPoolConns
 	// (see the MaxOpenConnections doc in Run). Sizing for the ceilings ensures a
@@ -818,7 +819,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 		Applier:         appl,
 		Unbuffered:      r.migration.Unbuffered,
 		Autoscale: copier.AutoscaleConfig{
-			Enabled:      autoscale,
+			Enabled:      autoscaleEnabled,
 			StartThreads: r.migration.WriteThreads,
 			MaxThreads:   maxWrite,
 		},
@@ -866,7 +867,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 		// checksum-specific term is checksumOffPoolConns, for the queries that run
 		// off-pool.
 		Autoscale: checksum.AutoscaleConfig{
-			Enabled:    autoscale,
+			Enabled:    autoscaleEnabled,
 			MaxThreads: maxRead,
 		},
 	})

--- a/pkg/throttler/README.md
+++ b/pkg/throttler/README.md
@@ -164,6 +164,7 @@ func (t *CustomThrottler) BlockWait(ctx context.Context) {
 
 ## See Also
 
+- [pkg/autoscale](../autoscale/README.md) - What the `GradualThrottler` signal drives: the shared zone law and cooldown gate
 - [MySQL 8.0 Replication Lag Implementation](https://github.com/block/spirit/issues/286)
 - [Freno - Throttling Service](https://github.com/github/freno)
 - [Doorman - Global Distributed Client Side Rate Limiting](https://github.com/youtube/doorman)

--- a/pkg/throttler/aurora_threads.go
+++ b/pkg/throttler/aurora_threads.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"sync/atomic"
 	"time"
+
+	"github.com/block/spirit/pkg/autoscale"
 )
 
 // The Aurora "threads" throttler — the second Aurora signal, from issue #831.
@@ -194,7 +196,7 @@ func AuroraVCPUs(ctx context.Context, db *sql.DB) (int, error) {
 // the whole instance: the copier's read side, the checksum, and the server's
 // own work need room too. Auto-sizing resolves to max(1, vCPUs - this). On 4+
 // vCPU instances it is the autoscaler's starting value (the controller can grow
-// back up under spare capacity); below MinAutoscaleVCPUs it is the fixed size.
+// back up under spare capacity); below autoscale.MinVCPUs it is the fixed size.
 const WriteThreadVCPUReserve = 2
 
 // ResolveWriteThreads resolves the number of apply (write) threads to use
@@ -235,39 +237,23 @@ func ResolveWriteThreads(ctx context.Context, db *sql.DB, requested int, logger 
 	return max(1, vCPUs-WriteThreadVCPUReserve), nil
 }
 
-// MinAutoscaleVCPUs is the smallest instance size (in vCPUs) on which the
-// write-thread autoscaler is allowed to engage. Below this the utilization
-// signal is too coarse to control on: one thread is half or a third of the
-// whole scale, so there is no dead band wide enough to rest in and the
-// controller can only oscillate. Observed in staging on r6g.large (2 vCPUs):
-// the thread count ping-ponged 1↔2 indefinitely (issue #831). At 4+ vCPUs the
-// worst-case per-thread utilization step (0.25) fits inside the autoscaler's
-// dead band.
-const MinAutoscaleVCPUs = 4
-
 // ResolveMaxWriteThreads resolves the upper bound the write-thread autoscaler
-// may scale to. When autoscaling is disabled the cap equals start, so the
-// thread count cannot move. When enabled the cap is fixed at 2 × start —
-// deliberately not configurable for now, to keep the experimental surface
-// small. See issue #831.
+// may scale to: autoscale.Ceiling (start when scaling is off, 2 × start when on
+// — deliberately not configurable for now, to keep the experimental surface
+// small), plus one rule that is specific to the write side. See issue #831.
 //
-// Scaling above the starting value additionally requires the commit-latency
-// throttler when the redo-aware signal is in use: that signal deliberately
-// ignores threads parked on redo-log waits — which is what makes oversubscribing
-// the log safe to attempt — so it will not self-limit if the extra write threads
-// saturate the log, and commit-latency is then the only signal that would
-// notice. Without that backstop the cap stays at start (the autoscaler may
-// still shed threads under CPU pressure, but never adds any). The Threads_running
-// fallback counts redo-log waiters as load, so it self-limits and needs no such
-// backstop.
+// That rule: scaling above the starting value additionally requires the
+// commit-latency throttler when the redo-aware signal is in use. That signal
+// deliberately ignores threads parked on redo-log waits — which is what makes
+// oversubscribing the log safe to attempt — so it will not self-limit if the
+// extra write threads saturate the log, and commit-latency is then the only
+// signal that would notice. Without that backstop the cap stays at start (the
+// autoscaler may still shed threads under CPU pressure, but never adds any). The
+// Threads_running fallback counts redo-log waiters as load, so it self-limits and
+// needs no such backstop.
 func ResolveMaxWriteThreads(start int, autoscaleEnabled, redoAware, commitLatencyEnabled bool) int {
-	if !autoscaleEnabled {
-		return start
-	}
-	if redoAware && !commitLatencyEnabled {
-		return start
-	}
-	return 2 * start
+	unguardedRedo := redoAware && !commitLatencyEnabled
+	return autoscale.Ceiling(start, autoscaleEnabled && !unguardedRedo)
 }
 
 // threadsRunningPollInterval mirrors commitLatencyPollInterval — fast enough to

--- a/pkg/throttler/stale.go
+++ b/pkg/throttler/stale.go
@@ -40,7 +40,7 @@ const (
 	// a brief failover blip, one stalled status query — don't flap the guard,
 	// but the signal is declared stale before the autoscaler can take more
 	// than one blind step, since its increases are spaced
-	// (acCooldownTicks+1)*acTick = 15s apart.
+	// (autoscale.CooldownTicks+1)*autoscale.Tick = 15s apart.
 	staleSignalThreshold = 15 * time.Second
 
 	// StaleUtilizationHold is the utilization reported while the signal is

--- a/pkg/throttler/stale.go
+++ b/pkg/throttler/stale.go
@@ -34,13 +34,17 @@ import (
 //     IsThrottled() reports true, pausing the copy until polling recovers.
 const (
 	// staleSignalThreshold is how old the last successful sample may be
-	// before the cached value is no longer trusted. Three poll intervals
+	// before the cached value is no longer trusted. It is three poll intervals
 	// (commitLatencyPollInterval, threadsRunningPollInterval and the replica
-	// throttler's loopInterval are all 5s): one or two failed or slow polls —
-	// a brief failover blip, one stalled status query — don't flap the guard,
-	// but the signal is declared stale before the autoscaler can take more
-	// than one blind step, since its increases are spaced
-	// (autoscale.CooldownTicks+1)*autoscale.Tick = 15s apart.
+	// throttler's loopInterval are all 5s), so one or two failed or slow polls —
+	// a brief failover blip, one stalled status query — don't flap the guard.
+	//
+	// It is deliberately NOT derived from the autoscaler's cooldown, because the
+	// poll interval is what it measures. But it does have to stay short enough
+	// that the signal is declared stale before the autoscaler can take more than
+	// one blind step on the frozen value, which bounds it by the spacing of the
+	// autoscaler's increases — see TestStaleThresholdBoundsBlindAutoscalerSteps,
+	// which pins that relationship so moving either side fails loudly.
 	staleSignalThreshold = 15 * time.Second
 
 	// StaleUtilizationHold is the utilization reported while the signal is

--- a/pkg/throttler/stale_test.go
+++ b/pkg/throttler/stale_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/autoscale"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,4 +93,21 @@ func TestStaleGuard_NewStalePeriodWarnsAgain(t *testing.T) {
 	stale, entering := g.check(time.Second)
 	require.True(t, stale)
 	require.True(t, entering)
+}
+
+// TestStaleThresholdBoundsBlindAutoscalerSteps pins the cross-package
+// relationship staleSignalThreshold's doc comment claims. The threshold itself
+// is three poll intervals — that is what it measures — but it also has to be
+// short enough that a frozen signal is declared stale before the autoscaler can
+// take more than one blind step on it. The autoscaler's increases are spaced
+// (CooldownTicks+1) ticks apart, so that spacing is the bound.
+//
+// This is the same guard as TestAutoScaler_StaleHoldValueParksInDeadBand, which
+// pins the sibling constant StaleUtilizationHold against the dead band: if
+// either side of the relationship moves, one of these fails loudly rather than
+// leaving a comment quietly asserting something untrue.
+func TestStaleThresholdBoundsBlindAutoscalerSteps(t *testing.T) {
+	increaseSpacing := time.Duration(autoscale.CooldownTicks+1) * autoscale.Tick
+	require.LessOrEqual(t, staleSignalThreshold, increaseSpacing,
+		"a stale signal must be caught within one autoscaler increase interval, or the controller ramps blind on a frozen value")
 }


### PR DESCRIPTION
Follow-up to #1087. Pure refactor, no behaviour change.

`pkg/autoscale` was introduced in #1087 holding only the watermark constants, `Classify` and `Limiter`. The two controllers that use it — the copier's write/read autoscaler and the checksum's reader controller — still each kept their own copy of everything around that: the tick loop, the metrics send, the pool-ceiling formula, and, most importantly, the decision switch with its cooldown bookkeeping. The two switches already differed in *shape* while agreeing on outcome, which is exactly the state that drifts silently.

This moves everything that isn't phase-specific into `pkg/autoscale`.

## What moved

**`Gate`** — resolves one tick's signals (`Inputs`) into a `Plan`. It owns the precedence between the zones, a caller-supplied veto, and the cooldown bookkeeping. Precedence, highest first: `Halve`, then the veto, then `Shed`, `Grow`, and recovery inside the dead band.

`Decide` is pure; the caller reports back with `Applied` or `Idle`. That split is load-bearing rather than stylistic: a controller may legitimately decline a permitted plan — the copier does not grow a balanced pipeline — and must not burn a cooldown for a move it never made. It preserves both controllers' existing `acted` semantics exactly.

**`Ceiling`** — the "start, or 2× start when scaling is on" pool bound. `copier.ResolveMaxReadThreads` is now a naming of it; `throttler.ResolveMaxWriteThreads` is it plus the redo-log rule.

**`RunTicker`** / **`Emit`** — the tick loop and the best-effort gauge send both controllers repeated verbatim.

**`MinVCPUs`** — moved from `pkg/throttler`. Its entire justification is the dead band's width versus the per-thread utilization step, not anything Aurora-specific, and `pkg/copier` was already reaching across packages to cite it in a comment. A test now pins the relationship, so moving a watermark tells you whether `MinVCPUs` has to move with it.

## What deliberately stayed

Everything genuinely phase-specific: how big a step is, which pool it lands on, and what may veto one.

- **Copier**: two pools fed by one signal, so the applier queue arbitrates *where* a permitted step lands. The write side additionally refuses to grow when the redo-aware signal has no commit-latency backstop.
- **Checksum**: one pool, no arbitration, plus the change-feed backlog veto — pressure the utilization signal cannot see, and the only shedding lever on stock MySQL.

## Evidence

Both controllers' existing test suites pass **unchanged** — that's the behaviour-preservation evidence, since those suites already pin the zone edges, the cooldown spacing, the self-induced-signal convergence, the backlog veto's hysteresis and the frozen-flush freeze. New `pkg/autoscale` tests cover the primitives directly: `Gate` precedence, cooldown gating and decay, the increase/decrease asymmetry, the declined-plan case, `Ceiling`, `RunTicker` and `Emit`.

On non-test code the two controllers shed 130 lines between them (`copier/autoscaler.go` net −69, `checksum/autoscaler.go` net −61) against `pkg/autoscale/controller.go`'s +200, most of which is the doc comment explaining the precedence and the pure-`Decide` split — so roughly break-even on line count, with one copy of the logic instead of two. Also adds `pkg/autoscale/README.md`, since the package now owns the shared law rather than just a few constants.

## The one edge that moves

`ResolveMaxWriteThreads` gains a floor of 1 for a zero or negative `start`, which the read side already had (a zero start would under-budget the connection pool for a phase that always runs at least one worker). The runner cannot reach it: `ResolveWriteThreads` never returns 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
