### PR TITLE
feat(move): return cutover mutation results

### DIFF
--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -27,6 +27,15 @@ var renameRetryWait = 1 * time.Second
 // that state cannot converge, so the retry loop aborts immediately.
 var errRenameRollbackFailed = errors.New("rename rollback failed")
 
+// CutoverResult reports whether a caller-owned forward cutover callback made a
+// durable ownership or topology mutation, even when it also returned an error.
+type CutoverResult struct {
+	DurableMutation bool
+}
+
+// CutoverResultCallback is the result-bearing form of a forward cutover callback.
+type CutoverResultCallback func(context.Context) (CutoverResult, error)
+
 // CutOverSource holds per-source state needed for the cutover.
 type CutOverSource struct {
 	DB         *sql.DB
@@ -35,16 +44,16 @@ type CutOverSource struct {
 }
 
 type CutOver struct {
-	sources     []CutOverSource
-	cutoverFunc func(ctx context.Context) error
-	dbConfig    *dbconn.DBConfig
-	logger      *slog.Logger
-	// cutoverFuncSucceeded tracks whether cutoverFunc has been invoked and
-	// returned nil. The cutover function is a caller-supplied traffic switch
-	// (e.g. a Vitess routing change) and is not assumed to be idempotent:
-	// once it has succeeded it must never be invoked again, and retrying
-	// any later step must not reopen the window where straggler writes to
-	// the (now stale) source could be replayed over newer rows on the target.
+	sources            []CutOverSource
+	cutoverFunc        func(ctx context.Context) error
+	cutoverResultFunc  CutoverResultCallback
+	cutoverFuncMutated bool
+	dbConfig           *dbconn.DBConfig
+	logger             *slog.Logger
+	// cutoverFuncSucceeded tracks whether the cutover callback has returned nil.
+	// The callback is a caller-supplied traffic switch (e.g. a Vitess routing
+	// change) and is not assumed to be idempotent: once it has succeeded or
+	// reported a durable mutation it must never be invoked again.
 	cutoverFuncSucceeded bool
 
 	// postSwitch, when set, runs once under the source locks after the traffic
@@ -62,6 +71,13 @@ type CutOver struct {
 // traffic switch and before the source rename. See CutOver.postSwitch.
 func (c *CutOver) SetPostSwitch(fn func(ctx context.Context) error) {
 	c.postSwitch = fn
+}
+
+// SetCutoverWithResult installs a result-bearing forward cutover callback.
+// It is mutually exclusive with the legacy error-only callback.
+func (c *CutOver) SetCutoverWithResult(fn CutoverResultCallback) {
+	c.cutoverFunc = nil
+	c.cutoverResultFunc = fn
 }
 
 // NewCutOver creates a new CutOver that handles multiple sources.
@@ -103,11 +119,7 @@ func NewCutOver(sources []CutOverSource, cutoverFunc func(ctx context.Context) e
 }
 
 func (c *CutOver) Run(ctx context.Context) error {
-	var err error
-	for attempt := range c.dbConfig.MaxRetries {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
+	return c.runWithRetries(ctx, func(attempt int) error {
 		// Flush all sources before attempting the cutover.
 		for i, src := range c.sources {
 			if err := src.ReplClient.Flush(ctx); err != nil {
@@ -117,8 +129,23 @@ func (c *CutOver) Run(ctx context.Context) error {
 		c.logger.Warn("Attempting final cut over operation",
 			"attempt", attempt+1,
 			"max-retries", c.dbConfig.MaxRetries)
-		err = c.algorithmCutover(ctx)
+		return c.algorithmCutover(ctx)
+	})
+}
+
+func (c *CutOver) runWithRetries(ctx context.Context, runAttempt func(attempt int) error) error {
+	var err error
+	for attempt := range c.dbConfig.MaxRetries {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		err = runAttempt(attempt)
 		if err != nil {
+			if c.cutoverFuncMutated && !c.cutoverFuncSucceeded {
+				c.logger.Error("cutover callback failed after reporting a durable mutation; not retrying",
+					"error", err.Error())
+				return fmt.Errorf("cutover callback reported a durable ownership or topology mutation before failing; manual intervention required: %w", err)
+			}
 			if c.cutoverFuncSucceeded {
 				// The traffic switch has already succeeded, so traffic may be
 				// on the target. Another attempt would have released the
@@ -141,6 +168,25 @@ func (c *CutOver) Run(ctx context.Context) error {
 	}
 	c.logger.Error("cutover failed, and retries exhausted")
 	return err
+}
+
+func (c *CutOver) runCutoverCallback(ctx context.Context) error {
+	if c.cutoverFuncSucceeded || (c.cutoverResultFunc == nil && c.cutoverFunc == nil) {
+		return nil
+	}
+	c.logger.Info("Running cutover function")
+	if c.cutoverResultFunc != nil {
+		result, err := c.cutoverResultFunc(ctx)
+		c.cutoverFuncMutated = c.cutoverFuncMutated || result.DurableMutation
+		if err != nil {
+			return err
+		}
+	} else if err := c.cutoverFunc(ctx); err != nil {
+		return err
+	}
+	c.cutoverFuncSucceeded = true
+	c.logger.Info("Cutover function complete")
+	return nil
 }
 
 func (c *CutOver) algorithmCutover(ctx context.Context) error {
@@ -177,16 +223,8 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 		}
 	}
 
-	// Run the cutover function (Vitess coordination). It is invoked at most
-	// once per CutOver: the traffic switch is not assumed to be idempotent,
-	// so if a later step fails the retry must never re-run it.
-	if c.cutoverFunc != nil && !c.cutoverFuncSucceeded {
-		c.logger.Info("Running cutover function")
-		if err := c.cutoverFunc(ctx); err != nil {
-			return err
-		}
-		c.cutoverFuncSucceeded = true
-		c.logger.Info("Cutover function complete")
+	if err := c.runCutoverCallback(ctx); err != nil {
+		return err
 	}
 
 	// Reverse-window hook: after the traffic switch and before retiring the

--- a/pkg/move/cutover_test.go
+++ b/pkg/move/cutover_test.go
@@ -2,6 +2,7 @@ package move
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -280,4 +281,46 @@ func TestCutOverFuncCalledOnceAcrossRenameRetry(t *testing.T) {
 
 	_, err = srcDB.ExecContext(ctx, "SELECT 1 FROM t1")
 	require.Error(t, err, "t1 should not exist after rename")
+}
+
+func TestCutOverResultControlsRetry(t *testing.T) {
+	callbackErr := errors.New("cutover callback failed")
+	for _, tt := range []struct {
+		name            string
+		durableMutation bool
+		wantCalls       int
+		wantErr         bool
+	}{
+		{name: "retry before durable mutation", wantCalls: 2},
+		{name: "abort after durable mutation", durableMutation: true, wantCalls: 1, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dbConfig := dbconn.NewDBConfig()
+			dbConfig.MaxRetries = 3
+			cutover := &CutOver{dbConfig: dbConfig, logger: slog.Default()}
+			callbackCalls := 0
+			cutover.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+				callbackCalls++
+				if callbackCalls == 1 {
+					return CutoverResult{DurableMutation: tt.durableMutation}, callbackErr
+				}
+				return CutoverResult{}, nil
+			})
+
+			err := cutover.runWithRetries(t.Context(), func(int) error {
+				return cutover.runCutoverCallback(t.Context())
+			})
+			require.Equal(t, tt.wantCalls, callbackCalls)
+			if tt.wantErr {
+				require.ErrorIs(t, err, callbackErr)
+				require.ErrorContains(t, err, "manual intervention required")
+				require.True(t, cutover.cutoverFuncMutated)
+				require.False(t, cutover.cutoverFuncSucceeded)
+				return
+			}
+			require.NoError(t, err)
+			require.False(t, cutover.cutoverFuncMutated)
+			require.True(t, cutover.cutoverFuncSucceeded)
+		})
+	}
 }

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -3,6 +3,7 @@ package move
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -216,6 +217,77 @@ func TestEmptyDatabaseMove(t *testing.T) {
 
 	// Clean up
 	require.NoError(t, runner.Close())
+}
+
+func TestEmptyDatabaseMoveWithCutoverResult(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	src := cfg.Clone()
+	src.DBName = "source_empty_result"
+	dest := cfg.Clone()
+	dest.DBName = "dest_empty_result"
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS source_empty_result")
+	testutils.RunSQL(t, "CREATE DATABASE source_empty_result")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS dest_empty_result")
+	testutils.RunSQL(t, "CREATE DATABASE dest_empty_result")
+
+	runner, err := NewRunner(&Move{
+		SourceDSN:       src.FormatDSN(),
+		TargetDSN:       dest.FormatDSN(),
+		TargetChunkTime: 5 * time.Second,
+		Threads:         4,
+		WriteThreads:    4,
+	})
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+
+	callbackErr := errors.New("result-bearing cutover failed")
+	callbackCalls := 0
+	runner.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+		callbackCalls++
+		return CutoverResult{DurableMutation: true}, callbackErr
+	})
+
+	require.ErrorIs(t, runner.Run(t.Context()), callbackErr)
+	require.Equal(t, 1, callbackCalls)
+}
+
+func TestForwardCutoverCallbackConfiguration(t *testing.T) {
+	runner := &Runner{}
+	legacyErr := errors.New("legacy cutover failed")
+	legacyCalls := 0
+	runner.SetCutover(func(context.Context) error {
+		legacyCalls++
+		return legacyErr
+	})
+	require.NotNil(t, runner.cutoverFunc)
+	require.Nil(t, runner.cutoverResultFunc)
+
+	result, err := runner.runForwardCutoverCallback(t.Context())
+	require.Equal(t, CutoverResult{}, result)
+	require.ErrorIs(t, err, legacyErr)
+	require.Equal(t, 1, legacyCalls)
+
+	runner.SetCutoverWithResult(nil)
+	require.Nil(t, runner.cutoverFunc)
+	require.Nil(t, runner.cutoverResultFunc)
+
+	resultErr := errors.New("result cutover failed")
+	wantResult := CutoverResult{DurableMutation: true}
+	runner.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+		return wantResult, resultErr
+	})
+	require.Nil(t, runner.cutoverFunc)
+	require.NotNil(t, runner.cutoverResultFunc)
+
+	result, err = runner.runForwardCutoverCallback(t.Context())
+	require.Equal(t, wantResult, result)
+	require.ErrorIs(t, err, resultErr)
+
+	runner.SetCutover(nil)
+	require.Nil(t, runner.cutoverFunc)
+	require.Nil(t, runner.cutoverResultFunc)
 }
 
 // TestMoveReservedWordPK is a regression test for issue #828. Moving a

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -130,7 +130,8 @@ type Runner struct {
 	sentinelWaitStartTime    time.Time
 	usedResumeFromCheckpoint bool
 
-	cutoverFunc func(ctx context.Context) error
+	cutoverFunc       func(ctx context.Context) error
+	cutoverResultFunc CutoverResultCallback
 	// reverseCutoverFunc is the reverse-window rollback's traffic switch (route
 	// back to the source). Set via SetReverseCutover; used only when
 	// move.ReverseWindow > 0 and a revert is requested during the window.
@@ -1116,20 +1117,14 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	if len(r.sourceTables) == 0 {
 		// Because this is called from orchestration, there might be a bug where
-		// it is asked to move *no tables*. Since there are no tables,
-		// there is no:
-		// - copier, replication changes
-		// - advisory lock
-		// - cutover step
-		//
-		// But the caller will still want their cutoverFunc called. So we do that
-		// and then exit.
+		// it is asked to move *no tables*. Since there are no tables, there is no
+		// copier, replication, advisory lock, or physical cutover. The caller's
+		// cutover callback still runs through the same result-bearing helper as
+		// the full cutover path.
 		r.logger.Info("No tables to copy, proceeding directly to cutover")
 		r.status.Set(status.CutOver)
-		if r.cutoverFunc != nil {
-			if err := r.cutoverFunc(ctx); err != nil {
-				return err
-			}
+		if _, err := r.runForwardCutoverCallback(ctx); err != nil {
+			return err
 		}
 		r.logger.Info("Move operation complete.")
 		return nil
@@ -1232,9 +1227,12 @@ func (r *Runner) Run(ctx context.Context) error {
 			Tables:     r.sources[i].tables,
 		}
 	}
-	cutover, err := NewCutOver(cutoverSources, r.cutoverFunc, r.dbConfig, r.logger)
+	cutover, err := NewCutOver(cutoverSources, nil, r.dbConfig, r.logger)
 	if err != nil {
 		return err
+	}
+	if r.cutoverResultFunc != nil || r.cutoverFunc != nil {
+		cutover.SetCutoverWithResult(r.runForwardCutoverCallback)
 	}
 	if r.move.ReverseWindow > 0 {
 		// Under the cutover lock, right after the traffic switch, capture the
@@ -1716,8 +1714,29 @@ func (r *Runner) analyzeTable(ctx context.Context, db *sql.DB, tableName string)
 	return rows.Err()
 }
 
+// runForwardCutoverCallback invokes whichever mutually exclusive callback was
+// configured and always returns the result-bearing form used by both runner
+// cutover paths.
+func (r *Runner) runForwardCutoverCallback(ctx context.Context) (CutoverResult, error) {
+	if r.cutoverResultFunc != nil {
+		return r.cutoverResultFunc(ctx)
+	}
+	if r.cutoverFunc != nil {
+		return CutoverResult{}, r.cutoverFunc(ctx)
+	}
+	return CutoverResult{}, nil
+}
+
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {
+	r.cutoverResultFunc = nil
 	r.cutoverFunc = cutover
+}
+
+// SetCutoverWithResult installs a result-bearing forward cutover callback.
+// It is mutually exclusive with SetCutover; the most recent setter wins.
+func (r *Runner) SetCutoverWithResult(cutover CutoverResultCallback) {
+	r.cutoverFunc = nil
+	r.cutoverResultFunc = cutover
 }
 
 // SetReverseCutover registers the rollback traffic switch used if a revert is


### PR DESCRIPTION
## Summary

- Add a result-bearing forward cutover callback that reports durable external mutation separately from callback error.
- Stop retrying once a callback reports a durable ownership or topology change.
- Preserve the legacy callback path and use one result-bearing helper for empty and full moves.
- Keep legacy and result-bearing setters mutually exclusive, including nil reset behavior.

Third independent correctness/API slice extracted from #1111.

## Verification

- `MYSQL_DSN=tsandbox:msandbox@tcp(127.0.0.1:8043)/test go test -race -count=1 ./pkg/move -run '^(TestCutOverResultControlsRetry|TestForwardCutoverCallbackConfiguration|TestEmptyDatabaseMoveNoTables)$'`

## Review order

This PR is part of the dependency-ordered replacement for #1111:

1. #1112 — committed retry row accounting
2. #1113 — copier completed-work totals
3. #1114 — result-bearing cutover callbacks
4. #1115 — status-owned lifecycle API
5. #1116 — migration and move lifecycle adoption

Review and merge in order; each PR after #1112 is based on its predecessor. The stack supersedes #1111.
