### PR TITLE
feat(status): own workflow lifecycle events

### DIFF
--- a/pkg/status/lifecycle.go
+++ b/pkg/status/lifecycle.go
@@ -1,0 +1,168 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+// Lifecycle owns the current workflow state, event observer, and terminal
+// evidence delivery. Its zero value is ready for use.
+type Lifecycle struct {
+	state State
+
+	observerMu sync.RWMutex
+	observer   WorkflowObserver
+
+	durableMutationObserved atomic.Bool
+	terminalObserved        atomic.Bool
+}
+
+// Get returns the current workflow state.
+func (l *Lifecycle) Get() State {
+	if l == nil {
+		return Initial
+	}
+	return l.state.Get()
+}
+
+// Set updates the current workflow state without emitting an event.
+func (l *Lifecycle) Set(state State) {
+	if l == nil {
+		return
+	}
+	l.state.Set(state)
+}
+
+// SetObserver replaces the workflow observer. A nil observer disables delivery.
+func (l *Lifecycle) SetObserver(observer WorkflowObserver) {
+	if l == nil {
+		return
+	}
+	l.observerMu.Lock()
+	l.observer = observer
+	l.observerMu.Unlock()
+}
+
+// HasObserver reports whether workflow event delivery is enabled.
+func (l *Lifecycle) HasObserver() bool {
+	if l == nil {
+		return false
+	}
+	l.observerMu.RLock()
+	hasObserver := l.observer != nil
+	l.observerMu.RUnlock()
+	return hasObserver
+}
+
+// Start records state before synchronously delivering its started event. Each
+// call returns a distinct attempt, including repeated starts of the same state.
+func (l *Lifecycle) Start(parent context.Context, state State) WorkflowAttempt {
+	if l == nil {
+		return WorkflowAttempt{}
+	}
+	l.state.Set(state)
+	attempt := &workflowAttempt{
+		lifecycle: l,
+		parent:    parent,
+		state:     state,
+	}
+	l.emit(parent, WorkflowEvent{
+		State:      state,
+		Transition: WorkflowTransitionStarted,
+	})
+	return WorkflowAttempt{attempt: attempt}
+}
+
+// DurableMutation delivers durable-mutation evidence at most once until the
+// next ResetEvidence call.
+func (l *Lifecycle) DurableMutation(parent context.Context) {
+	if l == nil || !l.durableMutationObserved.CompareAndSwap(false, true) {
+		return
+	}
+	l.emit(parent, WorkflowEvent{DurableMutation: true})
+}
+
+// Terminal delivers valid terminal-ownership evidence at most once until the
+// next ResetEvidence call.
+func (l *Lifecycle) Terminal(parent context.Context, ownership WorkflowTerminalOwnership) {
+	if l == nil || !ownership.valid() || !l.terminalObserved.CompareAndSwap(false, true) {
+		return
+	}
+	l.emit(parent, WorkflowEvent{TerminalOwnership: ownership})
+}
+
+// ResetEvidence allows each terminal evidence category to be delivered once
+// for a new workflow run.
+func (l *Lifecycle) ResetEvidence() {
+	if l == nil {
+		return
+	}
+	l.durableMutationObserved.Store(false)
+	l.terminalObserved.Store(false)
+}
+
+func (l *Lifecycle) emit(parent context.Context, event WorkflowEvent) {
+	l.observerMu.RLock()
+	observer := l.observer
+	l.observerMu.RUnlock()
+	if observer == nil {
+		return
+	}
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+		observer.ObserveWorkflow(parent, event)
+	}()
+}
+
+// WorkflowAttempt is a small handle for one started workflow state. The
+// private pointer keeps its atomic completion guard from being copied.
+type WorkflowAttempt struct {
+	attempt *workflowAttempt
+}
+
+type workflowAttempt struct {
+	lifecycle *Lifecycle
+	parent    context.Context
+	state     State
+	finished  atomic.Bool
+}
+
+// Finish synchronously delivers this attempt's result at most once. The event
+// always uses the state and exact parent context captured by Start.
+func (a *WorkflowAttempt) Finish(runCtx context.Context, result WorkflowResult) {
+	if a == nil || a.attempt == nil {
+		return
+	}
+	attempt := a.attempt
+	if attempt.lifecycle == nil || !attempt.finished.CompareAndSwap(false, true) {
+		return
+	}
+
+	event := WorkflowEvent{
+		State:      attempt.state,
+		Transition: WorkflowTransitionFinished,
+		Outcome:    workflowOutcome(runCtx, result.Err),
+	}
+	if attempt.state == CopyRows && result.TotalsAvailable {
+		event.Totals = result.Totals
+		event.TotalsAvailable = true
+	}
+	attempt.lifecycle.emit(attempt.parent, event)
+}
+
+func workflowOutcome(runCtx context.Context, err error) WorkflowOutcome {
+	if err == nil {
+		return WorkflowOutcomeSucceeded
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return WorkflowOutcomeCancelled
+	}
+	if runCtx != nil && runCtx.Err() != nil {
+		return WorkflowOutcomeCancelled
+	}
+	return WorkflowOutcomeFailed
+}

--- a/pkg/status/lifecycle_test.go
+++ b/pkg/status/lifecycle_test.go
@@ -1,0 +1,358 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type workflowObserverFunc func(context.Context, WorkflowEvent)
+
+func (f workflowObserverFunc) ObserveWorkflow(ctx context.Context, event WorkflowEvent) {
+	f(ctx, event)
+}
+
+type workflowObservation struct {
+	ctx   context.Context
+	event WorkflowEvent
+}
+
+type workflowContextKey struct{}
+
+func TestLifecycleStoresStateBeforeStartAndPreservesAttemptInputs(t *testing.T) {
+	t.Parallel()
+
+	var lifecycle Lifecycle
+	parent := context.WithValue(context.Background(), workflowContextKey{}, "parent")
+	var observations []workflowObservation
+	var stateAtStart State
+	lifecycle.SetObserver(workflowObserverFunc(func(ctx context.Context, event WorkflowEvent) {
+		if event.Transition == WorkflowTransitionStarted {
+			stateAtStart = lifecycle.Get()
+		}
+		observations = append(observations, workflowObservation{ctx: ctx, event: event})
+	}))
+
+	require.True(t, lifecycle.HasObserver())
+	attempt := lifecycle.Start(parent, CopyRows)
+	require.Equal(t, CopyRows, stateAtStart)
+	require.Equal(t, CopyRows, lifecycle.Get())
+
+	lifecycle.Set(Checksum)
+	attempt.Finish(context.Background(), WorkflowResult{})
+
+	require.Len(t, observations, 2)
+	require.Same(t, parent, observations[0].ctx)
+	require.Same(t, parent, observations[1].ctx)
+	require.Equal(t, WorkflowEvent{
+		State:      CopyRows,
+		Transition: WorkflowTransitionStarted,
+	}, observations[0].event)
+	require.Equal(t, WorkflowEvent{
+		State:      CopyRows,
+		Transition: WorkflowTransitionFinished,
+		Outcome:    WorkflowOutcomeSucceeded,
+	}, observations[1].event)
+	require.Equal(t, Checksum, lifecycle.Get())
+}
+
+//nolint:staticcheck // This test verifies documented nil-context safety.
+func TestLifecycleSetAndObserverAreZeroValueSafe(t *testing.T) {
+	t.Parallel()
+
+	var lifecycle Lifecycle
+	require.Equal(t, Initial, lifecycle.Get())
+	require.False(t, lifecycle.HasObserver())
+
+	lifecycle.Set(ApplyChangeset)
+	require.Equal(t, ApplyChangeset, lifecycle.Get())
+
+	attempt := lifecycle.Start(context.Background(), CopyRows)
+	require.NotPanics(t, func() {
+		attempt.Finish(nil, WorkflowResult{Err: errors.New("failed")})
+		lifecycle.DurableMutation(nil)
+		lifecycle.Terminal(nil, WorkflowTerminalOwnershipAmbiguous)
+		lifecycle.ResetEvidence()
+	})
+
+	lifecycle.SetObserver(workflowObserverFunc(func(context.Context, WorkflowEvent) {}))
+	require.True(t, lifecycle.HasObserver())
+	lifecycle.SetObserver(nil)
+	require.False(t, lifecycle.HasObserver())
+
+	var zeroAttempt WorkflowAttempt
+	var nilAttempt *WorkflowAttempt
+	require.NotPanics(t, func() {
+		zeroAttempt.Finish(context.Background(), WorkflowResult{})
+		nilAttempt.Finish(context.Background(), WorkflowResult{})
+	})
+
+	var nilLifecycle *Lifecycle
+	require.Equal(t, Initial, nilLifecycle.Get())
+	require.False(t, nilLifecycle.HasObserver())
+	require.NotPanics(t, func() {
+		nilLifecycle.Set(CopyRows)
+		nilLifecycle.SetObserver(nil)
+		nilLifecycleAttempt := nilLifecycle.Start(nil, CopyRows)
+		nilLifecycleAttempt.Finish(nil, WorkflowResult{})
+		nilLifecycle.DurableMutation(nil)
+		nilLifecycle.Terminal(nil, WorkflowTerminalOwnershipAmbiguous)
+		nilLifecycle.ResetEvidence()
+	})
+}
+
+func TestLifecycleRepeatedStartsAreDistinctAndFinishIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	var lifecycle Lifecycle
+	var events []WorkflowEvent
+	lifecycle.SetObserver(workflowObserverFunc(func(_ context.Context, event WorkflowEvent) {
+		events = append(events, event)
+	}))
+
+	first := lifecycle.Start(context.Background(), Checksum)
+	second := lifecycle.Start(context.Background(), Checksum)
+	firstCopy := first
+	first.Finish(context.Background(), WorkflowResult{})
+	first.Finish(context.Background(), WorkflowResult{Err: errors.New("late failure")})
+	firstCopy.Finish(context.Background(), WorkflowResult{Err: errors.New("copied handle")})
+	second.Finish(context.Background(), WorkflowResult{Err: errors.New("second failure")})
+	second.Finish(context.Background(), WorkflowResult{})
+
+	require.Len(t, events, 4)
+	require.Equal(t, WorkflowTransitionStarted, events[0].Transition)
+	require.Equal(t, WorkflowTransitionStarted, events[1].Transition)
+	require.Equal(t, WorkflowOutcomeSucceeded, events[2].Outcome)
+	require.Equal(t, WorkflowOutcomeFailed, events[3].Outcome)
+}
+
+func TestWorkflowAttemptClassifiesOutcome(t *testing.T) {
+	t.Parallel()
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name   string
+		runCtx context.Context
+		err    error
+		want   WorkflowOutcome
+	}{
+		{
+			name:   "success",
+			runCtx: context.Background(),
+			want:   WorkflowOutcomeSucceeded,
+		},
+		{
+			name:   "failure",
+			runCtx: context.Background(),
+			err:    errors.New("failed"),
+			want:   WorkflowOutcomeFailed,
+		},
+		{
+			name:   "explicit cancellation",
+			runCtx: context.Background(),
+			err:    context.Canceled,
+			want:   WorkflowOutcomeCancelled,
+		},
+		{
+			name:   "wrapped cancellation",
+			runCtx: context.Background(),
+			err:    fmt.Errorf("stopped: %w", context.DeadlineExceeded),
+			want:   WorkflowOutcomeCancelled,
+		},
+		{
+			name:   "context cancellation",
+			runCtx: cancelledCtx,
+			err:    errors.New("runner returned another error"),
+			want:   WorkflowOutcomeCancelled,
+		},
+		{
+			name: "nil run context",
+			err:  errors.New("failed"),
+			want: WorkflowOutcomeFailed,
+		},
+		{
+			name:   "nil error wins over cancelled context",
+			runCtx: cancelledCtx,
+			want:   WorkflowOutcomeSucceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var lifecycle Lifecycle
+			var events []WorkflowEvent
+			lifecycle.SetObserver(workflowObserverFunc(func(_ context.Context, event WorkflowEvent) {
+				events = append(events, event)
+			}))
+
+			attempt := lifecycle.Start(context.Background(), ApplyChangeset)
+			attempt.Finish(tt.runCtx, WorkflowResult{Err: tt.err})
+
+			require.Len(t, events, 2)
+			require.Equal(t, tt.want, events[1].Outcome)
+		})
+	}
+}
+
+func TestLifecycleIsolatesObserverPanicsFromLaterEvents(t *testing.T) {
+	t.Parallel()
+
+	var lifecycle Lifecycle
+	calls := 0
+	var delivered []WorkflowEvent
+	lifecycle.SetObserver(workflowObserverFunc(func(_ context.Context, event WorkflowEvent) {
+		calls++
+		if calls <= 2 {
+			panic("observer failed")
+		}
+		delivered = append(delivered, event)
+	}))
+
+	require.NotPanics(t, func() {
+		first := lifecycle.Start(context.Background(), CopyRows)
+		first.Finish(context.Background(), WorkflowResult{})
+		first.Finish(context.Background(), WorkflowResult{Err: errors.New("duplicate")})
+
+		second := lifecycle.Start(context.Background(), Checksum)
+		second.Finish(context.Background(), WorkflowResult{})
+	})
+
+	require.Equal(t, 4, calls)
+	require.Equal(t, []WorkflowEvent{
+		{
+			State:      Checksum,
+			Transition: WorkflowTransitionStarted,
+		},
+		{
+			State:      Checksum,
+			Transition: WorkflowTransitionFinished,
+			Outcome:    WorkflowOutcomeSucceeded,
+		},
+	}, delivered)
+}
+
+func TestWorkflowAttemptCopyTotalsAvailability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		state  State
+		result WorkflowResult
+		want   WorkflowEvent
+	}{
+		{
+			name:  "available zero totals remain available",
+			state: CopyRows,
+			result: WorkflowResult{
+				TotalsAvailable: true,
+			},
+			want: WorkflowEvent{
+				State:           CopyRows,
+				Transition:      WorkflowTransitionFinished,
+				Outcome:         WorkflowOutcomeSucceeded,
+				TotalsAvailable: true,
+			},
+		},
+		{
+			name:  "unavailable copy totals are stripped",
+			state: CopyRows,
+			result: WorkflowResult{
+				Totals: WorkflowTotals{CompletedRows: 11, CompletedChunks: 3},
+			},
+			want: WorkflowEvent{
+				State:      CopyRows,
+				Transition: WorkflowTransitionFinished,
+				Outcome:    WorkflowOutcomeSucceeded,
+			},
+		},
+		{
+			name:  "available copy totals are preserved",
+			state: CopyRows,
+			result: WorkflowResult{
+				Totals:          WorkflowTotals{CompletedRows: 11, CompletedChunks: 3},
+				TotalsAvailable: true,
+			},
+			want: WorkflowEvent{
+				State:           CopyRows,
+				Transition:      WorkflowTransitionFinished,
+				Outcome:         WorkflowOutcomeSucceeded,
+				Totals:          WorkflowTotals{CompletedRows: 11, CompletedChunks: 3},
+				TotalsAvailable: true,
+			},
+		},
+		{
+			name:  "non-copy totals are stripped",
+			state: Checksum,
+			result: WorkflowResult{
+				Totals:          WorkflowTotals{CompletedRows: 11, CompletedChunks: 3},
+				TotalsAvailable: true,
+			},
+			want: WorkflowEvent{
+				State:      Checksum,
+				Transition: WorkflowTransitionFinished,
+				Outcome:    WorkflowOutcomeSucceeded,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var lifecycle Lifecycle
+			var finished WorkflowEvent
+			lifecycle.SetObserver(workflowObserverFunc(func(_ context.Context, event WorkflowEvent) {
+				if event.Transition == WorkflowTransitionFinished {
+					finished = event
+				}
+			}))
+			attempt := lifecycle.Start(context.Background(), tt.state)
+			attempt.Finish(context.Background(), tt.result)
+			require.Equal(t, tt.want, finished)
+		})
+	}
+}
+
+func TestLifecycleEvidenceShapesDeduplicationAndReset(t *testing.T) {
+	t.Parallel()
+
+	var lifecycle Lifecycle
+	parent := context.WithValue(context.Background(), workflowContextKey{}, "parent")
+	var observations []workflowObservation
+	lifecycle.SetObserver(workflowObserverFunc(func(ctx context.Context, event WorkflowEvent) {
+		observations = append(observations, workflowObservation{ctx: ctx, event: event})
+	}))
+
+	lifecycle.Terminal(parent, 0)
+	lifecycle.Terminal(parent, WorkflowTerminalOwnership(255))
+	lifecycle.DurableMutation(parent)
+	lifecycle.DurableMutation(context.Background())
+	lifecycle.Terminal(parent, WorkflowTerminalOwnershipReverseFinalized)
+	lifecycle.Terminal(context.Background(), WorkflowTerminalOwnershipAmbiguous)
+
+	require.Len(t, observations, 2)
+	require.Same(t, parent, observations[0].ctx)
+	require.Same(t, parent, observations[1].ctx)
+	require.Equal(t, WorkflowEvent{DurableMutation: true}, observations[0].event)
+	require.Equal(t, WorkflowEvent{
+		TerminalOwnership: WorkflowTerminalOwnershipReverseFinalized,
+	}, observations[1].event)
+
+	lifecycle.ResetEvidence()
+	lifecycle.Terminal(parent, 0)
+	lifecycle.Terminal(parent, WorkflowTerminalOwnershipAmbiguous)
+	lifecycle.DurableMutation(parent)
+
+	require.Len(t, observations, 4)
+	require.Equal(t, WorkflowEvent{
+		TerminalOwnership: WorkflowTerminalOwnershipAmbiguous,
+	}, observations[2].event)
+	require.Equal(t, WorkflowEvent{DurableMutation: true}, observations[3].event)
+}

--- a/pkg/status/workflow.go
+++ b/pkg/status/workflow.go
@@ -1,0 +1,107 @@
+package status
+
+import "context"
+
+// WorkflowTransition identifies whether a workflow state is beginning or ending.
+type WorkflowTransition uint8
+
+const (
+	WorkflowTransitionStarted WorkflowTransition = iota + 1
+	WorkflowTransitionFinished
+)
+
+func (t WorkflowTransition) String() string {
+	switch t {
+	case WorkflowTransitionStarted:
+		return "started"
+	case WorkflowTransitionFinished:
+		return "finished"
+	default:
+		return ""
+	}
+}
+
+// WorkflowOutcome is present only on a finished workflow event.
+type WorkflowOutcome uint8
+
+const (
+	WorkflowOutcomeSucceeded WorkflowOutcome = iota + 1
+	WorkflowOutcomeFailed
+	WorkflowOutcomeCancelled
+)
+
+func (o WorkflowOutcome) String() string {
+	switch o {
+	case WorkflowOutcomeSucceeded:
+		return "succeeded"
+	case WorkflowOutcomeFailed:
+		return "failed"
+	case WorkflowOutcomeCancelled:
+		return "cancelled"
+	default:
+		return ""
+	}
+}
+
+// WorkflowTerminalOwnership identifies terminal ownership evidence that cannot
+// be inferred safely from an error alone.
+type WorkflowTerminalOwnership uint8
+
+const (
+	WorkflowTerminalOwnershipReverseFinalized WorkflowTerminalOwnership = iota + 1
+	WorkflowTerminalOwnershipAmbiguous
+)
+
+func (o WorkflowTerminalOwnership) String() string {
+	switch o {
+	case WorkflowTerminalOwnershipReverseFinalized:
+		return "reverse_finalized"
+	case WorkflowTerminalOwnershipAmbiguous:
+		return "ownership_ambiguous"
+	default:
+		return ""
+	}
+}
+
+func (o WorkflowTerminalOwnership) valid() bool {
+	return o == WorkflowTerminalOwnershipReverseFinalized || o == WorkflowTerminalOwnershipAmbiguous
+}
+
+// WorkflowTotals contains authoritative aggregate work completed by a state.
+// Totals are terminal aggregates, never per-row or per-chunk notifications.
+type WorkflowTotals struct {
+	CompletedRows   uint64
+	CompletedChunks uint64
+}
+
+// WorkflowResult describes the result of one workflow attempt.
+type WorkflowResult struct {
+	Err             error
+	Totals          WorkflowTotals
+	TotalsAvailable bool
+}
+
+// WorkflowEvent is one typed workflow observation.
+//
+// State events set State and Transition. Finished state events also set Outcome;
+// a finished CopyRows event may set TotalsAvailable and Totals. Terminal
+// evidence events set exactly one of TerminalOwnership or DurableMutation and
+// leave all state fields at their zero values. DurableMutation means the
+// externally visible table-name swap has completed successfully, even if later
+// cleanup causes the workflow to return an error.
+type WorkflowEvent struct {
+	State             State
+	Transition        WorkflowTransition
+	Outcome           WorkflowOutcome
+	TerminalOwnership WorkflowTerminalOwnership
+	DurableMutation   bool
+	Totals            WorkflowTotals
+	TotalsAvailable   bool
+}
+
+// WorkflowObserver receives synchronous workflow events in authoritative order.
+// Implementations must return promptly and must be safe for the calling runner's
+// goroutine. Event contexts are the exact parent contexts supplied to Lifecycle.
+type WorkflowObserver interface {
+	ObserveWorkflow(context.Context, WorkflowEvent)
+}

--- a/pkg/status/workflow_test.go
+++ b/pkg/status/workflow_test.go
@@ -1,0 +1,27 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowValuesUseClosedVocabulary(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "started", WorkflowTransitionStarted.String())
+	require.Equal(t, "finished", WorkflowTransitionFinished.String())
+	require.Empty(t, WorkflowTransition(0).String())
+	require.Empty(t, WorkflowTransition(255).String())
+
+	require.Equal(t, "succeeded", WorkflowOutcomeSucceeded.String())
+	require.Equal(t, "failed", WorkflowOutcomeFailed.String())
+	require.Equal(t, "cancelled", WorkflowOutcomeCancelled.String())
+	require.Empty(t, WorkflowOutcome(0).String())
+	require.Empty(t, WorkflowOutcome(255).String())
+
+	require.Equal(t, "reverse_finalized", WorkflowTerminalOwnershipReverseFinalized.String())
+	require.Equal(t, "ownership_ambiguous", WorkflowTerminalOwnershipAmbiguous.String())
+	require.Empty(t, WorkflowTerminalOwnership(0).String())
+	require.Empty(t, WorkflowTerminalOwnership(255).String())
+}


### PR DESCRIPTION
## Summary

- Make the existing `status.State` the only workflow phase vocabulary carried by typed events.
- Add a zero-value-safe `status.Lifecycle` that owns state writes, exact attempts, outcomes, completed-work payloads, durable mutation, and terminal evidence.
- Preserve exact parent contexts and synchronously isolate observer panics from application behavior.
- Use opaque attempt handles so concurrent state changes cannot mislabel completions.

This replaces the duplicate `WorkflowStage` direction from #1111. Runner adoption is isolated in #1116.

## Verification

- `go test -race -count=1 ./pkg/status`
- `go build ./...`
- `make lint`

## Review order

This PR is part of the dependency-ordered replacement for #1111:

1. #1112 — committed retry row accounting
2. #1113 — copier completed-work totals
3. #1114 — result-bearing cutover callbacks
4. #1115 — status-owned lifecycle API
5. #1116 — migration and move lifecycle adoption

Review and merge in order; each PR after #1112 is based on its predecessor. The stack supersedes #1111.
