### PR TITLE
feat(workflow): unify status lifecycle reporting

### DIFF
--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -72,7 +72,7 @@ type Runner struct {
 	// With a stmt, alter, table, newTable.
 	changes []*tableChange
 
-	status     status.State  // must use atomic helpers to change.
+	status     status.Lifecycle
 	replClient change.Source // feed contains all binlog subscription activity.
 	throttler  throttler.Throttler
 
@@ -216,6 +216,12 @@ func (r *Runner) SetLogger(logger *slog.Logger) {
 	r.logger = logger
 }
 
+// SetWorkflowObserver installs an optional typed workflow observer. It must be
+// called before Run. A nil observer disables workflow observation.
+func (r *Runner) SetWorkflowObserver(observer status.WorkflowObserver) {
+	r.status.SetObserver(observer)
+}
+
 // attemptMySQLDDL tries to perform the DDL using MySQL's built-in
 // either with INSTANT or known safe INPLACE operations.
 func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
@@ -225,7 +231,31 @@ func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
 	return r.changes[0].attemptMySQLDDL(ctx)
 }
 
+func (r *Runner) runCopyAttempt(ctx context.Context, attempt *status.WorkflowAttempt) error {
+	err := r.copier.Run(ctx)
+	if err == nil && ctx.Err() != nil {
+		chunker := r.copier.GetChunker()
+		if chunker == nil || !chunker.IsRead() {
+			err = ctx.Err()
+		}
+	}
+
+	result := status.WorkflowResult{Err: err}
+	if r.status.HasObserver() {
+		rows, chunks, available := copier.CompletedWork(r.copier)
+		result.Totals = status.WorkflowTotals{
+			CompletedRows:   rows,
+			CompletedChunks: chunks,
+		}
+		result.TotalsAvailable = available
+	}
+	attempt.Finish(ctx, result)
+	return err
+}
+
 func (r *Runner) Run(ctx context.Context) error {
+	parentCtx := ctx
+	r.status.ResetEvidence()
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
 	r.startTime = time.Now()
@@ -395,24 +425,29 @@ func (r *Runner) Run(ctx context.Context) error {
 	// of migrations usually spend time. It is not strictly necessary,
 	// but we always recopy the last-bit, even if we are resuming
 	// partially through the checksum.
-	r.status.Set(status.CopyRows)
-	if err := r.copier.Run(ctx); err != nil {
+	copyAttempt := r.status.Start(parentCtx, status.CopyRows)
+	err = r.runCopyAttempt(ctx, &copyAttempt)
+	if err != nil {
 		return err
 	}
 	r.logger.Info("copy rows complete")
 	r.copyDuration = time.Since(r.copier.StartTime())
 
-	// Disable both watermark optimizations so that all changes can be flushed.
-	// For non-memory-comparable PKs this also drains the buffered map and
-	// switches the subscription into FIFO queue mode (see
-	// pkg/change/subscription_buffered.go), so the call can return an error.
-	if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+	// Disable both watermark optimizations, stop periodic flushing, and flush
+	// pending changes at the authoritative catch-up boundary.
+	catchUpAttempt := r.status.Start(parentCtx, status.ApplyChangeset)
+	err = r.replClient.SetWatermarkOptimization(ctx, false)
+	if err == nil {
+		r.replClient.StopPeriodicFlush()
+		err = r.replClient.Flush(ctx)
+	}
+	catchUpAttempt.Finish(ctx, status.WorkflowResult{Err: err})
+	if err != nil {
 		return err
 	}
 
-	// Post-copy phase: catch up on replClient apply, run ANALYZE TABLE
-	// so cutover stats are fresh, and run the initial checksum.
-	if err := r.postCopyPhase(ctx); err != nil {
+	// Post-copy phase: update table statistics and run the initial checksum.
+	if err := r.postCopyPhase(parentCtx, ctx); err != nil {
 		return err
 	}
 
@@ -427,19 +462,27 @@ func (r *Runner) Run(ctx context.Context) error {
 	// that the sentinel table was created manually after the migration
 	// started.
 	if r.migration.RespectSentinel {
-		r.sentinelWaitStartTime = time.Now()
-		r.status.Set(status.WaitingOnSentinelTable)
-		// Block on the sentinel via the shared sentinel.Wait (poll/timeout timing
-		// lives in the sentinel package). The continuous-checksum lifecycle and
-		// watermark invalidation are migration-specific — invalidateChecksumWatermark
-		// scopes its UPDATE by statement because the checkpoint table is shared in
-		// multi-table mode — so they are injected as callbacks. See pkg/sentinel.
-		if err := sentinel.Wait(ctx, sentinel.WaitConfig{
-			Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.db) },
+		var waitAttempt status.WorkflowAttempt
+		waitStarted := false
+		exists := func(ctx context.Context) (bool, error) {
+			ok, err := sentinel.Exists(ctx, r.db)
+			if err == nil && ok && !waitStarted {
+				waitStarted = true
+				r.sentinelWaitStartTime = time.Now()
+				waitAttempt = r.status.Start(parentCtx, status.WaitingOnSentinelTable)
+			}
+			return ok, err
+		}
+		err = sentinel.Wait(ctx, sentinel.WaitConfig{
+			Exists:              exists,
 			RunChecksum:         r.runContinuousChecksum,
 			InvalidateWatermark: r.invalidateChecksumWatermark,
 			Logger:              r.logger,
-		}); err != nil {
+		})
+		if waitStarted {
+			waitAttempt.Finish(ctx, status.WorkflowResult{Err: err})
+		}
+		if err != nil {
 			return err
 		}
 	}
@@ -473,6 +516,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err := cutover.Run(ctx); err != nil {
 		return fmt.Errorf("cutover failed: %w", err)
 	}
+	r.status.DurableMutation(parentCtx)
 	if !r.migration.SkipDropAfterCutover {
 		for _, change := range r.changes {
 			if err := change.dropOldTable(ctx); err != nil {
@@ -516,20 +560,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	return nil
 }
 
-// postCopyPhase runs the work that happens between copy-rows and the
-// sentinel wait: drain the binlog backlog, run ANALYZE TABLE, and
-// perform the initial checksum. When defer-cutover is not in use this
-// is also the last phase before cutover.
-func (r *Runner) postCopyPhase(ctx context.Context) error {
-	r.status.Set(status.ApplyChangeset)
-	// Disable the periodic flush and flush all pending events.
-	// We want it disabled for ANALYZE TABLE and acquiring a table lock
-	// *but* it will be started again briefly inside of the checksum
-	// runner to ensure that the lag does not grow too long.
-	r.replClient.StopPeriodicFlush()
-	if err := r.replClient.Flush(ctx); err != nil {
-		return err
-	}
+// postCopyPhase runs the work that happens between the authoritative binlog
+// catch-up and the sentinel wait: update table statistics and perform the
+// initial checksum. When defer-cutover is not in use this is also the last
+// phase before cutover.
+func (r *Runner) postCopyPhase(parentCtx, ctx context.Context) error {
 
 	// Run ANALYZE TABLE to update the statistics on the new table.
 	// This is required so on cutover plans don't go sideways, which
@@ -564,7 +599,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// The checksum is ONLINE after an initial lock
 	// for consistency. It is the main way that we determine that
 	// this program is safe to use even when immature.
-	return r.checksum(ctx)
+	return r.checksumAttempt(parentCtx, ctx)
 }
 
 // runChecks wraps around check.RunChecks and adds the context of this migration
@@ -1667,9 +1702,13 @@ func (r *Runner) initChunkers() error {
 	return nil
 }
 
-// checksum creates the checksum which opens the read view
+// checksum creates the checksum which opens the read view.
 func (r *Runner) checksum(ctx context.Context) error {
-	r.status.Set(status.Checksum)
+	return r.checksumAttempt(ctx, ctx)
+}
+
+func (r *Runner) checksumAttempt(parentCtx, ctx context.Context) error {
+	attempt := r.status.Start(parentCtx, status.Checksum)
 
 	// The checksum keeps the pool threads open, so we need to extend
 	// by more than +1 on threads as we did previously. We have:
@@ -1695,7 +1734,9 @@ func (r *Runner) checksum(ctx context.Context) error {
 	// (forcing full re-verification) or a watermark from a clean pass
 	// (safe to resume from). Either way the silent-cutover hole is
 	// closed without needing to special-case the error path.
-	if err := r.checker.Run(ctx); err != nil {
+	err := r.checker.Run(ctx)
+	attempt.Finish(ctx, status.WorkflowResult{Err: err})
+	if err != nil {
 		if r.addsUniqueIndex() {
 			// Overwrite the error if we think it's because of a unique index addition
 			return errors.New("checksum failed after several attempts. This is likely related to your statement adding a UNIQUE index on non-unique data")

--- a/pkg/migration/workflow_lifecycle_test.go
+++ b/pkg/migration/workflow_lifecycle_test.go
@@ -1,0 +1,249 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/block/spirit/pkg/copier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+type workflowLifecycleContextKey struct{}
+
+type workflowObserverFunc func(context.Context, status.WorkflowEvent)
+
+func (f workflowObserverFunc) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	f(ctx, event)
+}
+
+type recordingLifecycleObserver struct {
+	runner        *Runner
+	events        []status.WorkflowEvent
+	contexts      []context.Context
+	statesAtStart []status.State
+}
+
+func (o *recordingLifecycleObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.contexts = append(o.contexts, ctx)
+	o.events = append(o.events, event)
+	if o.runner != nil && event.Transition == status.WorkflowTransitionStarted {
+		o.statesAtStart = append(o.statesAtStart, o.runner.status.Get())
+	}
+}
+
+type lifecycleChunker struct {
+	table.Chunker
+	read bool
+}
+
+func (c *lifecycleChunker) IsRead() bool { return c.read }
+
+type lifecycleCopier struct {
+	copier.Copier
+	runErr  error
+	chunker table.Chunker
+	rows    uint64
+	chunks  uint64
+	panic   bool
+}
+
+func (c *lifecycleCopier) Run(context.Context) error { return c.runErr }
+func (c *lifecycleCopier) GetChunker() table.Chunker { return c.chunker }
+func (c *lifecycleCopier) CompletedWork() (uint64, uint64) {
+	if c.panic {
+		panic("CompletedWork called without an observer")
+	}
+	return c.rows, c.chunks
+}
+
+type cancelOnCopyStartObserver struct {
+	recordingLifecycleObserver
+	cancel context.CancelFunc
+}
+
+func (o *cancelOnCopyStartObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.recordingLifecycleObserver.ObserveWorkflow(ctx, event)
+	if event.State == status.CopyRows && event.Transition == status.WorkflowTransitionStarted {
+		o.cancel()
+	}
+}
+
+type cancelOnDurableMutationObserver struct {
+	recordingLifecycleObserver
+	cancel context.CancelFunc
+}
+
+func (o *cancelOnDurableMutationObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.recordingLifecycleObserver.ObserveWorkflow(ctx, event)
+	if event.DurableMutation {
+		o.cancel()
+	}
+}
+
+func TestWorkflowLifecycleOrderedStateAttemptsAndTotals(t *testing.T) {
+	parent := context.WithValue(t.Context(), workflowLifecycleContextKey{}, "parent")
+	runCtx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	r := &Runner{copier: &lifecycleCopier{
+		chunker: &lifecycleChunker{read: true},
+		rows:    42,
+		chunks:  7,
+	}}
+	observer := &recordingLifecycleObserver{runner: r}
+	r.SetWorkflowObserver(observer)
+
+	copyAttempt := r.status.Start(parent, status.CopyRows)
+	require.NoError(t, r.runCopyAttempt(runCtx, &copyAttempt))
+
+	catchUpAttempt := r.status.Start(parent, status.ApplyChangeset)
+	catchUpAttempt.Finish(runCtx, status.WorkflowResult{Err: errors.New("flush failed")})
+
+	checksumAttempt := r.status.Start(parent, status.Checksum)
+	checksumAttempt.Finish(runCtx, status.WorkflowResult{Err: context.Canceled})
+
+	require.Equal(t, status.Checksum, r.status.Get())
+	require.Equal(t, []status.State{status.CopyRows, status.ApplyChangeset, status.Checksum}, observer.statesAtStart)
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.CopyRows, Transition: status.WorkflowTransitionStarted},
+		{
+			State:           status.CopyRows,
+			Transition:      status.WorkflowTransitionFinished,
+			Outcome:         status.WorkflowOutcomeSucceeded,
+			Totals:          status.WorkflowTotals{CompletedRows: 42, CompletedChunks: 7},
+			TotalsAvailable: true,
+		},
+		{State: status.ApplyChangeset, Transition: status.WorkflowTransitionStarted},
+		{State: status.ApplyChangeset, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeFailed},
+		{State: status.Checksum, Transition: status.WorkflowTransitionStarted},
+		{State: status.Checksum, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled},
+	}, observer.events)
+	require.Len(t, observer.contexts, len(observer.events))
+	for _, observedCtx := range observer.contexts {
+		require.Same(t, parent, observedCtx)
+	}
+}
+
+func TestWorkflowLifecycleCancellationOnCopyStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	observer := &cancelOnCopyStartObserver{cancel: cancel}
+	r := &Runner{copier: &lifecycleCopier{}}
+	r.SetWorkflowObserver(observer)
+
+	attempt := r.status.Start(ctx, status.CopyRows)
+	require.ErrorIs(t, r.runCopyAttempt(ctx, &attempt), context.Canceled)
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.CopyRows, Transition: status.WorkflowTransitionStarted},
+		{State: status.CopyRows, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled, TotalsAvailable: true},
+	}, observer.events)
+}
+
+func TestWorkflowLifecycleNilCopyErrorAfterCompletedChunkerRemainsSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	observer := &recordingLifecycleObserver{}
+	r := &Runner{copier: &lifecycleCopier{chunker: &lifecycleChunker{read: true}}}
+	r.SetWorkflowObserver(observer)
+
+	attempt := r.status.Start(t.Context(), status.CopyRows)
+	require.NoError(t, r.runCopyAttempt(ctx, &attempt))
+	require.Equal(t, status.WorkflowOutcomeSucceeded, observer.events[1].Outcome)
+}
+
+func TestWorkflowLifecycleCompletedWorkCapabilityIsConditionalAndZeroIsAvailable(t *testing.T) {
+	t.Run("nil observer does not query capability", func(t *testing.T) {
+		r := &Runner{copier: &lifecycleCopier{panic: true}}
+		attempt := r.status.Start(t.Context(), status.CopyRows)
+		require.NotPanics(t, func() {
+			require.NoError(t, r.runCopyAttempt(t.Context(), &attempt))
+		})
+	})
+
+	t.Run("available zero totals are authoritative", func(t *testing.T) {
+		observer := &recordingLifecycleObserver{}
+		r := &Runner{copier: &lifecycleCopier{}}
+		r.SetWorkflowObserver(observer)
+		attempt := r.status.Start(t.Context(), status.CopyRows)
+		require.NoError(t, r.runCopyAttempt(t.Context(), &attempt))
+		require.Equal(t, status.WorkflowEvent{
+			State:           status.CopyRows,
+			Transition:      status.WorkflowTransitionFinished,
+			Outcome:         status.WorkflowOutcomeSucceeded,
+			TotalsAvailable: true,
+		}, observer.events[1])
+	})
+}
+
+func TestWorkflowLifecycleObserverPanicCannotChangeCopyResult(t *testing.T) {
+	calls := 0
+	r := &Runner{copier: &lifecycleCopier{rows: 1, chunks: 1}}
+	r.SetWorkflowObserver(workflowObserverFunc(func(context.Context, status.WorkflowEvent) {
+		calls++
+		panic("observer failed")
+	}))
+
+	require.NotPanics(t, func() {
+		attempt := r.status.Start(t.Context(), status.CopyRows)
+		require.NoError(t, r.runCopyAttempt(t.Context(), &attempt))
+	})
+	require.Equal(t, 2, calls)
+	require.Equal(t, status.CopyRows, r.status.Get())
+}
+
+func TestWorkflowLifecycleChecksumFinishesBeforeErrorRewrite(t *testing.T) {
+	r, err := NewRunner(&Migration{Table: "checksum_error_rewrite", Alter: "ADD UNIQUE INDEX idx_unique (id)"})
+	require.NoError(t, err)
+	r.db, err = sql.Open("mysql", "unused@tcp(127.0.0.1:1)/unused")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, r.db.Close()) })
+	r.dbConfig = dbconn.NewDBConfig()
+	r.checker = &mockChecker{runErr: context.Canceled}
+	observer := &recordingLifecycleObserver{}
+	r.SetWorkflowObserver(observer)
+
+	err = r.checksumAttempt(t.Context(), t.Context())
+	require.Error(t, err)
+	require.NotErrorIs(t, err, context.Canceled)
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.Checksum, Transition: status.WorkflowTransitionStarted},
+		{State: status.Checksum, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled},
+	}, observer.events)
+}
+
+func TestWorkflowLifecycleReportsDurableMutationBeforeCancelledCleanup(t *testing.T) {
+	dbName, _ := testutils.CreateUniqueTestDatabase(t)
+	const tableName = "observed_empty_cutover"
+	testutils.RunSQLInDatabase(t, dbName, fmt.Sprintf(`CREATE TABLE %s (
+		pk int UNSIGNED NOT NULL,
+		PRIMARY KEY(pk)
+	)`, tableName))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	observer := &cancelOnDurableMutationObserver{cancel: cancel}
+	r := NewTestRunner(t, tableName, "ADD INDEX observed_idx (pk)", WithDBName(dbName), WithRespectSentinel())
+	r.SetWorkflowObserver(observer)
+
+	err := r.Run(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, observer.events, status.WorkflowEvent{DurableMutation: true})
+	require.Same(t, ctx, observer.contexts[len(observer.contexts)-1])
+	for _, event := range observer.events {
+		require.NotEqual(t, status.WaitingOnSentinelTable, event.State, "absent optional sentinel must not start an attempt")
+	}
+
+	var indexCount int
+	require.NoError(t, r.db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE TABLE_SCHEMA=? AND TABLE_NAME=? AND INDEX_NAME='observed_idx'
+	`, dbName, tableName).Scan(&indexCount))
+	require.Equal(t, 1, indexCount)
+	require.NoError(t, r.Close())
+}

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -141,6 +141,11 @@ func (c *CutOver) runWithRetries(ctx context.Context, runAttempt func(attempt in
 		}
 		err = runAttempt(attempt)
 		if err != nil {
+			if errors.Is(err, errRenameRollbackFailed) {
+				c.logger.Error("source rename rollback failed; not retrying a partially renamed cutover",
+					"error", err.Error())
+				return err
+			}
 			if c.cutoverFuncMutated && !c.cutoverFuncSucceeded {
 				c.logger.Error("cutover callback failed after reporting a durable mutation; not retrying",
 					"error", err.Error())

--- a/pkg/move/cutover_test.go
+++ b/pkg/move/cutover_test.go
@@ -324,3 +324,20 @@ func TestCutOverResultControlsRetry(t *testing.T) {
 		})
 	}
 }
+
+func TestCutOverRenameRollbackFailureStopsOuterRetries(t *testing.T) {
+	dbConfig := dbconn.NewDBConfig()
+	dbConfig.MaxRetries = 3
+	cutover := &CutOver{dbConfig: dbConfig, logger: slog.Default()}
+	attempts := 0
+
+	err := cutover.runWithRetries(t.Context(), func(int) error {
+		attempts++
+		return fmt.Errorf("partially renamed source: %w", errRenameRollbackFailed)
+	})
+
+	require.ErrorIs(t, err, errRenameRollbackFailed)
+	require.Equal(t, 1, attempts)
+	require.False(t, cutover.cutoverFuncMutated)
+	require.False(t, cutover.cutoverFuncSucceeded)
+}

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -3,6 +3,7 @@ package move
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,8 +22,9 @@ import (
 // the copy phase — the only value migration/datasync ever write, and what a
 // normal move writes right up to (and including) its cutover.
 const (
-	phaseReverseWindow = "reverse_window" // forward cutover done, reverse feed live
-	phaseReverting     = "reverting"      // reverse cutover under way
+	phaseReverseWindow    = "reverse_window"    // forward cutover done, reverse feed live
+	phaseReverting        = "reverting"         // reverse cutover crossed its first mutation boundary
+	phaseReverseFinalized = "reverse_finalized" // source ownership restored; cleanup may remain
 )
 
 // reverseWindowPollInterval is how often the window loop checks for a revert
@@ -93,14 +95,40 @@ type reverseWindow struct {
 	feed *ReverseFeed
 	// watched[i] is target i's real-name tables, used to lock and then retire
 	// the targets during a reverse cutover.
-	watched [][]*table.TableInfo
+	watched        [][]*table.TableInfo
+	persistPhase   func(context.Context, string) error
+	dropMarker     func(context.Context) error
+	dropCheckpoint func(context.Context) error
 }
 
-func newReverseWindow(r *Runner) *reverseWindow { return &reverseWindow{r: r} }
+func newReverseWindow(r *Runner) *reverseWindow {
+	return &reverseWindow{
+		r: r,
+		persistPhase: func(ctx context.Context, phase string) error {
+			return r.checkpointTbl().Write(ctx, checkpoint.Record{Phase: phase, CutoverAt: r.cutoverAt})
+		},
+		dropMarker:     func(ctx context.Context) error { return dropRevertMarker(ctx, r.targets[0].DB) },
+		dropCheckpoint: func(ctx context.Context) error { return r.checkpointTbl().Drop(ctx) },
+	}
+}
+
+func finishReverseWindowAttempt(
+	attempt *status.WorkflowAttempt,
+	ctx context.Context,
+	runErr *error,
+	completedNormally *bool,
+) {
+	if !*completedNormally {
+		panicValue := recover()
+		attempt.Finish(context.WithoutCancel(ctx), status.WorkflowResult{Err: errors.New("reverse window panicked")})
+		panic(panicValue)
+	}
+	attempt.Finish(ctx, status.WorkflowResult{Err: *runErr})
+}
 
 // run holds the window and performs the terminal action. It owns the feed's
-// lifecycle.
-func (w *reverseWindow) run(ctx context.Context) error {
+// lifecycle. The authoritative state begins only after the reverse feed is live.
+func (w *reverseWindow) run(parentCtx, ctx context.Context) (runErr error) {
 	if err := w.buildFeed(ctx); err != nil {
 		return err
 	}
@@ -108,7 +136,16 @@ func (w *reverseWindow) run(ctx context.Context) error {
 	if err := w.feed.Start(ctx); err != nil {
 		return fmt.Errorf("reverse window: start feed: %w", err)
 	}
+	reverseAttempt := w.r.status.Start(parentCtx, status.ReverseWindow)
+	completedNormally := false
+	defer finishReverseWindowAttempt(&reverseAttempt, ctx, &runErr, &completedNormally)
 
+	runErr = w.wait(ctx)
+	completedNormally = true
+	return runErr
+}
+
+func (w *reverseWindow) wait(ctx context.Context) error {
 	r := w.r
 	deadline := r.cutoverAt.Add(r.move.ReverseWindow)
 	// Where an operator creates the revert marker to trigger a rollback:
@@ -117,7 +154,7 @@ func (w *reverseWindow) run(ctx context.Context) error {
 	r.logger.Info(fmt.Sprintf("reverse window open; watching for a table named %s to be created on %s (create it to roll back)",
 		revertMarkerName, revertLoc),
 		"window", r.move.ReverseWindow, "deadline", deadline, "reverse_sources", len(r.targets))
-	r.status.Set(status.ReverseWindow)
+	// ReverseWindow was recorded only after feed.Start succeeded above.
 
 	ticker := time.NewTicker(reverseWindowPollInterval)
 	defer ticker.Stop()
@@ -272,10 +309,10 @@ func (w *reverseWindow) revertRequested(ctx context.Context) (bool, error) {
 // checkpoint is dropped. The reverse feed is stopped.
 func (w *reverseWindow) completeForward(ctx context.Context) error {
 	w.feed.Close()
-	if err := dropRevertMarker(ctx, w.r.targets[0].DB); err != nil {
+	if err := w.dropMarker(ctx); err != nil {
 		return fmt.Errorf("reverse window: drop revert marker on complete-forward: %w", err)
 	}
-	if err := w.r.checkpointTbl().Drop(ctx); err != nil {
+	if err := w.dropCheckpoint(ctx); err != nil {
 		return fmt.Errorf("reverse window: drop checkpoint on complete-forward: %w", err)
 	}
 	w.r.logger.Info("reverse window complete; move finalized forward (source retired)")
@@ -288,11 +325,6 @@ func (w *reverseWindow) completeForward(ctx context.Context) error {
 // traffic returns to them.
 func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 	r := w.r
-
-	// Record that we are rolling back (best-effort; for a future resume).
-	if err := r.checkpointTbl().Write(ctx, checkpoint.Record{Phase: phaseReverting, CutoverAt: r.cutoverAt}); err != nil {
-		r.logger.Warn("could not persist reverting phase; continuing", "error", err)
-	}
 
 	// Clear any stale _revert tables on the targets before the retire (step 5)
 	// renames each target table to its _revert form — a leftover from a prior
@@ -327,6 +359,13 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 	}
 	w.feed.Close()
 
+	// Persist the ambiguous ownership boundary immediately before the first
+	// source rename. Fail closed: proceeding without this durable fact could
+	// make a restart mistake a partially reverted move for a live window.
+	if err := w.persistPhase(ctx, phaseReverting); err != nil {
+		return fmt.Errorf("reverse cutover: persist reverting phase: %w", err)
+	}
+
 	// 3. Un-retire the source: rename its _old tables back to their real names
 	//    (on every source shard) so it can serve again. The feed is stopped, so
 	//    nothing writes them.
@@ -337,6 +376,7 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 			if err := dbconn.Exec(ctx, s.db, "RENAME TABLE %n TO %n", oldName, t.TableName); err != nil {
 				return fmt.Errorf("reverse cutover: un-retire source %d table %q: %w", si, t.TableName, err)
 			}
+			r.ownershipAmbiguous = true
 		}
 	}
 
@@ -361,11 +401,23 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 		}
 	}
 
-	// 6. Drop the revert marker and the checkpoint.
-	if err := dropRevertMarker(ctx, r.targets[0].DB); err != nil {
+	return w.finalizeReverse(ctx)
+}
+
+// finalizeReverse records definitive reverse ownership before fallible
+// persistence and cleanup. Once every former target has been retired, no
+// remaining operation can move ownership away from the restored source.
+func (w *reverseWindow) finalizeReverse(ctx context.Context) error {
+	r := w.r
+	r.ownershipAmbiguous = false
+	r.reverseFinalized = true
+	if err := w.persistPhase(ctx, phaseReverseFinalized); err != nil {
+		return fmt.Errorf("reverse cutover: persist finalized phase: %w", err)
+	}
+	if err := w.dropMarker(ctx); err != nil {
 		return fmt.Errorf("reverse cutover: drop revert marker: %w", err)
 	}
-	if err := r.checkpointTbl().Drop(ctx); err != nil {
+	if err := w.dropCheckpoint(ctx); err != nil {
 		return fmt.Errorf("reverse cutover: drop checkpoint: %w", err)
 	}
 	r.logger.Info("reverse cutover complete; move rolled back to source")

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -183,6 +183,66 @@ func TestMoveReverseWindowRevert(t *testing.T) {
 	require.False(t, tableExists(t, ctl, "rwrv_dst", checkpointTableName), "checkpoint should be dropped")
 }
 
+func TestMoveLifecyclePartialReverseSourceRenameIsAmbiguous(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	sourceDSN, targetDSN, ctl := setupReverseWindowMove(t, "rwpartial_src", "rwpartial_dst")
+	testutils.RunSQL(t, "CREATE TABLE rwpartial_src.t2 (id INT PRIMARY KEY, val VARCHAR(255))")
+	testutils.RunSQL(t, "INSERT INTO rwpartial_src.t2 (id, val) VALUES (1,'one')")
+
+	runner, err := NewRunner(&Move{
+		SourceDSN:       sourceDSN,
+		TargetDSN:       targetDSN,
+		TargetChunkTime: time.Second,
+		Threads:         1,
+		WriteThreads:    1,
+		ReverseWindow:   30 * time.Second,
+	})
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+
+	observer := &recordingMoveWorkflowObserver{}
+	runner.SetWorkflowObserver(observer)
+	runner.SetCutover(func(context.Context) error { return nil })
+	runner.SetReverseCutover(func(context.Context) error { return nil })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runner.Run(context.Background()) }()
+	waitForReverseWindow(t, ctl, "rwpartial_dst")
+	waitForTable(t, ctl, "rwpartial_src", "t1_old")
+	waitForTable(t, ctl, "rwpartial_src", "t2_old")
+
+	// The first source restore succeeds, then the collision forces the second
+	// restore to fail with both old and real source names present.
+	testutils.RunSQL(t, "CREATE TABLE rwpartial_src.t2 (id INT PRIMARY KEY)")
+	testutils.RunSQL(t, "CREATE TABLE rwpartial_dst."+revertMarkerName+" (id INT)")
+
+	select {
+	case runErr := <-errCh:
+		require.Error(t, runErr)
+		require.ErrorContains(t, runErr, "un-retire source")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for partial reverse cutover failure")
+	}
+
+	require.True(t, tableExists(t, ctl, "rwpartial_src", "t1"))
+	require.True(t, tableExists(t, ctl, "rwpartial_src", "t2_old"))
+	events, _ := observer.snapshot()
+	var reverseEvents, terminals []status.WorkflowEvent
+	for _, event := range events {
+		if event.State == status.ReverseWindow {
+			reverseEvents = append(reverseEvents, event)
+		}
+		if event.TerminalOwnership != 0 {
+			terminals = append(terminals, event)
+		}
+	}
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.ReverseWindow, Transition: status.WorkflowTransitionStarted},
+		{State: status.ReverseWindow, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeFailed},
+	}, reverseEvents)
+	require.Equal(t, []status.WorkflowEvent{{TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous}}, terminals)
+}
+
 // runRevertingMove runs one reverse-window move against the given DSNs and, once
 // the window opens, requests a revert (creates the marker), returning when the
 // reverse cutover has completed. Fails the test on any error.

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -92,7 +92,7 @@ type Runner struct {
 	move            *Move
 	sources         []sourceInfo     // one per source database
 	targets         []applier.Target // Combined DB, Config, and KeyRange
-	status          status.State     // must use atomic to get/set
+	status          status.Lifecycle
 	checkpointTable *table.TableInfo
 
 	sourceTables   []*table.TableInfo // canonical table list (from sources[0])
@@ -166,6 +166,9 @@ type Runner struct {
 	// (stopWatchTask) so the reverse window is the sole writer of the checkpoint
 	// row.
 	bgCancel context.CancelFunc
+
+	reverseFinalized   bool
+	ownershipAmbiguous bool
 }
 
 var _ status.Task = (*Runner)(nil)
@@ -202,6 +205,49 @@ func NewRunner(m *Move) (*Runner, error) {
 		logger: slog.Default(),
 	}
 	return r, nil
+}
+
+// SetWorkflowObserver installs the optional typed workflow observer. It must be
+// called before Run. A nil observer disables workflow observation.
+func (r *Runner) SetWorkflowObserver(observer status.WorkflowObserver) {
+	r.status.SetObserver(observer)
+}
+
+func (r *Runner) runCopy(parentCtx, ctx context.Context) error {
+	copyAttempt := r.status.Start(parentCtx, status.CopyRows)
+	err := r.copier.Run(ctx)
+	if err == nil && ctx.Err() != nil {
+		chunker := r.copier.GetChunker()
+		if chunker == nil || !chunker.IsRead() {
+			err = ctx.Err()
+		}
+	}
+	copyResult := status.WorkflowResult{Err: err}
+	if r.status.HasObserver() {
+		rows, chunks, available := copier.CompletedWork(r.copier)
+		copyResult.Totals = status.WorkflowTotals{CompletedRows: rows, CompletedChunks: chunks}
+		copyResult.TotalsAvailable = available
+	}
+	copyAttempt.Finish(ctx, copyResult)
+	return err
+}
+
+func (r *Runner) terminalOwnership() status.WorkflowTerminalOwnership {
+	switch {
+	case r.reverseFinalized:
+		return status.WorkflowTerminalOwnershipReverseFinalized
+	case r.ownershipAmbiguous:
+		return status.WorkflowTerminalOwnershipAmbiguous
+	default:
+		return 0
+	}
+}
+
+func (r *Runner) recordForwardCutoverFailure(cutover *CutOver, err error) {
+	r.ownershipAmbiguous = r.ownershipAmbiguous ||
+		cutover.cutoverFuncSucceeded ||
+		cutover.cutoverFuncMutated ||
+		errors.Is(err, errRenameRollbackFailed)
 }
 
 func (r *Runner) Close() error {
@@ -768,10 +814,10 @@ func (r *Runner) dropStaleRevertTables(ctx context.Context) error {
 // the checkpoint before any locks or discovery. Returns handled=true when it
 // owns the run.
 //
-// Not yet handled: an interrupted reverse *cutover* (phase "reverting") leaves
-// an ambiguous half-renamed state, so that surfaces as an error for manual
-// completion rather than an unsafe auto-resume.
-func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
+// An interrupted reverse cutover remains unsafe to resume automatically after
+// it crosses the persisted "reverting" boundary. A finalized reverse cutover
+// only needs its idempotent marker/checkpoint cleanup retried.
+func (r *Runner) maybeResumeReverseWindow(parentCtx, ctx context.Context) (bool, error) {
 	rec, err := r.checkpointTbl().ReadLatest(ctx)
 	if err != nil {
 		// No usable checkpoint (fresh move, empty, or a layout this version
@@ -782,8 +828,12 @@ func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
 	switch rec.Phase {
 	case phaseReverseWindow:
 		r.logger.Warn("resuming an interrupted reverse window from checkpoint", "cutover_at", rec.CutoverAt)
-		return true, r.resumeReverseWindow(ctx, rec)
+		return true, r.resumeReverseWindow(parentCtx, ctx, rec)
+	case phaseReverseFinalized:
+		r.cutoverAt = rec.CutoverAt
+		return true, newReverseWindow(r).finalizeReverse(ctx)
 	case phaseReverting:
+		r.ownershipAmbiguous = true
 		return true, fmt.Errorf("a reverse cutover was interrupted (checkpoint phase=%q); resuming a partial rollback is not yet supported — complete it manually", rec.Phase)
 	default:
 		return false, nil // phase "" (copy) — the normal flow handles resume/fresh
@@ -798,7 +848,7 @@ func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
 // of the same move is an operator error), and the feed always resumes from the
 // original cutover position — correct via idempotent apply, at the cost of
 // re-reading the window's binlog.
-func (r *Runner) resumeReverseWindow(ctx context.Context, rec checkpoint.Record) error {
+func (r *Runner) resumeReverseWindow(parentCtx, ctx context.Context, rec checkpoint.Record) error {
 	var positions map[string]string
 	if err := json.Unmarshal([]byte(rec.Position), &positions); err != nil {
 		return fmt.Errorf("resume reverse window: parse stored positions: %w", err)
@@ -827,7 +877,7 @@ func (r *Runner) resumeReverseWindow(ctx context.Context, rec checkpoint.Record)
 	}
 	r.sourceTables = r.sources[0].tables
 
-	return newReverseWindow(r).run(ctx)
+	return newReverseWindow(r).run(parentCtx, ctx)
 }
 
 // reverseWindowLogicalTables recovers the logical names of the moved tables when
@@ -980,6 +1030,13 @@ func (r *Runner) createCheckpointTable(ctx context.Context) error {
 }
 
 func (r *Runner) Run(ctx context.Context) error {
+	parentCtx := ctx
+	r.status.ResetEvidence()
+	r.reverseFinalized = false
+	r.ownershipAmbiguous = false
+	defer func() {
+		r.status.Terminal(parentCtx, r.terminalOwnership())
+	}()
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
 	r.startTime = time.Now()
@@ -1095,7 +1152,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// treat them as fresh data and re-copy them. This must run before the
 	// revert-marker pre-flight guard, since a resumed window legitimately honors
 	// a marker created before the crash.
-	if handled, err := r.maybeResumeReverseWindow(ctx); err != nil {
+	if handled, err := r.maybeResumeReverseWindow(parentCtx, ctx); err != nil {
 		return err
 	} else if handled {
 		return nil
@@ -1123,7 +1180,11 @@ func (r *Runner) Run(ctx context.Context) error {
 		// the full cutover path.
 		r.logger.Info("No tables to copy, proceeding directly to cutover")
 		r.status.Set(status.CutOver)
-		if _, err := r.runForwardCutoverCallback(ctx); err != nil {
+		result, err := r.runForwardCutoverCallback(ctx)
+		if result.DurableMutation {
+			r.status.DurableMutation(parentCtx)
+		}
+		if err != nil {
 			return err
 		}
 		r.logger.Info("Move operation complete.")
@@ -1167,19 +1228,19 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	r.status.Set(status.CopyRows)
-	if err := r.copier.Run(ctx); err != nil {
+	if err = r.runCopy(parentCtx, ctx); err != nil {
 		return err
 	}
 
-	// Disable both watermark optimizations so that all changes can be flushed.
-	// For non-memory-comparable PKs this also drains the buffered map and
-	// switches the subscription into FIFO queue mode (see
-	// pkg/change/subscription_buffered.go), so the call can return an error.
-	if err := r.setWatermarkOptimizationAll(ctx, false); err != nil {
-		return err
+	// Disable both watermark optimizations and flush pending changes at the
+	// first authoritative post-copy catch-up boundary.
+	catchUpAttempt := r.status.Start(parentCtx, status.ApplyChangeset)
+	err = r.setWatermarkOptimizationAll(ctx, false)
+	if err == nil {
+		err = r.flushAllReplClients(ctx)
 	}
-	if err := r.flushAllReplClients(ctx); err != nil {
+	catchUpAttempt.Finish(ctx, status.WorkflowResult{Err: err})
+	if err != nil {
 		return err
 	}
 
@@ -1189,24 +1250,32 @@ func (r *Runner) Run(ctx context.Context) error {
 	// ANALYZE TABLE, run the initial checksum. While the sentinel blocks
 	// cutover, waitOnSentinelTable runs a continuous checksum loop in the
 	// background — see docs/move.md for the two-checksum model.
-	if err := r.postCopyPhase(ctx); err != nil {
+	if err := r.postCopyPhaseObserved(parentCtx, ctx); err != nil {
 		return err
 	}
 	r.logger.Info("Initial checksum completed successfully")
 
-	r.sentinelWaitStartTime = time.Now()
-	r.status.Set(status.WaitingOnSentinelTable)
-	// Block on the sentinel via the shared sentinel.Wait (poll/timeout timing
-	// lives in the sentinel package). The continuous-checksum lifecycle and
-	// watermark invalidation are move-specific (multi-source feeds;
-	// invalidateChecksumWatermark blanks the whole per-move checkpoint table),
-	// so they are injected as callbacks. See pkg/sentinel.
-	if err := sentinel.Wait(ctx, sentinel.WaitConfig{
-		Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
+	var waitAttempt status.WorkflowAttempt
+	waitStarted := false
+	exists := func(ctx context.Context) (bool, error) {
+		ok, err := sentinel.Exists(ctx, r.targets[0].DB)
+		if err == nil && ok && !waitStarted {
+			waitStarted = true
+			r.sentinelWaitStartTime = time.Now()
+			waitAttempt = r.status.Start(parentCtx, status.WaitingOnSentinelTable)
+		}
+		return ok, err
+	}
+	err = sentinel.Wait(ctx, sentinel.WaitConfig{
+		Exists:              exists,
 		RunChecksum:         r.runContinuousChecksum,
 		InvalidateWatermark: r.invalidateChecksumWatermark,
 		Logger:              r.logger,
-	}); err != nil {
+	})
+	if waitStarted {
+		waitAttempt.Finish(ctx, status.WorkflowResult{Err: err})
+	}
+	if err != nil {
 		return err
 	}
 
@@ -1247,14 +1316,20 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 	if err = cutover.Run(ctx); err != nil {
+		r.recordForwardCutoverFailure(cutover, err)
+		if r.ownershipAmbiguous {
+			r.status.DurableMutation(parentCtx)
+		}
 		return err
 	}
+	r.ownershipAmbiguous = false
+	r.status.DurableMutation(parentCtx)
 
 	if r.move.ReverseWindow > 0 {
 		// Hold the reverse window keeping the source current, then complete
 		// forward (retire the source) or roll back. The checkpoint is dropped by
 		// the terminal action, not here.
-		return newReverseWindow(r).run(ctx)
+		return newReverseWindow(r).run(parentCtx, ctx)
 	}
 
 	// Delete checkpoint table from targets[0].
@@ -1575,6 +1650,10 @@ func (r *Runner) restoreIndexesForTargets(ctx context.Context, host string, targ
 // When create-sentinel is not in use this is also the last phase
 // before cutover.
 func (r *Runner) postCopyPhase(ctx context.Context) error {
+	return r.postCopyPhaseObserved(ctx, ctx)
+}
+
+func (r *Runner) postCopyPhaseObserved(parentCtx, ctx context.Context) error {
 	// Flush all pending events, but leave the periodic flush running until
 	// just before the checksum. With --defer-secondary-indexes,
 	// restoreSecondaryIndexes issues one giant ALTER per table that can run
@@ -1664,7 +1743,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	r.status.Set(status.Checksum)
+	checksumAttempt := r.status.Start(parentCtx, status.Checksum)
 	// On a checker error we just propagate. The DumpCheckpoint invariant
 	// guarantees that any persisted checksum_watermark describes only
 	// verified-clean chunks, so a resumed run either replays the checksum
@@ -1672,7 +1751,9 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// repair) or resumes safely from a watermark that came from a clean
 	// pass. See pkg/migration/runner.go DumpCheckpoint for the full
 	// rationale.
-	return r.checker.Run(ctx)
+	err = r.checker.Run(ctx)
+	checksumAttempt.Finish(ctx, status.WorkflowResult{Err: err})
+	return err
 }
 
 // analyzeTable runs ANALYZE TABLE for tableName on db, unqualified: db is
@@ -1718,13 +1799,18 @@ func (r *Runner) analyzeTable(ctx context.Context, db *sql.DB, tableName string)
 // configured and always returns the result-bearing form used by both runner
 // cutover paths.
 func (r *Runner) runForwardCutoverCallback(ctx context.Context) (CutoverResult, error) {
-	if r.cutoverResultFunc != nil {
-		return r.cutoverResultFunc(ctx)
+	var result CutoverResult
+	var err error
+	switch {
+	case r.cutoverResultFunc != nil:
+		result, err = r.cutoverResultFunc(ctx)
+	case r.cutoverFunc != nil:
+		err = r.cutoverFunc(ctx)
 	}
-	if r.cutoverFunc != nil {
-		return CutoverResult{}, r.cutoverFunc(ctx)
+	if err != nil && result.DurableMutation {
+		r.ownershipAmbiguous = true
 	}
-	return CutoverResult{}, nil
+	return result, err
 }
 
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {

--- a/pkg/move/workflow_lifecycle_test.go
+++ b/pkg/move/workflow_lifecycle_test.go
@@ -1,0 +1,468 @@
+package move
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/checkpoint"
+	"github.com/block/spirit/pkg/copier"
+	"github.com/block/spirit/pkg/sentinel"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+type moveLifecycleContextKey struct{}
+
+type recordingMoveWorkflowObserver struct {
+	mu       sync.Mutex
+	events   []status.WorkflowEvent
+	contexts []context.Context
+}
+
+func (o *recordingMoveWorkflowObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.contexts = append(o.contexts, ctx)
+	o.events = append(o.events, event)
+}
+
+func (o *recordingMoveWorkflowObserver) snapshot() ([]status.WorkflowEvent, []context.Context) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]status.WorkflowEvent(nil), o.events...), append([]context.Context(nil), o.contexts...)
+}
+
+type aggregateMoveCopier struct {
+	copier.Copier
+	runErr               error
+	rows, chunks         uint64
+	panicOnCompletedWork bool
+}
+
+func (c *aggregateMoveCopier) Run(context.Context) error { return c.runErr }
+func (c *aggregateMoveCopier) GetChunker() table.Chunker { return nil }
+func (c *aggregateMoveCopier) CompletedWork() (uint64, uint64) {
+	if c.panicOnCompletedWork {
+		panic("CompletedWork queried without an observer")
+	}
+	return c.rows, c.chunks
+}
+
+type cancelCopyObserver struct {
+	recordingMoveWorkflowObserver
+	cancel context.CancelFunc
+}
+
+func (o *cancelCopyObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.recordingMoveWorkflowObserver.ObserveWorkflow(ctx, event)
+	if event.State == status.CopyRows && event.Transition == status.WorkflowTransitionStarted {
+		o.cancel()
+	}
+}
+
+type panicMoveWorkflowObserver struct{}
+
+func (panicMoveWorkflowObserver) ObserveWorkflow(context.Context, status.WorkflowEvent) {
+	panic("observer panic")
+}
+
+type moveWorkflowObserverFunc func(context.Context, status.WorkflowEvent)
+
+func (f moveWorkflowObserverFunc) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	f(ctx, event)
+}
+
+func lifecycleMoveRunner(t *testing.T, prefix string, withTable bool) *Runner {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	sourceName := prefix + "_src"
+	targetName := prefix + "_dst"
+	testutils.RunSQL(t, fmt.Sprintf("DROP DATABASE IF EXISTS %s", sourceName))
+	testutils.RunSQL(t, fmt.Sprintf("CREATE DATABASE %s", sourceName))
+	testutils.RunSQL(t, fmt.Sprintf("DROP DATABASE IF EXISTS %s", targetName))
+	testutils.RunSQL(t, fmt.Sprintf("CREATE DATABASE %s", targetName))
+	if withTable {
+		testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE %s.t1 (id INT PRIMARY KEY, val VARCHAR(32))", sourceName))
+		testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s.t1 VALUES (1, 'one'), (2, 'two'), (3, 'three')", sourceName))
+	}
+	source := cfg.Clone()
+	source.DBName = sourceName
+	target := cfg.Clone()
+	target.DBName = targetName
+	r, err := NewRunner(&Move{
+		SourceDSN:       source.FormatDSN(),
+		TargetDSN:       target.FormatDSN(),
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         1,
+		WriteThreads:    1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+	return r
+}
+
+func TestMoveLifecycleOrderedStatesTotalsContextAndOptionalStates(t *testing.T) {
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "parent")
+	observer := &recordingMoveWorkflowObserver{}
+	r := lifecycleMoveRunner(t, "lifecycle_order", true)
+	r.SetWorkflowObserver(observer)
+	require.NoError(t, r.Run(parent))
+
+	events, contexts := observer.snapshot()
+	require.Len(t, events, 7)
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.CopyRows, Transition: status.WorkflowTransitionStarted},
+		{
+			State:           status.CopyRows,
+			Transition:      status.WorkflowTransitionFinished,
+			Outcome:         status.WorkflowOutcomeSucceeded,
+			Totals:          status.WorkflowTotals{CompletedRows: 3, CompletedChunks: events[1].Totals.CompletedChunks},
+			TotalsAvailable: true,
+		},
+		{State: status.ApplyChangeset, Transition: status.WorkflowTransitionStarted},
+		{State: status.ApplyChangeset, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeSucceeded},
+		{State: status.Checksum, Transition: status.WorkflowTransitionStarted},
+		{State: status.Checksum, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeSucceeded},
+		{DurableMutation: true},
+	}, events)
+	require.Positive(t, events[1].Totals.CompletedChunks)
+	require.Len(t, contexts, len(events))
+	for _, observedCtx := range contexts {
+		require.Same(t, parent, observedCtx, "events must use the exact Run parent context")
+	}
+	for _, event := range events {
+		require.NotEqual(t, status.WaitingOnSentinelTable, event.State)
+		require.NotEqual(t, status.ReverseWindow, event.State)
+		require.Zero(t, event.TerminalOwnership, "normal forward completion has no terminal evidence")
+	}
+}
+
+func TestMoveLifecycleZeroRowCutoverEmitsDurableMutation(t *testing.T) {
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "zero-row-cutover")
+	observer := &recordingMoveWorkflowObserver{}
+	r := lifecycleMoveRunner(t, "lifecycle_zero_row", true)
+	testutils.RunSQL(t, "DELETE FROM lifecycle_zero_row_src.t1")
+	r.SetWorkflowObserver(observer)
+
+	require.NoError(t, r.Run(parent))
+
+	events, contexts := observer.snapshot()
+	var copyFinished bool
+	var durableMutations int
+	for i, event := range events {
+		if event.State == status.CopyRows && event.Transition == status.WorkflowTransitionFinished {
+			copyFinished = true
+			require.True(t, event.TotalsAvailable)
+			require.Zero(t, event.Totals.CompletedRows)
+		}
+		if event.DurableMutation {
+			durableMutations++
+			require.Same(t, parent, contexts[i])
+		}
+	}
+	require.True(t, copyFinished)
+	require.Equal(t, 1, durableMutations)
+}
+
+func TestMoveLifecycleOptionalSentinelAttempt(t *testing.T) {
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "sentinel")
+	observer := &recordingMoveWorkflowObserver{}
+	r := lifecycleMoveRunner(t, "lifecycle_sentinel", true)
+	r.move.CreateSentinel = true
+	r.SetWorkflowObserver(observer)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- r.Run(parent) }()
+	require.Eventually(t, func() bool {
+		return r.status.Get() == status.WaitingOnSentinelTable
+	}, 30*time.Second, 20*time.Millisecond)
+	testutils.RunSQL(t, "DROP TABLE lifecycle_sentinel_dst."+sentinel.TableName)
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for sentinel lifecycle move")
+	}
+
+	events, contexts := observer.snapshot()
+	var waitEvents []status.WorkflowEvent
+	for i, event := range events {
+		if event.State == status.WaitingOnSentinelTable {
+			waitEvents = append(waitEvents, event)
+			require.Same(t, parent, contexts[i])
+		}
+	}
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.WaitingOnSentinelTable, Transition: status.WorkflowTransitionStarted},
+		{State: status.WaitingOnSentinelTable, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeSucceeded},
+	}, waitEvents)
+}
+
+func TestMoveLifecycleRepeatedAttemptsAndOutcomes(t *testing.T) {
+	observer := &recordingMoveWorkflowObserver{}
+	r := &Runner{copier: &aggregateMoveCopier{rows: 8, chunks: 2}}
+	r.SetWorkflowObserver(observer)
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "repeat")
+
+	require.NoError(t, r.runCopy(parent, parent))
+	require.NoError(t, r.runCopy(parent, parent))
+	events, _ := observer.snapshot()
+	require.Len(t, events, 4)
+	for i, event := range events {
+		require.Equal(t, status.CopyRows, event.State)
+		if i%2 == 0 {
+			require.Equal(t, status.WorkflowTransitionStarted, event.Transition)
+		} else {
+			require.Equal(t, status.WorkflowTransitionFinished, event.Transition)
+			require.Equal(t, status.WorkflowOutcomeSucceeded, event.Outcome)
+			require.Equal(t, status.WorkflowTotals{CompletedRows: 8, CompletedChunks: 2}, event.Totals)
+		}
+	}
+
+	failureObserver := &recordingMoveWorkflowObserver{}
+	failed := &Runner{copier: &aggregateMoveCopier{runErr: errors.New("copy failed")}}
+	failed.SetWorkflowObserver(failureObserver)
+	require.Error(t, failed.runCopy(parent, parent))
+	failureEvents, _ := failureObserver.snapshot()
+	require.Equal(t, status.WorkflowOutcomeFailed, failureEvents[1].Outcome)
+}
+
+func TestMoveLifecycleCopyStartCancellationStopsBeforeCatchUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	observer := &cancelCopyObserver{cancel: cancel}
+	r := &Runner{copier: &aggregateMoveCopier{}}
+	r.SetWorkflowObserver(observer)
+
+	require.ErrorIs(t, r.runCopy(ctx, ctx), context.Canceled)
+	events, contexts := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.CopyRows, Transition: status.WorkflowTransitionStarted},
+		{State: status.CopyRows, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled, TotalsAvailable: true},
+	}, events)
+	require.Len(t, contexts, 2)
+	require.Equal(t, status.CopyRows, r.status.Get())
+}
+
+func TestMoveLifecycleNilObserverSkipsCopyTotals(t *testing.T) {
+	r := &Runner{copier: &aggregateMoveCopier{panicOnCompletedWork: true}}
+	require.NotPanics(t, func() {
+		require.NoError(t, r.runCopy(t.Context(), t.Context()))
+	})
+	require.Equal(t, status.CopyRows, r.status.Get())
+}
+
+func TestMoveLifecycleObserverPanicCannotChangeRunnerBehavior(t *testing.T) {
+	r := &Runner{copier: &aggregateMoveCopier{rows: 1, chunks: 1}}
+	r.SetWorkflowObserver(panicMoveWorkflowObserver{})
+	require.NotPanics(t, func() {
+		require.NoError(t, r.runCopy(t.Context(), t.Context()))
+	})
+}
+
+func TestMoveLifecycleForwardResultAmbiguityAndTerminalOnce(t *testing.T) {
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "forward")
+	observer := &recordingMoveWorkflowObserver{}
+	r := lifecycleMoveRunner(t, "lifecycle_forward_result", false)
+	// Consume the previous evidence slot while observation is disabled. Run must
+	// reset lifecycle evidence before making this run's terminal decision.
+	r.status.Terminal(parent, status.WorkflowTerminalOwnershipAmbiguous)
+	r.SetWorkflowObserver(observer)
+	callbackErr := errors.New("cutover callback failed after mutation")
+	r.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+		return CutoverResult{DurableMutation: true}, callbackErr
+	})
+
+	require.ErrorIs(t, r.Run(parent), callbackErr)
+	events, contexts := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{
+		{DurableMutation: true},
+		{TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous},
+	}, events)
+	require.Len(t, contexts, 2)
+	for _, observedCtx := range contexts {
+		require.Same(t, parent, observedCtx)
+	}
+
+	// Lifecycle owns the exactly-once terminal guard; a second decision is inert.
+	r.status.Terminal(parent, status.WorkflowTerminalOwnershipReverseFinalized)
+	events, _ = observer.snapshot()
+	require.Len(t, events, 2)
+}
+
+func TestMoveLifecycleTerminalPrecedenceAndReverseCleanupFailure(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	for _, tt := range []struct {
+		name           string
+		dropMarker     func(context.Context) error
+		dropCheckpoint func(context.Context) error
+	}{
+		{
+			name:           "revert marker",
+			dropMarker:     func(context.Context) error { return cleanupErr },
+			dropCheckpoint: func(context.Context) error { return nil },
+		},
+		{
+			name:           "checkpoint",
+			dropMarker:     func(context.Context) error { return nil },
+			dropCheckpoint: func(context.Context) error { return cleanupErr },
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Runner{ownershipAmbiguous: true}
+			persisted := false
+			w := &reverseWindow{
+				r: r,
+				persistPhase: func(_ context.Context, phase string) error {
+					require.Equal(t, phaseReverseFinalized, phase)
+					persisted = true
+					return nil
+				},
+				dropMarker: func(ctx context.Context) error {
+					require.True(t, persisted)
+					return tt.dropMarker(ctx)
+				},
+				dropCheckpoint: func(ctx context.Context) error {
+					require.True(t, persisted)
+					return tt.dropCheckpoint(ctx)
+				},
+			}
+			require.ErrorIs(t, w.finalizeReverse(t.Context()), cleanupErr)
+			require.True(t, r.reverseFinalized)
+			require.False(t, r.ownershipAmbiguous)
+			require.Equal(t, status.WorkflowTerminalOwnershipReverseFinalized, r.terminalOwnership())
+
+			// Even stale ambiguous evidence cannot outrank definitive reverse ownership.
+			r.ownershipAmbiguous = true
+			require.Equal(t, status.WorkflowTerminalOwnershipReverseFinalized, r.terminalOwnership())
+		})
+	}
+}
+
+func TestMoveLifecyclePhaseRevertingResumeIsAmbiguous(t *testing.T) {
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "reverting")
+	observer := &recordingMoveWorkflowObserver{}
+	r := lifecycleMoveRunner(t, "lifecycle_reverting", false)
+	r.move.ReverseWindow = time.Minute
+	r.SetWorkflowObserver(observer)
+
+	targetDB, err := sql.Open("mysql", r.move.TargetDSN)
+	require.NoError(t, err)
+	checkpointTable := checkpoint.NewTable(targetDB, checkpointTableName, checkpoint.Transient)
+	require.NoError(t, checkpointTable.Create(parent))
+	require.NoError(t, checkpointTable.Write(parent, checkpoint.Record{Phase: phaseReverting, CutoverAt: time.Now()}))
+	require.NoError(t, targetDB.Close())
+
+	err = r.Run(parent)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "partial rollback")
+	events, contexts := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{{TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous}}, events)
+	require.Len(t, contexts, 1)
+	require.Same(t, parent, contexts[0])
+}
+
+func TestMoveLifecyclePostSwitchCheckpointDoesNotChangeOwnership(t *testing.T) {
+	r := &Runner{}
+	r.recordForwardCutoverFailure(
+		&CutOver{postSwitchDone: true},
+		errors.New("source rename failed and rolled back"),
+	)
+	require.Zero(t, r.terminalOwnership())
+
+	r.recordForwardCutoverFailure(&CutOver{}, errRenameRollbackFailed)
+	require.Equal(t, status.WorkflowTerminalOwnershipAmbiguous, r.terminalOwnership())
+}
+
+func TestMoveLifecyclePhaseReverseFinalizedResumeRetriesCleanup(t *testing.T) {
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "reverse-finalized")
+	observer := &recordingMoveWorkflowObserver{}
+	r := lifecycleMoveRunner(t, "lifecycle_reverse_finalized", false)
+	r.move.ReverseWindow = time.Minute
+	r.SetWorkflowObserver(observer)
+
+	targetDB, err := sql.Open("mysql", r.move.TargetDSN)
+	require.NoError(t, err)
+	checkpointTable := checkpoint.NewTable(targetDB, checkpointTableName, checkpoint.Transient)
+	require.NoError(t, checkpointTable.Create(parent))
+	require.NoError(t, checkpointTable.Write(parent, checkpoint.Record{
+		Phase:     phaseReverseFinalized,
+		CutoverAt: time.Now(),
+	}))
+	require.NoError(t, targetDB.Close())
+
+	require.NoError(t, r.Run(parent))
+	events, contexts := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{{
+		TerminalOwnership: status.WorkflowTerminalOwnershipReverseFinalized,
+	}}, events)
+	require.Len(t, contexts, 1)
+	require.Same(t, parent, contexts[0])
+}
+
+func TestFinishReverseWindowAttemptReportsFailureAndRepanics(t *testing.T) {
+	parent := context.WithValue(t.Context(), moveLifecycleContextKey{}, "panic")
+	observer := &recordingMoveWorkflowObserver{}
+	var lifecycle status.Lifecycle
+	lifecycle.SetObserver(observer)
+	attempt := lifecycle.Start(parent, status.ReverseWindow)
+	var runErr error
+	panicValue := &struct{ message string }{message: "callback panic"}
+	runCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	completedNormally := false
+	require.PanicsWithValue(t, panicValue, func() {
+		func() {
+			defer finishReverseWindowAttempt(&attempt, runCtx, &runErr, &completedNormally)
+			panic(panicValue)
+		}()
+	})
+
+	events, contexts := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.ReverseWindow, Transition: status.WorkflowTransitionStarted},
+		{
+			State:      status.ReverseWindow,
+			Transition: status.WorkflowTransitionFinished,
+			Outcome:    status.WorkflowOutcomeFailed,
+		},
+	}, events)
+	require.Len(t, contexts, 2)
+	require.Same(t, parent, contexts[0])
+	require.Same(t, parent, contexts[1])
+}
+
+func TestFinishReverseWindowAttemptPreservesNilPanic(t *testing.T) {
+	const childEnv = "SPIRIT_TEST_REVERSE_WINDOW_PANIC_NIL"
+	if os.Getenv(childEnv) == "1" {
+		var lifecycle status.Lifecycle
+		lifecycle.SetObserver(moveWorkflowObserverFunc(func(_ context.Context, event status.WorkflowEvent) {
+			if event.Transition == status.WorkflowTransitionFinished &&
+				event.Outcome == status.WorkflowOutcomeFailed {
+				fmt.Println("reverse-window-failed")
+			}
+		}))
+		attempt := lifecycle.Start(context.Background(), status.ReverseWindow)
+		var runErr error
+		completedNormally := false
+		defer finishReverseWindowAttempt(&attempt, context.Background(), &runErr, &completedNormally)
+		panic(nil)
+	}
+
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestFinishReverseWindowAttemptPreservesNilPanic$")
+	cmd.Env = append(os.Environ(), "GODEBUG=panicnil=1", childEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "an unhandled legacy panic(nil) must still terminate the child")
+	require.Contains(t, string(output), "reverse-window-failed")
+}


### PR DESCRIPTION
## Summary

- Replace the parallel migration and move observers with one `status.Lifecycle` owner.
- Emit typed start, finish, outcome, completed-work, durable-mutation, and terminal-ownership evidence.
- Emit move durable-mutation evidence immediately after successful physical cutover and before fallible checkpoint cleanup; result-bearing empty-database callbacks emit the same evidence when reported.
- Abort outer cutover retries when a source rename rollback fails so the authoritative partial-rename sentinel reaches lifecycle ownership classification.
- Make reverse-cutover ownership durable across restart boundaries.
- Emit failed ReverseWindow completion and re-panic unchanged when a callback panics, including legacy `panic(nil)` under `GODEBUG=panicnil=1`.
- Keep delivery synchronous, exact-parent-context, panic-isolated, and disabled at zero cost without an observer.

## Verification

- `MYSQL_DSN=tsandbox:msandbox@tcp(127.0.0.1:8033)/test go test -race -count=1 ./pkg/status ./pkg/migration ./pkg/move`
- `go test -race -count=1 ./pkg/move`
- `go build ./...`
- `make lint`
- independent migration, move, and final dependency reviews; all findings resolved

## Review order

This PR is part of the dependency-ordered replacement for #1111:

1. #1112 — committed retry row accounting
2. #1113 — copier completed-work totals
3. #1114 — result-bearing cutover callbacks
4. #1115 — status-owned lifecycle API
5. #1116 — migration and move lifecycle adoption

Review and merge in order; each PR after #1112 is based on its predecessor. The stack supersedes #1111.