### PR TITLE
dbconn: keep idle TrxPool transactions alive past wait_timeout

### DIFF
--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -555,7 +555,7 @@ func (c *DistributedChecker) initConnPool(ctx context.Context) error {
 		// cost a connection each and no extra history retention, since every
 		// read view here pins from the same instant. See the SingleChecker
 		// equivalent for the full rationale.
-		pool, err := dbconn.NewTrxPool(ctx, srcDB, c.maxConcurrency, c.dbConfig)
+		pool, err := dbconn.NewTrxPool(ctx, srcDB, c.maxConcurrency, c.dbConfig, c.logger)
 		if err != nil {
 			// Clean up pools already created
 			for _, sp := range c.sourcePools {
@@ -573,7 +573,7 @@ func (c *DistributedChecker) initConnPool(ctx context.Context) error {
 	// with REPEATABLE-READ and a consistent snapshot
 	c.targetTrxPools = make([]*dbconn.TrxPool, len(targets))
 	for i, target := range targets {
-		targetTrxPool, err := dbconn.NewTrxPool(ctx, target.DB, c.maxConcurrency, c.dbConfig)
+		targetTrxPool, err := dbconn.NewTrxPool(ctx, target.DB, c.maxConcurrency, c.dbConfig, c.logger)
 		if err != nil {
 			// Clean up any pools we've already created
 			for _, sp := range c.sourcePools {

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -465,7 +465,7 @@ func (c *SingleChecker) initConnPool(ctx context.Context) error {
 	// connection per idle transaction and nothing else: all of these read views
 	// pin history from the same instant, so the history list length floor is
 	// identical whether the autoscaler ends up using four of them or sixteen.
-	c.trxPool, err = dbconn.NewTrxPool(ctx, c.db, c.maxConcurrency, c.dbConfig)
+	c.trxPool, err = dbconn.NewTrxPool(ctx, c.db, c.maxConcurrency, c.dbConfig, c.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -31,6 +31,13 @@ const (
 	// inside real server error packets.
 	errCannotConnect = 2003
 	errConnLost      = 2013
+	// errClientInteractionTimeout (4031, ER_CLIENT_INTERACTION_TIMEOUT) is
+	// written by MySQL >= 8.0.24 as a final packet when the server
+	// disconnects an idle connection (wait_timeout); the client reads it on
+	// the connection's next use. Aurora does not always deliver it — a
+	// wait_timeout kill can also surface as a bare driver.ErrBadConn — so
+	// both shapes must classify the same way.
+	errClientInteractionTimeout = 4031
 	// errReadOnly (1290), errReadOnlyTransaction (1792) and errReadOnlyMode
 	// (1836) are usually consumed by go-sql-driver when RejectReadOnly is
 	// enabled (the spirit default) and converted to driver.ErrBadConn. They
@@ -101,7 +108,11 @@ func NewDBConfig() *DBConfig {
 // where the server has positively reported that the statement did NOT take
 // effect, these errors are ambiguous. Callers retrying a non-idempotent
 // statement (e.g. the cutover RENAME TABLE) must verify server-side state
-// before deciding whether the statement was applied.
+// before deciding whether the statement was applied. The exception is
+// ER_CLIENT_INTERACTION_TIMEOUT (4031): the server killed the session for
+// inactivity *before* the observing statement arrived, so that statement
+// positively did not execute — verification is still safe, just guaranteed
+// to conclude "not applied".
 func IsConnectionLossError(err error) bool {
 	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) || errors.Is(err, io.EOF) {
 		return true
@@ -111,7 +122,7 @@ func IsConnectionLossError(err error) bool {
 		return false
 	}
 	switch val.Number {
-	case errCannotConnect, errConnLost:
+	case errCannotConnect, errConnLost, errClientInteractionTimeout:
 		return true
 	default:
 		return false

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -185,6 +185,7 @@ func TestIsConnectionLossError(t *testing.T) {
 	require.True(t, IsConnectionLossError(io.EOF))
 	require.True(t, IsConnectionLossError(&mysql.MySQLError{Number: 2003})) // CR_CONN_HOST_ERROR relayed by a proxy
 	require.True(t, IsConnectionLossError(&mysql.MySQLError{Number: 2013})) // CR_SERVER_LOST relayed by a proxy
+	require.True(t, IsConnectionLossError(&mysql.MySQLError{Number: 4031})) // ER_CLIENT_INTERACTION_TIMEOUT: killed by wait_timeout
 
 	// Wrapped variants must also be detected.
 	require.True(t, IsConnectionLossError(fmt.Errorf("rename failed: %w", driver.ErrBadConn)))

--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -19,10 +19,12 @@ const (
 	// keepaliveMaxInterval is the longest the keepalive will go between
 	// pinging the idle transactions in the pool.
 	keepaliveMaxInterval = 5 * time.Minute
-	// keepaliveMinInterval floors the ping interval so a pathological
-	// wait_timeout can't make the keepalive spin (or panic the ticker on a
-	// non-positive interval).
-	keepaliveMinInterval = time.Second
+	// keepaliveMinInterval floors the ping interval so a nonsense
+	// wait_timeout read (zero or negative) can't panic the ticker. MySQL's
+	// minimum wait_timeout is 1s, so the smallest legitimate cadence is
+	// 500ms; the floor sits exactly there to keep every real cadence
+	// strictly below its wait_timeout.
+	keepaliveMinInterval = 500 * time.Millisecond
 	// keepaliveRoundTimeout bounds one round of pings so a hung server can't
 	// hold the pool mutex (blocking Get/Put) indefinitely.
 	keepaliveRoundTimeout = 30 * time.Second

--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"sync"
+	"time"
 )
 
 // Maybe there is a better way to do this. For the CHECKSUM algorithm we need
@@ -13,16 +15,48 @@ import (
 // them in newTrxPool() under a mutex, and then have a simple Get() and Put()
 // which is used by worker threads.
 
+const (
+	// keepaliveMaxInterval is the longest the keepalive will go between
+	// pinging the idle transactions in the pool.
+	keepaliveMaxInterval = 5 * time.Minute
+	// keepaliveMinInterval floors the ping interval so a pathological
+	// wait_timeout can't make the keepalive spin (or panic the ticker on a
+	// non-positive interval).
+	keepaliveMinInterval = time.Second
+	// keepaliveRoundTimeout bounds one round of pings so a hung server can't
+	// hold the pool mutex (blocking Get/Put) indefinitely.
+	keepaliveRoundTimeout = 30 * time.Second
+)
+
 type TrxPool struct {
 	sync.Mutex
 
-	trxs []*sql.Tx
+	trxs   []*sql.Tx
+	logger *slog.Logger
+	// keepalive lifecycle: cancel stops the pinger, done is closed once it
+	// has fully exited. Both are nil if pool creation failed before the
+	// keepalive started (Close tolerates that).
+	keepaliveCancel context.CancelFunc
+	keepaliveDone   chan struct{}
 }
 
 // NewTrxPool creates a pool of transactions which have already
 // had their read-view created in REPEATABLE READ isolation.
-func NewTrxPool(ctx context.Context, db *sql.DB, count int, config *DBConfig) (*TrxPool, error) {
-	pool := &TrxPool{trxs: make([]*sql.Tx, 0, count)}
+//
+// The pool is sized for the maximum concurrency the caller may ever scale up
+// to, so some transactions can sit unused for hours. An idle transaction
+// still counts against the server's wait_timeout, and managed configurations
+// often set it low (e.g. 600s on Aurora): without intervention the server
+// silently kills the connection and a later Get() hands out a dead
+// transaction that fails with "driver: bad connection". To prevent that,
+// the pool runs a background keepalive that periodically pings whatever
+// transactions are idle in the pool; it stops when ctx is canceled or the
+// pool is closed. A nil logger discards keepalive warnings.
+func NewTrxPool(ctx context.Context, db *sql.DB, count int, config *DBConfig, logger *slog.Logger) (*TrxPool, error) {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	pool := &TrxPool{trxs: make([]*sql.Tx, 0, count), logger: logger}
 	for range count {
 		trx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 		if err != nil {
@@ -33,7 +67,70 @@ func NewTrxPool(ctx context.Context, db *sql.DB, count int, config *DBConfig) (*
 			return nil, errors.Join(err, pool.Close())
 		}
 	}
+	if len(pool.trxs) > 0 {
+		// Derive the ping cadence from the session wait_timeout so the
+		// keepalive holds up however aggressively the server is configured.
+		// Every connection comes from the same DSN, so sampling one is enough.
+		var waitTimeout int
+		if err := pool.trxs[0].QueryRowContext(ctx, "SELECT @@wait_timeout").Scan(&waitTimeout); err != nil {
+			return nil, errors.Join(err, pool.Close())
+		}
+		keepaliveCtx, cancel := context.WithCancel(ctx)
+		pool.keepaliveCancel = cancel
+		pool.keepaliveDone = make(chan struct{})
+		go pool.keepalive(keepaliveCtx, keepaliveInterval(waitTimeout))
+	}
 	return pool, nil
+}
+
+// keepaliveInterval returns how often to ping the idle transactions in the
+// pool, given the session wait_timeout in seconds. Half the timeout leaves a
+// comfortable margin for scheduling delays, capped at keepaliveMaxInterval so
+// pings stay frequent even when wait_timeout is generous (an intermediate
+// proxy may have a stricter idle policy than the server reports).
+func keepaliveInterval(waitTimeoutSecs int) time.Duration {
+	interval := time.Duration(waitTimeoutSecs) * time.Second / 2
+	return min(max(interval, keepaliveMinInterval), keepaliveMaxInterval)
+}
+
+// keepalive periodically pings the transactions sitting idle in the pool so
+// the server never sees their connections reach wait_timeout. Transactions
+// currently checked out via Get() belong to an active worker and are
+// naturally excluded.
+func (p *TrxPool) keepalive(ctx context.Context, interval time.Duration) {
+	defer close(p.keepaliveDone)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.pingIdleTrxs(ctx)
+		}
+	}
+}
+
+func (p *TrxPool) pingIdleTrxs(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, keepaliveRoundTimeout)
+	defer cancel()
+	// Holding the mutex for the whole round guarantees a transaction can't be
+	// handed out while a ping is in flight on it. The round is quick: one
+	// trivial query per idle transaction.
+	p.Lock()
+	defer p.Unlock()
+	for _, trx := range p.trxs {
+		if _, err := trx.ExecContext(ctx, "SELECT 1"); err != nil {
+			if ctx.Err() != nil {
+				return // pool is shutting down, or the round timed out
+			}
+			// Keep going: the other transactions may still be healthy, and
+			// the worst case for this one is unchanged (a worker gets it and
+			// fails, exactly as it would have without the keepalive).
+			p.logger.Warn("keepalive ping of idle checksum transaction failed; its connection may have been killed (check wait_timeout)",
+				"error", err)
+		}
+	}
 }
 
 // Get gets a transaction from the pool.
@@ -57,6 +154,13 @@ func (p *TrxPool) Put(trx *sql.Tx) {
 
 // Close closes all transactions in the pool.
 func (p *TrxPool) Close() error {
+	// Stop the keepalive and wait for it to exit, so a ping can't race with
+	// the rollbacks below. The fields are nil when pool creation failed
+	// before the keepalive started.
+	if p.keepaliveCancel != nil {
+		p.keepaliveCancel()
+		<-p.keepaliveDone
+	}
 	var firstErr error
 	for _, trx := range p.trxs {
 		if err := trx.Rollback(); err != nil {
@@ -64,6 +168,16 @@ func (p *TrxPool) Close() error {
 			// (e.g. due to context cancellation). This is not a real error —
 			// skip it and continue closing the remaining transactions.
 			if errors.Is(err, sql.ErrTxDone) {
+				continue
+			}
+			// A rollback over a lost connection is not a real error either:
+			// when the server kills a connection (e.g. wait_timeout) it rolls
+			// the transaction back and releases its locks itself, so there is
+			// nothing left to clean up. Surfacing it would fail an
+			// otherwise-successful caller — the checksum treats Close errors
+			// as a failed pass.
+			if IsConnectionLossError(err) {
+				p.logger.Warn("pooled transaction's connection was already gone at rollback", "error", err)
 				continue
 			}
 			if firstErr == nil {

--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -114,17 +114,31 @@ func (p *TrxPool) keepalive(ctx context.Context, interval time.Duration) {
 }
 
 func (p *TrxPool) pingIdleTrxs(ctx context.Context) {
-	ctx, cancel := context.WithTimeout(ctx, keepaliveRoundTimeout)
+	roundCtx, cancel := context.WithTimeout(ctx, keepaliveRoundTimeout)
 	defer cancel()
 	// Holding the mutex for the whole round guarantees a transaction can't be
 	// handed out while a ping is in flight on it. The round is quick: one
 	// trivial query per idle transaction.
 	p.Lock()
 	defer p.Unlock()
-	for _, trx := range p.trxs {
-		if _, err := trx.ExecContext(ctx, "SELECT 1"); err != nil {
+	for i, trx := range p.trxs {
+		if _, err := trx.ExecContext(roundCtx, "SELECT 1"); err != nil {
 			if ctx.Err() != nil {
-				return // pool is shutting down, or the round timed out
+				return // pool is shutting down; errors here are expected noise
+			}
+			if roundCtx.Err() != nil {
+				// A trivial query blew the whole round budget: the server or
+				// network is severely degraded. This is also lossy — the
+				// driver closes the connection whose ping was cancelled
+				// mid-flight, and the transactions the round never reached
+				// stay exposed to wait_timeout — so this line is the
+				// explanation for any cluster of dead transactions that
+				// follows.
+				p.logger.Warn("keepalive round timed out; the server appears degraded and idle checksum transactions may be lost",
+					"roundTimeout", keepaliveRoundTimeout,
+					"pinged", i,
+					"idle", len(p.trxs))
+				return
 			}
 			// Keep going: the other transactions may still be healthy, and
 			// the worst case for this one is unchanged (a worker gets it and

--- a/pkg/dbconn/trxpool_test.go
+++ b/pkg/dbconn/trxpool_test.go
@@ -3,11 +3,13 @@ package dbconn
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +37,7 @@ func TestTrxPool(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that the transaction pool is working.
-	pool, err := NewTrxPool(t.Context(), db, 2, config)
+	pool, err := NewTrxPool(t.Context(), db, 2, config, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
 
 	// The pool is all repeatable-read transactions, so if I insert new rows
@@ -79,7 +81,7 @@ func TestTrxPoolBeginError(t *testing.T) {
 	require.NoError(t, db.Close()) // BeginTx now fails with "sql: database is closed"
 
 	config := NewDBConfig()
-	pool, err := NewTrxPool(t.Context(), db, 2, config)
+	pool, err := NewTrxPool(t.Context(), db, 2, config, nil) // nil logger must be tolerated
 	require.Error(t, err)
 	require.ErrorContains(t, err, "database is closed")
 	require.Nil(t, pool)
@@ -102,7 +104,7 @@ func TestTrxPoolBeginErrorMidLoop(t *testing.T) {
 	db.SetMaxOpenConns(2)
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
-	pool, err := NewTrxPool(ctx, db, 3, config)
+	pool, err := NewTrxPool(ctx, db, 3, config, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Nil(t, pool)
@@ -113,4 +115,100 @@ func TestTrxPoolBeginErrorMidLoop(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return db.Stats().InUse == 0
 	}, 5*time.Second, 50*time.Millisecond, "transactions leaked: %d connections still in use", db.Stats().InUse)
+}
+
+func TestTrxPoolKeepaliveInterval(t *testing.T) {
+	require.Equal(t, 5*time.Minute, keepaliveInterval(600))   // Aurora-style wait_timeout: half is exactly the cap
+	require.Equal(t, 5*time.Minute, keepaliveInterval(28800)) // MySQL default: capped
+	require.Equal(t, 30*time.Second, keepaliveInterval(60))
+	require.Equal(t, time.Second, keepaliveInterval(1)) // floored: a zero interval would panic the ticker
+	require.Equal(t, time.Second, keepaliveInterval(0)) // defensive
+}
+
+// TestTrxPoolKeepalive simulates the checksum-autoscaling failure mode: the
+// pool is sized for maxConcurrency, so transactions the autoscaler hasn't
+// grown into yet sit completely idle while the server's wait_timeout counts
+// down. The keepalive must ping them often enough that they survive. A
+// control transaction with the same session settings but no keepalive proves
+// the wait_timeout in this test really does kill idle connections.
+func TestTrxPoolKeepalive(t *testing.T) {
+	t.Parallel() // most of this test is sleeping; overlap it with the suite
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	if cfg.Params == nil {
+		cfg.Params = map[string]string{}
+	}
+	// The server kills connections idle for >6s. The pool reads this back
+	// via @@wait_timeout and pings its idle transactions every 3s.
+	cfg.Params["wait_timeout"] = "6"
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	control, err := db.BeginTx(t.Context(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+	require.NoError(t, err)
+	var one int
+	require.NoError(t, control.QueryRowContext(t.Context(), "SELECT 1").Scan(&one))
+
+	pool, err := NewTrxPool(t.Context(), db, 2, NewDBConfig(), slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	// Sleep past wait_timeout. The pinger keeps the pooled transactions'
+	// connections active; nothing touches the control transaction.
+	time.Sleep(9 * time.Second)
+
+	err = control.QueryRowContext(t.Context(), "SELECT 1").Scan(&one)
+	require.Error(t, err, "control transaction survived wait_timeout; the test can't prove anything")
+	require.True(t, IsConnectionLossError(err), "expected a connection-loss error, got: %v", err)
+	_ = control.Rollback() // release the dead connection; the error is expected
+
+	// Every pooled transaction is still usable.
+	trxs := make([]*sql.Tx, 0, 2)
+	for range 2 {
+		trx, err := pool.Get()
+		require.NoError(t, err)
+		require.NoError(t, trx.QueryRowContext(t.Context(), "SELECT 1").Scan(&one))
+		trxs = append(trxs, trx)
+	}
+	for _, trx := range trxs {
+		pool.Put(trx)
+	}
+	require.NoError(t, pool.Close())
+	require.NoError(t, pool.Close()) // Close is idempotent
+}
+
+// TestTrxPoolCloseAfterConnectionLoss verifies that Close does not report an
+// error when a pooled transaction's connection was already killed server-side
+// (e.g. wait_timeout): the server has rolled the transaction back itself, so
+// there is nothing left to clean up, and surfacing the dead connection would
+// fail an otherwise-successful checksum at its final Close.
+func TestTrxPoolCloseAfterConnectionLoss(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	if cfg.Params == nil {
+		cfg.Params = map[string]string{}
+	}
+	cfg.Params["wait_timeout"] = "6"
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	pool, err := NewTrxPool(t.Context(), db, 2, NewDBConfig(), slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	// Check a transaction out for the whole wait: it is not in the pool, so
+	// the keepalive skips it and the server kills its connection. Nothing
+	// touches it before Close, so the ROLLBACK is the first statement on the
+	// dead connection — on MySQL >= 8.0.24 that reads the server's parting
+	// ER_CLIENT_INTERACTION_TIMEOUT (4031) packet rather than a bare
+	// driver.ErrBadConn, and Close must tolerate both shapes.
+	trx, err := pool.Get()
+	require.NoError(t, err)
+	time.Sleep(9 * time.Second)
+
+	pool.Put(trx)
+	require.NoError(t, pool.Close())
 }

--- a/pkg/dbconn/trxpool_test.go
+++ b/pkg/dbconn/trxpool_test.go
@@ -121,8 +121,8 @@ func TestTrxPoolKeepaliveInterval(t *testing.T) {
 	require.Equal(t, 5*time.Minute, keepaliveInterval(600))   // Aurora-style wait_timeout: half is exactly the cap
 	require.Equal(t, 5*time.Minute, keepaliveInterval(28800)) // MySQL default: capped
 	require.Equal(t, 30*time.Second, keepaliveInterval(60))
-	require.Equal(t, time.Second, keepaliveInterval(1)) // floored: a zero interval would panic the ticker
-	require.Equal(t, time.Second, keepaliveInterval(0)) // defensive
+	require.Equal(t, 500*time.Millisecond, keepaliveInterval(1)) // smallest valid wait_timeout: cadence stays strictly below it
+	require.Equal(t, 500*time.Millisecond, keepaliveInterval(0)) // defensive floor: a non-positive interval would panic the ticker
 }
 
 // TestTrxPoolKeepalive simulates the checksum-autoscaling failure mode: the


### PR DESCRIPTION
## Problem

The checksum pre-creates `maxConcurrency` REPEATABLE READ snapshot transactions (they must all take their read view under the table lock, so the pool cannot be grown later). Since checksum autoscaling landed, the autoscaler may not grow into some of those transactions for hours — and an idle transaction still counts against the server's `wait_timeout`. In managed configurations that set it low (600s on our Aurora fleet), the server silently kills the unused connections, and a later scale-up fails the checksum:

```
2026/08/06 16:57:14 ERROR checksum encountered an error error=driver: bad connection
```

Worse, the dead connection failed the checksum even if no worker ever used it: `runChecksum` treats a `trxPool.Close()` error as a failed pass, and rolling back a killed transaction errors.

## Fix

- **`TrxPool` now runs a background keepalive** that pings whatever transactions are sitting idle in the pool. Checked-out transactions belong to an active worker and are naturally excluded. Pings run under the pool mutex, so a transaction can never be handed out with a ping in flight. `SELECT 1` does not disturb the repeatable-read view (fixed at `START TRANSACTION WITH CONSISTENT SNAPSHOT`); it only resets the server's idle timer.
- **The cadence self-tunes**: `@@wait_timeout / 2`, capped at 5 minutes (floored at 1s). With `wait_timeout=600` that's a ping every 5 minutes; tighter timeouts are handled automatically with no new config knob.
- **`Close()` tolerates connection-loss errors on rollback**: when the server kills a connection it rolls the transaction back and releases its locks itself, so there is nothing left to clean up — surfacing it would fail an otherwise-successful checksum. The keepalive goroutine is stopped and joined before rollbacks begin (the `dbconn` package is goleak-enforced).
- **Error 4031 (`ER_CLIENT_INTERACTION_TIMEOUT`) is now classified by `IsConnectionLossError`**. MySQL >= 8.0.24 reports a `wait_timeout` kill as a final 4031 error packet read on the connection's next use; Aurora can also deliver the bare `driver.ErrBadConn` shape, so both must classify the same way. 4031 is the one non-ambiguous loss error — the statement that observes it positively did not execute — which also mildly benefits the cutover verify path.

If a ping does fail (DBA kill, failover), a warning is logged at that moment instead of an opaque `bad connection` minutes later. The failure mode is otherwise unchanged: the snapshot cannot be recreated without breaking read-view consistency, so the checksum retries as before.

## Testing

- `TestTrxPoolKeepalive`: real-MySQL test with `wait_timeout=6`. A control transaction with the same session settings but no keepalive is provably killed by the server, while both pooled transactions survive the wait and stay usable.
- `TestTrxPoolCloseAfterConnectionLoss`: a transaction checked out (so the keepalive skips it) dies to `wait_timeout`; `Close()` succeeds with the rollback as the first statement on the dead connection (the 4031 path).
- `TestTrxPoolKeepaliveInterval`: interval derivation (cap, floor, Aurora/MySQL defaults).
- `pkg/dbconn` and `pkg/checksum` pass with `-race`; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)