### PR TITLE
fix(dbconn): return committed retry row count

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -181,6 +181,7 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 	)
 	for i := range config.MaxRetries {
 		func() {
+			var attemptRowsAffected int64
 			// Start a transaction
 			if trx, err = db.BeginTx(ctx, nil); err != nil {
 				return
@@ -256,13 +257,14 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 				// and that's absolutely fine!
 				count, errC := res.RowsAffected()
 				if errC == nil { // affectedRows is supported
-					rowsAffected += count
+					attemptRowsAffected += count
 				}
 			} // end for each statement
 			// Commit it!
 			if err = trx.Commit(); err != nil {
 				return
 			}
+			rowsAffected = attemptRowsAffected
 		}()
 		if isFatal { // don't retry loop if fatal
 			return rowsAffected, err

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -127,8 +127,16 @@ func TestRetryableTrx(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		rollbackErr <- trx.Rollback()
 	}()
-	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, config, "UPDATE test.dbexec SET colb=123 WHERE id = 1")
+	rowsAffected, err := RetryableTransaction(
+		t.Context(),
+		db,
+		ErrorOnDupKey,
+		config,
+		"UPDATE test.dbexec SET colb=colb+1 WHERE id = 2",
+		"UPDATE test.dbexec SET colb=123 WHERE id = 1",
+	)
 	require.NoError(t, err)
+	require.EqualValues(t, 2, rowsAffected, "rolled-back attempts must not contribute affected rows")
 	require.NoError(t, <-rollbackErr)
 	require.NoError(t, db.Close())
 
@@ -143,8 +151,16 @@ func TestRetryableTrx(t *testing.T) {
 	require.NoError(t, err)
 	_, err = trx.ExecContext(t.Context(), "SELECT * FROM test.dbexec WHERE id = 2 FOR UPDATE")
 	require.NoError(t, err)
-	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, config, "UPDATE test.dbexec SET colb=123 WHERE id = 2") // this will fail, since it times out and exhausts retries.
+	rowsAffected, err = RetryableTransaction(
+		t.Context(),
+		db,
+		ErrorOnDupKey,
+		config,
+		"UPDATE test.dbexec SET colb=colb+1 WHERE id = 1",
+		"UPDATE test.dbexec SET colb=123 WHERE id = 2",
+	) // this will fail, since it times out and exhausts retries.
 	require.Error(t, err)
+	require.Zero(t, rowsAffected, "rolled-back attempts must not report affected rows")
 	err = trx.Rollback() // now we can rollback.
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Return `RowsAffected` from the committed `RetryableTransaction` attempt only.
- Discard row counts from rolled-back attempts.
- Return zero rows when a fatal error or retry exhaustion prevents a commit.

First correctness slice extracted from #1111.

## Verification

- `MYSQL_DSN=tsandbox:msandbox@tcp(127.0.0.1:8043)/test go test -race -count=1 -run '^(TestRetryableTransactionRowsAffectedExcludesRolledBackAttempts|TestRetryableTrx)$' ./pkg/dbconn`

## Review order

This PR is part of the dependency-ordered replacement for #1111:

1. #1112 — committed retry row accounting
2. #1113 — copier completed-work totals
3. #1114 — result-bearing cutover callbacks
4. #1115 — status-owned lifecycle API
5. #1116 — migration and move lifecycle adoption

Review and merge in order; each PR after #1112 is based on its predecessor. The stack supersedes #1111.
