### PR TITLE
fix(change): stop the soft-limit park from starving the change reader

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -100,6 +100,13 @@ type binlogClient struct {
 	// cap. See DefaultSubscriptionSoftLimitBytes.
 	subscriptionSoftLimitBytes int64
 
+	// flushRequests receives a token whenever a subscription parks on
+	// its soft memory limit. runPeriodicFlush selects on it so a full
+	// buffer is drained immediately instead of leaving the binlog
+	// reader parked until the next ticker fire. Buffered (cap 1);
+	// tokens coalesce.
+	flushRequests chan struct{}
+
 	flushedBinlogs atomic.Int64 // for testing binlog flushing frequency
 }
 
@@ -131,6 +138,7 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
+		flushRequests:              make(chan struct{}, 1),
 	}
 }
 
@@ -153,6 +161,7 @@ func (c *binlogClient) AddSubscription(currentTable, newTable *table.TableInfo, 
 		Chunker:        chunker,
 		Logger:         c.logger,
 		SoftLimitBytes: c.subscriptionSoftLimitBytes,
+		FlushRequest:   c.flushRequests,
 	})
 	if err != nil {
 		return fmt.Errorf("could not build subscription for table %s.%s: %w", currentTable.SchemaName, currentTable.TableName, err)
@@ -1220,20 +1229,26 @@ func (c *binlogClient) runPeriodicFlush(ctx context.Context, interval time.Durat
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
+		trigger := "interval"
 		select {
 		case <-ctx.Done():
 			return
+		case <-c.flushRequests:
+			// A subscription parked on its soft memory limit. Flush now:
+			// the parked reader stalls binlog ingestion, and waiting out
+			// the remainder of the interval burns retention headroom.
+			trigger = "soft-limit-park"
 		case <-ticker.C:
-			startLoop := time.Now()
-			c.logger.Debug("starting periodic flush of binary log")
-			// The periodic flush does not respect the throttler since we want to advance the binlog position
-			// we allow this to run, and then expect that if it is under load the throttler
-			// will kick in and slow down the copy-rows.
-			if err := c.flush(ctx, false, nil); err != nil {
-				c.logger.Error("error flushing binary log", "error", err)
-			}
-			c.logger.Info("finished periodic flush of binary log", "total-duration", time.Since(startLoop).String())
 		}
+		startLoop := time.Now()
+		c.logger.Debug("starting periodic flush of binary log", "trigger", trigger)
+		// The periodic flush does not respect the throttler since we want to advance the binlog position
+		// we allow this to run, and then expect that if it is under load the throttler
+		// will kick in and slow down the copy-rows.
+		if err := c.flush(ctx, false, nil); err != nil {
+			c.logger.Error("error flushing binary log", "error", err)
+		}
+		c.logger.Info("finished periodic flush of binary log", "total-duration", time.Since(startLoop).String(), "trigger", trigger)
 	}
 }
 

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -100,12 +100,15 @@ type binlogClient struct {
 	// cap. See DefaultSubscriptionSoftLimitBytes.
 	subscriptionSoftLimitBytes int64
 
-	// flushRequests receives a token whenever a subscription parks on
-	// its soft memory limit. runPeriodicFlush selects on it so a full
-	// buffer is drained immediately instead of leaving the binlog
-	// reader parked until the next ticker fire. Buffered (cap 1);
-	// tokens coalesce.
-	flushRequests chan struct{}
+	// flushRequests receives the subscription that parked on its soft
+	// memory limit. runPeriodicFlush selects on it and flushes that
+	// subscription first — the all-subscription pass visits the
+	// registry in nondeterministic order, and draining another
+	// saturated subscription first would leave the binlog reader parked
+	// for that entire drain. Buffered (cap 1); only one subscription
+	// can be parked at a time (the single reader goroutine is what
+	// parks), so requests never queue behind each other.
+	flushRequests chan Subscription
 
 	flushedBinlogs atomic.Int64 // for testing binlog flushing frequency
 }
@@ -138,7 +141,7 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
-		flushRequests:              make(chan struct{}, 1),
+		flushRequests:              make(chan Subscription, 1),
 	}
 }
 
@@ -1233,11 +1236,19 @@ func (c *binlogClient) runPeriodicFlush(ctx context.Context, interval time.Durat
 		select {
 		case <-ctx.Done():
 			return
-		case <-c.flushRequests:
+		case parked := <-c.flushRequests:
 			// A subscription parked on its soft memory limit. Flush now:
 			// the parked reader stalls binlog ingestion, and waiting out
 			// the remainder of the interval burns retention headroom.
+			// Flush the parked subscription first — the all-subscription
+			// pass below visits the registry in nondeterministic order,
+			// and draining another saturated subscription first would
+			// leave the reader parked for that entire drain. The full
+			// pass still runs afterwards for position advancement.
 			trigger = "soft-limit-park"
+			if _, err := parked.Flush(ctx, false, nil); err != nil {
+				c.logger.Error("error flushing parked subscription", "error", err)
+			}
 		case <-ticker.C:
 		}
 		startLoop := time.Now()

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -92,6 +92,11 @@ type gtidClient struct {
 	streamWG   sync.WaitGroup
 
 	subscriptionSoftLimitBytes int64
+
+	// flushRequests receives a token whenever a subscription parks on
+	// its soft memory limit; runPeriodicFlush selects on it to flush
+	// immediately. See the binlog client's field of the same name.
+	flushRequests chan struct{}
 }
 
 // NewGTIDClient constructs the GTID-backed change.Source. It mirrors
@@ -123,6 +128,7 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
+		flushRequests:              make(chan struct{}, 1),
 	}
 }
 
@@ -136,6 +142,7 @@ func (c *gtidClient) AddSubscription(currentTable, newTable *table.TableInfo, ch
 		Chunker:        chunker,
 		Logger:         c.logger,
 		SoftLimitBytes: c.subscriptionSoftLimitBytes,
+		FlushRequest:   c.flushRequests,
 	})
 	if err != nil {
 		return fmt.Errorf("could not build subscription for table %s.%s: %w", currentTable.SchemaName, currentTable.TableName, err)
@@ -1151,17 +1158,23 @@ func (c *gtidClient) runPeriodicFlush(ctx context.Context, interval time.Duratio
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
+		trigger := "interval"
 		select {
 		case <-ctx.Done():
 			return
+		case <-c.flushRequests:
+			// A subscription parked on its soft memory limit. Flush now:
+			// the parked reader stalls GTID ingestion, and waiting out
+			// the remainder of the interval burns retention headroom.
+			trigger = "soft-limit-park"
 		case <-ticker.C:
-			startLoop := time.Now()
-			c.logger.Debug("starting periodic flush of GTID changeset")
-			if err := c.flush(ctx, false, nil); err != nil {
-				c.logger.Error("error flushing GTID changeset", "error", err)
-			}
-			c.logger.Info("finished periodic flush of GTID changeset", "total-duration", time.Since(startLoop).String())
 		}
+		startLoop := time.Now()
+		c.logger.Debug("starting periodic flush of GTID changeset", "trigger", trigger)
+		if err := c.flush(ctx, false, nil); err != nil {
+			c.logger.Error("error flushing GTID changeset", "error", err)
+		}
+		c.logger.Info("finished periodic flush of GTID changeset", "total-duration", time.Since(startLoop).String(), "trigger", trigger)
 	}
 }
 

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -93,10 +93,11 @@ type gtidClient struct {
 
 	subscriptionSoftLimitBytes int64
 
-	// flushRequests receives a token whenever a subscription parks on
-	// its soft memory limit; runPeriodicFlush selects on it to flush
-	// immediately. See the binlog client's field of the same name.
-	flushRequests chan struct{}
+	// flushRequests receives the subscription that parked on its soft
+	// memory limit; runPeriodicFlush selects on it and flushes that
+	// subscription first, then runs the normal all-subscription pass.
+	// See the binlog client's field of the same name.
+	flushRequests chan Subscription
 }
 
 // NewGTIDClient constructs the GTID-backed change.Source. It mirrors
@@ -128,7 +129,7 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
-		flushRequests:              make(chan struct{}, 1),
+		flushRequests:              make(chan Subscription, 1),
 	}
 }
 
@@ -1162,11 +1163,19 @@ func (c *gtidClient) runPeriodicFlush(ctx context.Context, interval time.Duratio
 		select {
 		case <-ctx.Done():
 			return
-		case <-c.flushRequests:
+		case parked := <-c.flushRequests:
 			// A subscription parked on its soft memory limit. Flush now:
 			// the parked reader stalls GTID ingestion, and waiting out
 			// the remainder of the interval burns retention headroom.
+			// Flush the parked subscription first — the all-subscription
+			// pass below visits the registry in nondeterministic order,
+			// and draining another saturated subscription first would
+			// leave the reader parked for that entire drain. The full
+			// pass still runs afterwards for position advancement.
 			trigger = "soft-limit-park"
+			if _, err := parked.Flush(ctx, false, nil); err != nil {
+				c.logger.Error("error flushing parked subscription", "error", err)
+			}
 		case <-ticker.C:
 		}
 		startLoop := time.Now()

--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -48,6 +48,13 @@ const (
 	// while still guaranteeing forward progress regardless of row width.
 	// See pkg/change/subscription_buffered.go for the accounting model.
 	//
+	// Three behaviours keep the cap from starving the change reader:
+	// map-mode overwrites of already-buffered keys bypass it (dedup
+	// stays live under backpressure), parking requests an immediate
+	// flush rather than waiting for the periodic interval, and flushes
+	// release capacity per applied batch — the reader resumes as soon
+	// as the first batch lands, not when the whole buffer has drained.
+	//
 	// Operators should be aware that pausing the binlog reader for an
 	// extended period risks falling past the source's binlog retention
 	// (binlog_expire_logs_seconds). Tune this value, or the source's

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -173,13 +173,17 @@ type bufferedMap struct {
 	// remain blocked on the cond with no flush in flight to wake it.
 	closed bool
 
-	// flushRequest, when non-nil, receives a non-blocking token each
-	// time HasChanged parks on the soft limit. The owning client selects
-	// on it in its periodic-flush loop so a full buffer is drained
-	// immediately rather than waiting out the remainder of the flush
-	// interval — a parked subscription stalls the binlog reader, and
-	// every second parked burns binlog-retention headroom.
-	flushRequest chan<- struct{}
+	// flushRequest, when non-nil, receives this subscription (a
+	// non-blocking send) each time HasChanged parks on the soft limit.
+	// The owning client selects on it in its periodic-flush loop and
+	// flushes the requesting subscription first, so a full buffer is
+	// drained immediately rather than waiting out the remainder of the
+	// flush interval — or, on multi-table clients, waiting behind
+	// another saturated subscription's entire drain in the
+	// nondeterministic all-subscription pass. A parked subscription
+	// stalls the binlog reader, and every second parked burns
+	// binlog-retention headroom.
+	flushRequest chan<- Subscription
 
 	// Counters for the bookend log emitted on watermark-optimization transitions.
 	keysAdded        atomic.Int64
@@ -252,12 +256,14 @@ type BufferedSubscriptionConfig struct {
 	// cap. See bufferedMap.softLimitBytes for the semantics.
 	SoftLimitBytes int64
 
-	// FlushRequest, when non-nil, receives a non-blocking token each
-	// time HasChanged parks on the soft limit. Owners that flush on a
-	// periodic ticker should select on it to flush a full buffer
-	// immediately instead of leaving the change reader parked for the
-	// rest of the interval. Optional; nil disables the signal.
-	FlushRequest chan<- struct{}
+	// FlushRequest, when non-nil, receives the parked subscription (a
+	// non-blocking send) each time HasChanged parks on the soft limit.
+	// Owners that flush on a periodic ticker should select on it and
+	// flush the received subscription first, then run their normal
+	// all-subscription pass — flushing others first would leave the
+	// change reader parked for those entire drains. Optional; nil
+	// disables the signal.
+	FlushRequest chan<- Subscription
 }
 
 // NewBufferedSubscription constructs the default bufferedMap-backed
@@ -535,16 +541,19 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 	s.keysAdded.Add(1)
 }
 
-// requestFlush performs a non-blocking send on the flush-request
-// channel, if one is configured. Caller holds s.Lock; the send must not
-// block (the channel is expected to be buffered, and a token already in
-// flight carries the same information).
+// requestFlush performs a non-blocking send of this subscription on the
+// flush-request channel, if one is configured. Caller holds s.Lock; the
+// send must not block. Only one subscription per client can be parked
+// at a time (the single change-reader goroutine is what parks), so a
+// buffered channel of capacity 1 never drops a live request; if a stale
+// token from an earlier park is still in flight, the receiver's
+// subsequent all-subscription pass covers this subscription anyway.
 func (s *bufferedMap) requestFlush() {
 	if s.flushRequest == nil {
 		return
 	}
 	select {
-	case s.flushRequest <- struct{}{}:
+	case s.flushRequest <- s:
 	default:
 	}
 }

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -60,14 +60,17 @@ import (
 // holds a unique value the new row is now claiming. That row is
 // briefly missing from the destination until its own event arrives in
 // a later batch (or a later row in the same batch) and re-inserts it.
-// Spirit's correctness relies on the bufferedMap being an up-to-date
-// and *disjoint* representation of pending changes — every PK appears
-// at most once at flush time, holding the latest row image — so every
-// transiently-deleted row is guaranteed to have its own event in the
-// buffer (or arriving shortly). The destination converges to source's
-// current state once the last unflushed event for each affected PK
-// has been applied; the post-cutover checksum (with
-// FixDifferences=true) catches any divergence that slips through.
+// Spirit's correctness relies on each flushed snapshot being a
+// *disjoint* representation of pending changes — within one flush,
+// every PK appears at most once, holding the latest image buffered at
+// swap time — so every transiently-deleted row is guaranteed to have
+// its own event in the buffer (or arriving shortly). A newer image for
+// a PK may arrive while its older image is mid-drain; it lands in the
+// active store and is applied by a later flush, preserving per-key
+// order. The destination converges to source's current state once the
+// last unflushed event for each affected PK has been applied; the
+// post-cutover checksum (with FixDifferences=true) catches any
+// divergence that slips through.
 //
 // SetWatermarkOptimization owns the watermark-driven transition: when
 // its toggle changes which store is active, it drains the outgoing
@@ -98,14 +101,24 @@ type bufferedMap struct {
 	sync.Mutex // protects the subscription from changes.
 
 	// cond signals waiters in HasChanged when sizeBytes drops below
-	// softLimitBytes. Broadcast at the end of every flush path. L =
-	// &Mutex. Construction invariant: every call site must wire this
-	// up immediately after the struct literal, e.g.
+	// softLimitBytes. Broadcast after every applied batch and at the
+	// end of every flush path. L = &Mutex. Construction invariant:
+	// every call site must wire this up immediately after the struct
+	// literal, e.g.
 	//   sub := &bufferedMap{...}
 	//   sub.cond = sync.NewCond(&sub.Mutex)
 	// HasChanged / Flush / SetWatermarkOptimization will panic on a
 	// nil cond, so a missing init shows up loudly in tests.
 	cond *sync.Cond
+
+	// flushMu serializes whole-flush operations — Flush and the inline
+	// drains in SetWatermarkOptimization — against each other. It is
+	// held for the full duration of a drain, while Mutex is only held
+	// for short buffer bookkeeping. That split is what lets HasChanged
+	// keep buffering (and deduping) while a flush's applier round
+	// trips are in flight. Lock order: flushMu before Mutex, never the
+	// reverse.
+	flushMu sync.Mutex
 
 	// logger is supplied by the change.Source that owns this subscription.
 	// We keep only a *slog.Logger (not a back-pointer to the source) so the
@@ -128,9 +141,17 @@ type bufferedMap struct {
 	// mode is selected.
 	queue []queuedChange
 
+	// flushingCount is the number of entries an in-flight Flush has
+	// swapped out of changes/queue but not yet applied. Their bytes
+	// remain in sizeBytes until each batch completes. Length() includes
+	// it so AllChangesFlushed cannot report true while a drain is mid-
+	// air. Zero whenever no Flush is in flight.
+	flushingCount int
+
 	// sizeBytes is an approximate count of memory currently held by
-	// changes + queue. Maintained by HasChanged and the flush paths;
-	// see estimateRowSize for the accounting.
+	// changes + queue, plus the still-unapplied portion of any snapshot
+	// a Flush is currently draining. Maintained by HasChanged and the
+	// flush paths; see estimateRowSize for the accounting.
 	sizeBytes int64
 
 	// softLimitBytes is the soft cap before HasChanged blocks waiting
@@ -152,11 +173,26 @@ type bufferedMap struct {
 	// remain blocked on the cond with no flush in flight to wake it.
 	closed bool
 
+	// flushRequest, when non-nil, receives a non-blocking token each
+	// time HasChanged parks on the soft limit. The owning client selects
+	// on it in its periodic-flush loop so a full buffer is drained
+	// immediately rather than waiting out the remainder of the flush
+	// interval — a parked subscription stalls the binlog reader, and
+	// every second parked burns binlog-retention headroom.
+	flushRequest chan<- struct{}
+
 	// Counters for the bookend log emitted on watermark-optimization transitions.
 	keysAdded        atomic.Int64
 	keysDroppedAbove atomic.Int64
 	keysSkippedBelow atomic.Int64
 	timesParked      atomic.Int64 // HasChanged was parked at least once on the soft limit
+
+	// lastParkWarn is when the park/unpark log pair was last emitted at
+	// Warn/Info level. Since flushes release capacity per batch, a
+	// saturated applier produces frequent short parks rather than one
+	// long one; without throttling, the pair would log every couple of
+	// seconds for the lifetime of a long drain. Guarded by Mutex.
+	lastParkWarn time.Time
 
 	pkIsMemoryComparable bool
 }
@@ -168,6 +204,13 @@ type bufferedMap struct {
 // against — these constants are noise next to the BLOB / large-string
 // payload sizes. Both are approximate; the cap is "soft" anyway.
 const (
+	// parkWarnInterval throttles the park/unpark log pair. Parks under
+	// sustained backpressure are frequent and short (capacity returns
+	// per applied batch), so the pair is emitted at Warn/Info level at
+	// most once per interval per subscription and at Debug otherwise.
+	// The timesParked counter still counts every park.
+	parkWarnInterval = 30 * time.Second
+
 	// bufferedChangeOverhead is the fixed per-entry cost for an item
 	// in s.changes beyond what estimateRowSize captures: the hashed-
 	// key string header (~16 B), the bufferedChange struct laid out
@@ -208,6 +251,13 @@ type BufferedSubscriptionConfig struct {
 	// HasChanged blocks waiting on the flush path. Zero disables the
 	// cap. See bufferedMap.softLimitBytes for the semantics.
 	SoftLimitBytes int64
+
+	// FlushRequest, when non-nil, receives a non-blocking token each
+	// time HasChanged parks on the soft limit. Owners that flush on a
+	// periodic ticker should select on it to flush a full buffer
+	// immediately instead of leaving the change reader parked for the
+	// rest of the interval. Optional; nil disables the signal.
+	FlushRequest chan<- struct{}
 }
 
 // NewBufferedSubscription constructs the default bufferedMap-backed
@@ -255,6 +305,7 @@ func NewBufferedSubscription(cfg BufferedSubscriptionConfig) (Subscription, erro
 		applier:              cfg.Applier,
 		pkIsMemoryComparable: cfg.CurrentTable.PrimaryKeyIsMemoryComparable() == nil,
 		softLimitBytes:       cfg.SoftLimitBytes,
+		flushRequest:         cfg.FlushRequest,
 	}
 	sub.cond = sync.NewCond(&sub.Mutex)
 	return sub, nil
@@ -339,7 +390,11 @@ func (s *bufferedMap) Length() int {
 	s.Lock()
 	defer s.Unlock()
 
-	return len(s.changes) + len(s.queue)
+	// flushingCount covers entries an in-flight Flush has swapped out
+	// but not yet applied — they are still pending changes, and callers
+	// like AllChangesFlushed must not see the buffer as empty while a
+	// drain is mid-air.
+	return len(s.changes) + len(s.queue) + s.flushingCount
 }
 
 func (s *bufferedMap) Tables() []*table.TableInfo {
@@ -400,15 +455,37 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 		return
 	}
 
+	hashedKey := utils.HashKey(key)
+
+	// A map-mode overwrite of a key that is already buffered is
+	// ~memory-neutral — the new image replaces the old one and sizeBytes
+	// is rebalanced below — so it is exempt from the soft limit. This
+	// matters enormously for convergence on hot-row workloads: the
+	// overwrite is exactly the traffic dedup collapses for free, and
+	// parking it would clamp the effective apply rate to the applier's
+	// raw drain rate. Keys mid-drain (swapped out by an in-flight Flush)
+	// are not overwrites; admitting them grows the map, so they park
+	// like any new key.
+	dedupOverwrite := false
+	if !s.queueModeActive() {
+		_, dedupOverwrite = s.changes[hashedKey]
+	}
+
 	// Soft backpressure: park while the buffer is at or above the byte
 	// threshold. See softLimitBytes on bufferedMap for the semantics.
 	// We log on entry and exit because parking stalls the binlog reader
 	// — the exit duration is the operator's main signal for binlog-
 	// retention risk, and without these lines a stalled migrator looks
 	// indistinguishable from one that's just slow.
-	if s.softLimitBytes > 0 && s.sizeBytes >= s.softLimitBytes && !s.closed {
+	if s.softLimitBytes > 0 && !dedupOverwrite && s.sizeBytes >= s.softLimitBytes && !s.closed {
 		s.timesParked.Add(1)
-		s.logger.Warn("subscription parked on soft memory limit",
+		s.requestFlush()
+		parkEntryLog, parkExitLog := s.logger.Debug, s.logger.Debug
+		if time.Since(s.lastParkWarn) >= parkWarnInterval {
+			s.lastParkWarn = time.Now()
+			parkEntryLog, parkExitLog = s.logger.Warn, s.logger.Info
+		}
+		parkEntryLog("subscription parked on soft memory limit",
 			"table", s.table.SchemaName+"."+s.table.TableName,
 			"size_bytes", s.sizeBytes,
 			"soft_limit_bytes", s.softLimitBytes,
@@ -417,7 +494,7 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 		for s.sizeBytes >= s.softLimitBytes && !s.closed {
 			s.cond.Wait()
 		}
-		s.logger.Info("subscription unparked from soft memory limit",
+		parkExitLog("subscription unparked from soft memory limit",
 			"table", s.table.SchemaName+"."+s.table.TableName,
 			"parked_duration", time.Since(parkStart).String(),
 			"size_bytes", s.sizeBytes,
@@ -429,8 +506,6 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 	// keeps subscription.Length() consistent with the buffered position
 	// that readStream advances after processRowsEvent returns, so a
 	// concurrent flush cannot publish a flushedPos that skips this event.
-
-	hashedKey := utils.HashKey(key)
 
 	logicalRow := applier.LogicalRow{RowImage: row}
 	if deleted {
@@ -460,25 +535,106 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 	s.keysAdded.Add(1)
 }
 
+// requestFlush performs a non-blocking send on the flush-request
+// channel, if one is configured. Caller holds s.Lock; the send must not
+// block (the channel is expected to be buffered, and a token already in
+// flight carries the same information).
+func (s *bufferedMap) requestFlush() {
+	if s.flushRequest == nil {
+		return
+	}
+	select {
+	case s.flushRequest <- struct{}{}:
+	default:
+	}
+}
+
 // Flush writes the pending changes to the new table.
-// We do this under a mutex, which means that unfortunately pending changes
-// are blocked from being collected while we do this. In future we may
-// come up with a more sophisticated approach to allow concurrent
-// collection of changes while we flush.
+//
+// The normal (not underLock) path does NOT hold the Mutex while the
+// applier round trips are in flight. It swaps the pending stores out
+// under the Mutex, drains the snapshot batch by batch, and releases
+// bytes (broadcasting the cond) as each batch lands. New events keep
+// buffering — and, in map mode, deduping — into the fresh stores the
+// whole time, so a long drain no longer stalls the change reader for
+// its full duration. Anything the drain could not apply (watermark-
+// deferred keys, or the remainder after an applier error) is merged
+// back into the active stores before returning; see reattachLocked.
+//
+// The reported allChangesFlushed covers the snapshot only: events that
+// arrive during the drain are, by design, not part of this flush. That
+// matches the position contract in the clients — the flushed position
+// they publish on success is captured *before* Flush is called.
+//
+// Per-key ordering is preserved: an event arriving during the drain is
+// strictly newer than the snapshot's image for the same key, lands in
+// the active store, and is applied by a later flush. Cross-key ordering
+// guarantees are unchanged (map mode is order-free across keys; queue
+// mode drains FIFO and flushes are serialized by flushMu).
+//
+// When underLock is true the entire drain runs while holding the Mutex,
+// exactly as before: the cutover flush must be atomic with respect to
+// event delivery, and with the source table locked there is no
+// concurrent traffic to win anyway.
 //
 // SetWatermarkOptimization drains the outgoing store inline before
 // flipping the mode flag, so under normal operation only one of
 // map/queue has entries when Flush runs. Both branches are still
-// iterated defensively in case anything ever leaves the inactive store
+// handled defensively in case anything ever leaves the inactive store
 // non-empty.
 func (s *bufferedMap) Flush(ctx context.Context, underLock bool, locks []*dbconn.TableLock) (allChangesFlushed bool, err error) {
+	s.flushMu.Lock()
+	defer s.flushMu.Unlock()
+
+	if underLock {
+		s.Lock()
+		defer s.Unlock()
+
+		allChangesFlushed = true
+		if len(s.changes) > 0 {
+			mapAllFlushed, err := s.flushMapLocked(ctx, true, locks, false)
+			if err != nil {
+				return false, err
+			}
+			if !mapAllFlushed {
+				allChangesFlushed = false
+			}
+		}
+		if len(s.queue) > 0 {
+			if err := s.flushQueueLocked(ctx, true, locks); err != nil {
+				return false, err
+			}
+		}
+		return allChangesFlushed, nil
+	}
+
+	// Swap the pending stores out under the Mutex. From here until the
+	// deferred reattach, the snapshot belongs exclusively to this
+	// goroutine; shared visibility of its pending entries is provided
+	// via flushingCount and sizeBytes only.
 	s.Lock()
-	defer s.Unlock()
+	snapshot := s.changes
+	if len(snapshot) > 0 {
+		s.changes = make(map[string]bufferedChange)
+	} else {
+		snapshot = nil
+	}
+	snapshotQueue := s.queue
+	s.queue = nil
+	s.flushingCount = len(snapshot) + len(snapshotQueue)
+	applyWatermarkFilter := s.watermarkOptimizationEnabled()
+	s.Unlock()
+
+	// Whatever the drains below leave in the snapshots — watermark-
+	// deferred keys on success, the unapplied remainder on error — is
+	// merged back into the active stores no matter how we return.
+	defer func() {
+		s.reattachLocked(snapshot, snapshotQueue)
+	}()
 
 	allChangesFlushed = true
-
-	if len(s.changes) > 0 {
-		mapAllFlushed, err := s.flushMapLocked(ctx, underLock, locks, false)
+	if len(snapshot) > 0 {
+		mapAllFlushed, err := s.drainMapSnapshot(ctx, snapshot, applyWatermarkFilter)
 		if err != nil {
 			return false, err
 		}
@@ -486,14 +642,175 @@ func (s *bufferedMap) Flush(ctx context.Context, underLock bool, locks []*dbconn
 			allChangesFlushed = false
 		}
 	}
-
-	if len(s.queue) > 0 {
-		if err := s.flushQueueLocked(ctx, underLock, locks); err != nil {
+	if len(snapshotQueue) > 0 {
+		remainder, err := s.drainQueueSnapshot(ctx, snapshotQueue)
+		snapshotQueue = remainder
+		if err != nil {
 			return false, err
 		}
 	}
-
 	return allChangesFlushed, nil
+}
+
+// drainMapSnapshot applies a swapped-out map snapshot through the
+// applier without holding s.Mutex. Applied entries are deleted from the
+// snapshot as each batch lands, and their bytes/count are released
+// under the Mutex (with a cond broadcast) so a parked HasChanged caller
+// resumes after the first batch, not after the whole drain. Entries
+// deferred by the low-watermark filter stay in the snapshot for the
+// caller to merge back. Returns false when any entry was deferred.
+func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]bufferedChange, applyWatermarkFilter bool) (bool, error) {
+	var deleteKeys [][]any
+	var upsertRows []applier.LogicalRow
+	var batchKeys []string
+	var batchBytes int64
+	allChangesFlushed := true
+
+	flushAndRelease := func() error {
+		if len(batchKeys) == 0 {
+			return nil
+		}
+		if err := s.flushBatch(ctx, deleteKeys, upsertRows, nil); err != nil {
+			return err
+		}
+		var drainedBytes int64
+		for _, key := range batchKeys {
+			drainedBytes += sizeOfBufferedChange(key, snapshot[key])
+			delete(snapshot, key)
+		}
+		s.Lock()
+		s.sizeBytes -= drainedBytes
+		s.flushingCount -= len(batchKeys)
+		s.cond.Broadcast()
+		s.Unlock()
+		deleteKeys, upsertRows, batchKeys, batchBytes = nil, nil, nil, 0
+		return nil
+	}
+
+	for key, change := range snapshot {
+		// The low-watermark check defers flushing keys that are still
+		// being copied (KeyBelowLowWatermark returns false). The chunker
+		// is internally synchronized, so no Mutex is needed here.
+		if applyWatermarkFilter && !s.chunker.KeyBelowLowWatermark(change.originalKey[0]) {
+			s.keysSkippedBelow.Add(1)
+			s.logger.Debug("key not below watermark", "key", change.originalKey[0])
+			allChangesFlushed = false
+			continue
+		}
+		// Cut the batch when either cap is reached: DefaultBatchSize rows,
+		// or the estimated rendered statement size would exceed the byte
+		// budget the copy path also uses. Without the byte cap, buffered
+		// wide rows (LONGTEXT / BLOB) can render into a single REPLACE
+		// larger than max_allowed_packet — a deterministic, non-retryable
+		// failure. A single row over the budget still flushes, alone in
+		// its own batch (a row can't be split).
+		rowBytes := renderedBytesOfChange(change.logicalRow, change.originalKey)
+		if batchLen := len(batchKeys); batchLen >= DefaultBatchSize ||
+			(batchLen > 0 && batchBytes+rowBytes > applier.MaxStatementSizeBytes) {
+			if err := flushAndRelease(); err != nil {
+				return false, err
+			}
+		}
+		batchKeys = append(batchKeys, key)
+		if change.logicalRow.IsDeleted {
+			deleteKeys = append(deleteKeys, change.originalKey)
+		} else {
+			upsertRows = append(upsertRows, change.logicalRow)
+		}
+		batchBytes += rowBytes
+	}
+	if err := flushAndRelease(); err != nil {
+		return false, err
+	}
+	return allChangesFlushed, nil
+}
+
+// drainQueueSnapshot applies a swapped-out queue snapshot through the
+// applier in FIFO order without holding s.Mutex, coalescing consecutive
+// same-type operations exactly like flushQueueLocked. Bytes and counts
+// are released per applied segment. Returns the unapplied remainder
+// (nil on success) so the caller can merge it back ahead of any events
+// that arrived during the drain.
+func (s *bufferedMap) drainQueueSnapshot(ctx context.Context, snapshot []queuedChange) ([]queuedChange, error) {
+	var deleteKeys [][]any
+	var upsertRows []applier.LogicalRow
+	var batchBytes int64
+	segmentStart := 0 // index of the first snapshot entry in the current segment
+	applied := 0      // count of snapshot entries applied so far
+
+	flushSegment := func(segmentEnd int) error {
+		if segmentEnd == segmentStart {
+			return nil
+		}
+		if err := s.flushBatch(ctx, deleteKeys, upsertRows, nil); err != nil {
+			return err
+		}
+		var drainedBytes int64
+		for _, qc := range snapshot[segmentStart:segmentEnd] {
+			drainedBytes += sizeOfQueuedChange(qc)
+		}
+		s.Lock()
+		s.sizeBytes -= drainedBytes
+		s.flushingCount -= segmentEnd - segmentStart
+		s.cond.Broadcast()
+		s.Unlock()
+		applied = segmentEnd
+		segmentStart = segmentEnd
+		deleteKeys = nil
+		upsertRows = nil
+		batchBytes = 0
+		return nil
+	}
+
+	prevIsDelete := snapshot[0].logicalRow.IsDeleted
+	for i, change := range snapshot {
+		rowBytes := renderedBytesOfChange(change.logicalRow, change.originalKey)
+		typeFlip := change.logicalRow.IsDeleted != prevIsDelete
+		batchFull := i-segmentStart >= DefaultBatchSize
+		overBudget := i > segmentStart && batchBytes+rowBytes > applier.MaxStatementSizeBytes
+		if typeFlip || batchFull || overBudget {
+			if err := flushSegment(i); err != nil {
+				return snapshot[applied:], err
+			}
+		}
+		if change.logicalRow.IsDeleted {
+			deleteKeys = append(deleteKeys, change.originalKey)
+		} else {
+			upsertRows = append(upsertRows, change.logicalRow)
+		}
+		batchBytes += rowBytes
+		prevIsDelete = change.logicalRow.IsDeleted
+	}
+	if err := flushSegment(len(snapshot)); err != nil {
+		return snapshot[applied:], err
+	}
+	return nil, nil
+}
+
+// reattachLocked merges the unapplied remainder of an in-flight flush
+// snapshot back into the active stores and clears flushingCount.
+//
+// Map entries follow newer-wins: any event that arrived during the drain
+// is strictly newer than the snapshot's image for the same key, so when
+// the active map already holds the key the snapshot's stale image is
+// dropped (releasing its bytes). Queue remainders are prepended so
+// binlog order is preserved ahead of events that arrived during the
+// drain. Safe to call with empty/nil snapshots.
+func (s *bufferedMap) reattachLocked(snapshot map[string]bufferedChange, snapshotQueue []queuedChange) {
+	s.Lock()
+	defer s.Unlock()
+	for key, change := range snapshot {
+		if _, ok := s.changes[key]; ok {
+			s.sizeBytes -= sizeOfBufferedChange(key, change)
+		} else {
+			s.changes[key] = change
+		}
+	}
+	if len(snapshotQueue) > 0 {
+		s.queue = append(snapshotQueue, s.queue...)
+	}
+	s.flushingCount = 0
+	s.cond.Broadcast()
 }
 
 // flushMapLocked drains s.changes through the applier. Caller must hold s.Lock.
@@ -727,7 +1044,15 @@ func (s *bufferedMap) Close() {
 // precisely to preserve order for non-memory-comparable PKs). The bypass
 // flag on flushMapLocked closes that gap, and we assert s.changes is empty
 // after the drain to catch any future regression.
+//
+// flushMu is taken first (same order as Flush): a mode transition must
+// not begin while a swapped-out flush snapshot is mid-drain, and its own
+// inline drain must hold the Mutex throughout — the transition invariant
+// ("only the active store may have entries afterwards") only holds if no
+// events can land in the outgoing store during the drain.
 func (s *bufferedMap) SetWatermarkOptimization(ctx context.Context, enabled bool) error {
+	s.flushMu.Lock()
+	defer s.flushMu.Unlock()
 	s.Lock()
 	defer s.Unlock()
 

--- a/pkg/change/subscription_buffered_concurrency_test.go
+++ b/pkg/change/subscription_buffered_concurrency_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -297,11 +298,12 @@ func TestBufferedMapOverwriteBypassesSoftLimit(t *testing.T) {
 }
 
 // TestBufferedMapParkRequestsFlush verifies that parking performs a
-// non-blocking send on the flush-request channel, so the owning client
-// can flush immediately instead of leaving the reader parked until the
-// next periodic-flush tick.
+// non-blocking send of the parked subscription on the flush-request
+// channel, so the owning client can flush that subscription first
+// instead of leaving the reader parked until the next periodic-flush
+// tick (or behind another subscription's drain).
 func TestBufferedMapParkRequestsFlush(t *testing.T) {
-	req := make(chan struct{}, 1)
+	req := make(chan Subscription, 1)
 	sub := newBareBufferedMap(1024)
 	sub.flushRequest = req
 
@@ -324,7 +326,8 @@ func TestBufferedMapParkRequestsFlush(t *testing.T) {
 	}()
 
 	select {
-	case <-req:
+	case parked := <-req:
+		require.Same(t, sub, parked, "the flush request must carry the subscription that parked")
 	case <-time.After(2 * time.Second):
 		t.Fatal("parking did not request a flush")
 	}
@@ -502,4 +505,102 @@ func TestPeriodicFlushRespondsToParkRequest(t *testing.T) {
 		return count >= 1
 	}, 15*time.Second, 50*time.Millisecond,
 		"park-requested flush did not run; reader would stay parked until the next interval tick")
+}
+
+// orderRecordingApplier wraps a real applier and records the source
+// table name of every UpsertRows call, in call order. Used to assert
+// which subscription a multi-subscription client flushed first.
+type orderRecordingApplier struct {
+	applier.Applier
+	mu    sync.Mutex
+	order []string
+}
+
+func (a *orderRecordingApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, locks []*dbconn.TableLock) (int64, error) {
+	a.mu.Lock()
+	a.order = append(a.order, mapping.SourceTable().TableName)
+	a.mu.Unlock()
+	return a.Applier.UpsertRows(ctx, mapping, rows, locks)
+}
+
+func (a *orderRecordingApplier) recorded() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.order...)
+}
+
+// TestPeriodicFlushPrioritizesParkedSubscription covers the
+// multi-subscription client: the park signal carries the subscription
+// that parked, and runPeriodicFlush must drain it before the
+// all-subscription pass. Without the priority, the pass visits the
+// registry in nondeterministic map order, and the parked reader can sit
+// behind another saturated subscription's entire drain — table B here
+// has pending changes when table A parks, so an unprioritized flush
+// would drain B first about half the time.
+func TestPeriodicFlushPrioritizesParkedSubscription(t *testing.T) {
+	makePair := func(suffix string) (*table.TableInfo, *table.TableInfo) {
+		srcBase, _ := uniqueTableNames(t)
+		srcName := srcBase + suffix
+		dstName := fmt.Sprintf("_%s_new", srcName)
+		testutils.RunSQL(t, fmt.Sprintf("DROP TABLE IF EXISTS `%s`, `%s`", srcName, dstName))
+		testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE `%s` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY (id))", srcName))
+		testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE `%s` (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY (id))", dstName))
+		db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+		require.NoError(t, err)
+		defer utils.CloseAndLog(db)
+		src := table.NewTableInfo(db, "test", srcName)
+		dst := table.NewTableInfo(db, "test", dstName)
+		require.NoError(t, src.SetInfo(t.Context()))
+		require.NoError(t, dst.SetInfo(t.Context()))
+		return src, dst
+	}
+	srcA, dstA := makePair("_a")
+	srcB, dstB := makePair("_b")
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	realApplier, err := applier.NewSingleTargetApplier(applier.Target{DB: db, KeyRange: "0", Config: cfg}, applier.NewApplierDefaultConfig())
+	require.NoError(t, err)
+	rec := &orderRecordingApplier{Applier: realApplier}
+	client := NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, rec, NewClientDefaultConfig()).(*binlogClient)
+	for _, pair := range []struct{ src, dst *table.TableInfo }{{srcA, dstA}, {srcB, dstB}} {
+		chunker, err := table.NewChunker(pair.src, table.ChunkerConfig{NewTable: pair.dst})
+		require.NoError(t, err)
+		require.NoError(t, client.AddSubscription(pair.src, pair.dst, chunker))
+	}
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+	subA := getBufferedMap(t, client, srcA.SchemaName+"."+srcA.TableName)
+
+	// Only the park signal can plausibly trigger a flush at this interval.
+	client.StartPeriodicFlush(t.Context(), time.Hour)
+	defer client.StopPeriodicFlush()
+
+	// B accumulates pending changes first, so it is a candidate to be
+	// drained ahead of A in an unprioritized all-subscription pass.
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'b'), (2, 'b'), (3, 'b')", srcB.QuotedTableName))
+	// Seed A with one buffered change, then clamp its limit so the next
+	// binlog-driven event parks the reader on A.
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", srcA.QuotedTableName))
+	require.NoError(t, client.BlockWait(t.Context()))
+	subA.Lock()
+	require.Positive(t, subA.sizeBytes, "seed change must be accounted")
+	subA.softLimitBytes = 1
+	subA.Unlock()
+
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'parked')", srcA.QuotedTableName))
+	require.Eventually(t, func() bool {
+		return subA.timesParked.Load() >= 1
+	}, 10*time.Second, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
+
+	// The priority flush drains A; the follow-up pass drains B.
+	require.Eventually(t, func() bool {
+		return len(rec.recorded()) >= 2
+	}, 15*time.Second, 50*time.Millisecond, "park-requested flush did not reach the applier")
+	order := rec.recorded()
+	require.Equal(t, srcA.TableName, order[0], "the parked subscription must be flushed before the all-subscription pass")
+	require.Contains(t, order, srcB.TableName, "the all-subscription pass must still drain the other subscription")
 }

--- a/pkg/change/subscription_buffered_concurrency_test.go
+++ b/pkg/change/subscription_buffered_concurrency_test.go
@@ -1,0 +1,505 @@
+package change
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedApplier wraps countingApplier so tests can hold a flush mid-batch
+// deterministically: when a gate channel is set, every UpsertRows /
+// DeleteKeys call first announces itself on entered (when set), then
+// receives one token from its gate before proceeding. Waiting on
+// entered is how a test knows the flush has swapped the buffer out and
+// is now blocked inside an applier round trip. The fail toggles make
+// the call error out (after the gate, without recording), exercising
+// the reattach paths.
+type gatedApplier struct {
+	countingApplier
+	entered     chan struct{}
+	upsertGate  chan struct{}
+	deleteGate  chan struct{}
+	failUpserts atomic.Bool
+	failDeletes atomic.Bool
+}
+
+var errInjected = errors.New("gatedApplier: injected failure")
+
+func (g *gatedApplier) announce() {
+	if g.entered != nil {
+		select {
+		case g.entered <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (g *gatedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, locks []*dbconn.TableLock) (int64, error) {
+	g.announce()
+	if g.upsertGate != nil {
+		<-g.upsertGate
+	}
+	if g.failUpserts.Load() {
+		return 0, errInjected
+	}
+	return g.countingApplier.UpsertRows(ctx, mapping, rows, locks)
+}
+
+func (g *gatedApplier) DeleteKeys(ctx context.Context, sourceTable, targetTable *table.TableInfo, keys [][]any, locks []*dbconn.TableLock) (int64, error) {
+	g.announce()
+	if g.deleteGate != nil {
+		<-g.deleteGate
+	}
+	if g.failDeletes.Load() {
+		return 0, errInjected
+	}
+	return g.countingApplier.DeleteKeys(ctx, sourceTable, targetTable, keys, locks)
+}
+
+// awaitEntered blocks until the applier reports a gated call in
+// progress, i.e. the flush snapshot has been swapped out.
+func awaitEntered(t *testing.T, fake *gatedApplier) {
+	t.Helper()
+	select {
+	case <-fake.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("flush did not reach the applier in time")
+	}
+}
+
+// newGatedBufferedMap builds a map-or-queue-mode bufferedMap wired to a
+// gatedApplier, mirroring newByteCapBufferedMap.
+func newGatedBufferedMap(fake *gatedApplier, queueMode bool) *bufferedMap {
+	sub := newByteCapBufferedMap(&fake.countingApplier, queueMode)
+	sub.applier = fake
+	return sub
+}
+
+// releaseGate closes a gate exactly once, releasing all current and
+// future receives. Registered via t.Cleanup so a failed assertion can't
+// leave a flush goroutine blocked forever.
+func releaseGate(gate chan struct{}) func() {
+	var once sync.Once
+	return func() { once.Do(func() { close(gate) }) }
+}
+
+// recomputeSizeBytes re-derives the byte accounting from the live
+// stores, for asserting sizeBytes stays balanced across swap flushes,
+// reattaches, and dedup overwrites. Takes s.Lock.
+func recomputeSizeBytes(s *bufferedMap) int64 {
+	s.Lock()
+	defer s.Unlock()
+	var n int64
+	for k, c := range s.changes {
+		n += sizeOfBufferedChange(k, c)
+	}
+	for _, qc := range s.queue {
+		n += sizeOfQueuedChange(qc)
+	}
+	return n
+}
+
+// TestBufferedMapHasChangedDuringFlush pins the core concurrency fix:
+// while a Flush is blocked inside an applier round trip, HasChanged must
+// keep admitting events instead of blocking on the subscription mutex
+// for the entire drain. Before the snapshot-swap flush, the binlog
+// reader was stalled for the full flush duration — for a saturated
+// applier that meant ~99% reader downtime and a dedup window frozen at
+// whatever fit under the soft limit.
+func TestBufferedMapHasChangedDuringFlush(t *testing.T) {
+	fake := &gatedApplier{upsertGate: make(chan struct{}), entered: make(chan struct{}, 8)}
+	release := releaseGate(fake.upsertGate)
+	t.Cleanup(release)
+	sub := newGatedBufferedMap(fake, false)
+
+	for i := range 10 {
+		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
+	}
+	require.Equal(t, 10, sub.Length())
+
+	flushDone := make(chan error, 1)
+	var allFlushed bool
+	go func() {
+		var err error
+		allFlushed, err = sub.Flush(t.Context(), false, nil)
+		flushDone <- err
+	}()
+	awaitEntered(t, fake)
+
+	// The flush is now parked inside UpsertRows holding NO subscription
+	// mutex. Both a brand-new key and a newer image for a key that is
+	// mid-drain must be admitted promptly.
+	admitted := make(chan struct{})
+	go func() {
+		sub.HasChanged([]any{int32(100)}, []any{int32(100), "new-during-flush"}, false)
+		sub.HasChanged([]any{int32(3)}, []any{int32(3), "newer-image"}, false)
+		close(admitted)
+	}()
+	select {
+	case <-admitted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HasChanged blocked while a flush was draining — the reader is starved for the whole flush again")
+	}
+
+	// The 10 swapped-out entries are still pending (mid-air), plus the
+	// two just admitted.
+	require.Equal(t, 12, sub.Length(),
+		"Length must count both the in-flight snapshot and newly-admitted entries")
+	select {
+	case err := <-flushDone:
+		t.Fatalf("flush finished before the gate was released: %v", err)
+	default:
+	}
+
+	release()
+	require.NoError(t, <-flushDone)
+	require.True(t, allFlushed)
+
+	// The snapshot drained; only the two events admitted during the
+	// drain remain, with the newer image for key 3 preserved.
+	require.Equal(t, 2, sub.Length())
+	sub.Lock()
+	c, ok := sub.changes[utils.HashKey([]any{int32(3)})]
+	sub.Unlock()
+	require.True(t, ok, "newer image admitted during the drain must survive the flush")
+	require.Equal(t, "newer-image", c.logicalRow.RowImage[1])
+	require.Equal(t, recomputeSizeBytes(sub), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }(),
+		"sizeBytes must balance after a swap flush with concurrent admissions")
+
+	// A follow-up flush applies the two live entries: key 3's stale
+	// image was applied by flush #1 and its newer image by flush #2 —
+	// per-key binlog order.
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Equal(t, 0, sub.Length())
+	require.Equal(t, int64(0), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }())
+}
+
+// TestBufferedMapParkedReaderWakesPerBatch verifies that a parked
+// HasChanged caller resumes as soon as enough batches have drained to
+// bring sizeBytes under the limit — not only when the entire flush
+// completes. With 1100 uniform rows the drain is two batches (1000 +
+// 100); the limit is set between the two so the parker must wake while
+// batch 2 is still gated.
+func TestBufferedMapParkedReaderWakesPerBatch(t *testing.T) {
+	fake := &gatedApplier{upsertGate: make(chan struct{})}
+	release := releaseGate(fake.upsertGate)
+	t.Cleanup(release)
+	sub := newGatedBufferedMap(fake, false)
+
+	for i := range 1100 {
+		sub.HasChanged([]any{int32(i)}, []any{int32(i), "0123456789012345678901234567890123456789"}, false)
+	}
+	sub.Lock()
+	total := sub.sizeBytes
+	sub.softLimitBytes = total / 2 // above the post-batch-1 residue, below the pre-drain total
+	sub.Unlock()
+
+	flushDone := make(chan error, 1)
+	go func() {
+		_, err := sub.Flush(t.Context(), false, nil)
+		flushDone <- err
+	}()
+
+	// Park a new-key caller while batch 1 is gated.
+	parked := make(chan struct{})
+	go func() {
+		sub.HasChanged([]any{int32(9999)}, []any{int32(9999), "parked"}, false)
+		close(parked)
+	}()
+	require.Eventually(t, func() bool {
+		return sub.timesParked.Load() >= 1
+	}, 5*time.Second, 5*time.Millisecond, "caller should park: buffer is over the soft limit")
+
+	// Release batch 1 only (1000 of 1100 rows ≈ 91% of the bytes). The
+	// per-batch release must wake the parker even though batch 2 is
+	// still gated.
+	fake.upsertGate <- struct{}{}
+	select {
+	case <-parked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parked HasChanged did not wake after the first batch drained — capacity is only released at end of flush")
+	}
+	select {
+	case err := <-flushDone:
+		t.Fatalf("flush finished with only one batch released: %v", err)
+	default:
+	}
+
+	release() // release batch 2
+	require.NoError(t, <-flushDone)
+	require.Len(t, fake.upserts(), 2, "1100 rows must drain as two batches (1000 + 100)")
+	require.Equal(t, 1, sub.Length(), "only the parker's row should remain buffered")
+}
+
+// TestBufferedMapOverwriteBypassesSoftLimit pins the dedup-bypass rule:
+// at or over the soft limit, a map-mode overwrite of an already-buffered
+// key is ~memory-neutral and must be admitted without parking — hot-row
+// churn is exactly the traffic dedup absorbs for free, and parking it
+// clamps the effective apply rate to the applier's raw drain rate. A
+// genuinely new key must still park.
+func TestBufferedMapOverwriteBypassesSoftLimit(t *testing.T) {
+	sub := newBareBufferedMap(1024)
+
+	sub.HasChanged([]any{int32(1)}, []any{int32(1), "v1"}, false)
+	sub.Lock()
+	sub.sizeBytes = 2048 // force over-limit
+	sub.Unlock()
+
+	// Overwrite of key 1: must complete without parking.
+	overwritten := make(chan struct{})
+	go func() {
+		sub.HasChanged([]any{int32(1)}, []any{int32(1), "v2"}, false)
+		close(overwritten)
+	}()
+	select {
+	case <-overwritten:
+	case <-time.After(2 * time.Second):
+		t.Fatal("overwrite of an already-buffered key parked on the soft limit")
+	}
+	require.Equal(t, int64(0), sub.timesParked.Load(),
+		"dedup overwrite must not count as a park")
+	sub.Lock()
+	require.Equal(t, "v2", sub.changes[utils.HashKey([]any{int32(1)})].logicalRow.RowImage[1],
+		"the newer image must have replaced the old one")
+	require.Len(t, sub.changes, 1)
+	sub.Unlock()
+
+	// A new key must still park.
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		sub.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("parked goroutine did not exit after t.Cleanup Close")
+		}
+	})
+	go func() {
+		sub.HasChanged([]any{int32(2)}, []any{int32(2), "new"}, false)
+		close(done)
+	}()
+	require.Eventually(t, func() bool {
+		return sub.timesParked.Load() >= 1
+	}, 2*time.Second, 5*time.Millisecond, "a new key must still park at the limit")
+}
+
+// TestBufferedMapParkRequestsFlush verifies that parking performs a
+// non-blocking send on the flush-request channel, so the owning client
+// can flush immediately instead of leaving the reader parked until the
+// next periodic-flush tick.
+func TestBufferedMapParkRequestsFlush(t *testing.T) {
+	req := make(chan struct{}, 1)
+	sub := newBareBufferedMap(1024)
+	sub.flushRequest = req
+
+	sub.Lock()
+	sub.sizeBytes = 2048
+	sub.Unlock()
+
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		sub.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("parked goroutine did not exit after t.Cleanup Close")
+		}
+	})
+	go func() {
+		sub.HasChanged([]any{int32(1)}, []any{int32(1), "x"}, false)
+		close(done)
+	}()
+
+	select {
+	case <-req:
+	case <-time.After(2 * time.Second):
+		t.Fatal("parking did not request a flush")
+	}
+}
+
+// TestBufferedMapFlushErrorReattachesRemainder exercises the failure
+// path of the swap flush: an applier error must merge the unapplied
+// snapshot back into the active map — with a newer image admitted
+// during the drain winning over the snapshot's stale one — leaving the
+// accounting balanced, and a retry must succeed.
+func TestBufferedMapFlushErrorReattachesRemainder(t *testing.T) {
+	fake := &gatedApplier{upsertGate: make(chan struct{}), entered: make(chan struct{}, 8)}
+	release := releaseGate(fake.upsertGate)
+	t.Cleanup(release)
+	sub := newGatedBufferedMap(fake, false)
+
+	for i := range 5 {
+		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
+	}
+	fake.failUpserts.Store(true)
+
+	flushDone := make(chan error, 1)
+	go func() {
+		_, err := sub.Flush(t.Context(), false, nil)
+		flushDone <- err
+	}()
+	awaitEntered(t, fake)
+
+	// While the (single) batch is gated, admit a newer image for key 3.
+	sub.HasChanged([]any{int32(3)}, []any{int32(3), "newer-image"}, false)
+
+	release()
+	require.ErrorIs(t, <-flushDone, errInjected)
+
+	// All five entries are live again, key 3 holding the newer image,
+	// and nothing leaked from the accounting.
+	require.Equal(t, 5, sub.Length())
+	sub.Lock()
+	require.Len(t, sub.changes, 5)
+	require.Equal(t, "newer-image", sub.changes[utils.HashKey([]any{int32(3)})].logicalRow.RowImage[1],
+		"reattach must not clobber a newer image admitted during the drain")
+	require.Equal(t, 0, sub.flushingCount, "no in-flight entries after reattach")
+	sub.Unlock()
+	require.Equal(t, recomputeSizeBytes(sub), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }(),
+		"sizeBytes must balance after an error reattach with a dedup overwrite")
+
+	// Clear the fault: the retry flushes everything.
+	fake.failUpserts.Store(false)
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Equal(t, 0, sub.Length())
+	require.Equal(t, int64(0), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }())
+}
+
+// TestBufferedMapQueueModeFlushOrderAcrossSwapAndError verifies queue
+// mode (non-memory-comparable PKs, post-copy) through the swap flush: a
+// failed segment is prepended back ahead of events appended during the
+// drain, and the retry applies everything in original binlog order.
+func TestBufferedMapQueueModeFlushOrderAcrossSwapAndError(t *testing.T) {
+	fake := &gatedApplier{upsertGate: make(chan struct{}), entered: make(chan struct{}, 8)}
+	release := releaseGate(fake.upsertGate)
+	t.Cleanup(release)
+	sub := newGatedBufferedMap(fake, true)
+
+	// Segments: [U1, U2], [D3], [U4].
+	sub.HasChanged([]any{"k1"}, []any{"k1", "v1"}, false)
+	sub.HasChanged([]any{"k2"}, []any{"k2", "v2"}, false)
+	sub.HasChanged([]any{"k3"}, nil, true)
+	sub.HasChanged([]any{"k4"}, []any{"k4", "v4"}, false)
+
+	// The delete segment will fail; the upsert segment before it succeeds.
+	fake.failDeletes.Store(true)
+
+	flushDone := make(chan error, 1)
+	go func() {
+		_, err := sub.Flush(t.Context(), false, nil)
+		flushDone <- err
+	}()
+	awaitEntered(t, fake)
+
+	// Append while the first segment is gated: must not block (well
+	// under the limit) and must stay ordered after the failed remainder.
+	appended := make(chan struct{})
+	go func() {
+		sub.HasChanged([]any{"k5"}, []any{"k5", "v5"}, false)
+		close(appended)
+	}()
+	select {
+	case <-appended:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queue-mode HasChanged blocked while a flush was draining")
+	}
+
+	release()
+	require.ErrorIs(t, <-flushDone, errInjected)
+
+	// [U1, U2] applied; remainder [D3, U4] prepended ahead of the
+	// concurrent append [U5].
+	require.Len(t, fake.upserts(), 1)
+	sub.Lock()
+	var keys []string
+	for _, qc := range sub.queue {
+		keys = append(keys, qc.originalKey[0].(string))
+	}
+	sub.Unlock()
+	require.Equal(t, []string{"k3", "k4", "k5"}, keys,
+		"failed remainder must be prepended ahead of events appended during the drain")
+	require.Equal(t, recomputeSizeBytes(sub), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }())
+
+	// Retry drains FIFO: DeleteKeys([k3]) then UpsertRows([k4, k5]).
+	fake.failDeletes.Store(false)
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Equal(t, 0, sub.Length())
+
+	deletes := fake.deletes()
+	require.Len(t, deletes, 1)
+	require.Equal(t, "k3", deletes[0][0][0])
+	upserts := fake.upserts()
+	require.Len(t, upserts, 2)
+	require.Equal(t, "k4", upserts[1][0].RowImage[0])
+	require.Equal(t, "k5", upserts[1][1].RowImage[0])
+}
+
+// TestBufferedMapFlushEmpty pins the trivial path: flushing an empty
+// subscription makes no applier calls and reports all-flushed.
+func TestBufferedMapFlushEmpty(t *testing.T) {
+	fake := &gatedApplier{}
+	sub := newGatedBufferedMap(fake, false)
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Empty(t, fake.upserts())
+	require.Empty(t, fake.deletes())
+}
+
+// TestPeriodicFlushRespondsToParkRequest is the end-to-end signal test:
+// with the periodic flush interval cranked to an hour, a binlog-driven
+// park must still be flushed within seconds via the flush-request
+// channel. Before the signal existed, a parked reader sat idle for the
+// remainder of the interval on every fill cycle.
+func TestPeriodicFlushRespondsToParkRequest(t *testing.T) {
+	db, client, srcTable, dstTable := setupBufferedTest(t)
+	defer client.Close()
+	defer utils.CloseAndLog(db)
+
+	sub := getBufferedMap(t, client, srcTable.SchemaName+"."+srcTable.TableName)
+
+	// Only the park signal can plausibly trigger a flush at this interval.
+	client.StartPeriodicFlush(t.Context(), time.Hour)
+	defer client.StopPeriodicFlush()
+
+	// Seed one buffered change, then clamp the limit so the next
+	// binlog-driven HasChanged parks.
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", srcTable.QuotedTableName))
+	require.NoError(t, client.BlockWait(t.Context()))
+	sub.Lock()
+	require.Positive(t, sub.sizeBytes, "seed change must be accounted")
+	sub.softLimitBytes = 1
+	sub.Unlock()
+
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'parked')", srcTable.QuotedTableName))
+	require.Eventually(t, func() bool {
+		return sub.timesParked.Load() >= 1
+	}, 10*time.Second, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
+
+	// The park requested a flush; the periodic goroutine must drain the
+	// seed row promptly — not in an hour — which also unparks the reader.
+	var count int
+	require.Eventually(t, func() bool {
+		require.NoError(t, db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable.QuotedTableName)).Scan(&count))
+		return count >= 1
+	}, 15*time.Second, 50*time.Millisecond,
+		"park-requested flush did not run; reader would stay parked until the next interval tick")
+}


### PR DESCRIPTION
Fixes #1120

## Problem

When the applier is saturated, the subscription soft limit (256MiB) turns into a convergence killer. Three compounding defects:

1. `bufferedMap.Flush` held the subscription mutex across the **entire** applier drain — ~13.6 minutes for a full buffer at serial 1000-row REPLACE batches. The change reader (`HasChanged`) was blocked or parked for the whole drain: no ingestion, no dedup, and the buffered position couldn't advance, so the catch-up loop's `BlockWait` always timed out. Observed in production as a ~99% parked duty cycle and a GTID gap diverging ~4M txn/h.
2. Parking never triggered a flush — a full buffer waited out the remainder of the 30s periodic interval with the reader stalled (burning binlog-retention headroom).
3. `HasChanged` parked before checking whether the key was already buffered, so memory-neutral hot-row overwrites — exactly the traffic LWW dedup collapses for free — were blocked, clamping the effective apply rate to the applier's raw serial drain rate.

Raising `SubscriptionSoftLimitBytes` would not have fixed this: with the mutex held during the drain, a bigger buffer just makes a longer lockstep cycle.

## Fix

- **Snapshot-swap flushing.** `Flush` (not underLock) swaps the pending stores out under the mutex, drains the snapshot without holding it, and releases bytes + broadcasts the cond per applied batch. The reader buffers and dedups continuously through a drain, and a parked reader resumes after the first batch (~seconds), not after the whole flush.
  - Watermark-deferred keys and error remainders merge back **newer-wins**: an image that arrived mid-drain is strictly newer than the snapshot's, so per-key binlog order is preserved. Queue-mode remainders are **prepended** to preserve FIFO.
  - A new `flushMu` serializes `Flush` against `SetWatermarkOptimization` (whose transition drains still run fully locked, as does the underLock cutover path — with the table locked there is no concurrent traffic to win).
  - `Length()` counts in-flight snapshot entries, so `AllChangesFlushed` stays honest mid-drain and the flushed-position contract is unchanged (the clients snapshot the buffered position *before* calling `Flush`).
- **Park-triggered flushing.** Parking performs a non-blocking send on a flush-request channel; both clients' periodic-flush loops select on it and flush immediately (`trigger=soft-limit-park` in the logs).
- **Dedup bypass at the limit.** Map-mode overwrites of already-buffered keys are exempt from the park. Keys mid-drain are not overwrites (admitting them grows the map), so they still park.
- Parks are now frequent-and-short instead of rare-and-long, so the park/unpark log pair is rate-limited to Warn/Info once per 30s per subscription (Debug otherwise). `timesParked` still counts every park.

## Testing

- New tests: buffering + dedup during a gated in-flight flush; per-batch unpark (wakes while the second batch is still gated); dedup bypass at the limit; park → flush-request; applier-error reattach with newer-wins and balanced byte accounting; queue-mode FIFO across swap + error + concurrent append; and a DB-backed end-to-end test proving a park is flushed in well under a second with the periodic interval set to an hour (`parked_duration=576µs` vs 13+ minutes before).
- `go test -race` green on `pkg/change`, `pkg/migration`, `pkg/move`, `pkg/checksum`, `pkg/copier`, `pkg/datasync`; `golangci-lint` clean.

## Not in this PR (see #1120)

The binlog apply path remains strictly serial (~350–660 rows/s ceiling); parallelizing map-mode flush batches is the follow-up lever if a workload's post-dedup distinct-key rate exceeds it. Metrics for park/lag and a fail-fast "cannot converge" signal are also follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)