### PR TITLE
dbconn: keep the pool's idle limit with its open limit

### DIFF
--- a/pkg/dbconn/README.md
+++ b/pkg/dbconn/README.md
@@ -6,6 +6,14 @@ The `dbconn` package provides MySQL database connection management and locking u
 
 When creating a new connection, Spirit appends standardized DSN parameters to ensure consistent behavior across all connections. These include setting `sql_mode=""` (to be able to copy legacy data like `0000-00-00`), `time_zone=+00:00`, `transaction_isolation=read-committed`, `charset=utf8mb4`, `collation=utf8mb4_bin`, and `rejectReadOnly=true` (for Aurora failover resilience). This means that regardless of the server's global configuration, Spirit connections behave predictably.
 
+## Pool sizing
+
+Use `SetPoolSize(db, n)` rather than `db.SetMaxOpenConns(n)` directly. It sets the open and idle limits together, and they must stay together: `database/sql` closes a connection returned to a pool whose free list already holds `MaxIdleConns` entries, so an idle limit below the open limit turns every release past that point into a close and every subsequent acquire into a fresh dial, TLS handshake and MySQL auth. The copy phase — hundreds of read and write workers cycling connections continuously — is exactly that workload, and the churn is invisible on the status line, which reports only `Stats().InUse`.
+
+Holding the connections idle instead costs nothing that was not already reserved: the open limit is the budget, and matching the idle limit to it only stops the pool from discarding what it is entitled to keep. Several call sites ratchet a pool's size after it was created (the migration runner once thread counts are final, the checksum, cutover), which is why this lives in a helper rather than at construction only.
+
+Connections are still recycled on `maxConnLifetime` (3 minutes), which pool sizing does not affect. With a large pool in steady use, that lifetime — not the idle limit — is the dominant source of reconnects.
+
 ## TLS
 
 Spirit supports five TLS modes: DISABLED, PREFERRED, REQUIRED, VERIFY_CA, and VERIFY_IDENTITY. The default is PREFERRED, which first attempts a TLS connection and falls back to plaintext if it fails. RDS hosts are auto-detected via hostname pattern matching (`*.rds.amazonaws.com`), and an embedded RDS CA bundle is used automatically.

--- a/pkg/dbconn/advisorylock.go
+++ b/pkg/dbconn/advisorylock.go
@@ -103,7 +103,7 @@ func NewAdvisoryLock(ctx context.Context, dsn string, tables []*table.TableInfo,
 			// against; surface it as a connection failure instead.
 			return nil, errors.New("connection factory returned a nil database")
 		}
-		db.SetMaxOpenConns(1)
+		SetPoolSize(db, 1)
 		db.SetConnMaxLifetime(0) // see comment above; keepalive is the refresh ticker
 		return db, nil
 	}

--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -24,7 +24,6 @@ const (
 	requiredTLSConfigName = "required"
 	verifyCATLSConfigName = "verify_ca"
 	verifyIDTLSConfigName = "verify_identity"
-	maxIdleConns          = 10
 )
 
 // maxConnLifetime is the default maximum lifetime for pooled connections.
@@ -33,6 +32,30 @@ const (
 // the advisory lock's GET_LOCK) are deliberately exempted from this limit —
 // see NewAdvisoryLock.
 var maxConnLifetime = time.Minute * 3
+
+// SetPoolSize sets a pool's connection limit, keeping the idle limit equal to
+// it. Both must move together: database/sql closes a connection returned to a
+// pool whose free list already holds MaxIdleConns entries, so an idle limit
+// below the open limit turns every release past that point into a close and
+// every subsequent acquire into a fresh dial, TLS handshake and MySQL auth.
+// The copy phase is exactly that workload — up to a few hundred write and read
+// workers cycling connections continuously — and the churn is invisible in the
+// status line, which reports only Stats().InUse.
+//
+// Holding the connections idle instead costs nothing the caller has not
+// already reserved: SetMaxOpenConns is the budget, and this only stops the pool
+// from throwing away what it is entitled to keep. Note that connections are
+// still recycled on maxConnLifetime, which this does not change.
+//
+// n <= 0 means unlimited to SetMaxOpenConns; pass it through unchanged (and
+// leave the idle limit alone, since "unlimited idle" is not expressible) rather
+// than silently reinterpreting it.
+func SetPoolSize(db *sql.DB, n int) {
+	db.SetMaxOpenConns(n)
+	if n > 0 {
+		db.SetMaxIdleConns(n)
+	}
+}
 
 // rdsAddr matches Amazon RDS hostnames with optional :port suffix.
 // It's used to automatically load the Amazon RDS CA and enable TLS.
@@ -356,9 +379,8 @@ func NewWithConnectionType(inputDSN string, config *DBConfig, connectionType str
 		if db != nil && err == nil { // successful connection
 			// There are many different ways we create a DB connection.
 			// Ensure we change conn settings in all code paths.
-			db.SetMaxOpenConns(config.MaxOpenConnections)
+			SetPoolSize(db, config.MaxOpenConnections)
 			db.SetConnMaxLifetime(maxConnLifetime)
-			db.SetMaxIdleConns(maxIdleConns)
 		}
 	}()
 	// For PREFERRED mode, implement fallback behavior

--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -3,6 +3,7 @@ package dbconn
 import (
 	"context"
 	"crypto/x509"
+	"database/sql"
 	"encoding/pem"
 	"fmt"
 	"testing"
@@ -151,6 +152,59 @@ func TestNewConn(t *testing.T) {
 	db, err = New("root:wrongpassword@tcp(127.0.0.1)/doesnotexist", NewDBConfig())
 	require.Error(t, err)
 	require.Nil(t, db)
+}
+
+// TestSetPoolSizeKeepsIdleWithOpen pins the reason SetPoolSize exists: an idle
+// limit below the open limit makes database/sql close connections on release
+// and redial on the next acquire, which during the copy phase is continuous
+// churn against the target. The two limits must move together at every call
+// site, including the ones that ratchet a pool after it was created.
+func TestSetPoolSizeKeepsIdleWithOpen(t *testing.T) {
+	db, err := New(testutils.DSN(), NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	// New() itself must not leave the pool churning: the default open limit is
+	// 32, so a pool that retains only the old hardcoded 10 would fail here.
+	require.Equal(t, 32, db.Stats().MaxOpenConnections)
+	require.Equal(t, 16, idleAfterCycling(t, db, 16))
+
+	SetPoolSize(db, 20)
+	require.Equal(t, 20, db.Stats().MaxOpenConnections)
+	require.Equal(t, 20, idleAfterCycling(t, db, 20),
+		"a ratcheted pool must retain everything it is allowed to open")
+
+	// Shrinking (the cutover path) applies to both, so a smaller pool does not
+	// retain more idle connections than it may open.
+	SetPoolSize(db, 5)
+	require.Equal(t, 5, db.Stats().MaxOpenConnections)
+	require.Equal(t, 5, idleAfterCycling(t, db, 5))
+
+	// Non-positive means unlimited to SetMaxOpenConns. The idle limit is left
+	// alone rather than set to a nonsense value, since database/sql has no
+	// "unlimited idle" setting.
+	SetPoolSize(db, 0)
+	require.Equal(t, 0, db.Stats().MaxOpenConnections)
+	require.Equal(t, 5, idleAfterCycling(t, db, 8),
+		"a non-positive size must leave the idle limit untouched")
+}
+
+// idleAfterCycling opens n connections, returns them all, and reports how many
+// the pool kept. database/sql does not expose MaxIdleConns, but it discards
+// anything returned beyond that limit, so the retained count is min(n,
+// MaxIdleConns) — which is exactly the churn behaviour under test.
+func idleAfterCycling(t *testing.T, db *sql.DB, n int) int {
+	t.Helper()
+	conns := make([]*sql.Conn, 0, n)
+	for range n {
+		c, err := db.Conn(t.Context())
+		require.NoError(t, err)
+		conns = append(conns, c)
+	}
+	for _, c := range conns {
+		require.NoError(t, c.Close())
+	}
+	return db.Stats().Idle
 }
 
 func TestNewConnRejectsReadOnlyConnections(t *testing.T) {

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -86,7 +86,7 @@ func (c *CutOver) Run(ctx context.Context) error {
 		// Pool size grows monotonically and is not restored — the
 		// migration ends after cutover, so there is nothing to shrink
 		// back for. See the MaxOpenConnections doc in (*Runner).Run.
-		c.db.SetMaxOpenConns(5)
+		dbconn.SetPoolSize(c.db, 5)
 	}
 	// Collect every attempt's error and join them on exit, so an operator
 	// debugging a flapping cutover sees the full failure history rather

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -828,7 +828,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context) error {
 	// the two phases reuse one allocation rather than each needing their own.
 	if poolSize := maxRead + maxWrite + r.controlPlaneConns() + checksumOffPoolConns; poolSize > r.dbConfig.MaxOpenConnections {
 		r.dbConfig.MaxOpenConnections = poolSize
-		r.db.SetMaxOpenConns(poolSize)
+		dbconn.SetPoolSize(r.db, poolSize)
 	}
 
 	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, r.checkpointTableName())
@@ -1633,7 +1633,7 @@ func (r *Runner) checksum(ctx context.Context) error {
 	// applies, and the only thing left is cutover, which itself wants at
 	// least 5 connections. Pool size grows monotonically; see the
 	// MaxOpenConnections doc in (*Runner).Run.
-	r.db.SetMaxOpenConns(r.dbConfig.MaxOpenConnections + 2)
+	dbconn.SetPoolSize(r.db, r.dbConfig.MaxOpenConnections+2)
 
 	// Run the checksum with internal retry logic.
 	//

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -594,10 +594,10 @@ func (r *Runner) setupUnderLocks(ctx context.Context) error {
 	if poolSize := r.move.Threads + r.move.WriteThreads + 2; poolSize > r.dbConfig.MaxOpenConnections {
 		r.dbConfig.MaxOpenConnections = poolSize
 		for i := range r.sources {
-			r.sources[i].db.SetMaxOpenConns(poolSize)
+			dbconn.SetPoolSize(r.sources[i].db, poolSize)
 		}
 		for i := range r.targets {
-			r.targets[i].DB.SetMaxOpenConns(poolSize)
+			dbconn.SetPoolSize(r.targets[i].DB, poolSize)
 		}
 	}
 


### PR DESCRIPTION
Extracted from #1097 (the experimentation draft), where a staging migration showed the connection pool churning: `maxIdleConns` was a hardcoded `10` while the migration runner ratchets `SetMaxOpenConns` into the hundreds. `database/sql` closes any connection returned to a pool whose free list already holds `MaxIdleConns` entries, so with tens of workers cycling connections continuously, nearly every release past the tenth was a close and nearly every acquire a fresh dial + TLS handshake + MySQL auth. The churn is invisible in the status line, which only reports `conns-in-use`.

`dbconn.SetPoolSize(db, n)` moves both limits together, and every sizing call site switches to it — including the two that ratchet the pool *after* construction (copy setup and the checksum's `+2`), which is why this is a helper rather than a one-time fix in `New()`: an idle limit set at construction goes stale the first time a phase resizes the pool.

Notes for review:

- Holding the connections idle costs nothing beyond what `SetMaxOpenConns` already reserved; this only stops the pool from discarding connections it is entitled to keep. `maxConnLifetime` (3m) still recycles them and is deliberately unchanged — with the idle limit fixed, that lifetime becomes the dominant remaining churn source (~22 reconnects/min at ~65 active connections), but raising it is a policy call that shouldn't be buried in this PR.
- In fairness, this is a correctness/hygiene fix more than a throughput lever: at the observed ~85 acquires/s the handshake cost is well under 1% of a 16-core client. The practical wins are less reconnect noise in server logs and no TLS/auth churn against the target.
- `n <= 0` (unlimited) passes through to `SetMaxOpenConns` and leaves the idle limit alone, since "unlimited idle" is not expressible; this is documented at the function and pinned by the test. No caller passes it today (`NewDBConfig` defaults to 32).

Tested: `pkg/dbconn`, `pkg/migration`, `pkg/move` green; `TestSetPoolSizeKeepsIdleWithOpen` covers the ratchet-up, shrink, and unlimited cases by cycling real connections and reading `Stats().Idle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
