### PR TITLE
feat(check): export StatementRefusal for pre-apply statement classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Larger instances can typically perform schema changes much faster, because they 
 - **`RENAME` column**. Some rename operations are intentionally not supported for now. For example, renaming a column and then reusing the same column name in adding a column. These are not impossible to support, but it's easy to get these wrong leading to data corruption. This is why (for now) we do not intend to support all cases.
 - **`ALTER`/NO PRIMARY KEY**. Spirit requires the table to have a primary key, and the primary key can not be altered by the schema change. There might be some flexibility to support UNIQUE keys and some modifications of the primary key in future, but it is not a priority for now.
 - **Lossy conversions**. Spirit does not support adding a `UNIQUE` index on non unique data, shortening a `VARCHAR` to a size less than the longest value, or adding a new `NOT NULL` column without a default value. To perform these changes you must fix the data, and then run the migration.
+- **Some `ENUM` and `SET` modifications**. Spirit's replication path receives these values from the binary log as integer ordinals and bitmasks, and its checksum compares their string form. A change that alters the meaning or the rendering of an existing value can not be supported:
+  - **`ENUM`**: appending values to the end of the list is supported, and so is dropping values from anywhere in the list. Reordering the values that are kept, or inserting a new value ahead of one that is kept, is not.
+  - **`SET`**: only appending values to the end of the list is supported. The new list must begin with the existing list, so reordering or removing members is not supported.
+  - **Type conversions**: converting `ENUM`/`SET` to a string type (`VARCHAR`, `CHAR`, `TEXT`, `BLOB`, etc.) is supported, and so is `ENUM` to `SET`. `SET` to `ENUM` is not, because a `SET` value can hold several members where an `ENUM` holds at most one. `ENUM`/`SET` to a numeric type is not, because the value would be coerced from its string form and lost.
 - **`FOREIGN KEYS`** or **`TRIGGERS`**. Spirit does not support migrating tables that have `FOREIGN KEYS` or `TRIGGERS`.
 
 ## Requirements

--- a/pkg/migration/check/check.go
+++ b/pkg/migration/check/check.go
@@ -96,7 +96,13 @@ func registerCheck(name string, callback func(context.Context, Resources, *slog.
 // RunChecks runs all checks that are registered for the given scope.
 // Checks run in name order so that a statement failing more than one
 // check always reports the same error.
+//
+// logger may be nil: checks log as they run, and a caller classifying a
+// statement without a logger to hand must get a verdict rather than a panic.
 func RunChecks(ctx context.Context, r Resources, logger *slog.Logger, scope ScopeFlag) error {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
 	lock.Lock()
 	registered := maps.Clone(checks)
 	lock.Unlock()

--- a/pkg/migration/check/check.go
+++ b/pkg/migration/check/check.go
@@ -37,16 +37,22 @@ const (
 	// Statement being unset.
 	//
 	// A failure here is a refusal the caller can report as certain, so the
-	// scope only carries checks no earlier stage can bypass. Spirit attempts
-	// MySQL's native DDL — ALGORITHM=INSTANT, then a safe-INPLACE subset —
-	// before it runs preflight checks, so a preflight check that the native
-	// DDL can complete anyway (dropadd, rename) is deliberately excluded:
-	// claiming those as refusals would report failure for an apply that
-	// succeeds.
+	// scope only carries checks that no earlier stage can bypass on any
+	// server. Spirit attempts MySQL's native DDL — ALGORITHM=INSTANT, then a
+	// safe-INPLACE subset — before it runs preflight checks, and MySQL decides
+	// what that completes, which varies with the server version and the table.
+	// A preflight check the native DDL may complete (dropadd, rename) is
+	// deliberately excluded: claiming those as refusals would report failure
+	// for an apply that succeeds.
 	//
-	// Passing these checks is not a promise Spirit will accept the statement.
-	// Checks that need a live connection (existing foreign keys, triggers,
-	// privileges, ...) still run only at preflight.
+	// That exclusion only ever under-reports, which is the safe direction:
+	// passing these checks is not a promise Spirit will accept the statement,
+	// only a failure is a claim. An excluded check still refuses at preflight
+	// whenever the native attempt does not take the statement — Spirit skips
+	// the attempt altogether for a multi-table change, and an older server
+	// rejects shapes a newer one completes instantly. Checks that need a live
+	// connection (existing foreign keys, triggers, privileges, ...) likewise
+	// run only at preflight.
 	ScopeStatement ScopeFlag = 1 << 6
 )
 
@@ -71,6 +77,11 @@ type Resources struct {
 	// change source. The configuration check uses this to additionally
 	// validate gtid_mode and enforce_gtid_consistency on the source.
 	GTID bool
+
+	// scope is the scope the checks are running under, set by RunChecks. A
+	// check that tolerates a missing resource for an external caller reads it
+	// to tell that case from a migration which failed to supply the resource.
+	scope ScopeFlag
 }
 
 type check struct {
@@ -103,6 +114,7 @@ func RunChecks(ctx context.Context, r Resources, logger *slog.Logger, scope Scop
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
+	r.scope = scope
 	lock.Lock()
 	registered := maps.Clone(checks)
 	lock.Unlock()

--- a/pkg/migration/check/check.go
+++ b/pkg/migration/check/check.go
@@ -26,17 +26,27 @@ const (
 	ScopeCutover     ScopeFlag = 1 << 3
 	ScopePostCutover ScopeFlag = 1 << 4
 	ScopeTesting     ScopeFlag = 1 << 5
-	// ScopeStatement marks preflight checks that classify the ALTER statement
-	// itself: they decide from the parsed statement alone whether Spirit
-	// refuses to run it, never touching a database connection. Callers can run
-	// them via RunChecks with only Resources.Statement set (Table is optional
-	// and widens coverage when present) to determine up front that a statement
-	// would be refused — for example, a planning tool classifying DDL before
-	// an apply. Passing these checks is not a promise Spirit will accept the
-	// statement: checks that need a live connection (existing foreign keys,
-	// triggers, privileges, ...) still run only at preflight. A check tagged
-	// with this scope must tolerate every Resources field except Statement
-	// being unset.
+	// ScopeStatement marks preflight checks a caller can run ahead of an apply
+	// to learn that Spirit will refuse a statement. Callers run them via
+	// RunChecks with Resources.Statement set and, optionally,
+	// Resources.Table — the table's current metadata, which widens coverage to
+	// the checks that compare the statement against the existing column
+	// definitions. Neither needs a database connection: Table can be built
+	// from the table's DDL with statement.CreateTable.ToTableInfo. A check
+	// tagged with this scope must tolerate every Resources field except
+	// Statement being unset.
+	//
+	// A failure here is a refusal the caller can report as certain, so the
+	// scope only carries checks no earlier stage can bypass. Spirit attempts
+	// MySQL's native DDL — ALGORITHM=INSTANT, then a safe-INPLACE subset —
+	// before it runs preflight checks, so a preflight check that the native
+	// DDL can complete anyway (dropadd, rename) is deliberately excluded:
+	// claiming those as refusals would report failure for an apply that
+	// succeeds.
+	//
+	// Passing these checks is not a promise Spirit will accept the statement.
+	// Checks that need a live connection (existing foreign keys, triggers,
+	// privileges, ...) still run only at preflight.
 	ScopeStatement ScopeFlag = 1 << 6
 )
 

--- a/pkg/migration/check/dropadd.go
+++ b/pkg/migration/check/dropadd.go
@@ -11,8 +11,11 @@ import (
 )
 
 // Not tagged ScopeStatement: MySQL's native DDL, which Spirit attempts before
-// preflight, can complete a drop and add of the same column in a single
-// statement, so this refusal is not one a caller may report ahead of an apply.
+// preflight for a single-table change, can complete a drop and add of the same
+// column in a single statement, so this refusal is not one a caller may report
+// ahead of an apply. It still refuses here when that attempt does not take the
+// statement — for a multi-table change Spirit skips the attempt entirely, and
+// an older server may not drop or add the column instantly.
 func init() {
 	registerCheck("dropadd", dropAddCheck, ScopePreflight)
 }

--- a/pkg/migration/check/dropadd.go
+++ b/pkg/migration/check/dropadd.go
@@ -10,8 +10,11 @@ import (
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 )
 
+// Not tagged ScopeStatement: MySQL's native DDL, which Spirit attempts before
+// preflight, can complete a drop and add of the same column in a single
+// statement, so this refusal is not one a caller may report ahead of an apply.
 func init() {
-	registerCheck("dropadd", dropAddCheck, ScopePreflight|ScopeStatement)
+	registerCheck("dropadd", dropAddCheck, ScopePreflight)
 }
 
 // dropAddCheck checks for a DROP and then ADD in the same statement.

--- a/pkg/migration/check/enumreorder.go
+++ b/pkg/migration/check/enumreorder.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registerCheck("enumReorder", enumReorderCheck, ScopePreflight)
+	registerCheck("enumReorder", enumReorderCheck, ScopePreflight|ScopeStatement)
 }
 
 // enumReorderCheck prevents ENUM value reordering and middle-insertion.
@@ -32,6 +32,9 @@ func init() {
 // "kept values keep their relative order" invariant that the decode path
 // relies on.
 func enumReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
+	if !hasCurrentColumnTypes(r, logger, "enumReorder") {
+		return nil
+	}
 	for _, col := range findModifiedEnumSetColumns(*r.Statement.StmtNode) {
 		if col.ColDef.Tp.GetType() == mysql.TypeSet {
 			continue // handled by setReorderCheck

--- a/pkg/migration/check/enumreorder.go
+++ b/pkg/migration/check/enumreorder.go
@@ -32,7 +32,11 @@ func init() {
 // "kept values keep their relative order" invariant that the decode path
 // relies on.
 func enumReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
-	if !hasCurrentColumnTypes(r, logger, "enumReorder") {
+	haveTypes, err := requireCurrentColumnTypes(r, logger, "enumReorder")
+	if err != nil {
+		return err
+	}
+	if !haveTypes {
 		return nil
 	}
 	for _, col := range findModifiedEnumSetColumns(*r.Statement.StmtNode) {
@@ -47,7 +51,7 @@ func enumReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) err
 
 		existingType, ok := r.Table.GetColumnMySQLType(col.LookupName)
 		if !ok {
-			return fmt.Errorf("unable to validate ENUM change for column %q: existing column type not found in table metadata", col.LookupName)
+			return cannotClassify("unable to validate ENUM change for column %q: existing column type not found in table metadata", col.LookupName)
 		}
 
 		// The ENUM reorder check only applies when the existing column is
@@ -60,7 +64,7 @@ func enumReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) err
 
 		existingElems, err := parseEnumSetValues(existingType)
 		if err != nil {
-			return fmt.Errorf("unable to validate ENUM change for column %q: %w", col.LookupName, err)
+			return cannotClassify("unable to validate ENUM change for column %q: %w", col.LookupName, err)
 		}
 		if len(existingElems) == 0 {
 			continue

--- a/pkg/migration/check/enumsetremoval.go
+++ b/pkg/migration/check/enumsetremoval.go
@@ -43,7 +43,11 @@ func init() {
 // disallows it because the checksum compares CAST(col AS char) and the
 // string order changes when bits are reordered.
 func enumSetRemovalCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
-	if !hasCurrentColumnTypes(r, logger, "enumSetRemoval") {
+	haveTypes, err := requireCurrentColumnTypes(r, logger, "enumSetRemoval")
+	if err != nil {
+		return err
+	}
+	if !haveTypes {
 		return nil
 	}
 	for _, col := range findModifiedColumns(*r.Statement.StmtNode) {

--- a/pkg/migration/check/enumsetremoval.go
+++ b/pkg/migration/check/enumsetremoval.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registerCheck("enumSetRemoval", enumSetRemovalCheck, ScopePreflight)
+	registerCheck("enumSetRemoval", enumSetRemovalCheck, ScopePreflight|ScopeStatement)
 }
 
 // enumSetRemovalCheck prevents unsafe ENUM/SET type conversions.
@@ -43,6 +43,9 @@ func init() {
 // disallows it because the checksum compares CAST(col AS char) and the
 // string order changes when bits are reordered.
 func enumSetRemovalCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
+	if !hasCurrentColumnTypes(r, logger, "enumSetRemoval") {
+		return nil
+	}
 	for _, col := range findModifiedColumns(*r.Statement.StmtNode) {
 		newTp := col.ColDef.Tp.GetType()
 

--- a/pkg/migration/check/enumsetutil.go
+++ b/pkg/migration/check/enumsetutil.go
@@ -2,11 +2,26 @@ package check
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 )
+
+// hasCurrentColumnTypes reports whether Resources carries the table metadata the
+// ENUM/SET checks need to compare a redeclared column against its current
+// definition. Preflight always supplies it; a ScopeStatement caller may not have
+// the table's DDL to build it from, in which case the check is skipped rather
+// than guessing at the current type (see ScopeStatement).
+func hasCurrentColumnTypes(r Resources, logger *slog.Logger, checkName string) bool {
+	if r.Table == nil {
+		logger.Debug("skipping check: no table metadata supplied, cannot compare against the current column types",
+			"check", checkName)
+		return false
+	}
+	return true
+}
 
 // isEnumOrSetType returns true if the MySQL type string represents an ENUM or SET type.
 func isEnumOrSetType(mysqlType string) bool {

--- a/pkg/migration/check/enumsetutil.go
+++ b/pkg/migration/check/enumsetutil.go
@@ -9,18 +9,26 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 )
 
-// hasCurrentColumnTypes reports whether Resources carries the table metadata the
-// ENUM/SET checks need to compare a redeclared column against its current
-// definition. Preflight always supplies it; a ScopeStatement caller may not have
-// the table's DDL to build it from, in which case the check is skipped rather
-// than guessing at the current type (see ScopeStatement).
-func hasCurrentColumnTypes(r Resources, logger *slog.Logger, checkName string) bool {
-	if r.Table == nil {
+// requireCurrentColumnTypes reports whether Resources carries the table metadata
+// the ENUM/SET checks need to compare a redeclared column against its current
+// definition.
+//
+// A ScopeStatement caller may not have the table's DDL to build it from, so the
+// check is skipped rather than guessing at the current type (see
+// ScopeStatement). Every other scope runs inside a migration, which loads the
+// table before it runs any check: metadata missing there means these three
+// guards against a data-corrupting ENUM/SET change would not run at all, so the
+// check fails rather than passing quietly.
+func requireCurrentColumnTypes(r Resources, logger *slog.Logger, checkName string) (bool, error) {
+	if r.Table != nil {
+		return true, nil
+	}
+	if r.scope&ScopeStatement != 0 {
 		logger.Debug("skipping check: no table metadata supplied, cannot compare against the current column types",
 			"check", checkName)
-		return false
+		return false, nil
 	}
-	return true
+	return false, fmt.Errorf("check %s cannot run: the table's current column types were not loaded", checkName)
 }
 
 // isEnumOrSetType returns true if the MySQL type string represents an ENUM or SET type.

--- a/pkg/migration/check/rename.go
+++ b/pkg/migration/check/rename.go
@@ -11,8 +11,11 @@ import (
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 )
 
+// Not tagged ScopeStatement: renames are metadata-only, so MySQL's native DDL,
+// which Spirit attempts before preflight, can complete the shapes refused here,
+// making them unsafe for a caller to report as refusals ahead of an apply.
 func init() {
-	registerCheck("rename", renameCheck, ScopePreflight|ScopeStatement)
+	registerCheck("rename", renameCheck, ScopePreflight)
 }
 
 // renameCheck validates rename operations in ALTER TABLE statements.

--- a/pkg/migration/check/rename.go
+++ b/pkg/migration/check/rename.go
@@ -12,8 +12,11 @@ import (
 )
 
 // Not tagged ScopeStatement: renames are metadata-only, so MySQL's native DDL,
-// which Spirit attempts before preflight, can complete the shapes refused here,
-// making them unsafe for a caller to report as refusals ahead of an apply.
+// which Spirit attempts before preflight for a single-table change, can complete
+// the shapes refused here, making them unsafe for a caller to report as refusals
+// ahead of an apply. It still refuses here when that attempt does not take the
+// statement — for a multi-table change Spirit skips the attempt entirely, and an
+// older server may not rename the column instantly.
 func init() {
 	registerCheck("rename", renameCheck, ScopePreflight)
 }

--- a/pkg/migration/check/setreorder.go
+++ b/pkg/migration/check/setreorder.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registerCheck("setReorder", setReorderCheck, ScopePreflight)
+	registerCheck("setReorder", setReorderCheck, ScopePreflight|ScopeStatement)
 }
 
 // setReorderCheck prevents SET value reordering in all modes.
@@ -29,6 +29,9 @@ func init() {
 // Adding new SET values at the end of the list is always safe. The new list must
 // start with the existing values as a prefix.
 func setReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
+	if !hasCurrentColumnTypes(r, logger, "setReorder") {
+		return nil
+	}
 	for _, col := range findModifiedEnumSetColumns(*r.Statement.StmtNode) {
 		if col.ColDef.Tp.GetType() != mysql.TypeSet {
 			continue // handled by enumReorderCheck

--- a/pkg/migration/check/setreorder.go
+++ b/pkg/migration/check/setreorder.go
@@ -29,7 +29,11 @@ func init() {
 // Adding new SET values at the end of the list is always safe. The new list must
 // start with the existing values as a prefix.
 func setReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
-	if !hasCurrentColumnTypes(r, logger, "setReorder") {
+	haveTypes, err := requireCurrentColumnTypes(r, logger, "setReorder")
+	if err != nil {
+		return err
+	}
+	if !haveTypes {
 		return nil
 	}
 	for _, col := range findModifiedEnumSetColumns(*r.Statement.StmtNode) {
@@ -44,7 +48,7 @@ func setReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 
 		existingType, ok := r.Table.GetColumnMySQLType(col.LookupName)
 		if !ok {
-			return fmt.Errorf("unable to validate SET reorder for column %q: existing column type not found in TableInfo", col.LookupName)
+			return cannotClassify("unable to validate SET reorder for column %q: existing column type not found in table metadata", col.LookupName)
 		}
 
 		// The SET reorder check only applies when the existing column is
@@ -57,7 +61,7 @@ func setReorderCheck(ctx context.Context, r Resources, logger *slog.Logger) erro
 
 		existingElems, err := parseEnumSetValues(existingType)
 		if err != nil {
-			return fmt.Errorf("unable to validate SET reorder for column %q: %w", col.LookupName, err)
+			return cannotClassify("unable to validate SET reorder for column %q: %w", col.LookupName, err)
 		}
 		if len(existingElems) == 0 {
 			continue

--- a/pkg/migration/check/statement_refusal.go
+++ b/pkg/migration/check/statement_refusal.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -32,9 +33,10 @@ import (
 // refused is true only when Spirit will refuse the statement, so a caller may
 // act on it. A statement that is not an ALTER TABLE is never refused: Spirit
 // runs CREATE TABLE and DROP TABLE as native DDL rather than through the copy
-// process. err reports input that cannot be classified at all — an unparseable
-// statement, more than one statement, or a currentCreateTable for a different
-// table — and is never itself a refusal.
+// process. err reports input that cannot be classified — an unparseable
+// statement, more than one statement, a currentCreateTable for a different
+// table, or one that does not describe a column the statement redeclares — and
+// is never itself a refusal.
 func StatementRefusal(ctx context.Context, stmt, currentCreateTable string, logger *slog.Logger) (reason string, refused bool, err error) {
 	stmts, err := statement.New(stmt)
 	if err != nil {
@@ -56,9 +58,35 @@ func StatementRefusal(ctx context.Context, stmt, currentCreateTable string, logg
 		}
 	}
 	if checkErr := RunChecks(ctx, resources, logger, ScopeStatement); checkErr != nil {
+		var unclassified *classificationError
+		if errors.As(checkErr, &unclassified) {
+			return "", false, fmt.Errorf("classify statement against the current definition of table %q: %w", abs.Table, checkErr)
+		}
 		return checkErr.Error(), true, nil
 	}
 	return "", false, nil
+}
+
+// classificationError marks a check error that is not a refusal: the check could
+// not reach a verdict, because the inputs do not describe what it has to
+// compare — typically a column the statement redeclares that the supplied table
+// definition does not carry. A refusal is a claim about the statement, so
+// StatementRefusal reports one of these as an error rather than letting a
+// caller act on it and block an apply that may well succeed.
+//
+// It keeps the wrapped error's message: a migration reaches these through
+// preflight, where the distinction does not apply and the check's own wording
+// is what the operator needs.
+type classificationError struct{ err error }
+
+func (e *classificationError) Error() string { return e.err.Error() }
+func (e *classificationError) Unwrap() error { return e.err }
+
+// cannotClassify marks an error as a failure to reach a verdict rather than a
+// refusal. A check uses it for a condition that says nothing about whether
+// Spirit accepts the statement.
+func cannotClassify(format string, args ...any) error {
+	return &classificationError{err: fmt.Errorf(format, args...)}
 }
 
 // tableMetadataFor parses the table's current definition into the metadata the

--- a/pkg/migration/check/statement_refusal.go
+++ b/pkg/migration/check/statement_refusal.go
@@ -27,6 +27,8 @@ import (
 // only the statement, and the ENUM/SET checks — which compare a redeclared
 // column against its current type — are skipped.
 //
+// logger may be nil, in which case the checks' own logging is discarded.
+//
 // refused is true only when Spirit will refuse the statement, so a caller may
 // act on it. A statement that is not an ALTER TABLE is never refused: Spirit
 // runs CREATE TABLE and DROP TABLE as native DDL rather than through the copy

--- a/pkg/migration/check/statement_refusal.go
+++ b/pkg/migration/check/statement_refusal.go
@@ -1,0 +1,80 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/block/spirit/pkg/statement"
+	"github.com/block/spirit/pkg/table"
+)
+
+// StatementRefusal reports whether Spirit deterministically refuses stmt, and
+// the reason it would give.
+//
+// It runs the ScopeStatement checks: the subset of Spirit's preflight checks
+// that decide from the statement — plus, when currentCreateTable is supplied,
+// the table's existing column definitions — and that MySQL's native DDL cannot
+// complete behind their back. That makes it the entry point for a caller which
+// needs to know an apply's outcome before starting it, such as a planning tool
+// classifying DDL. Checks Spirit adds to the scope later are picked up without
+// any change here.
+//
+// currentCreateTable is the table's current definition, normally its
+// SHOW CREATE TABLE. It must describe the table stmt alters. Pass an empty
+// string when it is not available: coverage then narrows to the checks that need
+// only the statement, and the ENUM/SET checks — which compare a redeclared
+// column against its current type — are skipped.
+//
+// refused is true only when Spirit will refuse the statement, so a caller may
+// act on it. A statement that is not an ALTER TABLE is never refused: Spirit
+// runs CREATE TABLE and DROP TABLE as native DDL rather than through the copy
+// process. err reports input that cannot be classified at all — an unparseable
+// statement, more than one statement, or a currentCreateTable for a different
+// table — and is never itself a refusal.
+func StatementRefusal(ctx context.Context, stmt, currentCreateTable string, logger *slog.Logger) (reason string, refused bool, err error) {
+	stmts, err := statement.New(stmt)
+	if err != nil {
+		return "", false, fmt.Errorf("parse statement to check for refusal: %w", err)
+	}
+	if len(stmts) != 1 {
+		return "", false, fmt.Errorf("refusal check requires exactly one statement, got %d", len(stmts))
+	}
+	abs := stmts[0]
+	if !abs.IsAlterTable() {
+		return "", false, nil
+	}
+
+	resources := Resources{Statement: abs}
+	if currentCreateTable != "" {
+		resources.Table, err = tableMetadataFor(abs, currentCreateTable)
+		if err != nil {
+			return "", false, err
+		}
+	}
+	if checkErr := RunChecks(ctx, resources, logger, ScopeStatement); checkErr != nil {
+		return checkErr.Error(), true, nil
+	}
+	return "", false, nil
+}
+
+// tableMetadataFor parses the table's current definition into the metadata the
+// ENUM/SET checks read. It rejects a definition for a different table than the
+// ALTER targets: those checks compare the ALTER's columns against the current
+// ones by name, so a mismatched definition would report refusals — or miss
+// them — for columns that have nothing to do with each other.
+func tableMetadataFor(abs *statement.AbstractStatement, currentCreateTable string) (*table.TableInfo, error) {
+	ct, err := statement.ParseCreateTable(currentCreateTable)
+	if err != nil {
+		return nil, fmt.Errorf("parse current definition of table %q: %w", abs.Table, err)
+	}
+	if !strings.EqualFold(ct.TableName, abs.Table) {
+		return nil, fmt.Errorf("current definition is for table %q but the statement alters table %q", ct.TableName, abs.Table)
+	}
+	ti, err := ct.ToTableInfo(abs.Schema)
+	if err != nil {
+		return nil, err
+	}
+	return ti, nil
+}

--- a/pkg/migration/check/statement_scope_test.go
+++ b/pkg/migration/check/statement_scope_test.go
@@ -309,6 +309,67 @@ func TestStatementRefusalErrors(t *testing.T) {
 	}
 }
 
+// TestStatementRefusalUncoveredColumn classifies a statement that redeclares a
+// column the supplied definition does not carry — a stale definition, or one
+// read after the column was dropped. The ENUM/SET checks cannot compare against
+// a current type they do not have, and that says nothing about whether Spirit
+// accepts the statement, so it surfaces as an error rather than a refusal a
+// caller would act on.
+func TestStatementRefusalUncoveredColumn(t *testing.T) {
+	tests := []struct {
+		name    string
+		stmt    string
+		wantErr string
+	}{
+		{
+			name:    "enum column absent from the definition",
+			stmt:    "ALTER TABLE orders MODIFY COLUMN ghost ENUM('a','b')",
+			wantErr: `unable to validate ENUM change for column "ghost"`,
+		},
+		{
+			name:    "set column absent from the definition",
+			stmt:    "ALTER TABLE orders MODIFY COLUMN ghost SET('a','b')",
+			wantErr: `unable to validate SET reorder for column "ghost"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, refused, err := StatementRefusal(t.Context(), tt.stmt, ordersTable, discardLogger())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.False(t, refused, "an unclassifiable statement must not be reported as refused")
+			assert.Empty(t, reason)
+		})
+	}
+}
+
+// TestEnumSetChecksRequireTableMetadataOutsideStatementScope covers the ENUM/SET
+// checks running without table metadata in a scope other than ScopeStatement.
+// Only a statement-scope caller is allowed to omit it; a migration loads the
+// table before it runs any check, so metadata missing there means these guards
+// against a data-corrupting change would not run at all, and the check fails
+// rather than passing quietly.
+func TestEnumSetChecksRequireTableMetadataOutsideStatementScope(t *testing.T) {
+	const stmt = "ALTER TABLE orders MODIFY COLUMN status ENUM('shipped','new','done') NOT NULL"
+	checks := map[string]func(context.Context, Resources, *slog.Logger) error{
+		"enumReorder":    enumReorderCheck,
+		"setReorder":     setReorderCheck,
+		"enumSetRemoval": enumSetRemovalCheck,
+	}
+	for name, check := range checks {
+		t.Run(name, func(t *testing.T) {
+			r := Resources{Statement: statement.MustNew(stmt)[0], scope: ScopePreflight}
+			err := check(t.Context(), r, discardLogger())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "check "+name+" cannot run")
+
+			r.scope = ScopeStatement
+			require.NoError(t, check(t.Context(), r, discardLogger()),
+				"a statement-scope caller may omit the table metadata")
+		})
+	}
+}
+
 // TestStatementScopeChecksDeterministicError verifies that a statement failing
 // more than one statement-scoped check reports the same error every run:
 // RunChecks iterates checks in name order, so classifiers surfacing the error

--- a/pkg/migration/check/statement_scope_test.go
+++ b/pkg/migration/check/statement_scope_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
@@ -8,6 +9,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// ordersTable is the current definition of the table the statement-scope tests
+// alter, in the form SHOW CREATE TABLE reports it.
+const ordersTable = "CREATE TABLE `orders` (\n" +
+	"  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n" +
+	"  `status` enum('new','shipped','done') NOT NULL DEFAULT 'new',\n" +
+	"  `perms` set('read','write','execute') DEFAULT NULL,\n" +
+	"  `name` varchar(100) DEFAULT NULL,\n" +
+	"  PRIMARY KEY (`id`)\n" +
+	") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
 
 // TestStatementScopeChecks runs the statement-scoped checks the way an
 // external classifier does: only Resources.Statement is set — no database
@@ -41,21 +56,6 @@ func TestStatementScopeChecks(t *testing.T) {
 			wantErr: "LOCK=",
 		},
 		{
-			name:    "drop and re-add of the same column is refused",
-			stmt:    "ALTER TABLE t1 DROP COLUMN b, ADD COLUMN b INT",
-			wantErr: "mentioned 2 times",
-		},
-		{
-			name:    "table rename is refused",
-			stmt:    "ALTER TABLE t1 RENAME TO t2",
-			wantErr: "table renames are not supported",
-		},
-		{
-			name:    "rename overlapping an added column is refused",
-			stmt:    "ALTER TABLE t1 RENAME COLUMN c1 TO n1, ADD COLUMN c1 INT",
-			wantErr: "could cause data corruption",
-		},
-		{
 			name: "add column passes",
 			stmt: "ALTER TABLE t1 ADD COLUMN b INT",
 		},
@@ -67,11 +67,15 @@ func TestStatementScopeChecks(t *testing.T) {
 			name: "column rename passes without table metadata",
 			stmt: "ALTER TABLE t1 RENAME COLUMN c1 TO c2",
 		},
+		{
+			name: "enum reorder passes without table metadata",
+			stmt: "ALTER TABLE t1 MODIFY COLUMN status ENUM('shipped','new')",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := Resources{Statement: statement.MustNew(tt.stmt)[0]}
-			err := RunChecks(t.Context(), r, slog.Default(), ScopeStatement)
+			err := RunChecks(t.Context(), r, discardLogger(), ScopeStatement)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return
@@ -82,16 +86,215 @@ func TestStatementScopeChecks(t *testing.T) {
 	}
 }
 
+// TestStatementScopeExcludesNativeDDLChecks covers the preflight checks
+// deliberately kept out of ScopeStatement. Spirit attempts MySQL's native DDL
+// before running preflight checks, and the native DDL can complete these
+// metadata-only statements, so a classifier must not report them as refusals.
+// Each is still refused at preflight, once Spirit knows the native DDL did not
+// take the statement.
+func TestStatementScopeExcludesNativeDDLChecks(t *testing.T) {
+	tests := []struct {
+		name    string
+		stmt    string
+		check   func(context.Context, Resources, *slog.Logger) error
+		wantErr string
+	}{
+		{
+			name:    "drop and re-add of the same column",
+			stmt:    "ALTER TABLE t1 DROP COLUMN b, ADD COLUMN b INT",
+			check:   dropAddCheck,
+			wantErr: "mentioned 2 times",
+		},
+		{
+			name:    "table rename",
+			stmt:    "ALTER TABLE t1 RENAME TO t2",
+			check:   renameCheck,
+			wantErr: "table renames are not supported",
+		},
+		{
+			name:    "rename overlapping an added column",
+			stmt:    "ALTER TABLE t1 RENAME COLUMN c1 TO n1, ADD COLUMN c1 INT",
+			check:   renameCheck,
+			wantErr: "could cause data corruption",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Resources{Statement: statement.MustNew(tt.stmt)[0]}
+			require.NoError(t, RunChecks(t.Context(), r, discardLogger(), ScopeStatement),
+				"statement-scope checks must stay silent on statements MySQL's native DDL can complete")
+			err := tt.check(t.Context(), r, discardLogger())
+			require.Error(t, err, "the preflight check must still refuse the statement")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestStatementRefusalWithTableMetadata classifies statements with the table's
+// current definition supplied, which widens coverage to the checks that compare
+// a redeclared column against its existing type. MySQL cannot complete any of
+// the refused shapes as native DDL — each needs a table rebuild — so they are
+// safe for a classifier to report ahead of an apply.
+func TestStatementRefusalWithTableMetadata(t *testing.T) {
+	tests := []struct {
+		name       string
+		stmt       string
+		wantReason string
+	}{
+		{
+			name:       "enum reorder is refused",
+			stmt:       "ALTER TABLE orders MODIFY COLUMN status ENUM('shipped','new','done') NOT NULL",
+			wantReason: `unsafe ENUM value reorder on column "status"`,
+		},
+		{
+			name:       "enum middle insertion is refused",
+			stmt:       "ALTER TABLE orders MODIFY COLUMN status ENUM('new','pending','shipped','done') NOT NULL",
+			wantReason: `unsafe ENUM value reorder on column "status"`,
+		},
+		{
+			name:       "set reorder is refused",
+			stmt:       "ALTER TABLE orders MODIFY COLUMN perms SET('write','read','execute')",
+			wantReason: `unsafe SET value reorder on column "perms"`,
+		},
+		{
+			name:       "enum to numeric conversion is refused",
+			stmt:       "ALTER TABLE orders MODIFY COLUMN status INT NOT NULL",
+			wantReason: `unsafe ENUM to int(11) type conversion on column "status"`,
+		},
+		{
+			name:       "set to enum conversion is refused",
+			stmt:       "ALTER TABLE orders MODIFY COLUMN perms ENUM('read','write')",
+			wantReason: `unsafe SET to ENUM type conversion on column "perms"`,
+		},
+		{
+			name: "appending enum values passes",
+			stmt: "ALTER TABLE orders MODIFY COLUMN status ENUM('new','shipped','done','lost') NOT NULL",
+		},
+		{
+			name: "dropping enum values passes",
+			stmt: "ALTER TABLE orders MODIFY COLUMN status ENUM('new','done') NOT NULL",
+		},
+		{
+			name: "appending set values passes",
+			stmt: "ALTER TABLE orders MODIFY COLUMN perms SET('read','write','execute','admin')",
+		},
+		{
+			name: "enum to varchar conversion passes",
+			stmt: "ALTER TABLE orders MODIFY COLUMN status VARCHAR(20) NOT NULL",
+		},
+		{
+			name: "widening an unrelated column passes",
+			stmt: "ALTER TABLE orders MODIFY COLUMN name VARCHAR(255)",
+		},
+		{
+			name: "adding a column passes",
+			stmt: "ALTER TABLE orders ADD COLUMN shipped_at DATETIME",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, refused, err := StatementRefusal(t.Context(), tt.stmt, ordersTable, discardLogger())
+			require.NoError(t, err)
+			if tt.wantReason == "" {
+				assert.False(t, refused)
+				assert.Empty(t, reason)
+				return
+			}
+			require.True(t, refused)
+			assert.Contains(t, reason, tt.wantReason)
+		})
+	}
+}
+
+// TestStatementRefusalNonAlterStatements classifies the statement types Spirit
+// runs as native DDL rather than through the copy process. They are never
+// refused, so a classifier reports them as applying normally.
+func TestStatementRefusalNonAlterStatements(t *testing.T) {
+	for _, stmt := range []string{
+		"CREATE TABLE t9 (id INT NOT NULL PRIMARY KEY)",
+		"DROP TABLE t9",
+	} {
+		t.Run(stmt, func(t *testing.T) {
+			reason, refused, err := StatementRefusal(t.Context(), stmt, ordersTable, discardLogger())
+			require.NoError(t, err)
+			assert.False(t, refused)
+			assert.Empty(t, reason)
+		})
+	}
+}
+
+// TestStatementRefusalWithoutTableMetadata omits the table's current definition.
+// The ENUM/SET checks cannot run without the existing column types, so they are
+// skipped rather than guessed at, while the statement-only refusals still apply.
+func TestStatementRefusalWithoutTableMetadata(t *testing.T) {
+	reason, refused, err := StatementRefusal(t.Context(),
+		"ALTER TABLE orders MODIFY COLUMN status ENUM('shipped','new','done') NOT NULL", "", discardLogger())
+	require.NoError(t, err)
+	assert.False(t, refused)
+	assert.Empty(t, reason)
+
+	reason, refused, err = StatementRefusal(t.Context(),
+		"ALTER TABLE orders DROP PRIMARY KEY", "", discardLogger())
+	require.NoError(t, err)
+	assert.True(t, refused)
+	assert.Equal(t, "dropping primary key is not supported", reason)
+}
+
+// TestStatementRefusalErrors covers input that cannot be classified at all. Each
+// case must surface as an error rather than a refusal: reporting "Spirit refuses
+// this statement" for input Spirit never judged would block an apply for the
+// wrong reason.
+func TestStatementRefusalErrors(t *testing.T) {
+	tests := []struct {
+		name               string
+		stmt               string
+		currentCreateTable string
+		wantErr            string
+	}{
+		{
+			name:    "unparseable statement",
+			stmt:    "ALTER TABLE orders FLUX CAPACITOR",
+			wantErr: "parse statement to check for refusal",
+		},
+		{
+			name:    "more than one statement",
+			stmt:    "ALTER TABLE a ADD COLUMN x INT; ALTER TABLE b ADD COLUMN y INT",
+			wantErr: "exactly one statement, got 2",
+		},
+		{
+			name:               "unparseable current definition",
+			stmt:               "ALTER TABLE orders ADD COLUMN x INT",
+			currentCreateTable: "CREATE TABLE orders (",
+			wantErr:            `parse current definition of table "orders"`,
+		},
+		{
+			name:               "current definition is for another table",
+			stmt:               "ALTER TABLE orders MODIFY COLUMN status ENUM('shipped','new')",
+			currentCreateTable: "CREATE TABLE `customers` (`id` INT NOT NULL PRIMARY KEY)",
+			wantErr:            `current definition is for table "customers" but the statement alters table "orders"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, refused, err := StatementRefusal(t.Context(), tt.stmt, tt.currentCreateTable, discardLogger())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.False(t, refused)
+			assert.Empty(t, reason)
+		})
+	}
+}
+
 // TestStatementScopeChecksDeterministicError verifies that a statement failing
 // more than one statement-scoped check reports the same error every run:
 // RunChecks iterates checks in name order, so classifiers surfacing the error
 // to users see a stable message.
 func TestStatementScopeChecksDeterministicError(t *testing.T) {
 	const stmt = "ALTER TABLE t1 DROP PRIMARY KEY, ADD CONSTRAINT fk FOREIGN KEY (user_id) REFERENCES users (id)"
-	first := RunChecks(t.Context(), Resources{Statement: statement.MustNew(stmt)[0]}, slog.Default(), ScopeStatement)
+	first := RunChecks(t.Context(), Resources{Statement: statement.MustNew(stmt)[0]}, discardLogger(), ScopeStatement)
 	require.Error(t, first)
 	for range 20 {
-		err := RunChecks(t.Context(), Resources{Statement: statement.MustNew(stmt)[0]}, slog.Default(), ScopeStatement)
+		err := RunChecks(t.Context(), Resources{Statement: statement.MustNew(stmt)[0]}, discardLogger(), ScopeStatement)
 		require.Error(t, err)
 		assert.Equal(t, first.Error(), err.Error())
 	}

--- a/pkg/migration/check/statement_scope_test.go
+++ b/pkg/migration/check/statement_scope_test.go
@@ -240,6 +240,30 @@ func TestStatementRefusalWithoutTableMetadata(t *testing.T) {
 	assert.Equal(t, "dropping primary key is not supported", reason)
 }
 
+// TestStatementRefusalNilLogger classifies statements without a logger. A caller
+// running the checks outside a migration has no logger to hand, and every path —
+// a refusal, a pass, and the skip taken when no table metadata is supplied —
+// must still return a verdict.
+func TestStatementRefusalNilLogger(t *testing.T) {
+	reason, refused, err := StatementRefusal(t.Context(),
+		"ALTER TABLE orders MODIFY COLUMN status ENUM('shipped','new','done') NOT NULL", ordersTable, nil)
+	require.NoError(t, err)
+	assert.True(t, refused)
+	assert.Contains(t, reason, `unsafe ENUM value reorder on column "status"`)
+
+	reason, refused, err = StatementRefusal(t.Context(),
+		"ALTER TABLE orders MODIFY COLUMN status ENUM('shipped','new','done') NOT NULL", "", nil)
+	require.NoError(t, err)
+	assert.False(t, refused, "the ENUM check must skip without table metadata")
+	assert.Empty(t, reason)
+
+	reason, refused, err = StatementRefusal(t.Context(),
+		"ALTER TABLE orders ADD COLUMN shipped_at DATETIME", ordersTable, nil)
+	require.NoError(t, err)
+	assert.False(t, refused)
+	assert.Empty(t, reason)
+}
+
 // TestStatementRefusalErrors covers input that cannot be classified at all. Each
 // case must surface as an error rather than a refusal: reporting "Spirit refuses
 // this statement" for input Spirit never judged would block an apply for the

--- a/pkg/statement/format.go
+++ b/pkg/statement/format.go
@@ -11,11 +11,27 @@ import (
 // SQL fragments used to build ALTER TABLE clauses. They are free functions; the
 // CreateTable receivers that assemble the statements live in diff.go.
 
-// formatColumnDefinition formats a column definition for ALTER TABLE
-func formatColumnDefinition(col *Column) string {
-	var parts []string
+// formatColumnType renders a column's data type for emission in an ALTER TABLE
+// clause: the type name with its length/precision/element list, followed by the
+// unsigned and zerofill display attributes. Charset and collation are excluded —
+// formatColumnDefinition emits those separately.
+func formatColumnType(col *Column) string {
+	return columnType(col, sqlescape.EscapeString)
+}
 
-	// Column name and type
+// formatColumnTypeAsMetadata renders a column's data type the way MySQL reports
+// it in information_schema.columns.column_type. It differs from formatColumnType
+// only in how ENUM/SET elements are escaped: MySQL's metadata doubles an embedded
+// single quote, where the SQL Spirit emits backslash-escapes it. Both are valid
+// SQL, but the parsers that read an element list back out of column_type accept
+// only the doubled form.
+func formatColumnTypeAsMetadata(col *Column) string {
+	return columnType(col, func(s string) string { return strings.ReplaceAll(s, "'", "''") })
+}
+
+// columnType renders a column's data type, escaping ENUM/SET elements with the
+// supplied escaper.
+func columnType(col *Column, escapeElement func(string) string) string {
 	typeDef := col.Type
 
 	// Determine the full type definition including length/precision/values
@@ -23,13 +39,13 @@ func formatColumnDefinition(col *Column) string {
 	case col.Type == "enum" && len(col.EnumValues) > 0:
 		var values []string
 		for _, v := range col.EnumValues {
-			values = append(values, fmt.Sprintf("'%s'", sqlescape.EscapeString(v)))
+			values = append(values, fmt.Sprintf("'%s'", escapeElement(v)))
 		}
 		typeDef = fmt.Sprintf("enum(%s)", strings.Join(values, ","))
 	case col.Type == "set" && len(col.SetValues) > 0:
 		var values []string
 		for _, v := range col.SetValues {
-			values = append(values, fmt.Sprintf("'%s'", sqlescape.EscapeString(v)))
+			values = append(values, fmt.Sprintf("'%s'", escapeElement(v)))
 		}
 		typeDef = fmt.Sprintf("set(%s)", strings.Join(values, ","))
 	case col.Precision != nil && col.Scale != nil:
@@ -52,7 +68,15 @@ func formatColumnDefinition(col *Column) string {
 		typeDef += " zerofill"
 	}
 
-	parts = append(parts, fmt.Sprintf("%s %s", sqlescape.EscapeIdentifier(col.Name), typeDef))
+	return typeDef
+}
+
+// formatColumnDefinition formats a column definition for ALTER TABLE
+func formatColumnDefinition(col *Column) string {
+	var parts []string
+
+	// Column name and type
+	parts = append(parts, fmt.Sprintf("%s %s", sqlescape.EscapeIdentifier(col.Name), formatColumnType(col)))
 
 	// Charset and collation (skip for binary types and JSON)
 	isBinaryType := col.Type == "varbinary" || col.Type == "binary" ||

--- a/pkg/statement/table_info.go
+++ b/pkg/statement/table_info.go
@@ -1,0 +1,45 @@
+package statement
+
+import (
+	"fmt"
+
+	"github.com/block/spirit/pkg/table"
+)
+
+// ToTableInfo builds a connection-less table.TableInfo from the parsed CREATE
+// TABLE, carrying the column types and primary key columns that Spirit's
+// checks read from table metadata. schemaName names the schema the table lives
+// in; it is only used for error messages and by checks that query MySQL, which
+// cannot run against the returned TableInfo anyway (see
+// table.NewTableInfoFromMeta).
+//
+// This lets a caller holding a table's DDL — typically its SHOW CREATE TABLE —
+// supply check.Resources.Table without opening a connection.
+func (ct *CreateTable) ToTableInfo(schemaName string) (*table.TableInfo, error) {
+	columns := make([]table.ColumnMeta, 0, len(ct.Columns))
+	for i := range ct.Columns {
+		col := &ct.Columns[i]
+		columns = append(columns, table.ColumnMeta{
+			Name:      col.Name,
+			MySQLType: formatColumnTypeAsMetadata(col),
+			Generated: col.GeneratedExpr != nil,
+		})
+	}
+	ti, err := table.NewTableInfoFromMeta(schemaName, ct.TableName, columns, ct.primaryKeyColumns())
+	if err != nil {
+		return nil, fmt.Errorf("build table metadata for %q: %w", ct.TableName, err)
+	}
+	return ti, nil
+}
+
+// primaryKeyColumns returns the table's primary key columns in key order, or
+// nil when the table has no primary key. An inline column-level PRIMARY KEY has
+// already been materialized into a table-level index by primaryKeyNormalizer,
+// so reading the PRIMARY KEY index covers both spellings.
+func (ct *CreateTable) primaryKeyColumns() []string {
+	pk := ct.getPrimaryKeyIndex()
+	if pk == nil {
+		return nil
+	}
+	return pk.Columns
+}

--- a/pkg/statement/table_info_test.go
+++ b/pkg/statement/table_info_test.go
@@ -1,0 +1,89 @@
+package statement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToTableInfo converts a table's SHOW CREATE TABLE output into the metadata
+// Spirit's checks read. The column types must match the `column_type` text
+// information_schema reports, since a check comparing an ALTER against them
+// cannot tell whether they came from a server or from DDL.
+func TestToTableInfo(t *testing.T) {
+	ct, err := ParseCreateTable("CREATE TABLE `orders` (\n" +
+		"  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n" +
+		"  `tenant_id` int NOT NULL,\n" +
+		"  `status` enum('new','shipped','done') NOT NULL DEFAULT 'new',\n" +
+		"  `perms` set('read','write','execute') DEFAULT NULL,\n" +
+		"  `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,\n" +
+		"  `total` decimal(10,2) NOT NULL,\n" +
+		"  `total_cents` int GENERATED ALWAYS AS ((`total` * 100)) VIRTUAL,\n" +
+		"  PRIMARY KEY (`tenant_id`,`id`)\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err)
+
+	ti, err := ct.ToTableInfo("mydb")
+	require.NoError(t, err)
+	assert.Equal(t, "mydb", ti.SchemaName)
+	assert.Equal(t, "orders", ti.TableName)
+
+	// The primary key is reported in key order, not column order.
+	assert.Equal(t, []string{"tenant_id", "id"}, ti.KeyColumns)
+
+	// Generated columns are excluded from NonGeneratedColumns but keep their
+	// ordinal position in Columns.
+	assert.Equal(t, []string{"id", "tenant_id", "status", "perms", "name", "total", "total_cents"}, ti.Columns)
+	assert.Equal(t, []string{"id", "tenant_id", "status", "perms", "name", "total"}, ti.NonGeneratedColumns)
+
+	for col, want := range map[string]string{
+		"id":          "bigint unsigned",
+		"tenant_id":   "int",
+		"status":      "enum('new','shipped','done')",
+		"perms":       "set('read','write','execute')",
+		"name":        "varchar(100)", // charset/collation live outside column_type
+		"total":       "decimal(10,2)",
+		"total_cents": "int",
+	} {
+		got, ok := ti.GetColumnMySQLType(col)
+		require.True(t, ok, "column %q missing", col)
+		assert.Equal(t, want, got, "column %q", col)
+	}
+}
+
+// TestToTableInfoInlinePrimaryKey reads the primary key of a table that declares
+// it inline on the column. The parser materializes it into a table-level index,
+// so both spellings must yield the same key columns.
+func TestToTableInfoInlinePrimaryKey(t *testing.T) {
+	ct, err := ParseCreateTable("CREATE TABLE `t1` (`id` int NOT NULL PRIMARY KEY, `a` int)")
+	require.NoError(t, err)
+	ti, err := ct.ToTableInfo("mydb")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, ti.KeyColumns)
+}
+
+// TestToTableInfoNoPrimaryKey converts a table with no primary key. Spirit
+// refuses to migrate such a table at preflight, but that refusal needs a live
+// connection, so the conversion itself must succeed and leave the key empty.
+func TestToTableInfoNoPrimaryKey(t *testing.T) {
+	ct, err := ParseCreateTable("CREATE TABLE `t1` (`a` int, `b` int)")
+	require.NoError(t, err)
+	ti, err := ct.ToTableInfo("mydb")
+	require.NoError(t, err)
+	assert.Empty(t, ti.KeyColumns)
+}
+
+// TestToTableInfoEscapedEnumValues round-trips ENUM elements containing the
+// characters that make up the element list's own syntax. A quote or comma that
+// is not re-escaped here would shift every following element by one position and
+// silently change what an ENUM reorder looks like.
+func TestToTableInfoEscapedEnumValues(t *testing.T) {
+	ct, err := ParseCreateTable("CREATE TABLE `t1` (`id` int PRIMARY KEY, `k` enum('a,b','it''s','plain'))")
+	require.NoError(t, err)
+	ti, err := ct.ToTableInfo("mydb")
+	require.NoError(t, err)
+	tp, ok := ti.GetColumnMySQLType("k")
+	require.True(t, ok)
+	assert.Equal(t, "enum('a,b','it''s','plain')", tp)
+}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -106,6 +106,37 @@ func NewTableInfo(db *sql.DB, schema, table string) *TableInfo {
 	}
 }
 
+// ColumnMeta describes one column the way a table definition declares it: the
+// column name, its information_schema `column_type` text (e.g. "enum('a','b')",
+// "varchar(100)", "int unsigned"), and whether it is a generated column.
+type ColumnMeta struct {
+	Name      string
+	MySQLType string
+	Generated bool
+}
+
+// NewTableInfoFromMeta builds a TableInfo from a table's declared column
+// metadata instead of from a live server. Columns must be supplied in ordinal
+// order, matching the order they appear in the table definition.
+//
+// The returned TableInfo carries no database connection, so it supports only
+// the metadata accessors (GetColumnMySQLType, Columns, KeyColumns, ...);
+// SetInfo, chunking, and anything else that queries MySQL will fail on the nil
+// connection. It exists for callers that hold a table's DDL but no connection —
+// a planning tool classifying an ALTER before an apply — so they can supply
+// Resources.Table to the statement-scope checks.
+func NewTableInfoFromMeta(schemaName, tableName string, columns []ColumnMeta, keyColumns []string) (*TableInfo, error) {
+	t := NewTableInfo(nil, schemaName, tableName)
+	t.resetColumns()
+	for _, col := range columns {
+		if err := t.addColumn(col.Name, col.MySQLType, col.Generated); err != nil {
+			return nil, err
+		}
+	}
+	t.KeyColumns = slices.Clone(keyColumns)
+	return t, nil
+}
+
 // PrimaryKeyValues helps extract the PRIMARY KEY from a row image.
 // It uses our knowledge of the ordinal position of columns to find the
 // position of primary key columns (there might be more than one).
@@ -218,42 +249,61 @@ func (t *TableInfo) setColumns(ctx context.Context) error {
 			slog.Error("failed to close rows", "error", err)
 		}
 	}()
-	t.Columns = []string{}
-	t.NonGeneratedColumns = []string{}
-	t.columnsMySQLTps = make(map[string]string)
-	t.enumSetElements = nil
-	t.binaryColumnWidths = nil
+	t.resetColumns()
 	for rows.Next() {
 		var col, tp, expression string
 		if err := rows.Scan(&col, &tp, &expression); err != nil {
 			return err
 		}
-		t.Columns = append(t.Columns, col)
-		t.columnsMySQLTps[col] = tp
-		if expression == "" {
-			t.NonGeneratedColumns = append(t.NonGeneratedColumns, col)
-		}
-		if isEnumColumnType(tp) || isSetColumnType(tp) {
-			elements, perr := parseEnumSetElements(tp)
-			if perr != nil {
-				return fmt.Errorf("parsing ENUM/SET elements for %s.%s.%s: %w", t.SchemaName, t.TableName, col, perr)
-			}
-			if t.enumSetElements == nil {
-				t.enumSetElements = make(map[int][]string)
-			}
-			t.enumSetElements[len(t.Columns)-1] = elements
-		}
-		if isBinaryColumnType(tp) {
-			if width := parseBinaryColumnWidth(tp); width > 0 {
-				if t.binaryColumnWidths == nil {
-					t.binaryColumnWidths = make(map[int]int)
-				}
-				t.binaryColumnWidths[len(t.Columns)-1] = width
-			}
+		if err := t.addColumn(col, tp, expression != ""); err != nil {
+			return err
 		}
 	}
 	if rows.Err() != nil {
 		return rows.Err()
+	}
+	return nil
+}
+
+// resetColumns clears the column metadata so it can be repopulated from
+// scratch. Columns must then be added in ordinal order: the ENUM/SET element
+// and BINARY width caches are keyed by ordinal position.
+func (t *TableInfo) resetColumns() {
+	t.Columns = []string{}
+	t.NonGeneratedColumns = []string{}
+	t.columnsMySQLTps = make(map[string]string)
+	t.enumSetElements = nil
+	t.binaryColumnWidths = nil
+}
+
+// addColumn records one column's metadata, caching the parsed ENUM/SET element
+// list and BINARY(N) declared width that the binlog decoder needs. mysqlType is
+// the information_schema `column_type` text, e.g. "enum('a','b')" or
+// "varbinary(16)". Columns must be added in ordinal order.
+func (t *TableInfo) addColumn(name, mysqlType string, generated bool) error {
+	t.Columns = append(t.Columns, name)
+	t.columnsMySQLTps[name] = mysqlType
+	if !generated {
+		t.NonGeneratedColumns = append(t.NonGeneratedColumns, name)
+	}
+	ordinal := len(t.Columns) - 1
+	if isEnumColumnType(mysqlType) || isSetColumnType(mysqlType) {
+		elements, err := parseEnumSetElements(mysqlType)
+		if err != nil {
+			return fmt.Errorf("parsing ENUM/SET elements for %s.%s.%s: %w", t.SchemaName, t.TableName, name, err)
+		}
+		if t.enumSetElements == nil {
+			t.enumSetElements = make(map[int][]string)
+		}
+		t.enumSetElements[ordinal] = elements
+	}
+	if isBinaryColumnType(mysqlType) {
+		if width := parseBinaryColumnWidth(mysqlType); width > 0 {
+			if t.binaryColumnWidths == nil {
+				t.binaryColumnWidths = make(map[int]int)
+			}
+			t.binaryColumnWidths[ordinal] = width
+		}
 	}
 	return nil
 }

--- a/pkg/table/tableinfo_meta_test.go
+++ b/pkg/table/tableinfo_meta_test.go
@@ -1,0 +1,71 @@
+package table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTableInfoFromMeta builds table metadata from a table definition rather
+// than a live server, the path a caller takes when it holds a table's DDL but no
+// connection. The result must expose the same column types, ordinals and key
+// columns that SetInfo would read from information_schema, since the checks that
+// consume it cannot tell the two apart.
+func TestNewTableInfoFromMeta(t *testing.T) {
+	ti, err := NewTableInfoFromMeta("mydb", "t1", []ColumnMeta{
+		{Name: "id", MySQLType: "bigint unsigned"},
+		{Name: "status", MySQLType: "enum('new','shipped','done')"},
+		{Name: "perms", MySQLType: "set('read','write')"},
+		{Name: "token", MySQLType: "binary(16)"},
+		{Name: "total", MySQLType: "int", Generated: true},
+	}, []string{"id"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "mydb", ti.SchemaName)
+	assert.Equal(t, "t1", ti.TableName)
+	assert.Equal(t, "`t1`", ti.QuotedTableName)
+	assert.Equal(t, []string{"id", "status", "perms", "token", "total"}, ti.Columns)
+	assert.Equal(t, []string{"id", "status", "perms", "token"}, ti.NonGeneratedColumns)
+	assert.Equal(t, []string{"id"}, ti.KeyColumns)
+
+	tp, ok := ti.GetColumnMySQLType("status")
+	require.True(t, ok)
+	assert.Equal(t, "enum('new','shipped','done')", tp)
+
+	// ENUM/SET elements and BINARY widths are cached by ordinal position, so
+	// they must line up with the order the columns were supplied in.
+	assert.Equal(t, map[int][]string{
+		1: {"new", "shipped", "done"},
+		2: {"read", "write"},
+	}, ti.enumSetElements)
+	assert.Equal(t, map[int]int{3: 16}, ti.binaryColumnWidths)
+	assert.True(t, ti.NeedsBinlogRowDecoding())
+
+	ord, err := ti.GetColumnOrdinal("perms")
+	require.NoError(t, err)
+	assert.Equal(t, 2, ord)
+}
+
+// TestNewTableInfoFromMetaMalformedEnum fails closed on an ENUM element list it
+// cannot parse: silently caching no elements would let the binlog decoder run
+// against a table it cannot decode.
+func TestNewTableInfoFromMetaMalformedEnum(t *testing.T) {
+	_, err := NewTableInfoFromMeta("mydb", "t1", []ColumnMeta{
+		{Name: "status", MySQLType: "enum('unterminated)"},
+	}, []string{"id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing ENUM/SET elements for mydb.t1.status")
+}
+
+// TestNewTableInfoFromMetaNoPrimaryKey accepts a table with no primary key.
+// Statement-scope callers only need the column types, and refusing here would
+// stop a caller from classifying an ALTER that adds the missing key.
+func TestNewTableInfoFromMetaNoPrimaryKey(t *testing.T) {
+	ti, err := NewTableInfoFromMeta("mydb", "t1", []ColumnMeta{
+		{Name: "a", MySQLType: "int"},
+	}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, ti.KeyColumns)
+	assert.False(t, ti.NeedsBinlogRowDecoding())
+}


### PR DESCRIPTION
`ScopeStatement` already existed so an external caller could learn, before starting an apply, that Spirit will refuse a statement. Two gaps made it unusable in practice:

- **It carried checks the native DDL can complete anyway.** Spirit attempts `ALGORITHM=INSTANT` and a safe-INPLACE subset *before* preflight, so `dropadd` and `rename` — both metadata-only shapes — fail a preflight check on statements that in fact apply cleanly. A caller acting on those would report failure for an apply that succeeds.
- **The ENUM/SET checks were excluded entirely.** They compare a redeclared column against its current type, and there was no way to supply that without a database connection.

`check.StatementRefusal` closes both. It takes a statement and, optionally, the table's current `CREATE TABLE`, and reports whether Spirit refuses the statement and why:

```
stmt ───────────────┐
                    ├─→ RunChecks(ScopeStatement) ─→ (reason, refused, err)
currentCreateTable ─┘   Table is optional; omit it and
                        the ENUM/SET checks skip.
```

`refused` is a claim the caller can act on. `err` is reserved for input Spirit cannot classify at all — unparseable, multi-statement, or a `CREATE TABLE` for a different table than the ALTER targets — and is never a refusal.

`ScopeStatement` is now defined as **the refusals no earlier stage can bypass**, and `dropadd`/`rename` are untagged accordingly. `enumReorder`, `setReorder` and `enumSetRemoval` join it, each skipping rather than guessing when no table metadata is supplied. Every shape those three refuse needs a table rebuild, so the native DDL cannot take them.

A caller gets the whole scope without mirroring any check, and picks up checks added to it later for free.

Supporting pieces:

- `table.NewTableInfoFromMeta` builds column metadata from a table definition instead of a live server. `setColumns` is refactored onto the same per-column bookkeeping so the two cannot drift.
- `statement.CreateTable.ToTableInfo` bridges parsed DDL to that metadata.
- `formatColumnTypeAsMetadata` renders ENUM/SET element lists in MySQL's `information_schema` convention, which doubles an embedded quote. The ALTER-emission path keeps its own backslash escaping; the element parsers accept only the doubled form, so reusing it would have shifted every element after an embedded quote by one position and silently changed what a reorder looks like.

The README's *Unsupported Features* list also gains an ENUM/SET entry. It previously said nothing about them, which reads as though any ENUM/SET change is fine.

No behaviour change for a migration — `ScopePreflight` runs the same checks it did before, in the same order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
