### PR TITLE
table: serialize empty binary values as x'' instead of 0x00

### DIFF
--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -129,8 +129,14 @@ func TestSingleTargetApplierBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, count, "Should have 4 rows in target")
 
-	// Verify specific rows
-	rows, err := targetDB.QueryContext(t.Context(), "SELECT id, name, value, binaryvalue FROM test_table ORDER BY id")
+	// Verify specific rows. The blob assertions check nullness and length
+	// explicitly: bytes.Equal (which testify uses for []byte) treats nil and
+	// []byte{} as equal, but NULL, the empty string, and a one-byte NUL are
+	// three distinct values and the applier must preserve each exactly.
+	// Regression: the empty value used to be written as 0x00 (a one-byte
+	// NUL), silently corrupting empty blobs applied via the binlog feed.
+	rows, err := targetDB.QueryContext(t.Context(),
+		"SELECT id, name, value, binaryvalue, binaryvalue IS NULL, COALESCE(LENGTH(binaryvalue), -1) FROM test_table ORDER BY id")
 	require.NoError(t, err)
 	defer utils.CloseAndLog(rows)
 
@@ -139,24 +145,29 @@ func TestSingleTargetApplierBasic(t *testing.T) {
 		name        string
 		value       int64
 		binaryvalue []byte
+		isNull      bool
+		length      int64
 	}{
-		{1, "Alice", 100, []byte{0x00}},
-		{2, "Bob", 200, nil},
-		{3, "Charlie", 300, []byte{0x62, 0x72, 0x6F, 0x77, 0x6E}},
-		{4, "Dan", 400, []byte{0x00}},
+		{1, "Alice", 100, []byte{0x00}, false, 1},
+		{2, "Bob", 200, nil, true, -1},
+		{3, "Charlie", 300, []byte{0x62, 0x72, 0x6F, 0x77, 0x6E}, false, 5},
+		{4, "Dan", 400, []byte{}, false, 0},
 	}
 
 	i := 0
 	for rows.Next() {
-		var id, value int64
+		var id, value, length int64
 		var name string
 		var binaryvalue []byte
-		err = rows.Scan(&id, &name, &value, &binaryvalue)
+		var isNull bool
+		err = rows.Scan(&id, &name, &value, &binaryvalue, &isNull, &length)
 		require.NoError(t, err)
 		require.Equal(t, expected[i].id, id)
 		require.Equal(t, expected[i].name, name)
 		require.Equal(t, expected[i].value, value)
 		require.Equal(t, expected[i].binaryvalue, binaryvalue)
+		require.Equal(t, expected[i].isNull, isNull, "row id=%d nullness", id)
+		require.Equal(t, expected[i].length, length, "row id=%d blob length", id)
 		i++
 	}
 	require.NoError(t, rows.Err())
@@ -681,6 +692,84 @@ func TestSingleTargetApplierUpsertRows(t *testing.T) {
 		require.Equal(t, expected[i].id, id)
 		require.Equal(t, expected[i].name, name)
 		require.Equal(t, expected[i].value, value)
+		i++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, 3, i)
+}
+
+// TestSingleTargetApplierUpsertRowsEmptyBlob is a regression test for the
+// binlog-apply path corrupting empty (zero-length, non-NULL) binary values.
+// Under row-based replication any update to a row produces a full row image,
+// so UpsertRows rewrites every column — including blobs the application never
+// touched. The empty value used to serialize as 0x00 (a one-byte NUL), so
+// each REPLACE turned ” into '\x00' in the target: on tables that store
+// empty strings (e.g. zero-length serialized protos) every feed-touched row
+// produced a checksum mismatch, was recopied byte-exact, and then re-minted
+// on the row's next update — a checksum that never converges, and real
+// corruption for rows whose last update lands after the final checksum pass.
+func TestSingleTargetApplierUpsertRowsEmptyBlob(t *testing.T) {
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS single_upsert_emptyblob_test")
+	testutils.RunSQL(t, "CREATE DATABASE single_upsert_emptyblob_test")
+
+	base, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	target := base.Clone()
+	target.DBName = "single_upsert_emptyblob_test"
+	targetDB, err := sql.Open("mysql", target.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+
+	_, err = targetDB.ExecContext(t.Context(),
+		"CREATE TABLE transfers (id INT PRIMARY KEY, state VARCHAR(20), instrument_proto BLOB)")
+	require.NoError(t, err)
+
+	// The copy phase wrote these rows byte-exact (server-side INSERT..SELECT).
+	_, err = targetDB.ExecContext(t.Context(),
+		"INSERT INTO transfers VALUES (1, 'pending', ''), (2, 'pending', NULL), (3, 'pending', 0x00)")
+	require.NoError(t, err)
+
+	targetTable := table.NewTableInfo(targetDB, target.DBName, "transfers")
+	require.NoError(t, targetTable.SetInfo(t.Context()))
+
+	applier, err := NewSingleTargetApplier(Target{DB: targetDB, Config: target, KeyRange: "0"}, NewApplierDefaultConfig())
+	require.NoError(t, err)
+
+	// The application updates only `state`; the binlog row images still carry
+	// the full row, so the blobs are rewritten with their existing values.
+	upsertRows := []LogicalRow{
+		{RowImage: []any{int64(1), "settled", []byte{}}},
+		{RowImage: []any{int64(2), "settled", nil}},
+		{RowImage: []any{int64(3), "settled", []byte{0x00}}},
+	}
+	_, err = applier.UpsertRows(t.Context(), table.NewColumnMapping(targetTable, targetTable, nil), upsertRows, nil)
+	require.NoError(t, err)
+
+	// The REPLACE must preserve all three distinct values: empty, NULL, and a
+	// one-byte NUL.
+	rows, err := targetDB.QueryContext(t.Context(),
+		"SELECT id, state, instrument_proto IS NULL, COALESCE(LENGTH(instrument_proto), -1) FROM transfers ORDER BY id")
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+
+	expected := []struct {
+		isNull bool
+		length int64
+	}{
+		{false, 0}, // id=1: empty string stays zero-length, NOT 0x00
+		{true, -1}, // id=2: NULL stays NULL
+		{false, 1}, // id=3: a real one-byte NUL stays one byte
+	}
+	i := 0
+	for rows.Next() {
+		var id, length int64
+		var state string
+		var isNull bool
+		require.NoError(t, rows.Scan(&id, &state, &isNull, &length))
+		require.Equal(t, "settled", state)
+		require.Equal(t, expected[i].isNull, isNull, "row id=%d nullness", id)
+		require.Equal(t, expected[i].length, length, "row id=%d blob length", id)
 		i++
 	}
 	require.NoError(t, rows.Err())

--- a/pkg/applier/single_target_test.go
+++ b/pkg/applier/single_target_test.go
@@ -702,12 +702,12 @@ func TestSingleTargetApplierUpsertRows(t *testing.T) {
 // binlog-apply path corrupting empty (zero-length, non-NULL) binary values.
 // Under row-based replication any update to a row produces a full row image,
 // so UpsertRows rewrites every column — including blobs the application never
-// touched. The empty value used to serialize as 0x00 (a one-byte NUL), so
-// each REPLACE turned ” into '\x00' in the target: on tables that store
-// empty strings (e.g. zero-length serialized protos) every feed-touched row
-// produced a checksum mismatch, was recopied byte-exact, and then re-minted
-// on the row's next update — a checksum that never converges, and real
-// corruption for rows whose last update lands after the final checksum pass.
+// touched. The empty value used to serialize as 0x00 — a one-byte NUL, a
+// different value — so on tables that store empty strings (e.g. zero-length
+// serialized protos) every feed-touched row produced a checksum mismatch,
+// was recopied byte-exact, and then re-minted on the row's next update: a
+// checksum that never converges, and real corruption for rows whose last
+// update lands after the final checksum pass.
 func TestSingleTargetApplierUpsertRowsEmptyBlob(t *testing.T) {
 	testutils.RunSQL(t, "DROP DATABASE IF EXISTS single_upsert_emptyblob_test")
 	testutils.RunSQL(t, "CREATE DATABASE single_upsert_emptyblob_test")

--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -118,8 +118,9 @@ func (b *Boundary) valuesString() string {
 
 // jsonQuoteDatum renders a boundary datum as a JSON string literal (always
 // quoted, properly escaped). Numeric values are quoted to avoid JSON float
-// behavior (#125); binary values are hex-encoded ("0x...") so they round-trip
-// via datumValFromString. Crucially it uses json.Marshal rather than
+// behavior (#125); binary values are hex-encoded ("0x...", or the empty
+// binary literal for a zero-length value) so they round-trip via
+// datumValFromString. Crucially it uses json.Marshal rather than
 // Datum.String() (which SQL-escapes for WHERE clauses): a string value that is
 // valid in a MySQL string literal but not in JSON — e.g. a VARCHAR PK holding a
 // control byte like 0x16, or an embedded quote — must be JSON-escaped here, or
@@ -135,7 +136,10 @@ func jsonQuoteDatum(v Datum) string {
 			bs = fmt.Sprintf("%v", v.Val)
 		}
 		if len(bs) == 0 {
-			s = "0x00" // MySQL binary string needs at least one character
+			// Matches Datum.String(): x'' is the zero-length binary value.
+			// It must not be 0x00 (a one-byte NUL — a different value);
+			// datumValFromString decodes x'' back to the empty string.
+			s = "x''"
 		} else {
 			s = fmt.Sprintf("%#x", bs)
 		}

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -150,8 +150,13 @@ func datumValFromString(val string, tp datumTp) (any, error) {
 	case unsignedType:
 		return strconv.ParseUint(val, 10, 64)
 	case binaryType:
-		// Binary types are always hex-encoded in checkpoint JSON via Datum.String().
-		// Decode the hex back to raw binary bytes.
+		// Binary types are hex-encoded ("0x...") in checkpoint JSON via
+		// jsonQuoteDatum, except the empty value, which is serialized as
+		// x'' (there is no zero-digit 0x literal). Decode both back to
+		// raw binary bytes.
+		if val == "x''" {
+			return "", nil
+		}
 		if strings.HasPrefix(val, "0x") {
 			tmp, err := hex.DecodeString(val[2:])
 			if err != nil {
@@ -322,6 +327,7 @@ func (d Datum) Range(d2 Datum) (uint64, error) {
 //   - NULL                            for IsNil()
 //   - the numeric literal (e.g. 42)   for IsNumeric()
 //   - 0x... hex literal               for IsBinaryString()
+//     (a zero-length value uses the empty binary literal instead — see below)
 //   - "..." with backslash escapes    for everything else
 //
 // The string-literal path runs sqlescape.EscapeString on the contents
@@ -351,9 +357,15 @@ func (d Datum) String() string {
 		s = fmt.Sprintf("%v", d.Val)
 	}
 	if d.IsBinaryString() {
-		// MySQL binary string needs at least one character
+		// The empty value still needs a valid SQL literal: %#x renders ""
+		// as "" and a bare "0x" parses as an identifier, so emit the
+		// standard zero-length hex literal instead. It must NOT be 0x00 —
+		// that is a one-byte NUL, a different value, and emitting it here
+		// made every binlog-applied REPLACE corrupt empty blobs (minting
+		// endless checksum mismatches on tables that store empty strings,
+		// e.g. zero-length serialized protos).
 		if len(s) == 0 {
-			return "0x00"
+			return "x''"
 		}
 		return fmt.Sprintf("%#x", s)
 	}

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -152,8 +152,9 @@ func datumValFromString(val string, tp datumTp) (any, error) {
 	case binaryType:
 		// Binary types are hex-encoded ("0x...") in checkpoint JSON via
 		// jsonQuoteDatum, except the empty value, which is serialized as
-		// x'' (there is no zero-digit 0x literal). Decode both back to
-		// raw binary bytes.
+		// x'' (there is no zero-digit 0x literal). Decode both back to a
+		// Go string holding the raw bytes: Datum.Val stores binary values
+		// as string, never []byte.
 		if val == "x''" {
 			return "", nil
 		}

--- a/pkg/table/datum_test.go
+++ b/pkg/table/datum_test.go
@@ -300,17 +300,20 @@ func TestNewDatumFromValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "0xfffefd", d.String())
 
-	// Test empty binary values - must NOT serialize as "0x" because
-	// MySQL parses that as an identifier, not a hex literal.
+	// A one-byte NUL serializes as its hex value.
 	d, err = NewDatumFromValue([]byte{0x00}, "MEDIUMBLOB")
 	require.NoError(t, err)
 	require.Equal(t, "0x00", d.String())
+	// Empty binary values must NOT serialize as "0x" (MySQL parses that as
+	// an identifier, not a hex literal) — and must NOT serialize as "0x00"
+	// either: a one-byte NUL is a different value, and emitting it here
+	// silently corrupted empty blobs applied via the binlog feed.
 	d, err = NewDatumFromValue([]byte{}, "VARBINARY(255)")
 	require.NoError(t, err)
-	require.Equal(t, "0x00", d.String())
+	require.Equal(t, "x''", d.String())
 	d, err = NewDatumFromValue("", "BLOB")
 	require.NoError(t, err)
-	require.Equal(t, "0x00", d.String())
+	require.Equal(t, "x''", d.String())
 	d, err = NewDatumFromValue(nil, "BLOB")
 	require.NoError(t, err)
 	require.Equal(t, "NULL", d.String())
@@ -473,4 +476,43 @@ func TestDatumCompareTypeMismatch(t *testing.T) {
 	gt, err := goodSigned.GreaterThan(Datum{Val: int64(0), Tp: signedType})
 	require.NoError(t, err)
 	require.True(t, gt)
+}
+
+// TestEmptyBinaryDatumRoundTrip is a regression test for empty (zero-length,
+// non-NULL) binary values. These used to serialize as 0x00 — a one-byte NUL,
+// a *different* value — so every binlog-applied REPLACE rewrote empty blobs
+// as \x00 in the target. On tables where the application stores empty strings
+// (e.g. zero-length serialized protos), the checksum then flagged every
+// feed-touched row, recopied it (which fixed it, byte-exact), and the next
+// application update re-minted the difference: a checksum that never
+// converges, plus real corruption for any row not re-verified after its last
+// update. The empty value must round-trip through both serialization paths:
+// Datum.String() (SQL literals for the applier and WHERE clauses) and
+// jsonQuoteDatum/datumValFromString (checkpoint watermarks).
+func TestEmptyBinaryDatumRoundTrip(t *testing.T) {
+	empty, err := NewDatumFromValue([]byte{}, "BLOB")
+	require.NoError(t, err)
+
+	// SQL literal path: x'' is MySQL's zero-length binary literal.
+	require.Equal(t, "x''", empty.String())
+
+	// Checkpoint JSON path: emit, then decode back to the empty string.
+	require.Equal(t, `"x''"`, jsonQuoteDatum(empty))
+	val, err := datumValFromString("x''", binaryType)
+	require.NoError(t, err)
+	decoded, ok := val.(string)
+	require.True(t, ok, "decoded empty binary should be a string, got %T", val)
+	require.Empty(t, decoded)
+
+	// A one-byte NUL is a distinct value and must stay 0x00 on both paths.
+	nul, err := NewDatumFromValue([]byte{0x00}, "BLOB")
+	require.NoError(t, err)
+	require.Equal(t, "0x00", nul.String())
+	require.Equal(t, `"0x00"`, jsonQuoteDatum(nul))
+	val, err = datumValFromString("0x00", binaryType)
+	require.NoError(t, err)
+	require.Equal(t, "\x00", val)
+
+	// NULL is also distinct from empty.
+	require.Equal(t, "NULL", NewNilDatum(binaryType).String())
 }


### PR DESCRIPTION
## The bug

`Datum.String()` (and its checkpoint-JSON twin `jsonQuoteDatum`) special-case empty binary values because `%#x` renders `""` as an empty string, which is not valid SQL. But the placeholder they emitted — `0x00` — is a **one-byte NUL**, a different value: `LENGTH('') = 0`, `LENGTH(0x00) = 1`. Introduced in 4f4a6ae5 ("Handle Datum binary type values of empty string", 2026-04-28); the test added there codified the corruption, inserting `[]byte{}` and asserting it reads back as `[]byte{0x00}`.

Every SQL emission path funnels through `Datum.String()`: the binlog applier's `REPLACE INTO` (single-target and sharded) and the buffered copier's `INSERT IGNORE`. So any row whose blob/varbinary column holds the empty string got silently rewritten as `'\x00'` in the target every time the feed applied its row image.

## Production impact (how we found it)

On a 91M-row `transfers` migration (four blob columns; an empty serialized proto is a zero-byte string):

- Under RBR, an application update to *any* column carries the full row image — so the feed rewrote the blobs of every updated row, corrupting the empty ones. Every feed-touched empty-blob row minted a checksum mismatch (`sourceCount == targetCount`, content differs, mismatched pks clustered like application batch jobs).
- The checksum recopied each such chunk (server-side `REPLACE INTO ... SELECT` — byte-exact, so it *fixed* the row), and the row's next application update re-minted it: **a checksum that can never converge while writes continue**.
- Repairs serialize behind `recopyLock`, so nearly every worker queued behind ~30s recopies: 11-minute "chunk processing times", workers holding pooled checksum transactions idle past `wait_timeout=600` (the failure mode #1117/#1122 address), and checksum throughput collapsing to ~1 chunk per 30s while the autoscaler kept adding threads because blocked workers look idle.
- Worst case: any row whose **last** update lands after the final checksum pass ships `0x00` where the application wrote `''` at cutover. A lone `0x00` is not even a valid serialized proto (field number 0 is illegal) — this is app-visible corruption, not just checksum noise.

## The fix

- `Datum.String()`: emit `x''`, MySQL's zero-length binary literal (valid in VALUES clauses and WHERE comparisons). `0x00` remains the encoding for a genuine one-byte NUL, and NULL is unchanged.
- `jsonQuoteDatum` (checkpoint watermarks): same, and `datumValFromString` now decodes `x''` back to the empty string, so binary watermark boundaries round-trip.
- Tests: `TestEmptyBinaryDatumRoundTrip` covers both serialization paths plus the NUL/NULL/empty distinctions; the applier tests now assert `IS NULL` and `LENGTH()` explicitly (testify compares `[]byte` with `bytes.Equal`, which cannot tell `nil` from empty — the old assertions could not have caught this); `TestSingleTargetApplierUpsertRowsEmptyBlob` reproduces the production scenario end-to-end: a binlog-style REPLACE of rows whose blobs are `''`/`NULL`/`0x00` must preserve all three distinct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)