### PR TITLE
dbconn: tolerate stored context errors in TrxPool.Close rollbacks

### DIFF
--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -192,7 +192,15 @@ func (p *TrxPool) Close() error {
 			// nothing left to clean up. Surfacing it would fail an
 			// otherwise-successful caller — the checksum treats Close errors
 			// as a failed pass.
-			if IsConnectionLossError(err) {
+			//
+			// Context errors are the same situation with a client-side cause:
+			// when a statement is canceled mid-flight (keepaliveCancel above
+			// interrupting an in-flight ping round, or a ping round hitting
+			// keepaliveRoundTimeout), go-sql-driver closes the connection and
+			// stores the context error, and Rollback on the closed connection
+			// returns the stored error rather than ErrInvalidConn. The server
+			// rolls back on connection death regardless of which side closed.
+			if IsConnectionLossError(err) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				p.logger.Warn("pooled transaction's connection was already gone at rollback", "error", err)
 				continue
 			}

--- a/pkg/dbconn/trxpool_test.go
+++ b/pkg/dbconn/trxpool_test.go
@@ -212,3 +212,63 @@ func TestTrxPoolCloseAfterConnectionLoss(t *testing.T) {
 	pool.Put(trx)
 	require.NoError(t, pool.Close())
 }
+
+// TestTrxPoolCloseAfterCanceledStatement verifies that Close does not report
+// an error when a statement on a pooled transaction's connection was canceled
+// mid-flight. go-sql-driver then closes the connection and *stores* the
+// context error, and a later Rollback on the closed connection returns the
+// stored error rather than ErrInvalidConn — so this shape is not covered by
+// the connection-loss tolerance alone.
+//
+// This is the deterministic version of a race inherent to Close itself:
+// keepaliveCancel() interrupts an in-flight ping round, poisoning the pinged
+// connection with context.Canceled, and the rollback loop in the very same
+// Close call then trips over it. TestTrxPoolCloseAfterConnectionLoss flaked
+// in CI exactly this way (its 9s sleep is 3x the 3s keepalive cadence, so
+// the final tick races the test's wakeup).
+func TestTrxPoolCloseAfterCanceledStatement(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  func(t *testing.T) context.Context
+	}{
+		{
+			// What keepaliveCancel (via Close, or the parent context) does
+			// to an in-flight ping.
+			name: "canceled",
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				timer := time.AfterFunc(100*time.Millisecond, cancel)
+				t.Cleanup(func() { timer.Stop(); cancel() })
+				return ctx
+			},
+		},
+		{
+			// What keepaliveRoundTimeout does to a ping that outlives the
+			// round budget.
+			name: "deadline exceeded",
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+				t.Cleanup(cancel)
+				return ctx
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := sql.Open("mysql", testutils.DSN())
+			require.NoError(t, err)
+			defer utils.CloseAndLog(db)
+
+			pool, err := NewTrxPool(t.Context(), db, 1, NewDBConfig(), slog.New(slog.DiscardHandler))
+			require.NoError(t, err)
+
+			trx, err := pool.Get()
+			require.NoError(t, err)
+			_, err = trx.ExecContext(tc.ctx(t), "SELECT SLEEP(2)")
+			require.Error(t, err) // the driver closed the connection and stored this context error
+
+			pool.Put(trx)
+			require.NoError(t, pool.Close())
+		})
+	}
+}


### PR DESCRIPTION
## Associated discussion

Fixes a flake in `TestTrxPoolCloseAfterConnectionLoss` (introduced in #1117), first observed on #1118's CI:

```
--- FAIL: TestTrxPoolCloseAfterConnectionLoss (9.01s)
    trxpool_test.go:213:
        Error:  Received unexpected error:
                context canceled
```

The test is fine — it found a real (if narrow) bug in `TrxPool.Close()`.

## Root cause

`Close()` can poison a connection with its own shutdown sequence:

1. `Close()` calls `keepaliveCancel()` while a ping round happens to be mid-`ExecContext`.
2. go-sql-driver's context watcher closes that connection and **stores** the context error on it (`mc.cancel` → `mc.canceled.Set`).
3. The rollback loop in the very same `Close()` call then hits that transaction, and `mysqlTx.Rollback()` on a closed connection returns the **stored** `context.Canceled` rather than `ErrInvalidConn` (`mc.error()` prefers `mc.canceled.Value()`).
4. Neither `sql.ErrTxDone` nor `IsConnectionLossError` matches a context error, so `Close()` reports it.

The test makes the race easy to hit by construction: its 9s sleep is exactly 3× the 3s keepalive cadence (`wait_timeout=6`), so the final tick fires at the same instant the test wakes and calls `Close()`. Whether the cancel lands inside an in-flight ping is a sub-millisecond scheduling coincidence — rare on a fast machine (passes 3/3 locally), likelier on loaded CI runners.

This is not only a test problem: the same race exists at every real checksum completion (one in-flight ping per `Close()`), and `keepaliveRoundTimeout` produces the same shape with `context.DeadlineExceeded`. `SingleChecker.checksumTable` returns `closeErr`, so a checksum pass that actually verified cleanly can be reported as failed by its own cleanup.

## Fix

Treat `context.Canceled` / `context.DeadlineExceeded` from `Rollback` in `Close()` like the connection-loss case already tolerated: the stored context error means the connection was torn down mid-statement, and the server rolls back a killed connection's transaction itself, so there is nothing left to clean up.

Deliberately scoped to `Close()` — `IsConnectionLossError` itself is unchanged, since it drives retry decisions where "our context was canceled" must not read as "retryable".

## Verification

- New `TestTrxPoolCloseAfterCanceledStatement` reproduces the failure deterministically (no timing lottery): cancel a statement mid-flight exactly as `keepaliveCancel()` does to a ping, then `Close()`. Red without the fix — fails with the byte-identical `context canceled` — green with it; covers both the `Canceled` and `DeadlineExceeded` shapes.
- `go build ./...`, `go vet ./pkg/dbconn`, `golangci-lint run ./pkg/dbconn/` (0 issues)
- `go test -race ./pkg/dbconn` full package against the compose DB (all pass, incl. 3× stress runs of `TestTrxPoolCloseAfterConnectionLoss` + `TestTrxPoolKeepalive`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)