### PR TITLE
feat(status): own per-state timing via a bracketed Do() API

### DIFF
--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -76,8 +76,7 @@ type Runner struct {
 	// checkpointed position.
 	resuming bool
 
-	status    status.State
-	startTime time.Time
+	status status.Tracker
 
 	logger     *slog.Logger
 	cancelFunc context.CancelFunc
@@ -103,7 +102,7 @@ type Runner struct {
 	fatalOnce sync.Once
 
 	// progMu guards the progress-related fields (copier, copyChunker,
-	// replClient, startTime, cancelFunc) that Run assigns during setup and
+	// replClient, cancelFunc) that Run assigns during setup and
 	// that the status.Task accessors (Progress/Status/DumpCheckpoint/Cancel)
 	// read concurrently from a separate monitoring goroutine.
 	progMu sync.RWMutex
@@ -178,8 +177,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	defer cancel()
 	r.progMu.Lock()
 	r.cancelFunc = cancel
-	r.startTime = time.Now()
 	r.progMu.Unlock()
+	r.status.Begin()
 	r.logger.Info("Starting sync", "source_dsn", dbconn.RedactDSN(r.sync.SourceDSN))
 
 	r.sourceDBConfig = dbconn.NewDBConfig()
@@ -291,22 +290,26 @@ func (r *Runner) Run(ctx context.Context) error {
 			return err
 		}
 	}
-	r.status.Set(status.CopyRows)
-	r.logger.Info("Starting copy", "resuming", r.resuming)
-	if err := r.copier.Run(ctx); err != nil {
-		return fmt.Errorf("copy failed: %w", err)
-	}
-	if !r.sync.CopyOnly {
-		if !r.resuming {
-			if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
-				return err
+	if err := r.status.Do(status.CopyRows, func() error {
+		r.logger.Info("Starting copy", "resuming", r.resuming)
+		if err := r.copier.Run(ctx); err != nil {
+			return fmt.Errorf("copy failed: %w", err)
+		}
+		if !r.sync.CopyOnly {
+			if !r.resuming {
+				if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+					return err
+				}
+			}
+			// Drain the copy-phase backlog so every change observed so far is
+			// applied before steady-state streaming.
+			if err := r.replClient.Flush(ctx); err != nil {
+				return fmt.Errorf("failed to flush after copy: %w", err)
 			}
 		}
-		// Drain the copy-phase backlog so every change observed so far is
-		// applied before steady-state streaming.
-		if err := r.replClient.Flush(ctx); err != nil {
-			return fmt.Errorf("failed to flush after copy: %w", err)
-		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// The initial copy is done. Restore any secondary indexes deferred during
@@ -314,8 +317,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	// the post-copy checksum walks it (copy-only). Always called — it is a
 	// no-op when nothing was deferred and resume-safe; see
 	// restoreSecondaryIndexes.
-	r.status.Set(status.RestoreSecondaryIndexes)
-	if err := r.restoreSecondaryIndexes(ctx); err != nil {
+	if err := r.status.Do(status.RestoreSecondaryIndexes, func() error {
+		return r.restoreSecondaryIndexes(ctx)
+	}); err != nil {
 		return fmt.Errorf("failed to restore secondary indexes: %w", err)
 	}
 
@@ -331,11 +335,15 @@ func (r *Runner) Run(ctx context.Context) error {
 			r.logger.Warn("post-copy checkpoint write failed", "error", err)
 		}
 		r.logger.Info("Copy complete; entering continuous checksum (CopyOnly mode)")
-		return r.runCopyOnlyChecksum(ctx)
+		return r.status.Do(status.ApplyChangeset, func() error {
+			return r.runCopyOnlyChecksum(ctx)
+		})
 	}
 
 	r.logger.Info("Copy complete; entering continuous sync")
-	return r.runContinuous(ctx)
+	return r.status.Do(status.ApplyChangeset, func() error {
+		return r.runContinuous(ctx)
+	})
 }
 
 // runCopyOnlyChecksum runs the post-copy continuous checksum without a
@@ -346,10 +354,9 @@ func (r *Runner) Run(ctx context.Context) error {
 // final checkpoint.
 //
 // This is structurally a stripped-down runContinuous: same checker
-// lifecycle and shutdown contract, no replClient calls.
+// lifecycle and shutdown contract, no replClient calls. The caller brackets
+// it in the ApplyChangeset state.
 func (r *Runner) runCopyOnlyChecksum(ctx context.Context) error {
-	r.status.Set(status.ApplyChangeset)
-
 	checksumCtx, cancelChecksum := context.WithCancel(ctx)
 	defer cancelChecksum()
 	checksumDone := make(chan struct{})
@@ -390,7 +397,7 @@ func (r *Runner) runCopyOnlyChecksum(ctx context.Context) error {
 	if err := r.dumpCheckpoint(cpCtx); err != nil {
 		r.logger.Warn("Final checkpoint write failed", "error", err)
 	}
-	r.logger.Info("Copy-only sync stopped", "total_time", time.Since(r.startTime).Round(time.Second).String())
+	r.logger.Info("Copy-only sync stopped", "total_time", r.status.TotalElapsed().Round(time.Second).String())
 
 	// A recorded fatal (e.g. a checkpoint-write failure that status.WatchTask
 	// cancelled us for) must surface rather than be masked by the clean
@@ -414,13 +421,12 @@ func (r *Runner) runCopyOnlyChecksum(ctx context.Context) error {
 // backlog and returns nil; on a fatal source event or a checksum failure
 // it returns that error.
 func (r *Runner) runContinuous(ctx context.Context) error {
-	// status moves off CopyRows so the status goroutine logs the continuous
-	// phase. The checkpoint table and the periodic checkpoint loop were already
-	// set up before the copy (checkpointTbl().Create in startFresh/startResume,
-	// the loop in startBackgroundRoutines), so a restart at any point — copy or
+	// The caller brackets this in ApplyChangeset (off CopyRows) so the status
+	// goroutine logs the continuous phase. The checkpoint table and the
+	// periodic checkpoint loop were already set up before the copy
+	// (checkpointTbl().Create in startFresh/startResume, the loop in
+	// startBackgroundRoutines), so a restart at any point — copy or
 	// continuous — resumes from the last checkpoint.
-	r.status.Set(status.ApplyChangeset)
-
 	r.logger.Info("Continuous sync running; will run until cancelled")
 
 	// Spawn the continuous checksum. It uses a separate chunker so
@@ -493,7 +499,7 @@ func (r *Runner) runContinuous(ctx context.Context) error {
 	if err := r.dumpCheckpoint(cpCtx); err != nil {
 		r.logger.Warn("Final checkpoint write failed", "error", err)
 	}
-	r.logger.Info("Sync stopped", "total_time", time.Since(r.startTime).Round(time.Second).String())
+	r.logger.Info("Sync stopped", "total_time", r.status.TotalElapsed().Round(time.Second).String())
 	// A real checksum failure outranks a clean nil — surface it so the
 	// caller (and exit code) reflect the underlying problem rather than
 	// just "ctx cancelled."
@@ -1456,10 +1462,9 @@ func (r *Runner) Status() string {
 	r.progMu.RLock()
 	cp := r.copier
 	repl := r.replClient
-	start := r.startTime
 	r.progMu.RUnlock()
 
-	elapsed := time.Since(start).Round(time.Second)
+	elapsed := r.status.TotalElapsed().Round(time.Second)
 	switch state { //nolint:exhaustive // sync only uses Initial/CopyRows/ApplyChangeset
 	case status.CopyRows:
 		progress, eta := "", ""

--- a/pkg/migration/binlog_test.go
+++ b/pkg/migration/binlog_test.go
@@ -130,7 +130,7 @@ func TestE2EBinlogSubscribingCompositeKey(t *testing.T) {
 
 	// Usually we would call m.Run() but we want to step through
 	// the migration process manually.
-	m.startTime = time.Now()
+	m.status.Begin()
 	m.dbConfig = dbconn.NewDBConfig()
 	var err error
 	m.db, err = dbconn.New(testutils.DSN(), m.dbConfig)
@@ -243,7 +243,7 @@ func TestE2EBinlogSubscribingCompositeKeyVarchar(t *testing.T) {
 	}()
 
 	// Setup but don't call Run() - step through manually
-	m.startTime = time.Now()
+	m.status.Begin()
 	m.dbConfig = dbconn.NewDBConfig()
 	var err error
 	m.db, err = dbconn.New(testutils.DSN(), m.dbConfig)
@@ -348,7 +348,7 @@ func TestE2EBinlogSubscribingCompositeKeyCollation(t *testing.T) {
 	}()
 
 	// Setup for manual stepping to observe checksum behavior
-	m.startTime = time.Now()
+	m.status.Begin()
 	m.dbConfig = dbconn.NewDBConfig()
 	var err error
 	m.db, err = dbconn.New(testutils.DSN(), m.dbConfig)
@@ -498,7 +498,7 @@ func TestE2EBinlogSubscribingCompositeKeyBinary(t *testing.T) {
 	}()
 
 	// Setup for manual stepping to observe watermark behavior
-	m.startTime = time.Now()
+	m.status.Begin()
 	m.dbConfig = dbconn.NewDBConfig()
 	var err error
 	m.db, err = dbconn.New(testutils.DSN(), m.dbConfig)
@@ -641,7 +641,7 @@ func TestE2EBinlogSubscribingCompositeKeyDateTime(t *testing.T) {
 	}()
 
 	// Setup but don't call Run() - step through manually
-	m.startTime = time.Now()
+	m.status.Begin()
 	m.dbConfig = dbconn.NewDBConfig()
 	var err error
 	m.db, err = dbconn.New(testutils.DSN(), m.dbConfig)
@@ -716,7 +716,7 @@ func TestE2EBinlogSubscribingNonCompositeKey(t *testing.T) {
 	// Usually we would call m.Run() but we want to step through
 	// the migration process manually.
 	m.dbConfig = dbconn.NewDBConfig()
-	m.startTime = time.Now()
+	m.status.Begin()
 	var err error
 	m.db, err = dbconn.New(testutils.DSN(), m.dbConfig)
 	require.NoError(t, err)
@@ -921,7 +921,7 @@ func TestE2EBinlogSubscribingRogueValues(t *testing.T) {
 	// Usually we would call m.Run() but we want to step through
 	// the migration process manually.
 	m.dbConfig = dbconn.NewDBConfig()
-	m.startTime = time.Now()
+	m.status.Begin()
 	var err error
 	m.db, err = dbconn.New(testutils.DSN(), m.dbConfig)
 	require.NoError(t, err)

--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -120,7 +120,7 @@ func (c *tableChange) oldTableName() string {
 	if !c.runner.migration.SkipDropAfterCutover {
 		return utils.OldTableName(c.table.TableName)
 	}
-	timestamp := c.runner.startTime.UTC().Format(utils.NameFormatTimestamp)
+	timestamp := c.runner.status.StartTime().UTC().Format(utils.NameFormatTimestamp)
 	return utils.OldTableNameWithTimestamp(c.table.TableName, timestamp)
 }
 

--- a/pkg/migration/change_test.go
+++ b/pkg/migration/change_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
@@ -271,7 +270,6 @@ func TestModifyAddAutoIncrementPreservesZeroPK(t *testing.T) {
 
 func TestOldTableNameTruncation(t *testing.T) {
 	t.Parallel()
-	startTime := time.Date(2025, 6, 15, 10, 30, 45, 0, time.UTC)
 
 	tests := []struct {
 		name                 string
@@ -319,16 +317,17 @@ func TestOldTableNameTruncation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			r := &Runner{
+				migration: &Migration{
+					SkipDropAfterCutover: tt.skipDropAfterCutover,
+				},
+			}
+			r.status.Begin() // the run start the timestamped _old name derives from
 			c := &tableChange{
 				table: &table.TableInfo{
 					TableName: tt.tableName,
 				},
-				runner: &Runner{
-					migration: &Migration{
-						SkipDropAfterCutover: tt.skipDropAfterCutover,
-					},
-					startTime: startTime,
-				},
+				runner: r,
 			}
 
 			result := c.oldTableName()
@@ -338,8 +337,8 @@ func TestOldTableNameTruncation(t *testing.T) {
 			require.NotEmpty(t, result, "oldTableName() should not be empty")
 
 			if tt.skipDropAfterCutover {
-				// Should contain the timestamp
-				require.Contains(t, result, "20250615_103045")
+				// Should contain the run-start timestamp
+				require.Contains(t, result, r.status.StartTime().UTC().Format(utils.NameFormatTimestamp))
 				// Should have the expected format prefix and suffix
 				require.True(t, strings.HasPrefix(result, "_"))
 				require.Contains(t, result, "_old_")
@@ -364,16 +363,19 @@ func TestOldTableNameTruncationCollision(t *testing.T) {
 	// for the checkpoint table is provided by the original_table_name column
 	// (see TestResumeRejectsCheckpointFromDifferentTable); the old table is named
 	// only for human archaeology when SkipDropAfterCutover is set.
-	startTime := time.Date(2025, 6, 15, 10, 30, 45, 0, time.UTC)
 	prefix := strings.Repeat("x", 50)
 
+	// One shared runner, as in a real multi-table migration: both names
+	// derive from the same run-start timestamp.
+	r := &Runner{migration: &Migration{SkipDropAfterCutover: true}}
+	r.status.Begin()
 	c1 := &tableChange{
 		table:  &table.TableInfo{TableName: prefix + "_aaaaaaaaaaa"},
-		runner: &Runner{migration: &Migration{SkipDropAfterCutover: true}, startTime: startTime},
+		runner: r,
 	}
 	c2 := &tableChange{
 		table:  &table.TableInfo{TableName: prefix + "_bbbbbbbbbbb"},
-		runner: &Runner{migration: &Migration{SkipDropAfterCutover: true}, startTime: startTime},
+		runner: r,
 	}
 
 	result1 := c1.oldTableName()

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -72,13 +72,12 @@ type Runner struct {
 	// With a stmt, alter, table, newTable.
 	changes []*tableChange
 
-	status     status.State  // must use atomic helpers to change.
-	replClient change.Source // feed contains all binlog subscription activity.
+	status     status.Tracker // owns the current state and per-state timing.
+	replClient change.Source  // feed contains all binlog subscription activity.
 	throttler  throttler.Throttler
 
-	copier       copier.Copier
-	copyChunker  table.Chunker // the chunker for copying
-	copyDuration time.Duration // how long the copy took
+	copier      copier.Copier
+	copyChunker table.Chunker // the chunker for copying
 
 	// applier is the shared write layer used by both the copier (buffered
 	// copy) and the replication client (binlog deltas). Kept on the runner
@@ -109,10 +108,6 @@ type Runner struct {
 	// path's UPDATE, resurrecting the watermark on the latest row — the
 	// row resume reads. It also guards continuousChecker (see above).
 	checkpointMu sync.Mutex
-
-	// Track some key statistics.
-	startTime             time.Time
-	sentinelWaitStartTime time.Time
 
 	// Used by the test-suite and some post-migration output.
 	// Indicates if certain optimizations applied.
@@ -228,7 +223,7 @@ func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
 func (r *Runner) Run(ctx context.Context) error {
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
-	r.startTime = time.Now()
+	r.status.Begin()
 	bi := buildinfo.Get()
 	r.logger.Info("Starting spirit migration",
 		"version", bi.Version,
@@ -395,12 +390,12 @@ func (r *Runner) Run(ctx context.Context) error {
 	// of migrations usually spend time. It is not strictly necessary,
 	// but we always recopy the last-bit, even if we are resuming
 	// partially through the checksum.
-	r.status.Set(status.CopyRows)
-	if err := r.copier.Run(ctx); err != nil {
+	if err := r.status.Do(status.CopyRows, func() error {
+		return r.copier.Run(ctx)
+	}); err != nil {
 		return err
 	}
 	r.logger.Info("copy rows complete")
-	r.copyDuration = time.Since(r.copier.StartTime())
 
 	// Disable both watermark optimizations so that all changes can be flushed.
 	// For non-memory-comparable PKs this also drains the buffered map and
@@ -427,18 +422,18 @@ func (r *Runner) Run(ctx context.Context) error {
 	// that the sentinel table was created manually after the migration
 	// started.
 	if r.migration.RespectSentinel {
-		r.sentinelWaitStartTime = time.Now()
-		r.status.Set(status.WaitingOnSentinelTable)
 		// Block on the sentinel via the shared sentinel.Wait (poll/timeout timing
 		// lives in the sentinel package). The continuous-checksum lifecycle and
 		// watermark invalidation are migration-specific — invalidateChecksumWatermark
 		// scopes its UPDATE by statement because the checkpoint table is shared in
 		// multi-table mode — so they are injected as callbacks. See pkg/sentinel.
-		if err := sentinel.Wait(ctx, sentinel.WaitConfig{
-			Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.db) },
-			RunChecksum:         r.runContinuousChecksum,
-			InvalidateWatermark: r.invalidateChecksumWatermark,
-			Logger:              r.logger,
+		if err := r.status.Do(status.WaitingOnSentinelTable, func() error {
+			return sentinel.Wait(ctx, sentinel.WaitConfig{
+				Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.db) },
+				RunChecksum:         r.runContinuousChecksum,
+				InvalidateWatermark: r.invalidateChecksumWatermark,
+				Logger:              r.logger,
+			})
 		}); err != nil {
 			return err
 		}
@@ -449,29 +444,33 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	// It's time for the final cut-over, where
 	// the tables are swapped under a lock.
-	r.status.Set(status.CutOver)
-	cutoverCfg := []*cutoverConfig{}
-	for _, change := range r.changes {
-		cutoverCfg = append(cutoverCfg, &cutoverConfig{
-			table:          change.table,
-			newTable:       change.newTable,
-			oldTableName:   change.oldTableName(),
-			useTestCutover: r.migration.useTestCutover, // indicates we want the test cutover
-		})
-	}
-	cutover, err := NewCutOver(r.db, cutoverCfg, r.replClient, r.dbConfig, r.logger)
-	if err != nil {
-		return err
-	}
-	// Drop the _old table if it exists. This ensures
-	// that the rename will succeed (although there is a brief race)
-	for _, change := range r.changes {
-		if err := change.dropOldTable(ctx); err != nil {
+	if err := r.status.Do(status.CutOver, func() error {
+		cutoverCfg := []*cutoverConfig{}
+		for _, change := range r.changes {
+			cutoverCfg = append(cutoverCfg, &cutoverConfig{
+				table:          change.table,
+				newTable:       change.newTable,
+				oldTableName:   change.oldTableName(),
+				useTestCutover: r.migration.useTestCutover, // indicates we want the test cutover
+			})
+		}
+		cutover, err := NewCutOver(r.db, cutoverCfg, r.replClient, r.dbConfig, r.logger)
+		if err != nil {
 			return err
 		}
-	}
-	if err := cutover.Run(ctx); err != nil {
-		return fmt.Errorf("cutover failed: %w", err)
+		// Drop the _old table if it exists. This ensures
+		// that the rename will succeed (although there is a brief race)
+		for _, change := range r.changes {
+			if err := change.dropOldTable(ctx); err != nil {
+				return err
+			}
+		}
+		if err := cutover.Run(ctx); err != nil {
+			return fmt.Errorf("cutover failed: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	if !r.migration.SkipDropAfterCutover {
 		for _, change := range r.changes {
@@ -496,9 +495,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		"instant-ddl", r.usedInstantDDL,
 		"inplace-ddl", r.usedInplaceDDL,
 		"total-chunks", copiedChunks,
-		"copy-rows-time", r.copyDuration.Round(time.Second).String(),
-		"checksum-time", r.checker.ExecTime().Round(time.Second).String(),
-		"total-time", time.Since(r.startTime).Round(time.Second).String(),
+		"copy-rows-time", r.status.Duration(status.CopyRows).Round(time.Second).String(),
+		"checksum-time", r.status.Duration(status.Checksum).Round(time.Second).String(),
+		"total-time", r.status.TotalElapsed().Round(time.Second).String(),
 		"conns-in-use", r.db.Stats().InUse,
 	)
 	// cleanup all the tables
@@ -521,13 +520,14 @@ func (r *Runner) Run(ctx context.Context) error {
 // perform the initial checksum. When defer-cutover is not in use this
 // is also the last phase before cutover.
 func (r *Runner) postCopyPhase(ctx context.Context) error {
-	r.status.Set(status.ApplyChangeset)
 	// Disable the periodic flush and flush all pending events.
 	// We want it disabled for ANALYZE TABLE and acquiring a table lock
 	// *but* it will be started again briefly inside of the checksum
 	// runner to ensure that the lag does not grow too long.
-	r.replClient.StopPeriodicFlush()
-	if err := r.replClient.Flush(ctx); err != nil {
+	if err := r.status.Do(status.ApplyChangeset, func() error {
+		r.replClient.StopPeriodicFlush()
+		return r.replClient.Flush(ctx)
+	}); err != nil {
 		return err
 	}
 
@@ -535,30 +535,34 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// This is required so on cutover plans don't go sideways, which
 	// is at elevated risk because the batch loading can cause statistics
 	// to be out of date.
-	r.status.Set(status.AnalyzeTable)
-	r.logger.Info("Running ANALYZE TABLE")
-	for _, change := range r.changes {
-		if err := dbconn.Exec(ctx, r.db, "ANALYZE TABLE %n.%n", change.newTable.SchemaName, change.newTable.TableName); err != nil {
-			return err
-		}
+	if err := r.status.Do(status.AnalyzeTable, func() error {
+		r.logger.Info("Running ANALYZE TABLE")
+		for _, change := range r.changes {
+			if err := dbconn.Exec(ctx, r.db, "ANALYZE TABLE %n.%n", change.newTable.SchemaName, change.newTable.TableName); err != nil {
+				return err
+			}
 
-		// Disable the auto-update statistics go routine. This is because the
-		// checksum uses a consistent read and doesn't see any of the new rows in the
-		// table anyway. Chunking in the space where the consistent reads may need
-		// to read a lot of older versions is *much* slower.
-		// In a previous migration:
-		// - The checksum chunks were about 100K rows each
-		// - When the checksum reached the point at which the copier had reached,
-		//   the chunks slowed down to about 30 rows(!)
-		// - The checksum task should have finished in the next 5 minutes, but instead
-		//   the projected time was another 40 hours.
-		// My understanding of MVCC in MySQL is that the consistent read threads may
-		// have had to follow pointers to older versions of rows in UNDO, which is a
-		// linked list to find the specific versions these transactions needed. It
-		// appears that it is likely N^2 complexity, and we are better off to just
-		// have the last chunk of the checksum be slow and do this once rather than
-		// repeatedly chunking in this range.
-		change.table.DisableAutoUpdateStatistics.Store(true)
+			// Disable the auto-update statistics go routine. This is because the
+			// checksum uses a consistent read and doesn't see any of the new rows in the
+			// table anyway. Chunking in the space where the consistent reads may need
+			// to read a lot of older versions is *much* slower.
+			// In a previous migration:
+			// - The checksum chunks were about 100K rows each
+			// - When the checksum reached the point at which the copier had reached,
+			//   the chunks slowed down to about 30 rows(!)
+			// - The checksum task should have finished in the next 5 minutes, but instead
+			//   the projected time was another 40 hours.
+			// My understanding of MVCC in MySQL is that the consistent read threads may
+			// have had to follow pointers to older versions of rows in UNDO, which is a
+			// linked list to find the specific versions these transactions needed. It
+			// appears that it is likely N^2 complexity, and we are better off to just
+			// have the last chunk of the checksum be slow and do this once rather than
+			// repeatedly chunking in this range.
+			change.table.DisableAutoUpdateStatistics.Store(true)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// The checksum is ONLINE after an initial lock
@@ -1669,33 +1673,33 @@ func (r *Runner) initChunkers() error {
 
 // checksum creates the checksum which opens the read view
 func (r *Runner) checksum(ctx context.Context) error {
-	r.status.Set(status.Checksum)
+	if err := r.status.Do(status.Checksum, func() error {
+		// The checksum keeps the pool threads open, so we need to extend
+		// by more than +1 on threads as we did previously. We have:
+		// - background flushing
+		// - checkpoint thread
+		// - checksum "replaceChunk" DB connections
+		// Handle a case just in the tests not having a dbConfig.
+		//
+		// Not restored when checksum completes — by then we are past the copy
+		// phase, so the +1 backpressure between copier and applier no longer
+		// applies, and the only thing left is cutover, which itself wants at
+		// least 5 connections. Pool size grows monotonically; see the
+		// MaxOpenConnections doc in (*Runner).Run.
+		dbconn.SetPoolSize(r.db, r.dbConfig.MaxOpenConnections+2)
 
-	// The checksum keeps the pool threads open, so we need to extend
-	// by more than +1 on threads as we did previously. We have:
-	// - background flushing
-	// - checkpoint thread
-	// - checksum "replaceChunk" DB connections
-	// Handle a case just in the tests not having a dbConfig.
-	//
-	// Not restored when checksum completes — by then we are past the copy
-	// phase, so the +1 backpressure between copier and applier no longer
-	// applies, and the only thing left is cutover, which itself wants at
-	// least 5 connections. Pool size grows monotonically; see the
-	// MaxOpenConnections doc in (*Runner).Run.
-	dbconn.SetPoolSize(r.db, r.dbConfig.MaxOpenConnections+2)
-
-	// Run the checksum with internal retry logic.
-	//
-	// We do not invalidate the checkpoint on a checksum error. The dumper
-	// already refuses to persist a checksum_watermark for any pass that
-	// had to repair a chunk (see DumpCheckpoint), so on resume — whether
-	// the failure here was retry exhaustion, operator cancellation, or
-	// anything else — the persisted row either carries an empty watermark
-	// (forcing full re-verification) or a watermark from a clean pass
-	// (safe to resume from). Either way the silent-cutover hole is
-	// closed without needing to special-case the error path.
-	if err := r.checker.Run(ctx); err != nil {
+		// Run the checksum with internal retry logic.
+		//
+		// We do not invalidate the checkpoint on a checksum error. The dumper
+		// already refuses to persist a checksum_watermark for any pass that
+		// had to repair a chunk (see DumpCheckpoint), so on resume — whether
+		// the failure here was retry exhaustion, operator cancellation, or
+		// anything else — the persisted row either carries an empty watermark
+		// (forcing full re-verification) or a watermark from a clean pass
+		// (safe to resume from). Either way the silent-cutover hole is
+		// closed without needing to special-case the error path.
+		return r.checker.Run(ctx)
+	}); err != nil {
 		if r.addsUniqueIndex() {
 			// Overwrite the error if we think it's because of a unique index addition
 			return errors.New("checksum failed after several attempts. This is likely related to your statement adding a UNIQUE index on non-unique data")
@@ -1706,8 +1710,9 @@ func (r *Runner) checksum(ctx context.Context) error {
 	// A long checksum extends the binlog deltas
 	// So if we've called this optional checksum, we need one more state
 	// of applying the binlog deltas.
-	r.status.Set(status.PostChecksum)
-	return r.replClient.Flush(ctx)
+	return r.status.Do(status.PostChecksum, func() error {
+		return r.replClient.Flush(ctx)
+	})
 }
 
 func (r *Runner) addsUniqueIndex() bool {
@@ -1834,8 +1839,8 @@ func (r *Runner) Status() string {
 			r.status.Get().String(),
 			r.copier.GetProgress(),
 			r.replClient.GetDeltaLen(),
-			time.Since(r.startTime).Round(time.Second),
-			time.Since(r.copier.StartTime()).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
+			r.status.Elapsed().Round(time.Second),
 			r.copier.GetETA(),
 			r.copier.GetThrottler().IsThrottled(),
 			r.db.Stats().InUse,
@@ -1846,8 +1851,8 @@ func (r *Runner) Status() string {
 			r.status.Get().String(),
 			r.changes[0].table.SchemaName,
 			sentinel.TableName,
-			time.Since(r.startTime).Round(time.Second),
-			time.Since(r.sentinelWaitStartTime).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
+			r.status.Elapsed().Round(time.Second),
 			sentinel.WaitLimit,
 			r.db.Stats().InUse,
 		)
@@ -1857,7 +1862,7 @@ func (r *Runner) Status() string {
 		return fmt.Sprintf("migration status: state=%s binlog-deltas=%v total-time=%s conns-in-use=%d%s",
 			r.status.Get().String(),
 			r.replClient.GetDeltaLen(),
-			time.Since(r.startTime).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
 			r.db.Stats().InUse,
 			applier.StatusSuffix(r.applier),
 		)
@@ -1866,8 +1871,8 @@ func (r *Runner) Status() string {
 			r.status.Get().String(),
 			r.checker.GetProgress().String(),
 			r.replClient.GetDeltaLen(),
-			time.Since(r.startTime).Round(time.Second),
-			time.Since(r.checker.StartTime()).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
+			r.status.Elapsed().Round(time.Second),
 			r.db.Stats().InUse,
 			// Mirrors copier-is-throttled on the copy line: without it a
 			// checksum that is deliberately paused or scaled down looks

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -117,35 +117,36 @@ func (w *reverseWindow) run(ctx context.Context) error {
 	r.logger.Info(fmt.Sprintf("reverse window open; watching for a table named %s to be created on %s (create it to roll back)",
 		revertMarkerName, revertLoc),
 		"window", r.move.ReverseWindow, "deadline", deadline, "reverse_sources", len(r.targets))
-	r.status.Set(status.ReverseWindow)
 
-	ticker := time.NewTicker(reverseWindowPollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			if ferr := w.feed.Err(); ferr != nil {
-				r.logger.Error("reverse feed died mid-window; completing forward (rollback no longer safe)", "error", ferr)
-				return w.completeForward(ctx)
-			}
-			requested, err := w.revertRequested(ctx)
-			if err != nil {
-				// A transient read error should not abandon the window; log and
-				// retry on the next tick.
-				r.logger.Warn("could not read revert flag; continuing window", "error", err)
-			} else if requested {
-				r.logger.Info(fmt.Sprintf("revert triggered: detected a table named %s on %s; rolling back to source",
-					revertMarkerName, revertLoc))
-				return w.reverseCutover(ctx)
-			}
-			if !time.Now().Before(deadline) {
-				r.logger.Info("reverse window elapsed; completing forward")
-				return w.completeForward(ctx)
+	return r.status.Do(status.ReverseWindow, func() error {
+		ticker := time.NewTicker(reverseWindowPollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ticker.C:
+				if ferr := w.feed.Err(); ferr != nil {
+					r.logger.Error("reverse feed died mid-window; completing forward (rollback no longer safe)", "error", ferr)
+					return w.completeForward(ctx)
+				}
+				requested, err := w.revertRequested(ctx)
+				if err != nil {
+					// A transient read error should not abandon the window; log and
+					// retry on the next tick.
+					r.logger.Warn("could not read revert flag; continuing window", "error", err)
+				} else if requested {
+					r.logger.Info(fmt.Sprintf("revert triggered: detected a table named %s on %s; rolling back to source",
+						revertMarkerName, revertLoc))
+					return w.reverseCutover(ctx)
+				}
+				if !time.Now().Before(deadline) {
+					r.logger.Info("reverse window elapsed; completing forward")
+					return w.completeForward(ctx)
+				}
 			}
 		}
-	}
+	})
 }
 
 // buildFeed constructs the reverse feed: reverse sources are the former targets

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -92,7 +92,7 @@ type Runner struct {
 	move            *Move
 	sources         []sourceInfo     // one per source database
 	targets         []applier.Target // Combined DB, Config, and KeyRange
-	status          status.State     // must use atomic to get/set
+	status          status.Tracker   // owns the current state and per-state timing
 	checkpointTable *table.TableInfo
 
 	sourceTables   []*table.TableInfo // canonical table list (from sources[0])
@@ -126,8 +126,6 @@ type Runner struct {
 	checkpointMu sync.Mutex
 
 	// Track some key statistics.
-	startTime                time.Time
-	sentinelWaitStartTime    time.Time
 	usedResumeFromCheckpoint bool
 
 	cutoverFunc func(ctx context.Context) error
@@ -981,7 +979,7 @@ func (r *Runner) createCheckpointTable(ctx context.Context) error {
 func (r *Runner) Run(ctx context.Context) error {
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
-	r.startTime = time.Now()
+	r.status.Begin()
 	bi := buildinfo.Get()
 	r.logger.Info("Starting table move",
 		"version", bi.Version,
@@ -1009,7 +1007,6 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
-	var err error
 	r.dbConfig = dbconn.NewDBConfig()
 	// ForceKill is now true by default in NewDBConfig(), no need to set explicitly.
 	// Buffered copier needs more connections due to parallel read/write workers
@@ -1125,11 +1122,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		// But the caller will still want their cutoverFunc called. So we do that
 		// and then exit.
 		r.logger.Info("No tables to copy, proceeding directly to cutover")
-		r.status.Set(status.CutOver)
-		if r.cutoverFunc != nil {
-			if err := r.cutoverFunc(ctx); err != nil {
-				return err
+		if err := r.status.Do(status.CutOver, func() error {
+			if r.cutoverFunc == nil {
+				return nil
 			}
+			return r.cutoverFunc(ctx)
+		}); err != nil {
+			return err
 		}
 		r.logger.Info("Move operation complete.")
 		return nil
@@ -1172,8 +1171,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	r.status.Set(status.CopyRows)
-	if err := r.copier.Run(ctx); err != nil {
+	if err := r.status.Do(status.CopyRows, func() error {
+		return r.copier.Run(ctx)
+	}); err != nil {
 		return err
 	}
 
@@ -1199,18 +1199,18 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	r.logger.Info("Initial checksum completed successfully")
 
-	r.sentinelWaitStartTime = time.Now()
-	r.status.Set(status.WaitingOnSentinelTable)
 	// Block on the sentinel via the shared sentinel.Wait (poll/timeout timing
 	// lives in the sentinel package). The continuous-checksum lifecycle and
 	// watermark invalidation are move-specific (multi-source feeds;
 	// invalidateChecksumWatermark blanks the whole per-move checkpoint table),
 	// so they are injected as callbacks. See pkg/sentinel.
-	if err := sentinel.Wait(ctx, sentinel.WaitConfig{
-		Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
-		RunChecksum:         r.runContinuousChecksum,
-		InvalidateWatermark: r.invalidateChecksumWatermark,
-		Logger:              r.logger,
+	if err := r.status.Do(status.WaitingOnSentinelTable, func() error {
+		return sentinel.Wait(ctx, sentinel.WaitConfig{
+			Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
+			RunChecksum:         r.runContinuousChecksum,
+			InvalidateWatermark: r.invalidateChecksumWatermark,
+			Logger:              r.logger,
+		})
 	}); err != nil {
 		return err
 	}
@@ -1223,32 +1223,33 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	r.logger.Info("Sentinel released, starting cutover")
 	// Create a cutover.
-	r.status.Set(status.CutOver)
-	cutoverSources := make([]CutOverSource, len(r.sources))
-	for i := range r.sources {
-		cutoverSources[i] = CutOverSource{
-			DB:         r.sources[i].db,
-			ReplClient: r.sources[i].replClient,
-			Tables:     r.sources[i].tables,
+	if err := r.status.Do(status.CutOver, func() error {
+		cutoverSources := make([]CutOverSource, len(r.sources))
+		for i := range r.sources {
+			cutoverSources[i] = CutOverSource{
+				DB:         r.sources[i].db,
+				ReplClient: r.sources[i].replClient,
+				Tables:     r.sources[i].tables,
+			}
 		}
-	}
-	cutover, err := NewCutOver(cutoverSources, r.cutoverFunc, r.dbConfig, r.logger)
-	if err != nil {
-		return err
-	}
-	if r.move.ReverseWindow > 0 {
-		// Under the cutover lock, right after the traffic switch, capture the
-		// reverse-feed start positions and record that the move has entered its
-		// reverse window (see captureReverseWindow). The source rename still runs.
-		cutover.SetPostSwitch(func(ctx context.Context) error { return captureReverseWindow(ctx, r) })
-	}
-	// Pre-cutover: refuse to switch traffic if a revert has been requested (a
-	// marker appeared on targets[0] during the copy). Cutting over only to
-	// immediately roll back is pointless — abort while the source is still live.
-	if err := r.assertNoRevertMarker(ctx, "pre-cutover"); err != nil {
-		return err
-	}
-	if err = cutover.Run(ctx); err != nil {
+		cutover, err := NewCutOver(cutoverSources, r.cutoverFunc, r.dbConfig, r.logger)
+		if err != nil {
+			return err
+		}
+		if r.move.ReverseWindow > 0 {
+			// Under the cutover lock, right after the traffic switch, capture the
+			// reverse-feed start positions and record that the move has entered its
+			// reverse window (see captureReverseWindow). The source rename still runs.
+			cutover.SetPostSwitch(func(ctx context.Context) error { return captureReverseWindow(ctx, r) })
+		}
+		// Pre-cutover: refuse to switch traffic if a revert has been requested (a
+		// marker appeared on targets[0] during the copy). Cutting over only to
+		// immediately roll back is pointless — abort while the source is still live.
+		if err := r.assertNoRevertMarker(ctx, "pre-cutover"); err != nil {
+			return err
+		}
+		return cutover.Run(ctx)
+	}); err != nil {
 		return err
 	}
 
@@ -1401,8 +1402,8 @@ func (r *Runner) Status() string {
 			r.status.Get().String(),
 			r.copier.GetProgress(),
 			r.getDeltaLenAll(),
-			time.Since(r.startTime).Round(time.Second),
-			time.Since(r.copier.StartTime()).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
+			r.status.Elapsed().Round(time.Second),
 			r.copier.GetETA(),
 			r.copier.GetThrottler().IsThrottled(),
 			applier.StatusSuffix(r.applier),
@@ -1410,8 +1411,8 @@ func (r *Runner) Status() string {
 	case status.WaitingOnSentinelTable:
 		return fmt.Sprintf("migration status: state=%s total-time=%s sentinel-wait-time=%s sentinel-max-wait-time=%s",
 			r.status.Get().String(),
-			time.Since(r.startTime).Round(time.Second),
-			time.Since(r.sentinelWaitStartTime).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
+			r.status.Elapsed().Round(time.Second),
 			sentinel.WaitLimit,
 		)
 	case status.ApplyChangeset, status.PostChecksum:
@@ -1420,7 +1421,7 @@ func (r *Runner) Status() string {
 		return fmt.Sprintf("migration status: state=%s binlog-deltas=%v total-time=%s%s",
 			r.status.Get().String(),
 			r.getDeltaLenAll(),
-			time.Since(r.startTime).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
 			applier.StatusSuffix(r.applier),
 		)
 	case status.Checksum:
@@ -1429,13 +1430,13 @@ func (r *Runner) Status() string {
 			r.status.Get().String(),
 			r.checker.GetProgress().String(),
 			r.getDeltaLenAll(),
-			time.Since(r.startTime).Round(time.Second),
-			time.Since(r.checker.StartTime()).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
+			r.status.Elapsed().Round(time.Second),
 		)
 	case status.RestoreSecondaryIndexes:
 		return fmt.Sprintf("migration status: state=%s total-time=%s",
 			r.status.Get().String(),
-			time.Since(r.startTime).Round(time.Second),
+			r.status.TotalElapsed().Round(time.Second),
 		)
 	default:
 		return ""
@@ -1589,16 +1590,18 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// pkg/change/subscription_buffered.go), unread binlog would pile up
 	// server-side, and a source purging binlogs past the reader's position
 	// during an hours-long index build would fail the move fatally.
-	r.status.Set(status.ApplyChangeset)
-	if err := r.flushAllReplClients(ctx); err != nil {
+	if err := r.status.Do(status.ApplyChangeset, func() error {
+		return r.flushAllReplClients(ctx)
+	}); err != nil {
 		return err
 	}
 
 	// Restore secondary indexes if they were deferred during table creation.
 	// This is always called (not conditional on DeferSecondaryIndexes) to handle
 	// checkpoint resume scenarios where indexes may have been deferred in a previous run.
-	r.status.Set(status.RestoreSecondaryIndexes)
-	if err := r.restoreSecondaryIndexes(ctx); err != nil {
+	if err := r.status.Do(status.RestoreSecondaryIndexes, func() error {
+		return r.restoreSecondaryIndexes(ctx)
+	}); err != nil {
 		return err
 	}
 
@@ -1606,17 +1609,21 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// This is required so on cutover plans don't go sideways, which
 	// is at elevated risk because the batch loading can cause statistics
 	// to be out of date.
-	r.status.Set(status.AnalyzeTable)
-	r.logger.Info("Running ANALYZE TABLE")
-	for _, target := range r.targets {
-		for _, tbl := range r.sourceTables {
-			// Unqualified on target.DB: the old code qualified with the source
-			// schema, which doesn't exist on a cross-cluster target (and breaks
-			// through a vtgate). See analyzeTable.
-			if err := r.analyzeTable(ctx, target.DB, tbl.TableName); err != nil {
-				return err
+	if err := r.status.Do(status.AnalyzeTable, func() error {
+		r.logger.Info("Running ANALYZE TABLE")
+		for _, target := range r.targets {
+			for _, tbl := range r.sourceTables {
+				// Unqualified on target.DB: the old code qualified with the source
+				// schema, which doesn't exist on a cross-cluster target (and breaks
+				// through a vtgate). See analyzeTable.
+				if err := r.analyzeTable(ctx, target.DB, tbl.TableName); err != nil {
+					return err
+				}
 			}
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Now stop the periodic flush: the checksum requires it. The checker
@@ -1666,7 +1673,6 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	r.status.Set(status.Checksum)
 	// On a checker error we just propagate. The DumpCheckpoint invariant
 	// guarantees that any persisted checksum_watermark describes only
 	// verified-clean chunks, so a resumed run either replays the checksum
@@ -1674,7 +1680,9 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// repair) or resumes safely from a watermark that came from a clean
 	// pass. See pkg/migration/runner.go DumpCheckpoint for the full
 	// rationale.
-	return r.checker.Run(ctx)
+	return r.status.Do(status.Checksum, func() error {
+		return r.checker.Run(ctx)
+	})
 }
 
 // analyzeTable runs ANALYZE TABLE for tableName on db, unqualified: db is
@@ -1740,8 +1748,8 @@ func (r *Runner) Progress() status.Progress {
 		r.logger.Info("migration status",
 			"state", r.status.Get().String(),
 			"sentinel-table", fmt.Sprintf("%s.%s", r.targets[0].Config.DBName, sentinel.TableName),
-			"total-time", time.Since(r.startTime).Round(time.Second).String(),
-			"sentinel-wait-time", time.Since(r.sentinelWaitStartTime).Round(time.Second).String(),
+			"total-time", r.status.TotalElapsed().Round(time.Second).String(),
+			"sentinel-wait-time", r.status.Elapsed().Round(time.Second).String(),
 			"sentinel-max-wait-time", sentinel.WaitLimit.String(),
 		)
 	case status.ApplyChangeset, status.PostChecksum:

--- a/pkg/status/README.md
+++ b/pkg/status/README.md
@@ -14,6 +14,20 @@ This ordering is deliberate — the code uses ordinal comparisons (e.g., `state 
 
 `ReverseWindow` is entered only by a `move` run with [`--reverse-window`](../../docs/move.md#reverse-window) set. It sorts immediately after `CutOver`: the forward cutover is done and traffic is on the target, but Spirit keeps the source current in change-only mode so the move can still be rolled back. Because it is `>= CutOver`, the background status/checkpoint loops have already stopped (the reverse-window driver manages its own checkpoint writes) while orchestration can still observe that a revert is possible.
 
+## Tracker
+
+`Tracker` wraps a `State` with per-state wall-clock timing, and is what the runners hold in place of a bare `State` field. Phases with a clear extent run under `Do(state, fn)`, which transitions to `state`, runs `fn`, and attributes `fn`'s elapsed time (panic inclusive) to that state:
+
+```go
+err := r.status.Do(status.CopyRows, func() error {
+    return r.copier.Run(ctx)
+})
+```
+
+`Set` remains the transition primitive for states with no bracketable extent from the setter's perspective (`Close`, `ErrCleanup`); it attributes the time since the previous transition to the previous state, preserving the historical "one state ends when the next starts" semantics. In both cases the state stays current after the phase's code completes — `Get()` and the ordinal comparisons above behave exactly as before.
+
+Because the tracker owns the timing, the runners no longer carry ad-hoc fields like `copyDuration` or `sentinelWaitStartTime`: status lines render `Elapsed()` (time in the current state) and final summaries render `Duration(state)` (total time attributed to a state, accumulating across repeat visits).
+
 ## Task Interface
 
 The `Task` interface defines the contract that a migration runner must implement: reporting progress, returning a status string, dumping checkpoints, and cancelling. Both the `migration.Runner` and `move.Runner` implement this interface.

--- a/pkg/status/README.md
+++ b/pkg/status/README.md
@@ -24,9 +24,11 @@ err := r.status.Do(status.CopyRows, func() error {
 })
 ```
 
-`Set` remains the transition primitive for states with no bracketable extent from the setter's perspective (`Close`, `ErrCleanup`); it attributes the time since the previous transition to the previous state, preserving the historical "one state ends when the next starts" semantics. In both cases the state stays current after the phase's code completes — `Get()` and the ordinal comparisons above behave exactly as before.
+`Set` remains the transition primitive for states with no bracketable extent from the setter's perspective (`Close`, `ErrCleanup`); it closes the previous state's still-open interval (a gap after a completed `Do` stays unattributed), preserving the historical "one state ends when the next starts" semantics. In both cases the state stays current after the phase's code completes — `Get()` and the ordinal comparisons above behave exactly as before.
 
-Because the tracker owns the timing, the runners no longer carry ad-hoc fields like `copyDuration` or `sentinelWaitStartTime`: status lines render `Elapsed()` (time in the current state) and final summaries render `Duration(state)` (total time attributed to a state, accumulating across repeat visits).
+Because the tracker owns the timing, the runners no longer carry ad-hoc fields like `copyDuration` or `sentinelWaitStartTime`: status lines render `Elapsed()` (time in the current state) and final summaries render `Duration(state)` (total time attributed to a state, accumulating across repeat visits). The two can disagree after a bracket completes: `Duration(state)` freezes when the bracket closes, while `Elapsed()` keeps growing until the next transition.
+
+The tracker assumes spirit's linear execution model — one goroutine advances through the phases in order, and the only concurrent transition is a fatal `Set(ErrCleanup)` racing an open bracket (time accrues to the bracketed state up to the fatal transition; the bracket's own exit becomes a no-op). It is not designed for concurrent or overlapping phases. `Begin()` marks the start of a run and resets all timing; runners call it once at the top of `Run`.
 
 ## Task Interface
 

--- a/pkg/status/state.go
+++ b/pkg/status/state.go
@@ -71,10 +71,12 @@ func (s State) String() string {
 	return "unknown"
 }
 
-func (s *State) Get() State {
+// get is now private, use tracker.Get instead
+func (s *State) get() State {
 	return State(atomic.LoadInt32((*int32)(s)))
 }
 
-func (s *State) Set(newState State) {
+// set is now private, use tracker.Set / tracker.Do instead
+func (s *State) set(newState State) {
 	atomic.StoreInt32((*int32)(s), int32(newState))
 }

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -1,0 +1,141 @@
+package status
+
+import (
+	"sync"
+	"time"
+)
+
+// Tracker owns the current State plus per-state wall-clock timing. Runners
+// embed it in place of a bare State field so that state transitions and phase
+// timing cannot drift apart, and so per-phase durations no longer need ad-hoc
+// fields on the runner (copyDuration, sentinelWaitStartTime, ...).
+//
+// The zero value is ready for use.
+//
+// Phases with a clear extent run under Do, which times exactly the function it
+// brackets. Set remains the primitive for transitions whose "phase" has no
+// meaningful end from the setter's perspective (Close, ErrCleanup); it closes
+// out the previous state's running interval, matching the historical "one
+// state ends when the next starts" semantics.
+type Tracker struct {
+	state State // atomic; safe to read via Get concurrently with Do/Set
+
+	mu        sync.Mutex
+	startedAt time.Time               // first transition; the zero point for TotalElapsed
+	enteredAt time.Time               // when the current state was entered
+	open      bool                    // the current state has a running interval
+	durations map[State]time.Duration // closed time attributed per state
+}
+
+// Begin marks the start of a run. It enters Initial, so setup work before the
+// first phase is attributed to Initial and TotalElapsed measures from here.
+// Runners call it where they previously recorded a startTime field.
+func (t *Tracker) Begin() {
+	t.enter(Initial)
+}
+
+// Get returns the current state.
+func (t *Tracker) Get() State {
+	return t.state.Get()
+}
+
+// Set transitions to state without a bracket: time since the previous
+// transition is attributed to the previous state, and state begins accruing
+// now. Prefer Do wherever the phase has a clear extent.
+func (t *Tracker) Set(state State) {
+	t.enter(state)
+}
+
+// Do runs fn as the given state: it transitions to state, runs fn, and
+// attributes fn's wall-clock time (panic inclusive) to state. The state
+// remains current after Do returns — as with Set, the next state begins only
+// when it is entered.
+func (t *Tracker) Do(state State, fn func() error) error {
+	t.enter(state)
+	defer t.exit(state)
+	return fn()
+}
+
+// StartTime returns when the run began: Begin, or the first transition if
+// Begin was never called. It is the zero time before either, and stable for
+// the life of a run — migration derives timestamped _old table names from it.
+func (t *Tracker) StartTime() time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.startedAt
+}
+
+// TotalElapsed returns how long the tracker has been running: the time since
+// Begin (or, if Begin was never called, since the first transition). It
+// reports 0 before either. This is the value to render as "total-time".
+func (t *Tracker) TotalElapsed() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.startedAt.IsZero() {
+		return 0
+	}
+	return time.Since(t.startedAt)
+}
+
+// Elapsed returns how long the current state has been current. It reports 0
+// before the first transition. This is the value to render on status lines
+// ("copier-time", "sentinel-wait-time", ...).
+func (t *Tracker) Elapsed() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.enteredAt.IsZero() {
+		return 0
+	}
+	return time.Since(t.enteredAt)
+}
+
+// Duration returns the total time attributed to state so far, including the
+// still-running interval when state is current. States visited more than once
+// accumulate.
+func (t *Tracker) Duration(state State) time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	d := t.durations[state]
+	if t.open && t.state.Get() == state {
+		d += time.Since(t.enteredAt)
+	}
+	return d
+}
+
+func (t *Tracker) enter(state State) {
+	now := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.startedAt.IsZero() {
+		t.startedAt = now
+	}
+	if t.open {
+		t.accrueLocked(now)
+	}
+	t.state.Set(state)
+	t.enteredAt = now
+	t.open = true
+}
+
+// exit closes the bracket opened by Do for state. If a nested Do or a Set has
+// already transitioned away, the interval was closed at that transition and
+// exit is a no-op — time between an inner bracket's end and the outer's end is
+// deliberately unattributed rather than double counted.
+func (t *Tracker) exit(state State) {
+	now := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.open && t.state.Get() == state {
+		t.accrueLocked(now)
+	}
+}
+
+// accrueLocked adds the running interval to the current state's total and
+// closes it. Callers must hold t.mu.
+func (t *Tracker) accrueLocked(now time.Time) {
+	if t.durations == nil {
+		t.durations = make(map[State]time.Duration)
+	}
+	t.durations[t.state.Get()] += now.Sub(t.enteredAt)
+	t.open = false
+}

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -17,6 +17,12 @@ import (
 // meaningful end from the setter's perspective (Close, ErrCleanup); it closes
 // out the previous state's running interval, matching the historical "one
 // state ends when the next starts" semantics.
+//
+// Tracker assumes spirit's linear execution model: a single goroutine advances
+// through the phases in order, and the only concurrent transition is a fatal
+// Set (ErrCleanup) racing an open bracket. In that case time accrues to the
+// bracketed state up to the fatal transition and the bracket's own exit
+// becomes a no-op. It is not designed for concurrent or overlapping phases.
 type Tracker struct {
 	state State // atomic; safe to read via Get concurrently with Do/Set
 
@@ -27,11 +33,20 @@ type Tracker struct {
 	durations map[State]time.Duration // closed time attributed per state
 }
 
-// Begin marks the start of a run. It enters Initial, so setup work before the
-// first phase is attributed to Initial and TotalElapsed measures from here.
-// Runners call it where they previously recorded a startTime field.
+// Begin marks the start of a run: it resets all timing (start time, per-state
+// durations) and enters Initial, so setup work before the first phase is
+// attributed to Initial and TotalElapsed measures from here. Runners call it
+// at the top of Run, where they previously recorded a startTime field. Calling
+// Begin again starts a fresh run rather than extending the previous one.
 func (t *Tracker) Begin() {
-	t.enter(Initial)
+	now := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.startedAt = now
+	t.enteredAt = now
+	t.open = true
+	t.durations = nil
+	t.state.set(Initial)
 }
 
 // Get returns the current state.
@@ -92,7 +107,9 @@ func (t *Tracker) Elapsed() time.Duration {
 
 // Duration returns the total time attributed to state so far, including the
 // still-running interval when state is current. States visited more than once
-// accumulate.
+// accumulate. Note that once a bracket completes its interval is closed:
+// Duration(state) freezes while Elapsed keeps growing until the next
+// transition — they answer different questions.
 func (t *Tracker) Duration(state State) time.Duration {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -36,7 +36,7 @@ func (t *Tracker) Begin() {
 
 // Get returns the current state.
 func (t *Tracker) Get() State {
-	return t.state.Get()
+	return t.state.get()
 }
 
 // Set transitions to state without a bracket: time since the previous
@@ -96,7 +96,7 @@ func (t *Tracker) Duration(state State) time.Duration {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	d := t.durations[state]
-	if t.open && t.state.Get() == state {
+	if t.open && t.state.get() == state {
 		d += time.Since(t.enteredAt)
 	}
 	return d
@@ -112,7 +112,7 @@ func (t *Tracker) enter(state State) {
 	if t.open {
 		t.accrueLocked(now)
 	}
-	t.state.Set(state)
+	t.state.set(state)
 	t.enteredAt = now
 	t.open = true
 }
@@ -125,7 +125,7 @@ func (t *Tracker) exit(state State) {
 	now := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.open && t.state.Get() == state {
+	if t.open && t.state.get() == state {
 		t.accrueLocked(now)
 	}
 }
@@ -136,6 +136,6 @@ func (t *Tracker) accrueLocked(now time.Time) {
 	if t.durations == nil {
 		t.durations = make(map[State]time.Duration)
 	}
-	t.durations[t.state.Get()] += now.Sub(t.enteredAt)
+	t.durations[t.state.get()] += now.Sub(t.enteredAt)
 	t.open = false
 }

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -39,9 +39,10 @@ func (t *Tracker) Get() State {
 	return t.state.get()
 }
 
-// Set transitions to state without a bracket: time since the previous
-// transition is attributed to the previous state, and state begins accruing
-// now. Prefer Do wherever the phase has a clear extent.
+// Set transitions to state without a bracket: it closes the previous state's
+// still-open interval (if a completed Do already closed it, the gap since is
+// left unattributed) and state begins accruing now. Prefer Do wherever the
+// phase has a clear extent.
 func (t *Tracker) Set(state State) {
 	t.enter(state)
 }

--- a/pkg/status/tracker_test.go
+++ b/pkg/status/tracker_test.go
@@ -52,6 +52,26 @@ func TestTrackerDoRecordsDuration(t *testing.T) {
 	require.Greater(t, tr.Elapsed(), closed)
 }
 
+func TestTrackerBeginResetsRun(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	tr.Begin()
+	first := tr.StartTime()
+	require.NoError(t, tr.Do(CopyRows, func() error {
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}))
+	require.Positive(t, tr.Duration(CopyRows))
+
+	// A second Begin starts a fresh run: new StartTime, cleared durations.
+	time.Sleep(5 * time.Millisecond)
+	tr.Begin()
+	require.True(t, tr.StartTime().After(first))
+	require.Zero(t, tr.Duration(CopyRows))
+	require.Equal(t, Initial, tr.Get())
+}
+
 func TestTrackerSetAttributesTimeToPreviousState(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/status/tracker_test.go
+++ b/pkg/status/tracker_test.go
@@ -1,0 +1,164 @@
+package status
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackerZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	require.Equal(t, Initial, tr.Get())
+	require.Zero(t, tr.Elapsed())
+	require.Zero(t, tr.Duration(CopyRows))
+}
+
+func TestTrackerDoSetsStateAndReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	sentinelErr := errors.New("copy failed")
+	err := tr.Do(CopyRows, func() error {
+		// The state is current while fn runs, so concurrent readers
+		// (status loggers, watchers) observe it.
+		require.Equal(t, CopyRows, tr.Get())
+		return sentinelErr
+	})
+	require.ErrorIs(t, err, sentinelErr)
+	// Like Set, the state remains current after the bracket: it only ends
+	// when the next state begins.
+	require.Equal(t, CopyRows, tr.Get())
+}
+
+func TestTrackerDoRecordsDuration(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	require.NoError(t, tr.Do(Checksum, func() error {
+		time.Sleep(20 * time.Millisecond)
+		return nil
+	}))
+	require.GreaterOrEqual(t, tr.Duration(Checksum), 20*time.Millisecond)
+	// Elapsed keeps growing after the bracket (the state is still current),
+	// but the attributed Duration is closed and stable.
+	closed := tr.Duration(Checksum)
+	time.Sleep(5 * time.Millisecond)
+	require.Equal(t, closed, tr.Duration(Checksum))
+	require.Greater(t, tr.Elapsed(), closed)
+}
+
+func TestTrackerSetAttributesTimeToPreviousState(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	tr.Set(CopyRows)
+	time.Sleep(20 * time.Millisecond)
+	tr.Set(ApplyChangeset)
+	require.GreaterOrEqual(t, tr.Duration(CopyRows), 20*time.Millisecond)
+	require.Equal(t, ApplyChangeset, tr.Get())
+
+	// The running interval of the current state is included in Duration.
+	time.Sleep(10 * time.Millisecond)
+	require.GreaterOrEqual(t, tr.Duration(ApplyChangeset), 10*time.Millisecond)
+}
+
+func TestTrackerRepeatedStatesAccumulate(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	for range 2 {
+		require.NoError(t, tr.Do(Checksum, func() error {
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		}))
+	}
+	require.GreaterOrEqual(t, tr.Duration(Checksum), 20*time.Millisecond)
+}
+
+func TestTrackerDoThenSetDoesNotDoubleCount(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	require.NoError(t, tr.Do(CopyRows, func() error {
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}))
+	closed := tr.Duration(CopyRows)
+	time.Sleep(10 * time.Millisecond) // gap between bracket end and next state
+	tr.Set(ApplyChangeset)
+	// The gap is not attributed to CopyRows: its interval closed at Do's end.
+	require.Equal(t, closed, tr.Duration(CopyRows))
+}
+
+func TestTrackerDoRecordsOnPanic(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	require.Panics(t, func() {
+		_ = tr.Do(CutOver, func() error {
+			time.Sleep(10 * time.Millisecond)
+			panic("cutover exploded")
+		})
+	})
+	require.GreaterOrEqual(t, tr.Duration(CutOver), 10*time.Millisecond)
+	// The interval is closed: nothing further accrues to CutOver.
+	closed := tr.Duration(CutOver)
+	tr.Set(ErrCleanup)
+	require.Equal(t, closed, tr.Duration(CutOver))
+}
+
+func TestTrackerNestedDoAttributesToInnermost(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	start := time.Now()
+	require.NoError(t, tr.Do(WaitingOnSentinelTable, func() error {
+		time.Sleep(10 * time.Millisecond)
+		return tr.Do(Checksum, func() error {
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		})
+	}))
+	total := time.Since(start)
+	require.GreaterOrEqual(t, tr.Duration(WaitingOnSentinelTable), 10*time.Millisecond)
+	require.GreaterOrEqual(t, tr.Duration(Checksum), 10*time.Millisecond)
+	// No double counting: the two attributions cannot exceed real time.
+	require.LessOrEqual(t, tr.Duration(WaitingOnSentinelTable)+tr.Duration(Checksum), total)
+	// Like Set, an inner transition is not "restored": the last entered state
+	// remains current.
+	require.Equal(t, Checksum, tr.Get())
+}
+
+func TestTrackerConcurrentReaders(t *testing.T) {
+	t.Parallel()
+
+	var tr Tracker
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = tr.Get()
+					_ = tr.Elapsed()
+					_ = tr.Duration(CopyRows)
+				}
+			}
+		})
+	}
+	for range 100 {
+		require.NoError(t, tr.Do(CopyRows, func() error { return nil }))
+		tr.Set(Checksum)
+	}
+	close(done)
+	wg.Wait()
+	require.Positive(t, tr.Duration(CopyRows))
+}


### PR DESCRIPTION
## Associated discussion

Draft alternative to #1115 / #1116 (workflow lifecycle events), per the review discussion there. It keeps `status.State` as the only vocabulary and makes the status package own phase boundaries and timing, rather than adding a parallel event system with split start/finish call sites.

## Summary

`status.Tracker` replaces the bare `status.State` field on the **migration**, **move**, and **datasync** runners. It owns the current state plus per-state wall-clock timing, and its zero value is ready for use.

Phases with a clear extent run under a bracket:

```go
err := r.status.Do(status.CopyRows, func() error {
    return r.copier.Run(ctx)
})
```

`Do` transitions to the state, runs the function, and attributes its elapsed time (panic inclusive) to that state. `Set` remains the primitive for the two transitions with no bracketable extent (`Close`, and `ErrCleanup` which fires inside `fatalOnce` from concurrent binlog-error callbacks); it shares the same bookkeeping.

Nothing changes for readers: the state still stays current after its bracket ends ("one state ends when the next starts"), so `Get()`, the ordinal comparisons (`state >= CutOver`, `state >= Checksum`), and the `State` enum are untouched.

## Runner timing machinery removed

Because status owns the timing, the ad-hoc runner fields are gone:

- `copyDuration`, `sentinelWaitStartTime` (migration); `sentinelWaitStartTime` (move); `startTime` (all three runners).
- Status lines render `Elapsed()` (time in the current state) instead of reaching into `copier.StartTime()` / `checker.StartTime()`; `total-time` is `TotalElapsed()`.
- The final apply-complete log reads `Duration(status.CopyRows)` / `Duration(status.Checksum)` — repeat visits to a state accumulate.
- `Run()` calls `status.Begin()` where it previously stamped `startTime`, which also attributes setup time to `Initial`. The timestamped `_old_<ts>` table names derive from `status.StartTime()`, which is stable for the life of the run.

## Behavior notes

- Final-log `checksum-time` is now phase wall-time (`Duration(Checksum)`) rather than `checker.ExecTime()`, so it includes retry backoff — marginally larger, arguably more honest.
- `Status()` during early checksum no longer renders `time.Since(zero)` if called before `checker.Run` stamps its start time.
- datasync's two long-running `ApplyChangeset` functions are bracketed at their call sites instead of `Set` at the top of the function body.

## Where #1115's observers fit

With every phase bracketed, typed started/finished events with an err-derived outcome (spans for Strata) become a small addition inside `Do`/`Set` — no second vocabulary, no attempt handles, no dual-context threading in the runners. The terminal-evidence facts from #1115 (`DurableMutation`, `TerminalOwnership`) are orthogonal to phases and would compose with this unchanged.

## Verification

- `go build ./...`, `go vet ./pkg/...`, `golangci-lint run` (0 issues)
- `go test -race ./pkg/status` (new `Tracker` unit tests: bracket timing, no double counting across Do/Set/nesting, panic attribution, concurrent readers)
- Against the compose DB: `TestOnline`, `TestCheckpoint` (`singleversion` tag; asserts exact `Status()` strings + resume), `TestOldTableName*`, `TestBasicMove`, `TestEmptyDatabaseMove` (no-tables cutover path), `TestMoveReverseWindowCompleteForward`, `TestMoveReverseWindowRevert`, `TestMoveSentinelDropReleasesCutover`, `TestDeferCutOverTwoMigrationsSharedSentinel`, `TestSyncContinuousChecksumFirstCleanPass`, `TestE2EBinlogSubscribingCompositeKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)