### PR TITLE
cutover: stop the change feed under the lock, not after it

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -64,6 +64,11 @@ type binlogClient struct {
 	ddlFilterSchema  string
 	ddlFilterTables  map[string]struct{}
 
+	// stopped is set once by Stop and read by the stream reader on every event
+	// it would otherwise deliver. Atomic because the two are different
+	// goroutines. Distinct from isClosed, which tears the reader down.
+	stopped atomic.Bool
+
 	serverID    uint32         // server ID for the binlog reader
 	bufferedPos mysql.Position // buffered position
 	flushedPos  mysql.Position // safely written to new table
@@ -714,6 +719,11 @@ func (c *binlogClient) readStream(ctx context.Context) {
 // specific tables within the schema triggers cancellation — this is used for partial
 // moves where only a subset of tables from a schema are being moved.
 func (c *binlogClient) processDDLNotification(schema, table string) {
+	if c.stopped.Load() {
+		// Post-cutover, where spirit's own RENAME TABLE is the DDL we would
+		// otherwise be reporting on ourselves. See Source.Stop.
+		return
+	}
 	if c.ddlFilterSchema != "" {
 		// Schema-level filtering: cancel on DDL in the specified schema.
 		if schema != c.ddlFilterSchema {
@@ -774,6 +784,13 @@ func (c *binlogClient) processDDLNotification(schema, table string) {
 // works the same way for all event types and no reconstruction is needed.
 // If a MINIMAL image slips through we error out.
 func (c *binlogClient) processRowsEvent(ev *replication.BinlogEvent, e *replication.RowsEvent) error {
+	if c.stopped.Load() {
+		// Post-cutover. The subscription's TableInfo no longer describes the
+		// table this event's name resolves to, so decoding it would fail on a
+		// row image that is perfectly valid for the table that produced it.
+		// See Source.Stop.
+		return nil
+	}
 	subName := encodeSchemaTable(string(e.Table.Schema), string(e.Table.Table))
 	sub, ok := c.subs.Get(subName)
 	if !ok {
@@ -917,6 +934,16 @@ func (c *binlogClient) fatalError(reason FatalReason) bool {
 		return c.callerCancelFunc(reason)
 	}
 	return false
+}
+
+// Stop satisfies Source. The reader goroutine keeps running — Close owns
+// teardown — but stops delivering events to subscriptions, which is what makes
+// it cheap enough to call inside cutover's lock window.
+func (c *binlogClient) Stop() {
+	if c.stopped.Swap(true) {
+		return
+	}
+	c.logger.Debug("change stream stopped; further events will not be dispatched")
 }
 
 func (c *binlogClient) Close() {

--- a/pkg/change/dispatch_test.go
+++ b/pkg/change/dispatch_test.go
@@ -1,0 +1,55 @@
+package change
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStopDispatchSuppressesDDLNotification pins the DDL half of
+// DispatchStopper: after cutover, the RENAME that swapped the tables is itself
+// DDL on a watched table, and reporting it back to the caller is pointless work
+// that only stays harmless because Runner.fatalError happens to decline it.
+//
+// The rows half is covered end-to-end by
+// migration.TestCutoverStopsFeedDispatchUnderLock, which needs a real stream.
+func TestStopDispatchSuppressesDDLNotification(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	// ddlFilterSchema is used so the notification does not need registered
+	// subscriptions (and therefore a database) to match.
+	for _, tc := range []struct {
+		name string
+		// build returns the notifier and a pointer to the call counter.
+		build func(cancel func(FatalReason) bool) (notify func(string, string), stop func())
+	}{
+		{
+			name: "binlog",
+			build: func(cancel func(FatalReason) bool) (func(string, string), func()) {
+				c := &binlogClient{logger: logger, callerCancelFunc: cancel, ddlFilterSchema: "test", subs: newSubscriptionRegistry()}
+				return c.processDDLNotification, c.Stop
+			},
+		},
+		{
+			name: "gtid",
+			build: func(cancel func(FatalReason) bool) (func(string, string), func()) {
+				c := &gtidClient{logger: logger, callerCancelFunc: cancel, ddlFilterSchema: "test", subs: newSubscriptionRegistry()}
+				return c.processDDLNotification, c.Stop
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			notify, stop := tc.build(func(FatalReason) bool { calls++; return true })
+
+			notify("test", "sometable")
+			require.Equal(t, 1, calls, "DDL on a watched schema must reach the caller before cutover")
+
+			stop()
+			stop() // idempotent
+			notify("test", "sometable")
+			require.Equal(t, 1, calls, "DDL must not reach the caller once dispatch has stopped")
+		})
+	}
+}

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -53,6 +53,9 @@ type gtidClient struct {
 	ddlFilterSchema  string
 	ddlFilterTables  map[string]struct{}
 
+	// stopped mirrors binlogClient.stopped; see Stop.
+	stopped atomic.Bool
+
 	serverID uint32
 
 	// bufferedGTID is everything we have seen from the stream and either
@@ -845,6 +848,10 @@ func (c *gtidClient) processTransactionPayload(e *replication.TransactionPayload
 
 // processDDLNotification mirrors binlogClient.processDDLNotification.
 func (c *gtidClient) processDDLNotification(schema, table string) {
+	if c.stopped.Load() {
+		// Post-cutover; see Source.Stop.
+		return
+	}
 	if c.ddlFilterSchema != "" {
 		if schema != c.ddlFilterSchema {
 			return
@@ -886,6 +893,10 @@ func (c *gtidClient) processDDLNotification(schema, table string) {
 
 // processRowsEvent mirrors binlogClient.processRowsEvent.
 func (c *gtidClient) processRowsEvent(ev *replication.BinlogEvent, e *replication.RowsEvent) error {
+	if c.stopped.Load() {
+		// Post-cutover; see Source.Stop and binlogClient.processRowsEvent.
+		return nil
+	}
 	subName := encodeSchemaTable(string(e.Table.Schema), string(e.Table.Table))
 	sub, ok := c.subs.Get(subName)
 	if !ok {
@@ -954,6 +965,14 @@ func (c *gtidClient) processRowsEvent(ev *replication.BinlogEvent, e *replicatio
 		}
 	}
 	return nil
+}
+
+// Stop mirrors binlogClient.Stop; see Source.Stop.
+func (c *gtidClient) Stop() {
+	if c.stopped.Swap(true) {
+		return
+	}
+	c.logger.Debug("change stream stopped; further events will not be dispatched")
 }
 
 // fatalError mirrors binlogClient.fatalError; see the doc comment there.

--- a/pkg/change/source.go
+++ b/pkg/change/source.go
@@ -28,7 +28,7 @@ var ErrPositionNotFound = errors.New("change.Source: cannot resume from position
 //
 // Lifecycle: construct → AddSubscription(...)* → Start(ctx) OR
 // StartFromPosition(ctx, pos) → Flush / BlockWait /
-// FlushUnderTableLock as needed → Close().
+// FlushUnderTableLock as needed → Stop() → Close().
 //
 // Events flow PUSH-style: when a row event matching one of the
 // subscribed tables arrives, the source implementation looks up the
@@ -164,6 +164,20 @@ type Source interface {
 	// remain). For non-binlog implementations, this is equivalent to
 	// "have all received events been applied?".
 	AllChangesFlushed() bool
+
+	// Stop ends delivery of events to subscriptions. Everything else stays
+	// live: the source keeps reading and tracking its position, and Flush /
+	// BlockWait / AllChangesFlushed / Position keep working. Close, not Stop,
+	// releases resources. One-way and idempotent.
+	//
+	// Cutover calls it once the tables are renamed and while it still holds
+	// the exclusive lock, so no write can be in flight — after UNLOCK TABLES
+	// the first post-cutover write is a race, and those events no longer
+	// decode against the subscriptions' TableInfo (see cutover.go). Hence two
+	// requirements: Stop must not block, because every write to the table is
+	// stalled behind it, and it must leave the source flushable, because a
+	// rename that fails ambiguously is retried via Flush and BlockWait.
+	Stop()
 
 	// Close releases all resources. Safe to call more than once.
 	Close()

--- a/pkg/checksum/continuous_test.go
+++ b/pkg/checksum/continuous_test.go
@@ -601,6 +601,7 @@ func (f *fakeFeed) SetWatermarkOptimization(context.Context, bool) error { retur
 func (f *fakeFeed) StartPeriodicFlush(context.Context, time.Duration)    {}
 func (f *fakeFeed) StopPeriodicFlush()                                   {}
 func (f *fakeFeed) AllChangesFlushed() bool                              { return true }
+func (f *fakeFeed) Stop()                                                {}
 func (f *fakeFeed) Close()                                               {}
 
 // TestDivergenceIsFatalReconcilesApplyLag is the regression test for the

--- a/pkg/checksum/distributed_test.go
+++ b/pkg/checksum/distributed_test.go
@@ -63,6 +63,7 @@ func (s *noopChangeSource) SetWatermarkOptimization(context.Context, bool) error
 func (s *noopChangeSource) StartPeriodicFlush(context.Context, time.Duration) {}
 func (s *noopChangeSource) StopPeriodicFlush()                                {}
 func (s *noopChangeSource) AllChangesFlushed() bool                           { return true }
+func (s *noopChangeSource) Stop()                                             {}
 func (s *noopChangeSource) Close()                                            {}
 
 func TestDistributedCheckerHonorsYieldTimeoutConfig(t *testing.T) {

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -262,12 +262,17 @@ func (c *CutOver) algorithmRenameUnderLock(ctx context.Context) error {
 			fmt.Sprintf("%s TO %s", cfg.newTable.QuotedTableName, cfg.table.QuotedTableName),
 		)
 	}
-	return c.executeRenameUnderLock(ctx, tablesToLock, renameFragments)
+	return c.executeRenameUnderLock(ctx, tablesToLock, renameFragments, true)
 }
 
 // executeRenameUnderLock is the shared implementation for performing renames under a table lock.
 // It handles locking, binlog flushing, and executing the rename statement.
-func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*table.TableInfo, renameFragments []string) error {
+//
+// stopFeed says whether a completed rename means the feed is finished with. It
+// is true for the real cutover and false for partialRenameForTest, which leaves
+// the tables half-renamed and expects Run's retry loop — and therefore the
+// feed — to carry on.
+func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*table.TableInfo, renameFragments []string, stopFeed bool) error {
 	tableLock, err := dbconn.NewTableLock(ctx, c.db, tablesToLock, c.dbConfig, c.logger)
 	if err != nil {
 		return err
@@ -303,6 +308,15 @@ func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*ta
 	if err := tableLock.ExecUnderLock(ctx, renameStatement); err != nil {
 		return err
 	}
+	// The tables are swapped and the lock is still held, so no application
+	// write can be in flight and nothing more can reach the changeset. Stop
+	// the feed here, in that window, rather than after the deferred UNLOCK
+	// TABLES: the first post-cutover write is a race with the unlock, and it
+	// carries a row image for the *post*-ALTER table while the subscription
+	// still holds the pre-ALTER TableInfo. See change.Source's Stop.
+	if stopFeed {
+		c.feed.Stop()
+	}
 	if c.testInjectRenameError != nil {
 		// Test-only seam: the rename was committed by the server, but we
 		// pretend the client never read the OK packet.
@@ -329,7 +343,7 @@ func (c *CutOver) partialRenameForTest(ctx context.Context) error {
 		)
 	}
 	// Execute the partial rename using the same code path
-	if err := c.executeRenameUnderLock(ctx, tablesToLock, renameFragments); err != nil {
+	if err := c.executeRenameUnderLock(ctx, tablesToLock, renameFragments, false); err != nil {
 		return err
 	}
 	// Intentionally return an error to simulate a partial cutover failure

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -82,6 +82,114 @@ func TestCutOver(t *testing.T) {
 	require.Equal(t, 2, count)
 }
 
+// errorCountingHandler counts ERROR-level records and keeps their messages.
+type errorCountingHandler struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (h *errorCountingHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= slog.LevelError
+}
+
+func (h *errorCountingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, r.Message)
+	return nil
+}
+
+func (h *errorCountingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *errorCountingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *errorCountingHandler) errors() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.msgs...)
+}
+
+// TestCutoverStopsFeedDispatchUnderLock is the regression test for a shrinking
+// ALTER's post-cutover writes.
+//
+// The change stream is not stopped by cutover itself — nothing stops it until
+// Close() — and subscriptions are keyed by the *source* table name. So after the
+// rename, `<table>` resolves to the post-ALTER table while the subscription
+// still holds the pre-ALTER TableInfo, and the next application write arrives
+// with a row image that is short of the old column count:
+//
+//	PrimaryKeyValues: row has 2 values, fewer than the 3 table columns
+//
+// which used to kill the stream and log at Error on a migration that had
+// already succeeded. Cutover now retires the feed while it still holds the
+// exclusive lock, so those events are never dispatched.
+//
+// The write below lands after UNLOCK TABLES, which is precisely the window the
+// stop has to beat, so a stop placed after the lock rather than under it fails
+// this test intermittently rather than cleanly.
+func TestCutoverStopsFeedDispatchUnderLock(t *testing.T) {
+	t.Parallel()
+	testutils.NewTestTable(t, "dispatchstop1", `CREATE TABLE dispatchstop1 (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		dropme varchar(255) NOT NULL DEFAULT '',
+		PRIMARY KEY (id)
+	)`)
+	// The shape of "ALTER TABLE dispatchstop1 DROP COLUMN dropme": one column
+	// fewer than the table the subscription was built from.
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS _dispatchstop1_new`)
+	testutils.RunSQL(t, `CREATE TABLE _dispatchstop1_new (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, cfg.DBName, "dispatchstop1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	require.Len(t, t1.Columns, 3)
+	t1new := table.NewTableInfo(db, cfg.DBName, "_dispatchstop1_new")
+	require.NoError(t, t1new.SetInfo(t.Context()))
+
+	errLog := &errorCountingHandler{}
+	clientCfg := change.NewClientDefaultConfig()
+	clientCfg.Logger = slog.New(errLog)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd,
+		applier.NewSingleTargetForTest(t, db), clientCfg)
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t1new, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+
+	cutover, err := NewCutOver(db, []*cutoverConfig{{
+		table:        t1,
+		newTable:     t1new,
+		oldTableName: "_dispatchstop1_old",
+	}}, feed, dbconn.NewDBConfig(), slog.New(errLog))
+	require.NoError(t, err)
+	require.NoError(t, cutover.Run(t.Context()))
+
+	// A post-cutover application write: 2 values against the subscription's
+	// 3-column TableInfo. This is the event that used to be fatal.
+	testutils.RunSQL(t, `INSERT INTO dispatchstop1 (name) VALUES ('after-cutover')`)
+
+	// BlockWait proves the reader goroutine is still alive: it waits for the
+	// buffered position to reach the server's head, which only advances while
+	// readStream is running. Bounded so a dead reader fails fast rather than
+	// waiting out change.DefaultTimeout.
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, feed.BlockWait(ctx), "the stream must survive post-cutover writes")
+
+	require.Empty(t, errLog.errors(), "a post-cutover write must not produce any Error-level log")
+	require.Zero(t, feed.GetDeltaLen(), "post-cutover events must not be buffered for apply")
+}
+
 // TestCutoverRenameCompletedDetection unit-tests the renameCompleted helper
 // against real server state: it must detect a committed cutover rename
 // (original exists, _new gone, _old exists — for every table in the config)

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -222,6 +222,14 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 			}
 		}
 		if err = c.renameAllSources(ctx, sourceLocks); err == nil {
+			// Every source is renamed and the source locks are still held, so no
+			// write can be in flight. Stop the forward feeds inside that window
+			// rather than after the deferred unlock, where the first straggler
+			// write races us. A reverse window is unaffected: its feeds are
+			// separate clients (ReverseFeed) reading the targets, and its start
+			// positions were captured by postSwitch above. See change.Source's
+			// Stop.
+			c.stopSourceFeeds()
 			return nil
 		}
 		if errors.Is(err, errRenameRollbackFailed) {
@@ -231,6 +239,15 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 		c.logger.Warn("rename failed", "error", err.Error())
 	}
 	return fmt.Errorf("rename failed after %d attempts under lock: %w", c.dbConfig.MaxRetries, err)
+}
+
+// stopSourceFeeds tells every source feed that its subscriptions have stopped
+// describing reality. Called once the rename has fully succeeded, while the
+// source locks are still held.
+func (c *CutOver) stopSourceFeeds() {
+	for _, src := range c.sources {
+		src.ReplClient.Stop()
+	}
 }
 
 // renameAllSources renames the tables on every source to their _old names,

--- a/pkg/move/runner_close_test.go
+++ b/pkg/move/runner_close_test.go
@@ -185,6 +185,7 @@ func (f *fakeChangeSource) SetWatermarkOptimization(_ context.Context, _ bool) e
 func (f *fakeChangeSource) StartPeriodicFlush(_ context.Context, _ time.Duration) {}
 func (f *fakeChangeSource) StopPeriodicFlush()                                    {}
 func (f *fakeChangeSource) AllChangesFlushed() bool                               { return true }
+func (f *fakeChangeSource) Stop()                                                 {}
 func (f *fakeChangeSource) Close()                                                { f.closed.Store(true) }
 
 // TestCloseRunsAllClosersOnError pins the Close() aggregation contract:


### PR DESCRIPTION
## The report

Staging Sentry, on a migration that **succeeded** (`engine_state=completed`, old table dropped):

```
16:34:49  final cut over operation complete
16:34:49  [ERR] fatal error processing GTID rows event
            PrimaryKeyValues: row has 8 values, fewer than the 11 table columns
16:34:49  successfully dropped old table
```

The ALTER was `DROP COLUMN bash_f5, taco, test` — 11 columns down to 8.

## Cause

Nothing stops the change stream until `replClient.Close()` in the end-of-migration cleanup, and subscriptions are keyed by the **source** table name. After the RENAME, `<table>` resolves to the post-ALTER table while `sub.Tables()[0]` is still the pre-ALTER `TableInfo`, so the next application write arrives with a row image short of the old column count. An *adding* ALTER never trips it: the new table is wider.

Cutover's only lever was `StopPeriodicFlush`, which stops buffered changes being **applied** but not **spooled** — the reader kept buffering post-cutover events into subscriptions nothing would ever flush. Inert, until spooling itself could fail. It now can: the row image is validated against the subscription's `TableInfo` on the way in, so instead of accumulating harmlessly the event kills the stream. The validation is correct and worth keeping — a PK sitting after a dropped column would read the wrong column — what was missing is a way to stop spooling.

## Fix

`Source` grows `Stop()`: end delivery to subscriptions, leave everything else live (reading, position tracking, `Flush`, `BlockWait`, `AllChangesFlushed`). `Close` still owns teardown.

Cutover calls it once the rename has committed and while it still holds the exclusive lock, so no write can be in flight. Under the lock is the whole point — after `UNLOCK TABLES` the first straggler write is a race, which would make this a mitigation rather than a fix. That placement drives both requirements in the interface doc:

- **Must not block** — every write to the table is stalled behind it. So the implementations are one atomic store, checked at the reader's two dispatch points. This is also why it isn't `Close()`, which does `streamWG.Wait()` plus a syncer teardown that talks to the server.
- **Must leave the feed flushable** — a cutover attempt can still fail ambiguously *after* the rename commits (connection loss before the OK packet), and the retry path calls `Flush` and `BlockWait`.

`partialRenameForTest` opts out via a parameter: it leaves the tables half-renamed and expects `Run`'s retry loop, and therefore the feed, to carry on. Move stops its forward feeds once every source has renamed, still under the source locks — which also closes a latent gap there, since those feeds are only closed in `Runner.Close()`: a reverse cutover renames the source tables back to their real names, at which point the forward subscriptions would match again and resume replaying source writes onto the abandoned target.

**Breaking change:** `Stop()` is required, so out-of-tree `Source` implementations need to add it — same class of change as `FlushResidual`. For a source that spools into `change` subscriptions it's a flag checked before dispatch.

## Tests

`migration.TestCutoverStopsFeedDispatchUnderLock` reproduces the failure end-to-end against a real stream — a subscription built on a 3-column table, a 2-column `_new`, an application write after the swap — then asserts no Error-level log, nothing buffered, and (via `BlockWait`) that the reader is still alive. Removing the `Stop()` call fails it with `context deadline exceeded`: the stream is dead. `change.TestStopDispatchSuppressesDDLNotification` covers the DDL dispatch point and idempotency on both clients.

`pkg/change` green; all 18 `Cutover|CutOver` tests in `pkg/migration`, the `Cutover|Reverse|Close` tests in `pkg/move` and the affected `pkg/checksum` tests green; new tests green under `-race`; `golangci-lint run ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)