### PR TITLE
checksum: survive wait_timeout kills during serialized chunk repairs

### DIFF
--- a/pkg/checksum/distributed.go
+++ b/pkg/checksum/distributed.go
@@ -198,8 +198,6 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		if err != nil {
 			return fmt.Errorf("failed to get transaction for source %d: %w", i, err)
 		}
-		defer c.sourcePools[i].trxPool.Put(srcTrx)
-
 		sourceQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
 			sourceChecksumCols,
 			chunk.Table.QuotedTableName,
@@ -207,7 +205,15 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		)
 		var cs int64
 		var cnt uint64
-		if err := srcTrx.QueryRowContext(ctx, sourceQuery).Scan(&cs, &cnt); err != nil {
+		err = srcTrx.QueryRowContext(ctx, sourceQuery).Scan(&cs, &cnt)
+		// Return the transaction as soon as its query is done (not deferred):
+		// a checked-out transaction is invisible to the pool's keepalive, and
+		// holding it across the remaining sources, the targets, and above all
+		// the recopyLock-serialized repair below can idle its connection past
+		// wait_timeout. Returning a transaction whose query just failed is
+		// fine — the pool treats dead transactions the same wherever they are.
+		c.sourcePools[i].trxPool.Put(srcTrx)
+		if err != nil {
 			return fmt.Errorf("failed to query source %d: %w", i, err)
 		}
 		sourceChecksum ^= cs
@@ -224,8 +230,6 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		if err != nil {
 			return fmt.Errorf("failed to get transaction for target %d: %w", i, err)
 		}
-		defer targetTrxPool.Put(targetTrx)
-
 		targetQuery := fmt.Sprintf("SELECT BIT_XOR(CRC32(CONCAT(%s))) as checksum, count(*) as c FROM %s WHERE %s",
 			targetChecksumCols,
 			chunk.Table.QuotedTableName,
@@ -233,7 +237,11 @@ func (c *DistributedChecker) ChecksumChunk(ctx context.Context, chunk *table.Chu
 		)
 		var cs int64
 		var cnt uint64
-		if err := targetTrx.QueryRowContext(ctx, targetQuery).Scan(&cs, &cnt); err != nil {
+		err = targetTrx.QueryRowContext(ctx, targetQuery).Scan(&cs, &cnt)
+		// Returned immediately for the same keepalive-visibility reason as
+		// the source transactions above.
+		targetTrxPool.Put(targetTrx)
+		if err != nil {
 			return fmt.Errorf("failed to query target %d: %w", i, err)
 		}
 		targetChecksum ^= cs

--- a/pkg/checksum/single.go
+++ b/pkg/checksum/single.go
@@ -129,7 +129,22 @@ func (c *SingleChecker) ChecksumChunk(ctx context.Context, trxPool *dbconn.TrxPo
 	if err != nil {
 		return err
 	}
-	defer trxPool.Put(trx)
+	// The transaction is only needed for the snapshot reads: the two checksum
+	// queries and (on mismatch) the row-level inspection. It must go back to
+	// the pool the moment those are done, not at function exit: the repair
+	// path below serializes on recopyLock and can park for many minutes
+	// behind other repairs, and a checked-out transaction is invisible to the
+	// pool's keepalive — holding it there idled connections past Aurora's
+	// wait_timeout in production and killed the whole pool. Guarded so the
+	// early call and the deferred one compose to exactly one Put.
+	trxReturned := false
+	putTrx := func() {
+		if !trxReturned {
+			trxReturned = true
+			trxPool.Put(trx)
+		}
+	}
+	defer putTrx()
 	c.logger.Debug("checksumming chunk", "chunk", chunk.String())
 	sourceChecksumCols, targetChecksumCols, err := chunk.ColumnMapping.ChecksumExprs()
 	if err != nil {
@@ -177,6 +192,11 @@ func (c *SingleChecker) ChecksumChunk(ctx context.Context, trxPool *dbconn.TrxPo
 		if err := c.inspectDifferences(ctx, trx, chunk); err != nil {
 			return err
 		}
+		// The snapshot reads are done. The repair below reads current data
+		// through the pooled connections (deliberately outside the snapshot),
+		// so return the transaction now and let the keepalive cover it while
+		// this worker queues on recopyLock.
+		putTrx()
 		// Are we allowed to fix the differences? If not, return an error.
 		// This is mostly used by the test-suite.
 		if !c.fixDifferences {
@@ -492,10 +512,34 @@ func (c *SingleChecker) Run(ctx context.Context) error {
 	var lastErr error
 	for attempt := 1; attempt <= c.maxRetries; attempt++ {
 		if attempt > 1 {
-			c.logger.Error("checksum failed, retrying", "attempt", attempt, "maxRetries", c.maxRetries)
-			// Reset the chunker to start from the beginning
-			if err := c.chunker.Reset(); err != nil {
-				return fmt.Errorf("failed to reset chunker for retry: %w", err)
+			// If the previous attempt errored without finding a single
+			// difference — e.g. the transaction pool's connections were killed
+			// mid-pass — the low watermark is still trustworthy: every chunk
+			// below it verified clean. Resume there rather than discarding
+			// hours of verified work; runChecksum re-acquires the table lock
+			// and takes fresh snapshots either way, exactly as the yield path
+			// does. An attempt that found differences (lastErr == nil, or an
+			// error after repairs) still restarts from the beginning, so the
+			// "clean pass over the whole table" guarantee after repairs is
+			// unchanged.
+			resumed := false
+			if lastErr != nil && c.differencesFound.Load() == 0 {
+				if watermark, wmErr := c.chunker.GetLowWatermark(); wmErr == nil {
+					if openErr := c.chunker.OpenAtWatermark(watermark); openErr == nil {
+						resumed = true
+						c.logger.Error("checksum failed, retrying from low watermark",
+							"attempt", attempt, "maxRetries", c.maxRetries, "watermark", watermark)
+					} else {
+						c.logger.Warn("failed to resume checksum at watermark, restarting from beginning", "error", openErr)
+					}
+				}
+			}
+			if !resumed {
+				c.logger.Error("checksum failed, retrying", "attempt", attempt, "maxRetries", c.maxRetries)
+				// Reset the chunker to start from the beginning
+				if err := c.chunker.Reset(); err != nil {
+					return fmt.Errorf("failed to reset chunker for retry: %w", err)
+				}
 			}
 			// Reset differences found counter
 			c.differencesFound.Store(0)

--- a/pkg/checksum/single_test.go
+++ b/pkg/checksum/single_test.go
@@ -2,6 +2,8 @@ package checksum
 
 import (
 	"database/sql"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -602,4 +604,230 @@ func TestColumnBoundaryShift(t *testing.T) {
 	require.True(t, ok, "checker is not of type *SingleChecker")
 	err = singleChecker.runChecksum(t.Context())
 	require.ErrorContains(t, err, "checksum mismatch")
+}
+
+// TestChecksumChunkReleasesTrxDuringRepair reproduces the production failure
+// mode where checksum transactions died to wait_timeout DESPITE the pool
+// keepalive: repairs serialize on recopyLock, so a worker that hit a mismatch
+// could park for many minutes holding its transaction — checked out and
+// therefore invisible to the keepalive. The fix returns the transaction to
+// the pool the moment the snapshot reads are done. This test holds recopyLock
+// (simulating another slow repair), drives a mismatched chunk through
+// ChecksumChunk, and requires the full pool to be available while the repair
+// is still queued.
+func TestChecksumChunkReleasesTrxDuringRepair(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS trxrelease, _trxrelease_new, _trxrelease_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE trxrelease (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _trxrelease_new (a INT NOT NULL, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE _trxrelease_chkpnt (a INT)")
+	testutils.RunSQL(t, "INSERT INTO trxrelease VALUES (1, 2, 3), (2, 2, 3), (3, 2, 3)")
+	testutils.RunSQL(t, "INSERT INTO _trxrelease_new VALUES (1, 2, 3), (2, 2, 3)") // row 3 missing: mismatch
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	t1 := table.NewTableInfo(db, "test", "trxrelease")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_trxrelease_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	defer feed.Close()
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.FixDifferences = true
+	checkerIntf, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+	checker, ok := checkerIntf.(*SingleChecker)
+	require.True(t, ok)
+
+	chunk, err := chunker.Next() // small table: one chunk covers everything
+	require.NoError(t, err)
+
+	pool, err := dbconn.NewTrxPool(t.Context(), db, 2, config.DBConfig, config.Logger)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pool.Close()) }()
+
+	// Simulate another worker's long-running repair.
+	checker.recopyLock.Lock()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- checker.ChecksumChunk(t.Context(), pool, chunk)
+	}()
+
+	// Once the mismatch has been inspected, the transaction must be back in
+	// the pool even though the repair is still queued on recopyLock. The
+	// differencesFound guard ensures we don't probe before the worker has
+	// taken (and must have returned) its transaction.
+	require.Eventually(t, func() bool {
+		if checker.differencesFound.Load() == 0 {
+			return false
+		}
+		trx1, err := pool.Get()
+		if err != nil {
+			return false
+		}
+		trx2, err := pool.Get()
+		if err != nil {
+			pool.Put(trx1)
+			return false
+		}
+		pool.Put(trx1)
+		pool.Put(trx2)
+		return true
+	}, 30*time.Second, 25*time.Millisecond, "transaction was not returned to the pool while the repair was queued")
+
+	// The repair itself must still be blocked on recopyLock.
+	select {
+	case err := <-errCh:
+		t.Fatalf("ChecksumChunk returned while recopyLock was held: %v", err)
+	default:
+	}
+
+	checker.recopyLock.Unlock()
+	require.NoError(t, <-errCh)
+
+	// And the repair actually repaired.
+	var cnt int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM _trxrelease_new").Scan(&cnt))
+	require.Equal(t, 3, cnt)
+}
+
+// flakyChunker wraps a real chunker and injects one transient Next() error at
+// a chosen call number, recording whether the retry that follows resumed from
+// the low watermark or reset to the beginning.
+type flakyChunker struct {
+	table.MappedChunker
+	sync.Mutex
+	failAtCall int // 1-indexed Next() call to fail once; 0 disables
+	nextCalls  int
+	wmResumes  int
+	resets     int
+}
+
+func (c *flakyChunker) Next() (*table.Chunk, error) {
+	c.Lock()
+	c.nextCalls++
+	inject := c.failAtCall != 0 && c.nextCalls == c.failAtCall
+	if inject {
+		c.failAtCall = 0
+	}
+	c.Unlock()
+	if inject {
+		return nil, errors.New("injected transient error")
+	}
+	return c.MappedChunker.Next()
+}
+
+func (c *flakyChunker) OpenAtWatermark(watermark string) error {
+	c.Lock()
+	c.wmResumes++
+	c.Unlock()
+	return c.MappedChunker.OpenAtWatermark(watermark)
+}
+
+func (c *flakyChunker) Reset() error {
+	c.Lock()
+	c.resets++
+	c.Unlock()
+	return c.MappedChunker.Reset()
+}
+
+// checksumRetryHarness builds a single-checker over a seeded 4096-row table
+// pair wrapped in a flakyChunker that errors on the third Next() call. By
+// then two chunks have completed: the first chunk has no lower bound (and so
+// cannot be expressed as a watermark on its own), the second has real bounds,
+// so the low watermark is ready when the injected error fires.
+//
+// mutateSQL (optional) plants a difference in the target table. It runs
+// before the binlog feed starts: a write to the _new table after the feed is
+// running is captured as a pending change, and the checksum's own
+// flush-under-lock would faithfully re-copy those keys from the source —
+// reverting the planted difference before any chunk gets to see it.
+func checksumRetryHarness(t *testing.T, name string, mutateSQL string) (*flakyChunker, Checker, func()) {
+	t.Helper()
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS "+name+", _"+name+"_new, _"+name+"_chkpnt")
+	testutils.RunSQL(t, "CREATE TABLE "+name+" (a INT NOT NULL AUTO_INCREMENT, b INT, c INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "INSERT INTO "+name+" (b, c) VALUES (2, 3)")
+	for range 12 { // 2^12 = 4096 rows: several chunks at the 1000-row starting size
+		testutils.RunSQL(t, "INSERT INTO "+name+" (b, c) SELECT b, c FROM "+name)
+	}
+	testutils.RunSQL(t, "CREATE TABLE _"+name+"_new LIKE "+name)
+	testutils.RunSQL(t, "INSERT INTO _"+name+"_new SELECT * FROM "+name)
+	testutils.RunSQL(t, "CREATE TABLE _"+name+"_chkpnt (a INT)")
+	if mutateSQL != "" {
+		testutils.RunSQL(t, mutateSQL)
+	}
+
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+
+	t1 := table.NewTableInfo(db, "test", name)
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "_"+name+"_new")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
+	inner, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	chunker := &flakyChunker{MappedChunker: inner, failAtCall: 3}
+	require.NoError(t, feed.AddSubscription(t1, t2, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+	require.NoError(t, chunker.Open())
+
+	config := NewCheckerDefaultConfig()
+	config.Concurrency = 1 // deterministic: chunks 1-2 complete (watermark ready) before Next() call 3 injects
+	config.FixDifferences = true
+	checker, err := NewChecker([]*sql.DB{db}, chunker, []change.Source{feed}, config)
+	require.NoError(t, err)
+	return chunker, checker, func() {
+		feed.Close()
+		utils.CloseAndLog(db)
+	}
+}
+
+// TestChecksumRetryResumesFromWatermark verifies that an attempt which errors
+// WITHOUT having found any differences (the connection-massacre shape from
+// production) resumes its retry from the low watermark instead of discarding
+// all verified work.
+func TestChecksumRetryResumesFromWatermark(t *testing.T) {
+	chunker, checker, cleanup := checksumRetryHarness(t, "retryresume", "")
+	defer cleanup()
+
+	require.NoError(t, checker.Run(t.Context()))
+
+	chunker.Lock()
+	defer chunker.Unlock()
+	require.Equal(t, 1, chunker.wmResumes, "error-only retry should resume from the low watermark")
+	require.Zero(t, chunker.resets, "error-only retry should not reset to the beginning")
+}
+
+// TestChecksumRetryResetsAfterDifferences verifies the guard on the resume
+// path: once an attempt has found (and repaired) differences, a retry must
+// restart from the beginning so the final pass provably verifies the whole
+// table clean — including the repaired chunks.
+func TestChecksumRetryResetsAfterDifferences(t *testing.T) {
+	// A difference inside the first bounded chunk's range, found and repaired
+	// before the injected error on Next() call 3. Row a=1 is the only id the
+	// seeding guarantees: the doubling INSERT..SELECTs leave auto-inc gaps.
+	chunker, checker, cleanup := checksumRetryHarness(t, "retryreset",
+		"UPDATE _retryreset_new SET b = 999 WHERE a = 1")
+	defer cleanup()
+
+	require.NoError(t, checker.Run(t.Context()))
+
+	chunker.Lock()
+	defer chunker.Unlock()
+	require.Zero(t, chunker.wmResumes, "retry after repairs must not skip re-verification")
+	require.GreaterOrEqual(t, chunker.resets, 1, "retry after repairs should reset to the beginning")
 }

--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -35,10 +35,11 @@ type TrxPool struct {
 
 	trxs   []*sql.Tx
 	logger *slog.Logger
-	// createdAt is when the snapshots were taken; every transaction in the
-	// pool is exactly this old. Logged on keepalive failures so deaths that
-	// cluster at a fixed age (an external long-transaction reaper) can be
-	// told apart from wait_timeout kills.
+	// createdAt is when pool creation completed: every snapshot is
+	// established by then, so every transaction in the pool is at least
+	// this old. Logged on keepalive failures so deaths that cluster at a
+	// fixed age (an external long-transaction reaper) can be told apart
+	// from wait_timeout kills.
 	createdAt time.Time
 	// keepalive lifecycle: cancel stops the pinger, done is closed once it
 	// has fully exited. Both are nil if pool creation failed before the
@@ -63,7 +64,7 @@ func NewTrxPool(ctx context.Context, db *sql.DB, count int, config *DBConfig, lo
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
-	pool := &TrxPool{trxs: make([]*sql.Tx, 0, count), logger: logger, createdAt: time.Now()}
+	pool := &TrxPool{trxs: make([]*sql.Tx, 0, count), logger: logger}
 	for range count {
 		trx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 		if err != nil {
@@ -74,6 +75,12 @@ func NewTrxPool(ctx context.Context, db *sql.DB, count int, config *DBConfig, lo
 			return nil, errors.Join(err, pool.Close())
 		}
 	}
+	// Timestamp the pool only after every snapshot is established, so that
+	// poolAge in keepalive warnings is a floor on each transaction's true
+	// age. Stamping before the loop would inflate it by the creation time
+	// and could suggest an age threshold (wait_timeout, a reaper) that no
+	// snapshot has actually reached.
+	pool.createdAt = time.Now()
 	if len(pool.trxs) > 0 {
 		// Derive the ping cadence from the session wait_timeout so the
 		// keepalive holds up however aggressively the server is configured.

--- a/pkg/dbconn/trxpool.go
+++ b/pkg/dbconn/trxpool.go
@@ -35,6 +35,11 @@ type TrxPool struct {
 
 	trxs   []*sql.Tx
 	logger *slog.Logger
+	// createdAt is when the snapshots were taken; every transaction in the
+	// pool is exactly this old. Logged on keepalive failures so deaths that
+	// cluster at a fixed age (an external long-transaction reaper) can be
+	// told apart from wait_timeout kills.
+	createdAt time.Time
 	// keepalive lifecycle: cancel stops the pinger, done is closed once it
 	// has fully exited. Both are nil if pool creation failed before the
 	// keepalive started (Close tolerates that).
@@ -58,7 +63,7 @@ func NewTrxPool(ctx context.Context, db *sql.DB, count int, config *DBConfig, lo
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
-	pool := &TrxPool{trxs: make([]*sql.Tx, 0, count), logger: logger}
+	pool := &TrxPool{trxs: make([]*sql.Tx, 0, count), logger: logger, createdAt: time.Now()}
 	for range count {
 		trx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 		if err != nil {
@@ -103,17 +108,19 @@ func (p *TrxPool) keepalive(ctx context.Context, interval time.Duration) {
 	defer close(p.keepaliveDone)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	lastRound := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.pingIdleTrxs(ctx)
+			p.pingIdleTrxs(ctx, time.Since(lastRound))
+			lastRound = time.Now()
 		}
 	}
 }
 
-func (p *TrxPool) pingIdleTrxs(ctx context.Context) {
+func (p *TrxPool) pingIdleTrxs(ctx context.Context, sinceLastRound time.Duration) {
 	roundCtx, cancel := context.WithTimeout(ctx, keepaliveRoundTimeout)
 	defer cancel()
 	// Holding the mutex for the whole round guarantees a transaction can't be
@@ -137,14 +144,24 @@ func (p *TrxPool) pingIdleTrxs(ctx context.Context) {
 				p.logger.Warn("keepalive round timed out; the server appears degraded and idle checksum transactions may be lost",
 					"roundTimeout", keepaliveRoundTimeout,
 					"pinged", i,
-					"idle", len(p.trxs))
+					"idle", len(p.trxs),
+					"poolAge", time.Since(p.createdAt))
 				return
 			}
 			// Keep going: the other transactions may still be healthy, and
 			// the worst case for this one is unchanged (a worker gets it and
 			// fails, exactly as it would have without the keepalive).
+			//
+			// sinceLastRound ~= the ping interval means the cadence was
+			// honored and the kill happened anyway: the transaction either
+			// died while checked out (held past wait_timeout outside the
+			// pool) or was killed by something other than idleness (failover,
+			// a long-transaction reaper — compare poolAge against any such
+			// threshold).
 			p.logger.Warn("keepalive ping of idle checksum transaction failed; its connection may have been killed (check wait_timeout)",
-				"error", err)
+				"error", err,
+				"poolAge", time.Since(p.createdAt),
+				"sinceLastRound", sinceLastRound)
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #1117, which keeps *idle, in-pool* transactions alive but turned out not to be enough in production. Sibling of #1123, which removes the cause of the incident below — this PR fixes how the checksum survives whenever repairs happen at scale, whatever the cause.

## What production showed

Deployed #1117 and ran a migration with `wait_timeout=600`; the checksum still failed at 37.6% after 1h17m:

- `high chunk processing time time=11m2s` — repairs are serialized behind `recopyLock`, so once one worker starts a `replaceChunk`, every other worker with a mismatch queues behind it. A "chunk time" of 11 minutes is really queue time: the chunker's `Feedback` duration wraps the whole of `ChecksumChunk`, including the mutex wait and the repair DML. That's also why the server's `max_execution_time=600s` never killed anything — it applies only to top-level read-only SELECTs, and a connection parked on a Go mutex is simply *idle*, which is exactly what `wait_timeout` counts.
- 14× `keepalive ping of idle checksum transaction failed ... driver: bad connection` — the keepalive found already-dead transactions **in** the pool. They didn't die there: they died while **checked out**, held by workers stuck in the repair queue for longer than `wait_timeout` (the keepalive rightly never touches checked-out transactions — the worker owns them). The dead transactions were then Put back, poisoning the pool.
- A later worker drew a poisoned transaction → `checksum failed` → `Run()`'s retry called `chunker.Reset()` and restarted verification from row zero, discarding 1h17m of progress.

Root-causing *why* nearly every chunk needed a repair led to #1123: the binlog applier rewrote empty (zero-length) blobs as `0x00` on every applied row image, so on a table storing empty serialized protos, every feed-touched row minted a checksum mismatch — enough repair volume to keep the `recopyLock` queue past `wait_timeout` continuously.

## Relationship to #1123

#1123 stops the mismatch *minting*; with it deployed, this table's repair rate returns to ~zero. But the repair path exists because real divergence happens (#1121's parked-subscription starvation, rogue writes to the shadow table, #947's BINARY truncation — there will be a next one), and `replaceChunk`'s own comment accepts that a recopy of an XL chunk can stall. This incident showed that when the repair path is actually load-bearing, it kills its own transaction pool and then throws away all verified progress — i.e., the safety net fails precisely when it's needed. Either PR alone would have prevented this incident; this one makes the checksum robust to the next cause.

## Fixes

1. **Return the pooled transaction before repairing** (`single.go`). The snapshot reads are complete once `inspectDifferences` returns; `replaceChunk` deliberately reads *current* data through `c.db`, not the snapshot (that's the point of the repair). So the worker now Puts its transaction back **before** queueing on `recopyLock`, putting it under keepalive cover for however long the repair queue takes. `ChecksumChunk` uses a guarded `putTrx` closure so the normal path still returns it exactly once via defer.
2. **Same for the distributed checker** (`distributed.go`): source/target transactions are returned immediately after their checksum query is scanned, instead of via loop-deferred Puts that held every transaction until the whole chunk finished.
3. **Resume retries from the low watermark instead of resetting** (`single.go`). If the failed attempt found **zero differences**, a connection loss says nothing about data correctness — re-verifying from the beginning is pure waste (and on a big table it can turn one transient kill into hours of lost work, repeatedly). The retry now does `GetLowWatermark()` + `OpenAtWatermark()` and continues, exactly like the yield path — `initConnPool` re-locks the tables and takes fresh snapshots for the new pass either way. If the attempt *did* find differences, we keep the full `Reset()`, because repaired chunks must be re-verified under a fresh snapshot.
4. **Attribution fields on keepalive warnings** (`trxpool.go`): `poolAge` and `sinceLastRound`, so the next log can distinguish wait_timeout races from fixed-age transaction reapers or a stalled pinger.

## Tests

- `TestChecksumChunkReleasesTrxDuringRepair` — holds `recopyLock` the way a slow repair does, then proves the worker's transaction is back in the pool (Get-able) *while* the repair is still blocked.
- `TestChecksumRetryResumesFromWatermark` — injects a transient `Next()` error on a clean table; asserts the retry resumed from the watermark and never Reset.
- `TestChecksumRetryResetsAfterDifferences` — plants a real mismatch, then injects the same transient error; asserts the retry Reset (no watermark resume) because differences had been found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)