### PR TITLE
statement: compare expressions in canonical parenthesization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,8 @@ Key principles:
 
 ### Adding a normalization rule
 Normalization canonicalizes a parsed `CreateTable` so a user-written schema matches what MySQL stores (and reports via `SHOW CREATE TABLE`), preventing spurious diffs. It mirrors the linter registration pattern.
+
+**All MySQL canonical-form handling belongs in this layer.** When the desired schema and the live `SHOW CREATE TABLE` disagree only in representation — parenthesization, display widths, inline vs table-level declarations, auto-generated names — fix it by adding a `Normalizer` rule, never by special-casing `Diff`, the parse helpers, or restore functions. Keeping every MySQL-ism in the registry is what keeps the rest of the code free of per-exception complexity: `Diff` and the parser assume canonical input and stay simple.
 1. Create `pkg/statement/normalize_<name>.go` with a type implementing the `Normalizer` interface (`Name() string` + `Normalize(*CreateTable) *CreateTable`)
 2. Register it in an `init()` function using `registerNormalizer()` (defined in `normalize.go`)
 3. Mutate the **structured** fields of `CreateTable` (`Columns`, `Indexes`, …) and return the same instance — never touch `Raw`

--- a/pkg/statement/README.md
+++ b/pkg/statement/README.md
@@ -343,6 +343,7 @@ Two layers of canonicalization apply:
    | `primaryKeyNormalizer` | inline `id INT PRIMARY KEY` → table-level `PRIMARY KEY` index |
    | `indexNormalizer` | inline `c INT UNIQUE` → table-level `UNIQUE KEY`; assigns MySQL's default names to unnamed indexes |
    | `columnCheckNormalizer` | hoists a column-level `CHECK` into a table-level constraint |
+   | `expressionParenNormalizer` | rewrites `CHECK` and generated-column expressions into a canonical parenthesization (MySQL stores them fully parenthesized; the parser preserves input parens verbatim) |
    | `binaryAttributeNormalizer` | resolves the legacy `BINARY` column attribute to the column charset's `_bin` collation |
    | `integerDisplayWidthNormalizer` | strips deprecated integer display widths (`int(11)` → `int`), keeping `tinyint(1)` and `ZEROFILL` |
 

--- a/pkg/statement/check_paren_roundtrip_test.go
+++ b/pkg/statement/check_paren_roundtrip_test.go
@@ -1,0 +1,85 @@
+package statement
+
+import (
+	"context"
+	"testing"
+
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
+	"github.com/stretchr/testify/require"
+)
+
+// createAndDiffAgainstLive creates a table from fileSQL in the scratch
+// database, reads back MySQL's stored form via SHOW CREATE TABLE, and returns
+// the diff from the live table to the file form. A declarative schema run
+// starts from exactly this comparison, so a table that was just created from
+// the file must produce an empty diff.
+func createAndDiffAgainstLive(t *testing.T, table, fileSQL string) []*AbstractStatement {
+	t.Helper()
+	db := openScratch(t)
+
+	_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(), fileSQL)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// t.Context() is already cancelled by cleanup time; the drop must
+		// really run, or the schema-scoped CHECK constraint names this table
+		// holds collide with later tests in the shared scratch database.
+		_, _ = db.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))
+	})
+
+	live, err := ParseCreateTable(showCreate(t, db, table))
+	require.NoError(t, err)
+	desired, err := ParseCreateTable(fileSQL)
+	require.NoError(t, err)
+
+	stmts, err := live.Diff(desired, nil)
+	require.NoError(t, err)
+	return stmts
+}
+
+// TestRoundTrip_CheckConstraintParens verifies that CHECK constraints written
+// in ordinary human form converge against MySQL's stored form. MySQL rewrites
+// stored CHECK expressions into its own fully parenthesized canonical form
+// (a user's CHECK (a = 1 AND b = 2) comes back from SHOW CREATE TABLE as
+// CHECK (((`a` = 1) and (`b` = 2)))), so the expression never round-trips
+// textually as written; the differ must still recognize the two as equal, or
+// every declarative run re-emits a spurious DROP CHECK + ADD CONSTRAINT for
+// constraints that never changed.
+func TestRoundTrip_CheckConstraintParens(t *testing.T) {
+	fileSQL := `CREATE TABLE rt_chk (
+		id INT PRIMARY KEY,
+		kind enum('x','y','z') NOT NULL,
+		ref_x INT,
+		ref_y INT,
+		note VARCHAR(20) NOT NULL DEFAULT '',
+		CONSTRAINT chk_kind_ref CHECK ((kind = 'x' AND ref_x IS NOT NULL AND ref_y IS NULL) OR (kind = 'y' AND ref_y IS NOT NULL AND ref_x IS NULL) OR (kind = 'z' AND ref_x IS NULL AND ref_y IS NULL)),
+		CONSTRAINT chk_note CHECK ((kind = 'z' AND note = '') OR (kind <> 'z' AND TRIM(note) <> ''))
+	)`
+
+	stmts := createAndDiffAgainstLive(t, "rt_chk", fileSQL)
+	require.Empty(t, stmts, "table just created from the file must produce an empty diff")
+}
+
+// TestRoundTrip_AddCheckConstraintParens verifies the emission side: adding a
+// compound CHECK constraint emits DDL in canonical parenthesization, which
+// must apply cleanly against real MySQL and then converge (re-diffing the
+// altered table against the target produces nothing).
+func TestRoundTrip_AddCheckConstraintParens(t *testing.T) {
+	db := openScratch(t)
+
+	applyAndConverge(t, db, "rt_chk_add",
+		"CREATE TABLE rt_chk_add (id INT PRIMARY KEY, kind enum('x','y') NOT NULL, ref_x INT, ref_y INT)",
+		"CREATE TABLE rt_chk_add (id INT PRIMARY KEY, kind enum('x','y') NOT NULL, ref_x INT, ref_y INT, CONSTRAINT chk_add_kind_ref CHECK ((kind = 'x' AND ref_x IS NOT NULL) OR (kind = 'y' AND ref_y IS NOT NULL)))")
+}
+
+// TestRoundTrip_GeneratedColumnParens verifies the same convergence for
+// generated-column expressions, which MySQL canonicalizes the same way as
+// CHECK expressions (interior precedence parentheses are made explicit in
+// the stored form).
+func TestRoundTrip_GeneratedColumnParens(t *testing.T) {
+	fileSQL := "CREATE TABLE rt_gen (id INT PRIMARY KEY, a INT, b INT, c INT GENERATED ALWAYS AS (a + b * 2) STORED)"
+
+	stmts := createAndDiffAgainstLive(t, "rt_gen", fileSQL)
+	require.Empty(t, stmts, "table just created from the file must produce an empty diff")
+}

--- a/pkg/statement/create_table.go
+++ b/pkg/statement/create_table.go
@@ -675,12 +675,15 @@ func (ct *CreateTable) parseConstraint(constraint *ast.Constraint) Constraint {
 
 		if constraint.Expr != nil {
 			// Use restoreExpressionText (not parseExpression) so the stored
-			// expression has any balanced outer parentheses stripped. MySQL's
-			// SHOW CREATE TABLE wraps the CHECK body in an extra set of parens
-			// (e.g. CHECK ((`age` >= 0))) while user-written DDL usually does
-			// not (CHECK (age >= 0)). Normalizing both to the unwrapped form
-			// (`age`>=0) lets the two compare equal so a re-diff converges
-			// instead of emitting a spurious DROP+ADD.
+			// expression is in canonical parenthesization (see
+			// parenCanonicalizer). MySQL's SHOW CREATE TABLE rewrites the CHECK
+			// body into its own fully-parenthesized form (CHECK (a = 1 AND
+			// b = 2) comes back as CHECK (((`a` = 1) and (`b` = 2)))) while
+			// user-written DDL carries whatever parentheses the author typed.
+			// Canonicalizing both makes semantically identical expressions
+			// compare equal so a re-diff converges instead of emitting a
+			// spurious DROP+ADD, while expressions with different structure
+			// still compare different.
 			if exprStr, ok := restoreExpressionText(constraint.Expr); ok {
 				constr.Expression = &exprStr
 				// Generate definition string

--- a/pkg/statement/create_table.go
+++ b/pkg/statement/create_table.go
@@ -674,16 +674,14 @@ func (ct *CreateTable) parseConstraint(constraint *ast.Constraint) Constraint {
 		constr.NotEnforced = !constraint.Enforced
 
 		if constraint.Expr != nil {
-			// Use restoreExpressionText (not parseExpression) so the stored
-			// expression is in canonical parenthesization (see
-			// parenCanonicalizer). MySQL's SHOW CREATE TABLE rewrites the CHECK
-			// body into its own fully-parenthesized form (CHECK (a = 1 AND
-			// b = 2) comes back as CHECK (((`a` = 1) and (`b` = 2)))) while
-			// user-written DDL carries whatever parentheses the author typed.
-			// Canonicalizing both makes semantically identical expressions
-			// compare equal so a re-diff converges instead of emitting a
-			// spurious DROP+ADD, while expressions with different structure
-			// still compare different.
+			// Use restoreExpressionText (not parseExpression) because CHECK
+			// expressions may contain case-sensitive string literals: the
+			// result is not lowercased and literals keep their quotes. The
+			// stored text is then rewritten into canonical parenthesization
+			// by expressionParenNormalizer when the normalization rules run,
+			// so MySQL's fully-parenthesized SHOW CREATE TABLE form and
+			// user-written DDL compare equal when — and only when — the
+			// expressions are structurally identical.
 			if exprStr, ok := restoreExpressionText(constraint.Expr); ok {
 				constr.Expression = &exprStr
 				// Generate definition string

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -537,6 +537,45 @@ func TestDiff(t *testing.T) {
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, age INT, CONSTRAINT chk_v2 CHECK (age >= 18))",
 			expected: "ALTER TABLE `t1` DROP CHECK `chk_v1`, ADD CONSTRAINT `chk_v2` CHECK (`age`>=18)",
 		},
+		{
+			// MySQL rewrites stored CHECK expressions into a fully
+			// parenthesized canonical form, so SHOW CREATE TABLE (the source
+			// here) never returns the expression as the user wrote it (the
+			// target). The two must converge with no diff.
+			name:     "CheckConstraintMySQLCanonicalParensNoDiff",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, kind enum('x','y') NOT NULL, ref_x INT, ref_y INT, CONSTRAINT chk_kind_ref CHECK ((((`kind` = _utf8mb4'x') and (`ref_x` is not null) and (`ref_y` is null)) or ((`kind` = _utf8mb4'y') and (`ref_y` is not null) and (`ref_x` is null)))))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, kind enum('x','y') NOT NULL, ref_x INT, ref_y INT, CONSTRAINT chk_kind_ref CHECK ((kind = 'x' AND ref_x IS NOT NULL AND ref_y IS NULL) OR (kind = 'y' AND ref_y IS NOT NULL AND ref_x IS NULL)))",
+			expected: "",
+		},
+		{
+			// CHECK constraint names are schema-scoped, so creating a shadow
+			// table renames them; after cutover the live table carries a
+			// different name AND MySQL's canonical parenthesization. The
+			// cross-name expression matching must still converge with no diff.
+			name:     "CheckConstraintRenamedAndCanonicalParensNoDiff",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, kind enum('x','y') NOT NULL, ref_x INT, ref_y INT, CONSTRAINT chk_kind_ref_renamed CHECK ((((`kind` = _utf8mb4'x') and (`ref_x` is not null)) or ((`kind` = _utf8mb4'y') and (`ref_y` is not null)))))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, kind enum('x','y') NOT NULL, ref_x INT, ref_y INT, CONSTRAINT chk_kind_ref CHECK ((kind = 'x' AND ref_x IS NOT NULL) OR (kind = 'y' AND ref_y IS NOT NULL)))",
+			expected: "",
+		},
+		{
+			// Parentheses that change operator binding are semantic, not
+			// cosmetic: (a OR b) AND c is a different constraint from
+			// a OR b AND c, and normalization must keep them distinct.
+			name:     "CheckConstraintMovedParensStillDiffs",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT, c INT, CONSTRAINT chk_expr CHECK ((a = 1 OR b = 2) AND c = 3))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, b INT, c INT, CONSTRAINT chk_expr CHECK (a = 1 OR b = 2 AND c = 3))",
+			expected: "ALTER TABLE `t1` DROP CHECK `chk_expr`, ADD CONSTRAINT `chk_expr` CHECK ((`a`=1) OR ((`b`=2) AND (`c`=3)))",
+		},
+		{
+			// Same distinctness for non-binary operators: NOT and IS NULL
+			// render without connecting parentheses, so only explicit
+			// parenthesization of each operator keeps (NOT a) IS NULL apart
+			// from NOT (a IS NULL).
+			name:     "CheckConstraintUnaryIsNullParensStillDiffs",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, CONSTRAINT chk_expr CHECK (NOT (a IS NULL)))",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, a INT, CONSTRAINT chk_expr CHECK ((NOT a) IS NULL))",
+			expected: "ALTER TABLE `t1` DROP CHECK `chk_expr`, ADD CONSTRAINT `chk_expr` CHECK ((NOT `a`) IS NULL)",
+		},
 		// CHECK constraint enforcement ([NOT] ENFORCED)
 		{
 			// MySQL's SHOW CREATE TABLE renders NOT ENFORCED inside a

--- a/pkg/statement/normalize_expression_parens.go
+++ b/pkg/statement/normalize_expression_parens.go
@@ -1,0 +1,119 @@
+package statement
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/format"
+)
+
+func init() { registerNormalizer(expressionParenNormalizer{}) }
+
+// expressionParenNormalizer rewrites CHECK-constraint and generated-column
+// expressions into a canonical parenthesization, mirroring the fact that
+// MySQL stores these expressions in its own fully parenthesized form. A
+// user's CHECK (a = 1 AND b = 2) comes back from SHOW CREATE TABLE as
+// CHECK (((`a` = 1) and (`b` = 2))), while the parser preserves whichever
+// parentheses the input happened to contain. Without a canonical form the
+// desired and live expressions differ textually forever and a declarative
+// diff re-emits the same DROP+ADD on every run. CHECK comparison is
+// definition-based (constraint names are schema-scoped, so the shadow table
+// renames them and diffConstraints pairs constraints by expression), which
+// makes the definition text the only thing that can converge.
+//
+// The canonical form: every user-written (or MySQL-added) parenthesis is
+// dropped, and every operator expression — binary, unary, IS NULL, IS TRUE,
+// BETWEEN, IN, LIKE, REGEXP — is re-wrapped in exactly one set. The rewrite
+// is semantics-preserving (parentheses only move to positions the parse tree
+// already encodes) and idempotent, so the rendered string is a bijective
+// encoding of the expression's structure: two expressions render identically
+// if and only if they parse to the same tree.
+//
+// Stripping parentheses without re-wrapping would not be safe: the parser's
+// Restore does not regenerate precedence parentheses from tree structure, so
+// (a OR b) AND c and a OR b AND c — different trees — would both render as
+// a OR b AND c. Wrapping every operator node keeps distinct trees distinct,
+// including for operators that render without connecting parens
+// ((NOT a) IS NULL vs NOT (a IS NULL)).
+type expressionParenNormalizer struct{}
+
+func (expressionParenNormalizer) Name() string { return "expression-parens" }
+
+func (expressionParenNormalizer) Normalize(ct *CreateTable) *CreateTable {
+	p := parser.New()
+	for i := range ct.Columns {
+		col := &ct.Columns[i]
+		canonicalizeExprParens(p, col.GeneratedExpr)
+		canonicalizeExprParens(p, col.Check)
+	}
+	for i := range ct.Constraints {
+		c := &ct.Constraints[i]
+		if c.Type != "CHECK" || c.Expression == nil {
+			continue
+		}
+		canonicalizeExprParens(p, c.Expression)
+		definition := fmt.Sprintf("CHECK (%s)", *c.Expression)
+		if c.NotEnforced {
+			definition += " NOT ENFORCED"
+		}
+		c.Definition = &definition
+	}
+	return ct
+}
+
+// parenCanonicalizer is the ast.Visitor behind canonicalizeExprParens: it
+// removes every ParenthesesExpr and wraps every operator expression in
+// exactly one ParenthesesExpr on the way back up the tree.
+type parenCanonicalizer struct{}
+
+func (parenCanonicalizer) Enter(n ast.Node) (ast.Node, bool) { return n, false }
+
+func (parenCanonicalizer) Leave(n ast.Node) (ast.Node, bool) {
+	switch e := n.(type) {
+	case *ast.ParenthesesExpr:
+		return e.Expr, true
+	case *ast.BinaryOperationExpr, *ast.UnaryOperationExpr, *ast.IsNullExpr, *ast.IsTruthExpr,
+		*ast.BetweenExpr, *ast.PatternInExpr, *ast.PatternLikeOrIlikeExpr, *ast.PatternRegexpExpr:
+		return &ast.ParenthesesExpr{Expr: n.(ast.ExprNode)}, true
+	}
+	return n, true
+}
+
+// canonicalizeExprParens re-parses the expression text and rewrites it in
+// canonical parenthesization, in place. A nil or empty text is left alone.
+//
+// The text was produced by restoring a successfully parsed expression, so a
+// re-parse failure is not expected; if one occurs the text is left unchanged
+// — the worst outcome is a spurious diff on that expression, never a
+// corrupted definition.
+func canonicalizeExprParens(p *parser.Parser, text *string) {
+	if text == nil || *text == "" {
+		return
+	}
+	stmt, err := p.ParseOneStmt("SELECT "+*text, "", "")
+	if err != nil {
+		return
+	}
+	sel, ok := stmt.(*ast.SelectStmt)
+	if !ok || sel.Fields == nil || len(sel.Fields.Fields) != 1 || sel.Fields.Fields[0].Expr == nil {
+		return
+	}
+	node, ok := sel.Fields.Fields[0].Expr.Accept(parenCanonicalizer{})
+	if !ok {
+		return
+	}
+	expr := node.(ast.ExprNode)
+	// The outermost parentheses carry no information — the expression is
+	// already delimited by its surrounding CHECK (...) / AS (...) syntax.
+	if paren, isParen := expr.(*ast.ParenthesesExpr); isParen {
+		expr = paren.Expr
+	}
+	var sb strings.Builder
+	rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreStringWithoutCharset, &sb)
+	if err := expr.Restore(rCtx); err != nil {
+		return
+	}
+	*text = sb.String()
+}

--- a/pkg/statement/parse_helpers.go
+++ b/pkg/statement/parse_helpers.go
@@ -62,19 +62,56 @@ func isExpressionDefault(expr ast.ExprNode) bool {
 	}
 }
 
-// restoreExpressionText restores an expression AST node to its SQL text,
-// stripping redundant outer parentheses. MySQL's SHOW CREATE TABLE wraps
-// generated-column and CHECK expressions in an extra set of parentheses
-// (e.g. GENERATED ALWAYS AS ((`a` + 1))); stripping them ensures a
-// user-written `AS (a + 1)` compares equal to the canonical form.
+// parenCanonicalizer rewrites an expression tree into a canonical
+// parenthesization: every ParenthesesExpr is removed and every operator
+// expression (binary, unary, IS NULL, IS TRUE, BETWEEN, IN, LIKE, REGEXP)
+// is re-wrapped in exactly one set of parentheses. The rewrite is
+// semantics-preserving — parentheses only move to the positions the parse
+// tree already encodes — and idempotent, so restoring the result yields a
+// string that is a bijective encoding of the expression's structure: two
+// expressions render identically if and only if they parse to the same tree.
+//
+// This is what makes CHECK and generated-column expressions comparable as
+// strings. MySQL rewrites stored expressions into its own fully-parenthesized
+// form (a user's CHECK (a = 1 AND b = 2) comes back from SHOW CREATE TABLE as
+// CHECK (((`a` = 1) and (`b` = 2)))), while the TiDB parser preserves
+// whichever parentheses the input happened to contain. Without a canonical
+// form, the desired and live expressions differ textually forever and a
+// declarative diff re-emits the same DROP+ADD on every run.
+//
+// Stripping parentheses without re-wrapping would not be safe: TiDB's
+// Restore does not regenerate precedence parentheses from tree structure, so
+// (a OR b) AND c and a OR b AND c — different trees — would both render as
+// a OR b AND c. Wrapping every operator node keeps distinct trees distinct.
+type parenCanonicalizer struct{}
+
+func (parenCanonicalizer) Enter(n ast.Node) (ast.Node, bool) { return n, false }
+
+func (parenCanonicalizer) Leave(n ast.Node) (ast.Node, bool) {
+	switch e := n.(type) {
+	case *ast.ParenthesesExpr:
+		return e.Expr, true
+	case *ast.BinaryOperationExpr, *ast.UnaryOperationExpr, *ast.IsNullExpr, *ast.IsTruthExpr,
+		*ast.BetweenExpr, *ast.PatternInExpr, *ast.PatternLikeOrIlikeExpr, *ast.PatternRegexpExpr:
+		return &ast.ParenthesesExpr{Expr: n.(ast.ExprNode)}, true
+	}
+	return n, true
+}
+
+// restoreExpressionText restores an expression AST node to its SQL text in
+// canonical parenthesization (see parenCanonicalizer), with no redundant
+// parentheses around the outermost expression. The canonicalization mutates
+// the given AST in place; the rewrite is semantics-preserving, so a later
+// restore of the surrounding statement stays correct.
 // Unlike parseExpression, the result is NOT lowercased and string literals
 // keep their quotes — these expressions may contain case-sensitive literals.
 func restoreExpressionText(expr ast.ExprNode) (string, bool) {
-	for {
-		paren, ok := expr.(*ast.ParenthesesExpr)
-		if !ok {
-			break
-		}
+	node, ok := expr.Accept(parenCanonicalizer{})
+	if !ok {
+		return "", false
+	}
+	expr = node.(ast.ExprNode)
+	if paren, isParen := expr.(*ast.ParenthesesExpr); isParen {
 		expr = paren.Expr
 	}
 

--- a/pkg/statement/parse_helpers.go
+++ b/pkg/statement/parse_helpers.go
@@ -62,56 +62,19 @@ func isExpressionDefault(expr ast.ExprNode) bool {
 	}
 }
 
-// parenCanonicalizer rewrites an expression tree into a canonical
-// parenthesization: every ParenthesesExpr is removed and every operator
-// expression (binary, unary, IS NULL, IS TRUE, BETWEEN, IN, LIKE, REGEXP)
-// is re-wrapped in exactly one set of parentheses. The rewrite is
-// semantics-preserving — parentheses only move to the positions the parse
-// tree already encodes — and idempotent, so restoring the result yields a
-// string that is a bijective encoding of the expression's structure: two
-// expressions render identically if and only if they parse to the same tree.
-//
-// This is what makes CHECK and generated-column expressions comparable as
-// strings. MySQL rewrites stored expressions into its own fully-parenthesized
-// form (a user's CHECK (a = 1 AND b = 2) comes back from SHOW CREATE TABLE as
-// CHECK (((`a` = 1) and (`b` = 2)))), while the TiDB parser preserves
-// whichever parentheses the input happened to contain. Without a canonical
-// form, the desired and live expressions differ textually forever and a
-// declarative diff re-emits the same DROP+ADD on every run.
-//
-// Stripping parentheses without re-wrapping would not be safe: TiDB's
-// Restore does not regenerate precedence parentheses from tree structure, so
-// (a OR b) AND c and a OR b AND c — different trees — would both render as
-// a OR b AND c. Wrapping every operator node keeps distinct trees distinct.
-type parenCanonicalizer struct{}
-
-func (parenCanonicalizer) Enter(n ast.Node) (ast.Node, bool) { return n, false }
-
-func (parenCanonicalizer) Leave(n ast.Node) (ast.Node, bool) {
-	switch e := n.(type) {
-	case *ast.ParenthesesExpr:
-		return e.Expr, true
-	case *ast.BinaryOperationExpr, *ast.UnaryOperationExpr, *ast.IsNullExpr, *ast.IsTruthExpr,
-		*ast.BetweenExpr, *ast.PatternInExpr, *ast.PatternLikeOrIlikeExpr, *ast.PatternRegexpExpr:
-		return &ast.ParenthesesExpr{Expr: n.(ast.ExprNode)}, true
-	}
-	return n, true
-}
-
-// restoreExpressionText restores an expression AST node to its SQL text in
-// canonical parenthesization (see parenCanonicalizer), with no redundant
-// parentheses around the outermost expression. The canonicalization mutates
-// the given AST in place; the rewrite is semantics-preserving, so a later
-// restore of the surrounding statement stays correct.
+// restoreExpressionText restores an expression AST node to its SQL text,
+// stripping redundant outer parentheses. MySQL's SHOW CREATE TABLE wraps
+// generated-column and CHECK expressions in an extra set of parentheses
+// (e.g. GENERATED ALWAYS AS ((`a` + 1))); stripping them ensures a
+// user-written `AS (a + 1)` compares equal to the canonical form.
 // Unlike parseExpression, the result is NOT lowercased and string literals
 // keep their quotes — these expressions may contain case-sensitive literals.
 func restoreExpressionText(expr ast.ExprNode) (string, bool) {
-	node, ok := expr.Accept(parenCanonicalizer{})
-	if !ok {
-		return "", false
-	}
-	expr = node.(ast.ExprNode)
-	if paren, isParen := expr.(*ast.ParenthesesExpr); isParen {
+	for {
+		paren, ok := expr.(*ast.ParenthesesExpr)
+		if !ok {
+			break
+		}
 		expr = paren.Expr
 	}
 


### PR DESCRIPTION
## Why this matters

MySQL rewrites stored CHECK and generated-column expressions into its own fully parenthesized form, while the parser preserves whichever parentheses the input happened to contain. The differ compares the two as restored text, so a declared expression never matches the `SHOW CREATE TABLE` form — and a declarative diff re-emits the same `DROP CHECK` + `ADD CONSTRAINT` for constraints that never changed, on every run. Since CHECK comparison is already definition-based (constraint names are schema-scoped and change on the shadow table), the definition text has to be canonical for the differ to converge.

## What it does

Adds a normalization rule, `expressionParenNormalizer` (`normalize_expression_parens.go`), that rewrites CHECK-constraint, column-level CHECK, and generated-column expressions into a canonical parenthesization: user-written (and MySQL-added) parentheses are dropped, and every operator expression — binary, unary, `IS NULL`, `IS TRUE`, `BETWEEN`, `IN`, `LIKE`, `REGEXP` — is re-wrapped in exactly one set. The rendered string is then a bijective encoding of the expression's structure, so two expressions compare equal if and only if they parse to the same tree:

```
file:  CHECK ((kind = 'x' AND ref_x IS NOT NULL) OR (kind = 'y' AND ref_y IS NOT NULL))
live:  CHECK ((((`kind` = _utf8mb4'x') and (`ref_x` is not null)) or ((`kind` = _utf8mb4'y') and (`ref_y` is not null))))
both:  ((`kind`='x') AND (`ref_x` IS NOT NULL)) OR ((`kind`='y') AND (`ref_y` IS NOT NULL))
```

The rule lives in the `Normalizer` registry (per maintainer guidance that all MySQL canonical-form handling stays in that layer), self-registers like the existing rules, and is order-independent and idempotent — it rewrites only the stored expression strings, never `Raw`. `restoreExpressionText` stays a plain restore. AGENTS.md now records the layering rule for future contributors.

Stripping parentheses without re-wrapping would not be safe: `Restore` does not regenerate precedence parentheses from tree structure, so `(a OR b) AND c` and `a OR b AND c` — different constraints — would render identically. Wrapping every operator node keeps them distinct, including for operators that render without connecting parens (`(NOT a) IS NULL` vs `NOT (a IS NULL)`); the new tests pin both directions, including the post-cutover state where the live constraint carries both a shadow-rename name and MySQL's parenthesization, so the cross-name expression matching must do the convergence. Live round-trip tests verify convergence against real MySQL for table-level CHECKs and generated columns, and that the emitted canonical `ADD CONSTRAINT` DDL applies cleanly.

*This PR was drafted by Claude Code (claude-fable-5) on Armand's behalf.*
