### PR TITLE
feat(copier): expose completed work totals

### DIFF
--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -37,6 +37,8 @@ type buffered struct {
 	isInvalid        atomic.Bool
 	errMu            sync.Mutex // guards firstErr
 	firstErr         error      // first error that invalidated the copy (any goroutine)
+	completedRows    atomic.Uint64
+	completedChunks  atomic.Uint64
 	startTime        time.Time
 	throttler        throttler.Throttler
 	dbConfig         *dbconn.DBConfig
@@ -186,6 +188,8 @@ func (c *buffered) Run(ctx context.Context) error {
 	c.Lock()
 	c.startTime = time.Now()
 	c.Unlock()
+	c.completedRows.Store(0)
+	c.completedChunks.Store(0)
 	go c.estimateRowsPerSecondLoop(ctx) // estimate rows while copying
 
 	// Start the applier
@@ -357,6 +361,7 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 			totalTime := time.Since(chunkStartTime)
 			c.logger.Debug("readWorker chunk is empty, sending immediate feedback", "chunk", chunk.String())
 			c.chunker.Feedback(chunk, totalTime, 0)
+			c.recordCompletedChunk(0)
 
 			// Send metrics for empty chunk
 			err := c.sendMetrics(ctx, totalTime, chunk.ChunkSize, 0)
@@ -398,6 +403,7 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 
 			// Send feedback to chunker with total processing time
 			c.chunker.Feedback(capturedChunk, totalTime, uint64(affectedRows))
+			c.recordCompletedChunk(uint64(affectedRows))
 
 			// Send metrics with total processing time
 			metricsErr := c.sendMetrics(ctx, totalTime, capturedChunk.ChunkSize, uint64(affectedRows))
@@ -644,6 +650,15 @@ func (c *buffered) sendMetrics(ctx context.Context, processingTime time.Duration
 // GetChunker returns the chunker for accessing progress information
 func (c *buffered) GetChunker() table.Chunker {
 	return c.chunker
+}
+
+func (c *buffered) recordCompletedChunk(affectedRows uint64) {
+	c.completedRows.Add(affectedRows)
+	c.completedChunks.Add(1)
+}
+
+func (c *buffered) CompletedWork() (uint64, uint64) {
+	return c.completedRows.Load(), c.completedChunks.Load()
 }
 
 func (c *buffered) GetThrottler() throttler.Throttler {

--- a/pkg/copier/completed_work_test.go
+++ b/pkg/copier/completed_work_test.go
@@ -1,0 +1,35 @@
+package copier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type copierWithoutCompletedWork struct{ Copier }
+
+func TestCompletedWorkCountsAffectedRowsAndZeroRowChunks(t *testing.T) {
+	bufferedCopier := &buffered{}
+	bufferedCopier.recordCompletedChunk(12)
+	bufferedCopier.recordCompletedChunk(0)
+	bufferedCopier.recordCompletedChunk(0)
+	rows, chunks, available := CompletedWork(bufferedCopier)
+	require.True(t, available)
+	require.Equal(t, uint64(12), rows)
+	require.Equal(t, uint64(3), chunks)
+
+	unbufferedCopier := &Unbuffered{}
+	unbufferedCopier.recordCompletedChunk(9)
+	unbufferedCopier.recordCompletedChunk(0)
+	rows, chunks, available = CompletedWork(unbufferedCopier)
+	require.True(t, available)
+	require.Equal(t, uint64(9), rows)
+	require.Equal(t, uint64(2), chunks)
+}
+
+func TestCompletedWorkUnavailableForCopierWithoutCapability(t *testing.T) {
+	rows, chunks, available := CompletedWork(&copierWithoutCompletedWork{})
+	require.False(t, available)
+	require.Zero(t, rows)
+	require.Zero(t, chunks)
+}

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -68,6 +68,24 @@ type Copier interface {
 	GetProgress() string
 }
 
+// CompletedWorkReporter is an optional capability implemented by copiers that
+// can report exact terminal aggregate work.
+type CompletedWorkReporter interface {
+	CompletedWork() (rows uint64, chunks uint64)
+}
+
+// CompletedWork returns authoritative aggregate rows and chunks completed by a
+// built-in copier. The boolean is false for Copier implementations that do not
+// implement CompletedWorkReporter.
+func CompletedWork(c Copier) (rows uint64, chunks uint64, available bool) {
+	reporter, ok := c.(CompletedWorkReporter)
+	if !ok {
+		return 0, 0, false
+	}
+	rows, chunks = reporter.CompletedWork()
+	return rows, chunks, true
+}
+
 type CopierConfig struct {
 	Concurrency     int
 	TargetChunkTime time.Duration

--- a/pkg/copier/unbuffered.go
+++ b/pkg/copier/unbuffered.go
@@ -26,6 +26,8 @@ type Unbuffered struct {
 	concurrency      int
 	rowsPerSecond    atomic.Uint64
 	isInvalid        bool
+	completedRows    atomic.Uint64
+	completedChunks  atomic.Uint64
 	startTime        time.Time
 	throttler        throttler.Throttler
 	dbConfig         *dbconn.DBConfig
@@ -80,6 +82,7 @@ func (c *Unbuffered) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 
 	// Send feedback to chunker with processing time and statistics
 	c.chunker.Feedback(chunk, chunkProcessingTime, uint64(affectedRows))
+	c.recordCompletedChunk(uint64(affectedRows))
 
 	// Send metrics
 	err = c.sendMetrics(ctx, chunkProcessingTime, chunk.ChunkSize, uint64(affectedRows))
@@ -109,6 +112,8 @@ func (c *Unbuffered) Run(ctx context.Context) error {
 	c.Lock()
 	c.startTime = time.Now()
 	c.Unlock()
+	c.completedRows.Store(0)
+	c.completedChunks.Store(0)
 	go c.estimateRowsPerSecondLoop(ctx) // estimate rows while copying
 	g, errGrpCtx := errgroup.WithContext(ctx)
 	g.SetLimit(c.concurrency)
@@ -253,6 +258,15 @@ func (c *Unbuffered) sendMetrics(ctx context.Context, processingTime time.Durati
 // GetChunker returns the chunker for accessing progress information
 func (c *Unbuffered) GetChunker() table.Chunker {
 	return c.chunker
+}
+
+func (c *Unbuffered) recordCompletedChunk(affectedRows uint64) {
+	c.completedRows.Add(affectedRows)
+	c.completedChunks.Add(1)
+}
+
+func (c *Unbuffered) CompletedWork() (uint64, uint64) {
+	return c.completedRows.Load(), c.completedChunks.Load()
 }
 
 func (c *Unbuffered) GetThrottler() throttler.Throttler {


### PR DESCRIPTION
## Summary

- Add an optional `CompletedWorkReporter` capability without changing the `Copier` interface.
- Track exact completed rows and chunks for buffered and unbuffered copiers.
- Reset totals per run, count zero-row completed chunks, and record only successful durable application.

Exporter-neutral prerequisite extracted from #1111.

## Verification

- `go test -race -count=1 -run '^TestCompletedWork' ./pkg/copier`

## Review order

This PR is part of the dependency-ordered replacement for #1111:

1. #1112 — committed retry row accounting
2. #1113 — copier completed-work totals
3. #1114 — result-bearing cutover callbacks
4. #1115 — status-owned lifecycle API
5. #1116 — migration and move lifecycle adoption

Review and merge in order; each PR after #1112 is based on its predecessor. The stack supersedes #1111.
