### PR TITLE
feat(observer): expose typed workflow events

### DIFF
--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -37,6 +37,8 @@ type buffered struct {
 	isInvalid        atomic.Bool
 	errMu            sync.Mutex // guards firstErr
 	firstErr         error      // first error that invalidated the copy (any goroutine)
+	completedRows    atomic.Uint64
+	completedChunks  atomic.Uint64
 	startTime        time.Time
 	throttler        throttler.Throttler
 	dbConfig         *dbconn.DBConfig
@@ -186,6 +188,8 @@ func (c *buffered) Run(ctx context.Context) error {
 	c.Lock()
 	c.startTime = time.Now()
 	c.Unlock()
+	c.completedRows.Store(0)
+	c.completedChunks.Store(0)
 	go c.estimateRowsPerSecondLoop(ctx) // estimate rows while copying
 
 	// Start the applier
@@ -357,6 +361,7 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 			totalTime := time.Since(chunkStartTime)
 			c.logger.Debug("readWorker chunk is empty, sending immediate feedback", "chunk", chunk.String())
 			c.chunker.Feedback(chunk, totalTime, 0)
+			c.recordCompletedChunk(0)
 
 			// Send metrics for empty chunk
 			err := c.sendMetrics(ctx, totalTime, chunk.ChunkSize, 0)
@@ -398,6 +403,7 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 
 			// Send feedback to chunker with total processing time
 			c.chunker.Feedback(capturedChunk, totalTime, uint64(affectedRows))
+			c.recordCompletedChunk(uint64(affectedRows))
 
 			// Send metrics with total processing time
 			metricsErr := c.sendMetrics(ctx, totalTime, capturedChunk.ChunkSize, uint64(affectedRows))
@@ -644,6 +650,15 @@ func (c *buffered) sendMetrics(ctx context.Context, processingTime time.Duration
 // GetChunker returns the chunker for accessing progress information
 func (c *buffered) GetChunker() table.Chunker {
 	return c.chunker
+}
+
+func (c *buffered) recordCompletedChunk(affectedRows uint64) {
+	c.completedRows.Add(affectedRows)
+	c.completedChunks.Add(1)
+}
+
+func (c *buffered) CompletedWork() (uint64, uint64) {
+	return c.completedRows.Load(), c.completedChunks.Load()
 }
 
 func (c *buffered) GetThrottler() throttler.Throttler {

--- a/pkg/copier/completed_work_test.go
+++ b/pkg/copier/completed_work_test.go
@@ -1,0 +1,35 @@
+package copier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type copierWithoutCompletedWork struct{ Copier }
+
+func TestCompletedWorkCountsAffectedRowsAndZeroRowChunks(t *testing.T) {
+	bufferedCopier := &buffered{}
+	bufferedCopier.recordCompletedChunk(12)
+	bufferedCopier.recordCompletedChunk(0)
+	bufferedCopier.recordCompletedChunk(0)
+	rows, chunks, available := CompletedWork(bufferedCopier)
+	require.True(t, available)
+	require.Equal(t, uint64(12), rows)
+	require.Equal(t, uint64(3), chunks)
+
+	unbufferedCopier := &Unbuffered{}
+	unbufferedCopier.recordCompletedChunk(9)
+	unbufferedCopier.recordCompletedChunk(0)
+	rows, chunks, available = CompletedWork(unbufferedCopier)
+	require.True(t, available)
+	require.Equal(t, uint64(9), rows)
+	require.Equal(t, uint64(2), chunks)
+}
+
+func TestCompletedWorkUnavailableForCopierWithoutCapability(t *testing.T) {
+	rows, chunks, available := CompletedWork(&copierWithoutCompletedWork{})
+	require.False(t, available)
+	require.Zero(t, rows)
+	require.Zero(t, chunks)
+}

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -68,6 +68,24 @@ type Copier interface {
 	GetProgress() string
 }
 
+// CompletedWorkReporter is an optional capability implemented by copiers that
+// can report exact terminal aggregate work.
+type CompletedWorkReporter interface {
+	CompletedWork() (rows uint64, chunks uint64)
+}
+
+// CompletedWork returns authoritative aggregate rows and chunks completed by a
+// built-in copier. The boolean is false for Copier implementations that do not
+// implement CompletedWorkReporter.
+func CompletedWork(c Copier) (rows uint64, chunks uint64, available bool) {
+	reporter, ok := c.(CompletedWorkReporter)
+	if !ok {
+		return 0, 0, false
+	}
+	rows, chunks = reporter.CompletedWork()
+	return rows, chunks, true
+}
+
 type CopierConfig struct {
 	Concurrency     int
 	TargetChunkTime time.Duration

--- a/pkg/copier/unbuffered.go
+++ b/pkg/copier/unbuffered.go
@@ -26,6 +26,8 @@ type Unbuffered struct {
 	concurrency      int
 	rowsPerSecond    atomic.Uint64
 	isInvalid        bool
+	completedRows    atomic.Uint64
+	completedChunks  atomic.Uint64
 	startTime        time.Time
 	throttler        throttler.Throttler
 	dbConfig         *dbconn.DBConfig
@@ -80,6 +82,7 @@ func (c *Unbuffered) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 
 	// Send feedback to chunker with processing time and statistics
 	c.chunker.Feedback(chunk, chunkProcessingTime, uint64(affectedRows))
+	c.recordCompletedChunk(uint64(affectedRows))
 
 	// Send metrics
 	err = c.sendMetrics(ctx, chunkProcessingTime, chunk.ChunkSize, uint64(affectedRows))
@@ -109,6 +112,8 @@ func (c *Unbuffered) Run(ctx context.Context) error {
 	c.Lock()
 	c.startTime = time.Now()
 	c.Unlock()
+	c.completedRows.Store(0)
+	c.completedChunks.Store(0)
 	go c.estimateRowsPerSecondLoop(ctx) // estimate rows while copying
 	g, errGrpCtx := errgroup.WithContext(ctx)
 	g.SetLimit(c.concurrency)
@@ -253,6 +258,15 @@ func (c *Unbuffered) sendMetrics(ctx context.Context, processingTime time.Durati
 // GetChunker returns the chunker for accessing progress information
 func (c *Unbuffered) GetChunker() table.Chunker {
 	return c.chunker
+}
+
+func (c *Unbuffered) recordCompletedChunk(affectedRows uint64) {
+	c.completedRows.Add(affectedRows)
+	c.completedChunks.Add(1)
+}
+
+func (c *Unbuffered) CompletedWork() (uint64, uint64) {
+	return c.completedRows.Load(), c.completedChunks.Load()
 }
 
 func (c *Unbuffered) GetThrottler() throttler.Throttler {

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -174,12 +174,12 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 		return 0, fmt.Errorf("RetryableTransaction: invalid DupKeyHandling value %d", dupKeyHandling)
 	}
 	var (
-		err          error
-		trx          *sql.Tx
-		rowsAffected int64
-		isFatal      bool
+		err     error
+		trx     *sql.Tx
+		isFatal bool
 	)
 	for i := range config.MaxRetries {
+		var attemptRowsAffected int64
 		func() {
 			// Start a transaction
 			if trx, err = db.BeginTx(ctx, nil); err != nil {
@@ -256,7 +256,7 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 				// and that's absolutely fine!
 				count, errC := res.RowsAffected()
 				if errC == nil { // affectedRows is supported
-					rowsAffected += count
+					attemptRowsAffected += count
 				}
 			} // end for each statement
 			// Commit it!
@@ -265,17 +265,17 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 			}
 		}()
 		if isFatal { // don't retry loop if fatal
-			return rowsAffected, err
+			return 0, err
 		}
 		// If error is nil, break the loop and return
 		// The transaction was successful
 		if err == nil {
-			return rowsAffected, nil
+			return attemptRowsAffected, nil
 		}
 	} // end of retry loop
 	// We've exhausted retries and the error is non-nil
 	// return the last error
-	return rowsAffected, err
+	return 0, err
 }
 
 // backoffDuration returns the delay before a retry for the given 0-based

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -149,6 +149,50 @@ func TestRetryableTrx(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRetryableTransactionRowsAffectedExcludesRolledBackAttempts(t *testing.T) {
+	config := NewDBConfig()
+	config.InnodbLockWaitTimeout = 1
+	config.MaxRetries = 3
+	db, err := New(testutils.DSN(), config)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	require.NoError(t, Exec(t.Context(), db, "DROP TABLE IF EXISTS test.retry_rows_affected"))
+	require.NoError(t, Exec(t.Context(), db, "CREATE TABLE test.retry_rows_affected (id INT PRIMARY KEY, val INT NOT NULL)"))
+	require.NoError(t, Exec(t.Context(), db, "INSERT INTO test.retry_rows_affected VALUES (1, 0)"))
+	defer func() {
+		_, _ = db.ExecContext(context.Background(), "DROP TABLE IF EXISTS test.retry_rows_affected")
+	}()
+
+	lockingTx, err := db.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = lockingTx.ExecContext(t.Context(), "SELECT * FROM test.retry_rows_affected WHERE id=1 FOR UPDATE")
+	require.NoError(t, err)
+
+	rollbackErr := make(chan error, 1)
+	go func() {
+		time.Sleep(1200 * time.Millisecond)
+		rollbackErr <- lockingTx.Rollback()
+	}()
+
+	rowsAffected, err := RetryableTransaction(
+		t.Context(),
+		db,
+		ErrorOnDupKey,
+		config,
+		"INSERT INTO test.retry_rows_affected VALUES (2, 0)",
+		"UPDATE test.retry_rows_affected SET val=val+1 WHERE id=1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, <-rollbackErr)
+	require.Equal(t, int64(2), rowsAffected,
+		"rolled-back attempt rows must not be added to the committed attempt")
+
+	var val int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT val FROM test.retry_rows_affected WHERE id=1").Scan(&val))
+	require.Equal(t, 1, val)
+}
+
 func TestCanRetryError(t *testing.T) {
 	// Server-side errors that are retryable.
 	require.True(t, canRetryError(&mysql.MySQLError{Number: 1205})) // lock wait timeout

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -954,6 +954,32 @@ func TestDropAfterCutover(t *testing.T) {
 	require.NoError(t, m.Close())
 }
 
+func TestWorkflowObserverReportsZeroRowCutoverBeforeCleanupError(t *testing.T) {
+	t.Parallel()
+	testutils.NewTestTable(t, "observed_cutover", `CREATE TABLE observed_cutover (
+		pk int UNSIGNED NOT NULL,
+		PRIMARY KEY(pk)
+	)`)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	observer := &cancelOnDurableMutationObserver{cancel: cancel}
+	m := NewTestRunner(t, "observed_cutover", "ADD INDEX observed_idx (pk)")
+	m.SetWorkflowObserver(observer)
+
+	err := m.Run(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, observer.events, status.WorkflowEvent{DurableMutation: true})
+	var indexCount int
+	require.NoError(t, m.db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='observed_cutover' AND INDEX_NAME='observed_idx'
+	`).Scan(&indexCount))
+	require.Equal(t, 1, indexCount)
+	require.NoError(t, m.Close())
+}
+
 // TestDeferCutOver tests that deferred cutover times out waiting for the sentinel table.
 func TestDeferCutOver(t *testing.T) {
 	t.Skip("skipping: this test waits for sentinel.WaitLimit to expire, which is too slow with the current 48 hour limit")

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -140,7 +140,8 @@ type Runner struct {
 	watchTaskWait func()
 
 	// MetricsSink
-	metricsSink metrics.Sink
+	metricsSink      metrics.Sink
+	workflowObserver status.WorkflowObserver
 }
 
 var _ status.Task = (*Runner)(nil)
@@ -166,6 +167,54 @@ func NewRunner(m *Migration) (*Runner, error) {
 		change.runner = runner // link back.
 	}
 	return runner, nil
+}
+
+// SetWorkflowObserver installs an optional typed workflow observer. It must be
+// called before Run. A nil observer disables workflow observation.
+func (r *Runner) SetWorkflowObserver(observer status.WorkflowObserver) {
+	r.workflowObserver = observer
+}
+
+func (r *Runner) observeWorkflowStageStarted(parent context.Context, stage status.WorkflowStage) {
+	if r.workflowObserver == nil {
+		return
+	}
+	r.workflowObserver.ObserveWorkflow(parent, status.WorkflowEvent{
+		Stage:      stage,
+		Transition: status.WorkflowTransitionStarted,
+	})
+}
+
+func (r *Runner) observeWorkflowStageFinished(parent, runCtx context.Context, stage status.WorkflowStage, err error) {
+	if r.workflowObserver == nil {
+		return
+	}
+	event := status.WorkflowEvent{
+		Stage:      stage,
+		Transition: status.WorkflowTransitionFinished,
+		Outcome:    workflowOutcome(runCtx, err),
+	}
+	if stage == status.WorkflowStageCopy {
+		rows, chunks, available := copier.CompletedWork(r.copier)
+		if available {
+			event.TotalsAvailable = true
+			event.Totals.CompletedRows = rows
+			event.Totals.CompletedChunks = chunks
+		}
+	}
+	r.workflowObserver.ObserveWorkflow(parent, event)
+}
+
+func (r *Runner) runObservedCopy(parent, ctx context.Context) error {
+	err := r.copier.Run(ctx)
+	if err == nil && ctx.Err() != nil {
+		chunker := r.copier.GetChunker()
+		if chunker == nil || !chunker.IsRead() {
+			err = ctx.Err()
+		}
+	}
+	r.observeWorkflowStageFinished(parent, ctx, status.WorkflowStageCopy, err)
+	return err
 }
 
 // checksumOffPoolConns is the connection headroom the checksum phase needs on
@@ -226,6 +275,7 @@ func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
 }
 
 func (r *Runner) Run(ctx context.Context) error {
+	parentCtx := ctx
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
 	r.startTime = time.Now()
@@ -395,24 +445,33 @@ func (r *Runner) Run(ctx context.Context) error {
 	// of migrations usually spend time. It is not strictly necessary,
 	// but we always recopy the last-bit, even if we are resuming
 	// partially through the checksum.
-	r.status.Set(status.CopyRows)
-	if err := r.copier.Run(ctx); err != nil {
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageCopy)
+	})
+	err = r.runObservedCopy(parentCtx, ctx)
+	if err != nil {
 		return err
 	}
 	r.logger.Info("copy rows complete")
 	r.copyDuration = time.Since(r.copier.StartTime())
 
-	// Disable both watermark optimizations so that all changes can be flushed.
-	// For non-memory-comparable PKs this also drains the buffered map and
-	// switches the subscription into FIFO queue mode (see
-	// pkg/change/subscription_buffered.go), so the call can return an error.
-	if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+	// Disable both watermark optimizations, stop periodic flushing, and flush
+	// pending changes at the authoritative catch-up boundary.
+	r.status.Set(status.ApplyChangeset, func() {
+		r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageCatchUp)
+	})
+	err = r.replClient.SetWatermarkOptimization(ctx, false)
+	if err == nil {
+		r.replClient.StopPeriodicFlush()
+		err = r.replClient.Flush(ctx)
+	}
+	r.observeWorkflowStageFinished(parentCtx, ctx, status.WorkflowStageCatchUp, err)
+	if err != nil {
 		return err
 	}
 
-	// Post-copy phase: catch up on replClient apply, run ANALYZE TABLE
-	// so cutover stats are fresh, and run the initial checksum.
-	if err := r.postCopyPhase(ctx); err != nil {
+	// Post-copy phase: update table statistics and run the initial checksum.
+	if err := r.postCopyPhase(parentCtx, ctx); err != nil {
 		return err
 	}
 
@@ -427,19 +486,28 @@ func (r *Runner) Run(ctx context.Context) error {
 	// that the sentinel table was created manually after the migration
 	// started.
 	if r.migration.RespectSentinel {
-		r.sentinelWaitStartTime = time.Now()
-		r.status.Set(status.WaitingOnSentinelTable)
-		// Block on the sentinel via the shared sentinel.Wait (poll/timeout timing
-		// lives in the sentinel package). The continuous-checksum lifecycle and
-		// watermark invalidation are migration-specific — invalidateChecksumWatermark
-		// scopes its UPDATE by statement because the checkpoint table is shared in
-		// multi-table mode — so they are injected as callbacks. See pkg/sentinel.
-		if err := sentinel.Wait(ctx, sentinel.WaitConfig{
-			Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.db) },
+		waitStarted := false
+		exists := func(ctx context.Context) (bool, error) {
+			ok, err := sentinel.Exists(ctx, r.db)
+			if err == nil && ok && !waitStarted {
+				waitStarted = true
+				r.sentinelWaitStartTime = time.Now()
+				r.status.Set(status.WaitingOnSentinelTable, func() {
+					r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageWaitForSentinel)
+				})
+			}
+			return ok, err
+		}
+		err = sentinel.Wait(ctx, sentinel.WaitConfig{
+			Exists:              exists,
 			RunChecksum:         r.runContinuousChecksum,
 			InvalidateWatermark: r.invalidateChecksumWatermark,
 			Logger:              r.logger,
-		}); err != nil {
+		})
+		if waitStarted {
+			r.observeWorkflowStageFinished(parentCtx, ctx, status.WorkflowStageWaitForSentinel, err)
+		}
+		if err != nil {
 			return err
 		}
 	}
@@ -520,16 +588,7 @@ func (r *Runner) Run(ctx context.Context) error {
 // sentinel wait: drain the binlog backlog, run ANALYZE TABLE, and
 // perform the initial checksum. When defer-cutover is not in use this
 // is also the last phase before cutover.
-func (r *Runner) postCopyPhase(ctx context.Context) error {
-	r.status.Set(status.ApplyChangeset)
-	// Disable the periodic flush and flush all pending events.
-	// We want it disabled for ANALYZE TABLE and acquiring a table lock
-	// *but* it will be started again briefly inside of the checksum
-	// runner to ensure that the lag does not grow too long.
-	r.replClient.StopPeriodicFlush()
-	if err := r.replClient.Flush(ctx); err != nil {
-		return err
-	}
+func (r *Runner) postCopyPhase(parentCtx, ctx context.Context) error {
 
 	// Run ANALYZE TABLE to update the statistics on the new table.
 	// This is required so on cutover plans don't go sideways, which
@@ -564,7 +623,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// The checksum is ONLINE after an initial lock
 	// for consistency. It is the main way that we determine that
 	// this program is safe to use even when immature.
-	return r.checksum(ctx)
+	return r.checksumObserved(parentCtx, ctx)
 }
 
 // runChecks wraps around check.RunChecks and adds the context of this migration
@@ -1669,7 +1728,13 @@ func (r *Runner) initChunkers() error {
 
 // checksum creates the checksum which opens the read view
 func (r *Runner) checksum(ctx context.Context) error {
-	r.status.Set(status.Checksum)
+	return r.checksumObserved(ctx, ctx)
+}
+
+func (r *Runner) checksumObserved(parentCtx, ctx context.Context) error {
+	r.status.Set(status.Checksum, func() {
+		r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageChecksum)
+	})
 
 	// The checksum keeps the pool threads open, so we need to extend
 	// by more than +1 on threads as we did previously. We have:
@@ -1695,7 +1760,9 @@ func (r *Runner) checksum(ctx context.Context) error {
 	// (forcing full re-verification) or a watermark from a clean pass
 	// (safe to resume from). Either way the silent-cutover hole is
 	// closed without needing to special-case the error path.
-	if err := r.checker.Run(ctx); err != nil {
+	err := r.checker.Run(ctx)
+	r.observeWorkflowStageFinished(parentCtx, ctx, status.WorkflowStageChecksum, err)
+	if err != nil {
 		if r.addsUniqueIndex() {
 			// Overwrite the error if we think it's because of a unique index addition
 			return errors.New("checksum failed after several attempts. This is likely related to your statement adding a UNIQUE index on non-unique data")

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -205,6 +205,17 @@ func (r *Runner) observeWorkflowStageFinished(parent, runCtx context.Context, st
 	r.workflowObserver.ObserveWorkflow(parent, event)
 }
 
+// observeWorkflowDurableMutation records that cutover atomically swapped the
+// source and shadow table names. It is emitted before post-cutover cleanup so a
+// caller can distinguish a pre-cutover failure from a cleanup failure after the
+// migration has already taken effect.
+func (r *Runner) observeWorkflowDurableMutation(parent context.Context) {
+	if r.workflowObserver == nil {
+		return
+	}
+	r.workflowObserver.ObserveWorkflow(parent, status.WorkflowEvent{DurableMutation: true})
+}
+
 func (r *Runner) runObservedCopy(parent, ctx context.Context) error {
 	err := r.copier.Run(ctx)
 	if err == nil && ctx.Err() != nil {
@@ -541,6 +552,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err := cutover.Run(ctx); err != nil {
 		return fmt.Errorf("cutover failed: %w", err)
 	}
+	r.observeWorkflowDurableMutation(parentCtx)
 	if !r.migration.SkipDropAfterCutover {
 		for _, change := range r.changes {
 			if err := change.dropOldTable(ctx); err != nil {

--- a/pkg/migration/workflow_observer.go
+++ b/pkg/migration/workflow_observer.go
@@ -1,0 +1,18 @@
+package migration
+
+import (
+	"context"
+	"errors"
+
+	"github.com/block/spirit/pkg/status"
+)
+
+func workflowOutcome(ctx context.Context, err error) status.WorkflowOutcome {
+	if err == nil {
+		return status.WorkflowOutcomeSucceeded
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+		return status.WorkflowOutcomeCancelled
+	}
+	return status.WorkflowOutcomeFailed
+}

--- a/pkg/migration/workflow_observer_test.go
+++ b/pkg/migration/workflow_observer_test.go
@@ -1,0 +1,131 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/block/spirit/pkg/copier"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/stretchr/testify/require"
+)
+
+type workflowObserverContextKey struct{}
+
+type recordingWorkflowObserver struct {
+	events   []status.WorkflowEvent
+	contexts []context.Context
+}
+
+func (o *recordingWorkflowObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.contexts = append(o.contexts, ctx)
+	o.events = append(o.events, event)
+}
+
+type aggregateCopier struct {
+	copier.Copier
+	rows   uint64
+	chunks uint64
+	panic  bool
+}
+
+func (c *aggregateCopier) CompletedWork() (uint64, uint64) {
+	if c.panic {
+		panic("CompletedWork called with nil observer")
+	}
+	return c.rows, c.chunks
+}
+
+type nilCompletingCopier struct{ copier.Copier }
+
+func (*nilCompletingCopier) Run(context.Context) error { return nil }
+func (*nilCompletingCopier) GetChunker() table.Chunker { return nil }
+
+type cancelOnCopyStartObserver struct {
+	recordingWorkflowObserver
+	cancel context.CancelFunc
+}
+
+func (o *cancelOnCopyStartObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.recordingWorkflowObserver.ObserveWorkflow(ctx, event)
+	if event.Stage == status.WorkflowStageCopy && event.Transition == status.WorkflowTransitionStarted {
+		o.cancel()
+	}
+}
+
+func TestWorkflowObserverOrderedBalancedStagesAndTotals(t *testing.T) {
+	parent := context.WithValue(t.Context(), workflowObserverContextKey{}, "parent")
+	runCtx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{
+		workflowObserver: observer,
+		copier:           &aggregateCopier{rows: 42, chunks: 7},
+	}
+
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(parent, status.WorkflowStageCopy)
+	})
+	r.observeWorkflowStageFinished(parent, runCtx, status.WorkflowStageCopy, nil)
+	r.status.Set(status.ApplyChangeset, func() {
+		r.observeWorkflowStageStarted(parent, status.WorkflowStageCatchUp)
+	})
+	r.observeWorkflowStageFinished(parent, runCtx, status.WorkflowStageCatchUp, errors.New("flush failed"))
+	r.status.Set(status.Checksum, func() {
+		r.observeWorkflowStageStarted(parent, status.WorkflowStageChecksum)
+	})
+	r.observeWorkflowStageFinished(parent, runCtx, status.WorkflowStageChecksum, context.Canceled)
+	require.Equal(t, status.Checksum, r.status.Get())
+
+	require.Equal(t, []status.WorkflowEvent{
+		{Stage: status.WorkflowStageCopy, Transition: status.WorkflowTransitionStarted},
+		{
+			Stage:           status.WorkflowStageCopy,
+			Transition:      status.WorkflowTransitionFinished,
+			Outcome:         status.WorkflowOutcomeSucceeded,
+			Totals:          status.WorkflowTotals{CompletedRows: 42, CompletedChunks: 7},
+			TotalsAvailable: true,
+		},
+		{Stage: status.WorkflowStageCatchUp, Transition: status.WorkflowTransitionStarted},
+		{Stage: status.WorkflowStageCatchUp, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeFailed},
+		{Stage: status.WorkflowStageChecksum, Transition: status.WorkflowTransitionStarted},
+		{Stage: status.WorkflowStageChecksum, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled},
+	}, observer.events)
+	require.Len(t, observer.contexts, len(observer.events))
+	for _, observedCtx := range observer.contexts {
+		require.Same(t, parent, observedCtx)
+	}
+}
+
+func TestWorkflowObserverCancellationDuringCopyDoesNotStartCatchUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	observer := &cancelOnCopyStartObserver{cancel: cancel}
+	r := &Runner{workflowObserver: observer, copier: &nilCompletingCopier{}}
+
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(ctx, status.WorkflowStageCopy)
+	})
+	require.ErrorIs(t, r.runObservedCopy(ctx, ctx), context.Canceled)
+	require.Equal(t, []status.WorkflowEvent{
+		{Stage: status.WorkflowStageCopy, Transition: status.WorkflowTransitionStarted},
+		{Stage: status.WorkflowStageCopy, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled},
+	}, observer.events)
+}
+
+func TestWorkflowObserverOptionalAndNilBehavior(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{workflowObserver: observer}
+
+	// An optional stage that never starts emits nothing.
+	require.Empty(t, observer.events)
+
+	r.workflowObserver = nil
+	r.copier = &aggregateCopier{panic: true}
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(t.Context(), status.WorkflowStageCopy)
+	})
+	r.observeWorkflowStageFinished(t.Context(), t.Context(), status.WorkflowStageCopy, nil)
+	require.Empty(t, observer.events)
+}

--- a/pkg/migration/workflow_observer_test.go
+++ b/pkg/migration/workflow_observer_test.go
@@ -47,6 +47,18 @@ type cancelOnCopyStartObserver struct {
 	cancel context.CancelFunc
 }
 
+type cancelOnDurableMutationObserver struct {
+	recordingWorkflowObserver
+	cancel context.CancelFunc
+}
+
+func (o *cancelOnDurableMutationObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.recordingWorkflowObserver.ObserveWorkflow(ctx, event)
+	if event.DurableMutation {
+		o.cancel()
+	}
+}
+
 func (o *cancelOnCopyStartObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
 	o.recordingWorkflowObserver.ObserveWorkflow(ctx, event)
 	if event.Stage == status.WorkflowStageCopy && event.Transition == status.WorkflowTransitionStarted {
@@ -128,4 +140,19 @@ func TestWorkflowObserverOptionalAndNilBehavior(t *testing.T) {
 	})
 	r.observeWorkflowStageFinished(t.Context(), t.Context(), status.WorkflowStageCopy, nil)
 	require.Empty(t, observer.events)
+}
+
+func TestWorkflowObserverReportsDurableMutation(t *testing.T) {
+	parent := context.WithValue(t.Context(), workflowObserverContextKey{}, "parent")
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{workflowObserver: observer}
+
+	r.observeWorkflowDurableMutation(parent)
+
+	require.Equal(t, []status.WorkflowEvent{{DurableMutation: true}}, observer.events)
+	require.Equal(t, []context.Context{parent}, observer.contexts)
+
+	r.workflowObserver = nil
+	r.observeWorkflowDurableMutation(parent)
+	require.Len(t, observer.events, 1)
 }

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -27,6 +27,15 @@ var renameRetryWait = 1 * time.Second
 // that state cannot converge, so the retry loop aborts immediately.
 var errRenameRollbackFailed = errors.New("rename rollback failed")
 
+// CutoverResult reports whether a caller-owned forward cutover callback made a
+// durable ownership or topology mutation, even when it also returned an error.
+type CutoverResult struct {
+	DurableMutation bool
+}
+
+// CutoverResultCallback is the result-bearing form of a forward cutover callback.
+type CutoverResultCallback func(context.Context) (CutoverResult, error)
+
 // CutOverSource holds per-source state needed for the cutover.
 type CutOverSource struct {
 	DB         *sql.DB
@@ -35,10 +44,12 @@ type CutOverSource struct {
 }
 
 type CutOver struct {
-	sources     []CutOverSource
-	cutoverFunc func(ctx context.Context) error
-	dbConfig    *dbconn.DBConfig
-	logger      *slog.Logger
+	sources            []CutOverSource
+	cutoverFunc        func(ctx context.Context) error
+	dbConfig           *dbconn.DBConfig
+	cutoverResultFunc  CutoverResultCallback
+	cutoverFuncMutated bool
+	logger             *slog.Logger
 	// cutoverFuncSucceeded tracks whether cutoverFunc has been invoked and
 	// returned nil. The cutover function is a caller-supplied traffic switch
 	// (e.g. a Vitess routing change) and is not assumed to be idempotent:
@@ -62,6 +73,13 @@ type CutOver struct {
 // traffic switch and before the source rename. See CutOver.postSwitch.
 func (c *CutOver) SetPostSwitch(fn func(ctx context.Context) error) {
 	c.postSwitch = fn
+}
+
+// SetCutoverWithResult installs a result-bearing forward cutover callback.
+// It is mutually exclusive with the legacy error-only callback.
+func (c *CutOver) SetCutoverWithResult(fn CutoverResultCallback) {
+	c.cutoverFunc = nil
+	c.cutoverResultFunc = fn
 }
 
 // NewCutOver creates a new CutOver that handles multiple sources.
@@ -119,6 +137,11 @@ func (c *CutOver) Run(ctx context.Context) error {
 			"max-retries", c.dbConfig.MaxRetries)
 		err = c.algorithmCutover(ctx)
 		if err != nil {
+			if c.cutoverFuncMutated && !c.cutoverFuncSucceeded {
+				c.logger.Error("cutover callback failed after reporting a durable mutation; not retrying",
+					"error", err.Error())
+				return fmt.Errorf("cutover callback reported a durable ownership or topology mutation before failing; manual intervention required: %w", err)
+			}
 			if c.cutoverFuncSucceeded {
 				// The traffic switch has already succeeded, so traffic may be
 				// on the target. Another attempt would have released the
@@ -178,15 +201,25 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 	}
 
 	// Run the cutover function (Vitess coordination). It is invoked at most
-	// once per CutOver: the traffic switch is not assumed to be idempotent,
-	// so if a later step fails the retry must never re-run it.
-	if c.cutoverFunc != nil && !c.cutoverFuncSucceeded {
+	// once after it succeeds or reports a durable mutation.
+	if !c.cutoverFuncSucceeded && (c.cutoverResultFunc != nil || c.cutoverFunc != nil) {
 		c.logger.Info("Running cutover function")
-		if err := c.cutoverFunc(ctx); err != nil {
-			return err
+		if c.cutoverResultFunc != nil {
+			result, callbackErr := c.cutoverResultFunc(ctx)
+			c.cutoverFuncMutated = c.cutoverFuncMutated || result.DurableMutation
+			if callbackErr != nil {
+				return callbackErr
+			}
+			c.cutoverFuncSucceeded = true
+		} else if c.cutoverFunc != nil {
+			if err := c.cutoverFunc(ctx); err != nil {
+				return err
+			}
+			c.cutoverFuncSucceeded = true
 		}
-		c.cutoverFuncSucceeded = true
-		c.logger.Info("Cutover function complete")
+		if c.cutoverFuncSucceeded {
+			c.logger.Info("Cutover function complete")
+		}
 	}
 
 	// Reverse-window hook: after the traffic switch and before retiring the

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -12,7 +12,6 @@ import (
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/move/check"
-	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 )
@@ -93,20 +92,31 @@ type reverseWindow struct {
 	feed *ReverseFeed
 	// watched[i] is target i's real-name tables, used to lock and then retire
 	// the targets during a reverse cutover.
-	watched [][]*table.TableInfo
+	watched        [][]*table.TableInfo
+	dropMarker     func(context.Context) error
+	dropCheckpoint func(context.Context) error
 }
 
-func newReverseWindow(r *Runner) *reverseWindow { return &reverseWindow{r: r} }
+func newReverseWindow(r *Runner) *reverseWindow {
+	return &reverseWindow{
+		r:              r,
+		dropMarker:     func(ctx context.Context) error { return dropRevertMarker(ctx, r.targets[0].DB) },
+		dropCheckpoint: func(ctx context.Context) error { return r.checkpointTbl().Drop(ctx) },
+	}
+}
 
 // run holds the window and performs the terminal action. It owns the feed's
-// lifecycle.
-func (w *reverseWindow) run(ctx context.Context) error {
+// lifecycle. started runs after the reverse feed is live.
+func (w *reverseWindow) run(ctx context.Context, started func()) error {
 	if err := w.buildFeed(ctx); err != nil {
 		return err
 	}
 	defer w.feed.Close() // idempotent; the terminal actions also close explicitly
 	if err := w.feed.Start(ctx); err != nil {
 		return fmt.Errorf("reverse window: start feed: %w", err)
+	}
+	if started != nil {
+		started()
 	}
 
 	r := w.r
@@ -117,7 +127,6 @@ func (w *reverseWindow) run(ctx context.Context) error {
 	r.logger.Info(fmt.Sprintf("reverse window open; watching for a table named %s to be created on %s (create it to roll back)",
 		revertMarkerName, revertLoc),
 		"window", r.move.ReverseWindow, "deadline", deadline, "reverse_sources", len(r.targets))
-	r.status.Set(status.ReverseWindow)
 
 	ticker := time.NewTicker(reverseWindowPollInterval)
 	defer ticker.Stop()
@@ -272,10 +281,10 @@ func (w *reverseWindow) revertRequested(ctx context.Context) (bool, error) {
 // checkpoint is dropped. The reverse feed is stopped.
 func (w *reverseWindow) completeForward(ctx context.Context) error {
 	w.feed.Close()
-	if err := dropRevertMarker(ctx, w.r.targets[0].DB); err != nil {
+	if err := w.dropMarker(ctx); err != nil {
 		return fmt.Errorf("reverse window: drop revert marker on complete-forward: %w", err)
 	}
-	if err := w.r.checkpointTbl().Drop(ctx); err != nil {
+	if err := w.dropCheckpoint(ctx); err != nil {
 		return fmt.Errorf("reverse window: drop checkpoint on complete-forward: %w", err)
 	}
 	w.r.logger.Info("reverse window complete; move finalized forward (source retired)")
@@ -337,6 +346,7 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 			if err := dbconn.Exec(ctx, s.db, "RENAME TABLE %n TO %n", oldName, t.TableName); err != nil {
 				return fmt.Errorf("reverse cutover: un-retire source %d table %q: %w", si, t.TableName, err)
 			}
+			r.ownershipAmbiguous = true
 		}
 	}
 
@@ -361,11 +371,20 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 		}
 	}
 
-	// 6. Drop the revert marker and the checkpoint.
-	if err := dropRevertMarker(ctx, r.targets[0].DB); err != nil {
+	return w.finalizeReverse(ctx)
+}
+
+// finalizeReverse records definitive reverse ownership before best-effort
+// cleanup. Once every target has been retired, cleanup failure cannot move
+// ownership away from the restored source.
+func (w *reverseWindow) finalizeReverse(ctx context.Context) error {
+	r := w.r
+	r.ownershipAmbiguous = false
+	r.reverseFinalized = true
+	if err := w.dropMarker(ctx); err != nil {
 		return fmt.Errorf("reverse cutover: drop revert marker: %w", err)
 	}
-	if err := r.checkpointTbl().Drop(ctx); err != nil {
+	if err := w.dropCheckpoint(ctx); err != nil {
 		return fmt.Errorf("reverse cutover: drop checkpoint: %w", err)
 	}
 	r.logger.Info("reverse cutover complete; move rolled back to source")

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -183,6 +183,57 @@ func TestMoveReverseWindowRevert(t *testing.T) {
 	require.False(t, tableExists(t, ctl, "rwrv_dst", checkpointTableName), "checkpoint should be dropped")
 }
 
+func TestMoveReverseWindowPartialSourceRestoreReportsAmbiguous(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	sourceDSN, targetDSN, ctl := setupReverseWindowMove(t, "rwpartial_src", "rwpartial_dst")
+	testutils.RunSQL(t, "CREATE TABLE rwpartial_src.t2 (id INT PRIMARY KEY, val VARCHAR(255))")
+	testutils.RunSQL(t, "INSERT INTO rwpartial_src.t2 (id, val) VALUES (1,'one')")
+
+	runner, err := NewRunner(&Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: time.Second,
+		Threads:         1,
+		WriteThreads:    1,
+		ReverseWindow:   30 * time.Second,
+	})
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+
+	observer := &recordingWorkflowObserver{}
+	runner.SetWorkflowObserver(observer)
+	runner.SetCutover(func(context.Context) error { return nil })
+	runner.SetReverseCutover(func(context.Context) error { return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Run(context.Background()) }()
+	waitForReverseWindow(t, ctl, "rwpartial_dst")
+	waitForTable(t, ctl, "rwpartial_src", "t1_old")
+	waitForTable(t, ctl, "rwpartial_src", "t2_old")
+
+	// Force the second source restore to fail after t1_old -> t1 succeeds.
+	testutils.RunSQL(t, "CREATE TABLE rwpartial_src.t2 (id INT PRIMARY KEY)")
+	testutils.RunSQL(t, "CREATE TABLE rwpartial_dst."+revertMarkerName+" (id INT)")
+
+	select {
+	case runErr := <-errCh:
+		require.Error(t, runErr)
+		require.Contains(t, runErr.Error(), "un-retire source")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for partial reverse cutover failure")
+	}
+
+	require.True(t, tableExists(t, ctl, "rwpartial_src", "t1"))
+	require.True(t, tableExists(t, ctl, "rwpartial_src", "t2_old"))
+	var terminals []status.WorkflowEvent
+	for _, event := range observer.events {
+		if event.TerminalOwnership != 0 {
+			terminals = append(terminals, event)
+		}
+	}
+	require.Equal(t, []status.WorkflowEvent{{TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous}}, terminals)
+}
+
 // runRevertingMove runs one reverse-window move against the given DSNs and, once
 // the window opens, requests a revert (creates the marker), returning when the
 // reverse cutover has completed. Fails the test on any error.

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -130,7 +130,8 @@ type Runner struct {
 	sentinelWaitStartTime    time.Time
 	usedResumeFromCheckpoint bool
 
-	cutoverFunc func(ctx context.Context) error
+	cutoverFunc       func(ctx context.Context) error
+	cutoverResultFunc CutoverResultCallback
 	// reverseCutoverFunc is the reverse-window rollback's traffic switch (route
 	// back to the source). Set via SetReverseCutover; used only when
 	// move.ReverseWindow > 0 and a revert is requested during the window.
@@ -164,7 +165,11 @@ type Runner struct {
 	// goroutines run under. Reverse-window mode stops the dumper before cutover
 	// (stopWatchTask) so the reverse window is the sole writer of the checkpoint
 	// row.
-	bgCancel context.CancelFunc
+	bgCancel           context.CancelFunc
+	workflowObserver   status.WorkflowObserver
+	reverseFinalized   bool
+	ownershipAmbiguous bool
+	terminalObserved   bool
 }
 
 var _ status.Task = (*Runner)(nil)
@@ -201,6 +206,88 @@ func NewRunner(m *Move) (*Runner, error) {
 		logger: slog.Default(),
 	}
 	return r, nil
+}
+
+// SetWorkflowObserver installs an optional typed workflow observer. It must be
+// called before Run. A nil observer disables workflow observation.
+func (r *Runner) SetWorkflowObserver(observer status.WorkflowObserver) {
+	r.workflowObserver = observer
+}
+
+func (r *Runner) observeWorkflowStageStarted(parent context.Context, stage status.WorkflowStage) {
+	if r.workflowObserver == nil {
+		return
+	}
+	r.workflowObserver.ObserveWorkflow(parent, status.WorkflowEvent{
+		Stage:      stage,
+		Transition: status.WorkflowTransitionStarted,
+	})
+}
+
+func (r *Runner) observeWorkflowStageFinished(parent, runCtx context.Context, stage status.WorkflowStage, err error) {
+	if r.workflowObserver == nil {
+		return
+	}
+	event := status.WorkflowEvent{
+		Stage:      stage,
+		Transition: status.WorkflowTransitionFinished,
+		Outcome:    workflowOutcome(runCtx, err),
+	}
+	if stage == status.WorkflowStageCopy {
+		rows, chunks, available := copier.CompletedWork(r.copier)
+		if available {
+			event.TotalsAvailable = true
+			event.Totals.CompletedRows = rows
+			event.Totals.CompletedChunks = chunks
+		}
+	}
+	r.workflowObserver.ObserveWorkflow(parent, event)
+}
+
+func (r *Runner) runObservedCopy(parent, ctx context.Context) error {
+	err := r.copier.Run(ctx)
+	if err == nil && ctx.Err() != nil {
+		chunker := r.copier.GetChunker()
+		if chunker == nil || !chunker.IsRead() {
+			err = ctx.Err()
+		}
+	}
+	r.observeWorkflowStageFinished(parent, ctx, status.WorkflowStageCopy, err)
+	return err
+}
+
+func (r *Runner) observeWorkflowTerminal(parent context.Context) {
+	if r.workflowObserver == nil {
+		return
+	}
+	if r.terminalObserved {
+		return
+	}
+	var ownership status.WorkflowTerminalOwnership
+	switch {
+	case r.reverseFinalized:
+		ownership = status.WorkflowTerminalOwnershipReverseFinalized
+	case r.ownershipAmbiguous:
+		ownership = status.WorkflowTerminalOwnershipAmbiguous
+	default:
+		return
+	}
+	r.terminalObserved = true
+	r.workflowObserver.ObserveWorkflow(parent, status.WorkflowEvent{TerminalOwnership: ownership})
+}
+
+func (r *Runner) runReverseWindow(parent, ctx context.Context) error {
+	started := false
+	err := newReverseWindow(r).run(ctx, func() {
+		started = true
+		r.status.Set(status.ReverseWindow, func() {
+			r.observeWorkflowStageStarted(parent, status.WorkflowStageReverseWindow)
+		})
+	})
+	if started {
+		r.observeWorkflowStageFinished(parent, ctx, status.WorkflowStageReverseWindow, err)
+	}
+	return err
 }
 
 func (r *Runner) Close() error {
@@ -770,7 +857,7 @@ func (r *Runner) dropStaleRevertTables(ctx context.Context) error {
 // Not yet handled: an interrupted reverse *cutover* (phase "reverting") leaves
 // an ambiguous half-renamed state, so that surfaces as an error for manual
 // completion rather than an unsafe auto-resume.
-func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
+func (r *Runner) maybeResumeReverseWindow(parentCtx, ctx context.Context) (bool, error) {
 	rec, err := r.checkpointTbl().ReadLatest(ctx)
 	if err != nil {
 		// No usable checkpoint (fresh move, empty, or a layout this version
@@ -781,8 +868,9 @@ func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
 	switch rec.Phase {
 	case phaseReverseWindow:
 		r.logger.Warn("resuming an interrupted reverse window from checkpoint", "cutover_at", rec.CutoverAt)
-		return true, r.resumeReverseWindow(ctx, rec)
+		return true, r.resumeReverseWindow(parentCtx, ctx, rec)
 	case phaseReverting:
+		r.ownershipAmbiguous = true
 		return true, fmt.Errorf("a reverse cutover was interrupted (checkpoint phase=%q); resuming a partial rollback is not yet supported — complete it manually", rec.Phase)
 	default:
 		return false, nil // phase "" (copy) — the normal flow handles resume/fresh
@@ -797,7 +885,7 @@ func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
 // of the same move is an operator error), and the feed always resumes from the
 // original cutover position — correct via idempotent apply, at the cost of
 // re-reading the window's binlog.
-func (r *Runner) resumeReverseWindow(ctx context.Context, rec checkpoint.Record) error {
+func (r *Runner) resumeReverseWindow(parentCtx, ctx context.Context, rec checkpoint.Record) error {
 	var positions map[string]string
 	if err := json.Unmarshal([]byte(rec.Position), &positions); err != nil {
 		return fmt.Errorf("resume reverse window: parse stored positions: %w", err)
@@ -826,7 +914,7 @@ func (r *Runner) resumeReverseWindow(ctx context.Context, rec checkpoint.Record)
 	}
 	r.sourceTables = r.sources[0].tables
 
-	return newReverseWindow(r).run(ctx)
+	return r.runReverseWindow(parentCtx, ctx)
 }
 
 // reverseWindowLogicalTables recovers the logical names of the moved tables when
@@ -979,6 +1067,11 @@ func (r *Runner) createCheckpointTable(ctx context.Context) error {
 }
 
 func (r *Runner) Run(ctx context.Context) error {
+	parentCtx := ctx
+	r.reverseFinalized = false
+	r.ownershipAmbiguous = false
+	r.terminalObserved = false
+	defer func() { r.observeWorkflowTerminal(parentCtx) }()
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
 	r.startTime = time.Now()
@@ -1094,7 +1187,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// treat them as fresh data and re-copy them. This must run before the
 	// revert-marker pre-flight guard, since a resumed window legitimately honors
 	// a marker created before the crash.
-	if handled, err := r.maybeResumeReverseWindow(ctx); err != nil {
+	if handled, err := r.maybeResumeReverseWindow(parentCtx, ctx); err != nil {
 		return err
 	} else if handled {
 		return nil
@@ -1116,20 +1209,13 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	if len(r.sourceTables) == 0 {
 		// Because this is called from orchestration, there might be a bug where
-		// it is asked to move *no tables*. Since there are no tables,
-		// there is no:
-		// - copier, replication changes
-		// - advisory lock
-		// - cutover step
-		//
-		// But the caller will still want their cutoverFunc called. So we do that
-		// and then exit.
+		// it is asked to move *no tables*. Since there are no tables, there is no
+		// copier, replication, advisory lock, or physical cutover. The caller's
+		// cutover callback still runs.
 		r.logger.Info("No tables to copy, proceeding directly to cutover")
 		r.status.Set(status.CutOver)
-		if r.cutoverFunc != nil {
-			if err := r.cutoverFunc(ctx); err != nil {
-				return err
-			}
+		if err := r.runForwardCutoverCallback(ctx); err != nil {
+			return err
 		}
 		r.logger.Info("Move operation complete.")
 		return nil
@@ -1172,19 +1258,25 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	r.status.Set(status.CopyRows)
-	if err := r.copier.Run(ctx); err != nil {
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageCopy)
+	})
+	err = r.runObservedCopy(parentCtx, ctx)
+	if err != nil {
 		return err
 	}
 
-	// Disable both watermark optimizations so that all changes can be flushed.
-	// For non-memory-comparable PKs this also drains the buffered map and
-	// switches the subscription into FIFO queue mode (see
-	// pkg/change/subscription_buffered.go), so the call can return an error.
-	if err := r.setWatermarkOptimizationAll(ctx, false); err != nil {
-		return err
+	// Disable both watermark optimizations and flush pending changes at the
+	// authoritative catch-up boundary.
+	r.status.Set(status.ApplyChangeset, func() {
+		r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageCatchUp)
+	})
+	err = r.setWatermarkOptimizationAll(ctx, false)
+	if err == nil {
+		err = r.flushAllReplClients(ctx)
 	}
-	if err := r.flushAllReplClients(ctx); err != nil {
+	r.observeWorkflowStageFinished(parentCtx, ctx, status.WorkflowStageCatchUp, err)
+	if err != nil {
 		return err
 	}
 
@@ -1194,24 +1286,33 @@ func (r *Runner) Run(ctx context.Context) error {
 	// ANALYZE TABLE, run the initial checksum. While the sentinel blocks
 	// cutover, waitOnSentinelTable runs a continuous checksum loop in the
 	// background — see docs/move.md for the two-checksum model.
-	if err := r.postCopyPhase(ctx); err != nil {
+	if err := r.postCopyPhaseObserved(parentCtx, ctx); err != nil {
 		return err
 	}
 	r.logger.Info("Initial checksum completed successfully")
 
-	r.sentinelWaitStartTime = time.Now()
-	r.status.Set(status.WaitingOnSentinelTable)
-	// Block on the sentinel via the shared sentinel.Wait (poll/timeout timing
-	// lives in the sentinel package). The continuous-checksum lifecycle and
-	// watermark invalidation are move-specific (multi-source feeds;
-	// invalidateChecksumWatermark blanks the whole per-move checkpoint table),
-	// so they are injected as callbacks. See pkg/sentinel.
-	if err := sentinel.Wait(ctx, sentinel.WaitConfig{
-		Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
+	waitStarted := false
+	exists := func(ctx context.Context) (bool, error) {
+		ok, err := sentinel.Exists(ctx, r.targets[0].DB)
+		if err == nil && ok && !waitStarted {
+			waitStarted = true
+			r.sentinelWaitStartTime = time.Now()
+			r.status.Set(status.WaitingOnSentinelTable, func() {
+				r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageWaitForSentinel)
+			})
+		}
+		return ok, err
+	}
+	err = sentinel.Wait(ctx, sentinel.WaitConfig{
+		Exists:              exists,
 		RunChecksum:         r.runContinuousChecksum,
 		InvalidateWatermark: r.invalidateChecksumWatermark,
 		Logger:              r.logger,
-	}); err != nil {
+	})
+	if waitStarted {
+		r.observeWorkflowStageFinished(parentCtx, ctx, status.WorkflowStageWaitForSentinel, err)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -1236,6 +1337,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if r.cutoverResultFunc != nil {
+		cutover.SetCutoverWithResult(r.cutoverResultFunc)
+	}
 	if r.move.ReverseWindow > 0 {
 		// Under the cutover lock, right after the traffic switch, capture the
 		// reverse-feed start positions and record that the move has entered its
@@ -1249,14 +1353,16 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 	if err = cutover.Run(ctx); err != nil {
+		r.ownershipAmbiguous = cutover.cutoverFuncSucceeded || cutover.cutoverFuncMutated || cutover.postSwitchDone || errors.Is(err, errRenameRollbackFailed)
 		return err
 	}
+	r.ownershipAmbiguous = false
 
 	if r.move.ReverseWindow > 0 {
 		// Hold the reverse window keeping the source current, then complete
 		// forward (retire the source) or roll back. The checkpoint is dropped by
 		// the terminal action, not here.
-		return newReverseWindow(r).run(ctx)
+		return r.runReverseWindow(parentCtx, ctx)
 	}
 
 	// Delete checkpoint table from targets[0].
@@ -1577,6 +1683,10 @@ func (r *Runner) restoreIndexesForTargets(ctx context.Context, host string, targ
 // When create-sentinel is not in use this is also the last phase
 // before cutover.
 func (r *Runner) postCopyPhase(ctx context.Context) error {
+	return r.postCopyPhaseObserved(ctx, ctx)
+}
+
+func (r *Runner) postCopyPhaseObserved(parentCtx, ctx context.Context) error {
 	// Flush all pending events, but leave the periodic flush running until
 	// just before the checksum. With --defer-secondary-indexes,
 	// restoreSecondaryIndexes issues one giant ALTER per table that can run
@@ -1666,15 +1776,12 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	r.status.Set(status.Checksum)
-	// On a checker error we just propagate. The DumpCheckpoint invariant
-	// guarantees that any persisted checksum_watermark describes only
-	// verified-clean chunks, so a resumed run either replays the checksum
-	// from scratch (empty watermark, set whenever the failing pass had any
-	// repair) or resumes safely from a watermark that came from a clean
-	// pass. See pkg/migration/runner.go DumpCheckpoint for the full
-	// rationale.
-	return r.checker.Run(ctx)
+	r.status.Set(status.Checksum, func() {
+		r.observeWorkflowStageStarted(parentCtx, status.WorkflowStageChecksum)
+	})
+	err = r.checker.Run(ctx)
+	r.observeWorkflowStageFinished(parentCtx, ctx, status.WorkflowStageChecksum, err)
+	return err
 }
 
 // analyzeTable runs ANALYZE TABLE for tableName on db, unqualified: db is
@@ -1716,8 +1823,28 @@ func (r *Runner) analyzeTable(ctx context.Context, db *sql.DB, tableName string)
 	return rows.Err()
 }
 
+func (r *Runner) runForwardCutoverCallback(ctx context.Context) error {
+	if r.cutoverResultFunc != nil {
+		result, err := r.cutoverResultFunc(ctx)
+		r.ownershipAmbiguous = result.DurableMutation && err != nil
+		return err
+	}
+	if r.cutoverFunc != nil {
+		return r.cutoverFunc(ctx)
+	}
+	return nil
+}
+
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {
+	r.cutoverResultFunc = nil
 	r.cutoverFunc = cutover
+}
+
+// SetCutoverWithResult installs a result-bearing forward cutover callback.
+// It is mutually exclusive with SetCutover; the most recent setter wins.
+func (r *Runner) SetCutoverWithResult(cutover CutoverResultCallback) {
+	r.cutoverFunc = nil
+	r.cutoverResultFunc = cutover
 }
 
 // SetReverseCutover registers the rollback traffic switch used if a revert is

--- a/pkg/move/workflow_observer.go
+++ b/pkg/move/workflow_observer.go
@@ -1,0 +1,18 @@
+package move
+
+import (
+	"context"
+	"errors"
+
+	"github.com/block/spirit/pkg/status"
+)
+
+func workflowOutcome(ctx context.Context, err error) status.WorkflowOutcome {
+	if err == nil {
+		return status.WorkflowOutcomeSucceeded
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+		return status.WorkflowOutcomeCancelled
+	}
+	return status.WorkflowOutcomeFailed
+}

--- a/pkg/move/workflow_observer_test.go
+++ b/pkg/move/workflow_observer_test.go
@@ -1,0 +1,233 @@
+package move
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/block/spirit/pkg/copier"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/stretchr/testify/require"
+)
+
+type workflowObserverContextKey struct{}
+
+type recordingWorkflowObserver struct {
+	events   []status.WorkflowEvent
+	contexts []context.Context
+}
+
+func (o *recordingWorkflowObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.contexts = append(o.contexts, ctx)
+	o.events = append(o.events, event)
+}
+
+type aggregateCopier struct {
+	copier.Copier
+	rows   uint64
+	chunks uint64
+	panic  bool
+}
+
+func (c *aggregateCopier) CompletedWork() (uint64, uint64) {
+	if c.panic {
+		panic("CompletedWork called with nil observer")
+	}
+	return c.rows, c.chunks
+}
+
+type nilCompletingCopier struct{ copier.Copier }
+
+func (*nilCompletingCopier) Run(context.Context) error { return nil }
+func (*nilCompletingCopier) GetChunker() table.Chunker { return nil }
+
+type cancelOnCopyStartObserver struct {
+	recordingWorkflowObserver
+	cancel context.CancelFunc
+}
+
+func (o *cancelOnCopyStartObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.recordingWorkflowObserver.ObserveWorkflow(ctx, event)
+	if event.Stage == status.WorkflowStageCopy && event.Transition == status.WorkflowTransitionStarted {
+		o.cancel()
+	}
+}
+
+func TestWorkflowObserverOrderOutcomesAggregatesAndTerminalOwnership(t *testing.T) {
+	parent := context.WithValue(t.Context(), workflowObserverContextKey{}, "parent")
+	runCtx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{
+		workflowObserver: observer,
+		copier:           &aggregateCopier{rows: 100, chunks: 4},
+	}
+
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(parent, status.WorkflowStageCopy)
+	})
+	r.observeWorkflowStageFinished(parent, runCtx, status.WorkflowStageCopy, nil)
+	r.status.Set(status.ApplyChangeset, func() {
+		r.observeWorkflowStageStarted(parent, status.WorkflowStageCatchUp)
+	})
+	r.observeWorkflowStageFinished(parent, runCtx, status.WorkflowStageCatchUp, errors.New("flush failed"))
+	r.status.Set(status.WaitingOnSentinelTable, func() {
+		r.observeWorkflowStageStarted(parent, status.WorkflowStageWaitForSentinel)
+	})
+	r.observeWorkflowStageFinished(parent, runCtx, status.WorkflowStageWaitForSentinel, context.DeadlineExceeded)
+	r.reverseFinalized = true
+	r.ownershipAmbiguous = true // reverse finalization is the stronger terminal fact.
+	r.observeWorkflowTerminal(parent)
+	require.Equal(t, status.WaitingOnSentinelTable, r.status.Get())
+
+	require.Equal(t, []status.WorkflowEvent{
+		{Stage: status.WorkflowStageCopy, Transition: status.WorkflowTransitionStarted},
+		{
+			Stage:           status.WorkflowStageCopy,
+			Transition:      status.WorkflowTransitionFinished,
+			Outcome:         status.WorkflowOutcomeSucceeded,
+			Totals:          status.WorkflowTotals{CompletedRows: 100, CompletedChunks: 4},
+			TotalsAvailable: true,
+		},
+		{Stage: status.WorkflowStageCatchUp, Transition: status.WorkflowTransitionStarted},
+		{Stage: status.WorkflowStageCatchUp, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeFailed},
+		{Stage: status.WorkflowStageWaitForSentinel, Transition: status.WorkflowTransitionStarted},
+		{Stage: status.WorkflowStageWaitForSentinel, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled},
+		{TerminalOwnership: status.WorkflowTerminalOwnershipReverseFinalized},
+	}, observer.events)
+	totalsEvents := 0
+	for _, event := range observer.events {
+		if event.TotalsAvailable {
+			totalsEvents++
+		}
+	}
+	require.Equal(t, 1, totalsEvents, "copy totals must be one terminal aggregate, not per chunk")
+	require.Len(t, observer.contexts, len(observer.events))
+	for _, observedCtx := range observer.contexts {
+		require.Same(t, parent, observedCtx)
+	}
+}
+
+func TestWorkflowObserverAmbiguousOwnershipExactlyOnce(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{workflowObserver: observer, ownershipAmbiguous: true}
+
+	r.observeWorkflowTerminal(t.Context())
+	r.observeWorkflowTerminal(t.Context())
+	require.Equal(t, []status.WorkflowEvent{{TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous}}, observer.events)
+}
+
+func TestWorkflowObserverCancellationDuringCopyDoesNotStartCatchUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	observer := &cancelOnCopyStartObserver{cancel: cancel}
+	r := &Runner{workflowObserver: observer, copier: &nilCompletingCopier{}}
+
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(ctx, status.WorkflowStageCopy)
+	})
+	require.ErrorIs(t, r.runObservedCopy(ctx, ctx), context.Canceled)
+	require.Equal(t, []status.WorkflowEvent{
+		{Stage: status.WorkflowStageCopy, Transition: status.WorkflowTransitionStarted},
+		{Stage: status.WorkflowStageCopy, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled},
+	}, observer.events)
+}
+
+func TestForwardCutoverResultControlsAmbiguousOwnership(t *testing.T) {
+	callbackErr := errors.New("cutover failed")
+	for _, tt := range []struct {
+		name     string
+		mutated  bool
+		expected []status.WorkflowEvent
+	}{
+		{
+			name:     "durable mutation",
+			mutated:  true,
+			expected: []status.WorkflowEvent{{TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous}},
+		},
+		{name: "no mutation"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			observer := &recordingWorkflowObserver{}
+			r := &Runner{workflowObserver: observer}
+			r.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+				return CutoverResult{DurableMutation: tt.mutated}, callbackErr
+			})
+
+			require.ErrorIs(t, r.runForwardCutoverCallback(t.Context()), callbackErr)
+			r.observeWorkflowTerminal(t.Context())
+			require.Equal(t, tt.expected, observer.events)
+		})
+	}
+}
+
+func TestForwardCutoverSettersAreMutuallyExclusiveAndNilSafe(t *testing.T) {
+	r := &Runner{}
+	r.SetCutover(func(context.Context) error { return nil })
+	require.NotNil(t, r.cutoverFunc)
+	require.Nil(t, r.cutoverResultFunc)
+
+	r.SetCutoverWithResult(func(context.Context) (CutoverResult, error) { return CutoverResult{}, nil })
+	require.Nil(t, r.cutoverFunc)
+	require.NotNil(t, r.cutoverResultFunc)
+
+	r.SetCutover(nil)
+	require.Nil(t, r.cutoverFunc)
+	require.Nil(t, r.cutoverResultFunc)
+}
+
+func TestReverseFinalizedSurvivesCleanupFailure(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	tests := []struct {
+		name           string
+		dropMarker     func(context.Context) error
+		dropCheckpoint func(context.Context) error
+	}{
+		{
+			name:           "revert marker",
+			dropMarker:     func(context.Context) error { return cleanupErr },
+			dropCheckpoint: func(context.Context) error { return nil },
+		},
+		{
+			name:           "checkpoint",
+			dropMarker:     func(context.Context) error { return nil },
+			dropCheckpoint: func(context.Context) error { return cleanupErr },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer := &recordingWorkflowObserver{}
+			r := &Runner{workflowObserver: observer, ownershipAmbiguous: true}
+			w := &reverseWindow{
+				r:              r,
+				dropMarker:     tt.dropMarker,
+				dropCheckpoint: tt.dropCheckpoint,
+			}
+
+			require.ErrorIs(t, w.finalizeReverse(t.Context()), cleanupErr)
+			require.True(t, r.reverseFinalized)
+			require.False(t, r.ownershipAmbiguous)
+			r.observeWorkflowTerminal(t.Context())
+			require.Equal(t, []status.WorkflowEvent{{TerminalOwnership: status.WorkflowTerminalOwnershipReverseFinalized}}, observer.events)
+		})
+	}
+}
+
+func TestWorkflowObserverOptionalAndNilBehavior(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{workflowObserver: observer}
+
+	// Optional sentinel and reverse-window stages that never start emit nothing.
+	require.Empty(t, observer.events)
+
+	r.workflowObserver = nil
+	r.copier = &aggregateCopier{panic: true}
+	r.status.Set(status.CopyRows, func() {
+		r.observeWorkflowStageStarted(t.Context(), status.WorkflowStageCopy)
+	})
+	r.observeWorkflowStageFinished(t.Context(), t.Context(), status.WorkflowStageCopy, nil)
+	r.reverseFinalized = true
+	r.observeWorkflowTerminal(t.Context())
+	require.Empty(t, observer.events)
+}

--- a/pkg/status/state.go
+++ b/pkg/status/state.go
@@ -75,6 +75,13 @@ func (s *State) Get() State {
 	return State(atomic.LoadInt32((*int32)(s)))
 }
 
-func (s *State) Set(newState State) {
+// Set stores newState, then synchronously invokes any supplied notifications.
+// Notifications observe the new value and must return promptly.
+func (s *State) Set(newState State, notifications ...func()) {
 	atomic.StoreInt32((*int32)(s), int32(newState))
+	for _, notify := range notifications {
+		if notify != nil {
+			notify()
+		}
+	}
 }

--- a/pkg/status/state_test.go
+++ b/pkg/status/state_test.go
@@ -22,3 +22,16 @@ func TestStateString(t *testing.T) {
 	require.Equal(t, "analyzeTable", AnalyzeTable.String())
 	require.Equal(t, "close", Close.String())
 }
+
+func TestStateSetNotifiesAfterStore(t *testing.T) {
+	var state State
+	notifications := 0
+
+	state.Set(CopyRows, func() {
+		notifications++
+		require.Equal(t, CopyRows, state.Get())
+	}, nil)
+
+	require.Equal(t, CopyRows, state.Get())
+	require.Equal(t, 1, notifications)
+}

--- a/pkg/status/workflow.go
+++ b/pkg/status/workflow.go
@@ -108,14 +108,17 @@ type WorkflowTotals struct {
 // WorkflowEvent is one typed workflow observation.
 //
 // Stage events set Stage and Transition. Finished stage events also set Outcome;
-// a finished copy event may set TotalsAvailable and Totals. Terminal ownership
-// evidence is emitted as a terminal-only event with TerminalOwnership set and
-// all stage fields left at their zero values.
+// a finished copy event may set TotalsAvailable and Totals. Terminal evidence
+// events set exactly one of TerminalOwnership or DurableMutation and leave all
+// stage fields at their zero values. DurableMutation means the externally
+// visible table-name swap has completed successfully, even if later cleanup
+// causes Runner.Run to return an error.
 type WorkflowEvent struct {
 	Stage             WorkflowStage
 	Transition        WorkflowTransition
 	Outcome           WorkflowOutcome
 	TerminalOwnership WorkflowTerminalOwnership
+	DurableMutation   bool
 	Totals            WorkflowTotals
 	TotalsAvailable   bool
 }

--- a/pkg/status/workflow.go
+++ b/pkg/status/workflow.go
@@ -1,0 +1,128 @@
+package status
+
+import "context"
+
+// WorkflowStage identifies a closed workflow stage observed at an authoritative
+// runner boundary.
+type WorkflowStage uint8
+
+const (
+	WorkflowStageCopy WorkflowStage = iota + 1
+	WorkflowStageCatchUp
+	WorkflowStageChecksum
+	// WorkflowStageCheckpoint is reserved for a future single authoritative
+	// post-checksum checkpoint boundary. Current periodic checkpoint writes are
+	// internal attempts and intentionally emit no workflow stage.
+	WorkflowStageCheckpoint
+	WorkflowStageWaitForSentinel
+	WorkflowStageReverseWindow
+)
+
+func (s WorkflowStage) String() string {
+	switch s {
+	case WorkflowStageCopy:
+		return "copy"
+	case WorkflowStageCatchUp:
+		return "catch_up"
+	case WorkflowStageChecksum:
+		return "checksum"
+	case WorkflowStageCheckpoint:
+		return "checkpoint"
+	case WorkflowStageWaitForSentinel:
+		return "wait_for_sentinel"
+	case WorkflowStageReverseWindow:
+		return "reverse_window"
+	default:
+		return ""
+	}
+}
+
+// WorkflowTransition identifies whether a stage is beginning or ending.
+type WorkflowTransition uint8
+
+const (
+	WorkflowTransitionStarted WorkflowTransition = iota + 1
+	WorkflowTransitionFinished
+)
+
+func (t WorkflowTransition) String() string {
+	switch t {
+	case WorkflowTransitionStarted:
+		return "started"
+	case WorkflowTransitionFinished:
+		return "finished"
+	default:
+		return ""
+	}
+}
+
+// WorkflowOutcome is present only on a finished stage event.
+type WorkflowOutcome uint8
+
+const (
+	WorkflowOutcomeSucceeded WorkflowOutcome = iota + 1
+	WorkflowOutcomeFailed
+	WorkflowOutcomeCancelled
+)
+
+func (o WorkflowOutcome) String() string {
+	switch o {
+	case WorkflowOutcomeSucceeded:
+		return "succeeded"
+	case WorkflowOutcomeFailed:
+		return "failed"
+	case WorkflowOutcomeCancelled:
+		return "cancelled"
+	default:
+		return ""
+	}
+}
+
+// WorkflowTerminalOwnership identifies terminal ownership evidence that cannot
+// be inferred safely from an error alone.
+type WorkflowTerminalOwnership uint8
+
+const (
+	WorkflowTerminalOwnershipReverseFinalized WorkflowTerminalOwnership = iota + 1
+	WorkflowTerminalOwnershipAmbiguous
+)
+
+func (o WorkflowTerminalOwnership) String() string {
+	switch o {
+	case WorkflowTerminalOwnershipReverseFinalized:
+		return "reverse_finalized"
+	case WorkflowTerminalOwnershipAmbiguous:
+		return "ownership_ambiguous"
+	default:
+		return ""
+	}
+}
+
+// WorkflowTotals contains authoritative aggregate work completed by a stage.
+// Totals are terminal aggregates, never per-row or per-chunk notifications.
+type WorkflowTotals struct {
+	CompletedRows   uint64
+	CompletedChunks uint64
+}
+
+// WorkflowEvent is one typed workflow observation.
+//
+// Stage events set Stage and Transition. Finished stage events also set Outcome;
+// a finished copy event may set TotalsAvailable and Totals. Terminal ownership
+// evidence is emitted as a terminal-only event with TerminalOwnership set and
+// all stage fields left at their zero values.
+type WorkflowEvent struct {
+	Stage             WorkflowStage
+	Transition        WorkflowTransition
+	Outcome           WorkflowOutcome
+	TerminalOwnership WorkflowTerminalOwnership
+	Totals            WorkflowTotals
+	TotalsAvailable   bool
+}
+
+// WorkflowObserver receives synchronous workflow events in authoritative order.
+// Implementations must return promptly and must be safe for the calling runner's
+// goroutine. The context is the parent context supplied to Runner.Run.
+type WorkflowObserver interface {
+	ObserveWorkflow(context.Context, WorkflowEvent)
+}

--- a/pkg/status/workflow_test.go
+++ b/pkg/status/workflow_test.go
@@ -1,0 +1,30 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowValuesUseClosedVocabulary(t *testing.T) {
+	require.Equal(t, "copy", WorkflowStageCopy.String())
+	require.Equal(t, "catch_up", WorkflowStageCatchUp.String())
+	require.Equal(t, "checksum", WorkflowStageChecksum.String())
+	require.Equal(t, "checkpoint", WorkflowStageCheckpoint.String())
+	require.Equal(t, "wait_for_sentinel", WorkflowStageWaitForSentinel.String())
+	require.Equal(t, "reverse_window", WorkflowStageReverseWindow.String())
+	require.Empty(t, WorkflowStage(255).String())
+
+	require.Equal(t, "started", WorkflowTransitionStarted.String())
+	require.Equal(t, "finished", WorkflowTransitionFinished.String())
+	require.Empty(t, WorkflowTransition(255).String())
+
+	require.Equal(t, "succeeded", WorkflowOutcomeSucceeded.String())
+	require.Equal(t, "failed", WorkflowOutcomeFailed.String())
+	require.Equal(t, "cancelled", WorkflowOutcomeCancelled.String())
+	require.Empty(t, WorkflowOutcome(255).String())
+
+	require.Equal(t, "reverse_finalized", WorkflowTerminalOwnershipReverseFinalized.String())
+	require.Equal(t, "ownership_ambiguous", WorkflowTerminalOwnershipAmbiguous.String())
+	require.Empty(t, WorkflowTerminalOwnership(255).String())
+}


### PR DESCRIPTION
## Superseded

Do not merge this monolithic PR. Review the smaller dependency-ordered replacement stack instead:

1. #1112 — committed retry row accounting
2. #1113 — copier completed-work totals
3. #1114 — result-bearing cutover callbacks
4. #1115 — status-owned lifecycle API
5. #1116 — migration and move lifecycle adoption

The sequence preserves the original exporter-neutral workflow evidence goal while separating prerequisite correctness fixes from the lifecycle API and runner integration. Each PR is independently reviewed and verified, and each PR after #1112 is based on its predecessor.

## Original scope

Typed workflow stage, outcome, completed-work, durable-mutation, and terminal-ownership events for migration and move consumers such as Strata. No OpenTelemetry dependency is introduced in Spirit.
