### PR TITLE
change: parallelize the map-mode flush drain

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -396,13 +396,13 @@ Spirit uses `threads` to set the parallelism of:
 - The copier task
 - The checksum task
 
-The parallelism of the replication applier is controlled separately by [write-threads](#write-threads).
+The write side of the copy — the applier's write workers — is controlled separately by [write-threads](#write-threads).
 
 This flag is **ignored** when [enable-experimental-autoscaling](#enable-experimental-autoscaling) engages: the autoscaler sizes both pools from the instance instead.
 
-Internal to Spirit, the database pool is sized as `threads + write-threads + control-plane + checksum-off-pool`. This is intentional because the replication applier runs concurrently to the copier and checksum tasks: `threads` covers the copier/checksum work and `write-threads` covers the applier, while the two headroom terms keep the periodic work from queueing behind a saturated hot path:
+Internal to Spirit, the database pool is sized as `threads + write-threads + control-plane + checksum-off-pool`. This is intentional because copy writes run concurrently to copy reads and checksums: `threads` covers the copier/checksum work and `write-threads` covers the applier's write workers, while the two headroom terms keep the periodic work from queueing behind a saturated hot path:
 
-- **control-plane** is `2 + one per changed table`, for the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater — all of which run on the same pool as the copier and applier.
+- **control-plane** is `2 + one per changed table`, for the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater — all of which run on the same pool as the copier and applier. The replication flush itself has no dedicated per-connection budget: a map-mode drain applies up to `8` batches concurrently (see [write-threads](#write-threads)) from the shared pool, borrowing capacity the copier is not using. Worst case — a drain overlapping a saturated copy — the flush batches briefly queue on connection checkout; during post-copy catch-up, when only the flush is running, the idle copier's share of the pool is available to it.
 - **checksum-off-pool** is a fixed `2`, for the two things the checksum does outside its `REPEATABLE READ` transaction pool: repairing a mismatched chunk, and the chunker's `LIMIT 1 OFFSET n` boundary prefetch. Both are serialized, so one connection each. The transaction pool itself is provisioned separately and every one of its transactions pins a connection for the whole phase, so there is no incidental slack for these to borrow.
 
 Throttler polling is not counted: it runs on a dedicated monitoring pool.
@@ -418,7 +418,9 @@ One piece of pacing is *not* opt-in: the checksum phase waits on the throttler b
 - Type: Integer
 - Default value: `4`
 
-Sets the parallelism of the **replication applier** — the number of concurrent write threads used to apply changes (read from the binlog) to the new table. Copier and checksum parallelism are controlled separately by [threads](#threads).
+Sets the parallelism of the **applier's write workers** — the pool that lands copied rows into the new table during the copy phase. Copier read and checksum parallelism are controlled separately by [threads](#threads).
+
+Replication (binlog) apply parallelism is **not** controlled by this flag. Buffered replication changes for tables with a memory-comparable primary key are drained with up to `8` applier batches in flight (a flush snapshot holds one image per key, so batches are disjoint and commute); other drains — non-memory-comparable keys post-copy, and the final under-lock flush at cutover — apply serially. The concurrency is a library-level setting (`ClientConfig.FlushConcurrency`) with no CLI flag today; raising `write-threads` does not speed up binlog catch-up.
 
 This flag is **ignored** when [autoscaling](#enable-experimental-autoscaling) engages: the autoscaler sizes the write pool from the instance (vCPU count minus 2) and treats that as its starting point.
 
@@ -427,7 +429,7 @@ This flag is **ignored** when [autoscaling](#enable-experimental-autoscaling) en
 - Type: Boolean
 - Default value: `false`
 
-**Experimental.** When enabled, Spirit dynamically adjusts the number of copy read threads, the number of replication-applier write threads, and the number of checksum threads, based on feedback from the throttlers. The copy phase is described first; see [checksum scaling](#checksum-scaling) below for how the checksum differs. Each throttler reports a continuous *utilization* signal (0 = idle, 1.0 = the point at which it would hard-stop the copy); the controller takes the highest signal across all throttlers and steers the thread counts to keep it in a comfortable band. Because both pools contribute to the same signal, utilization alone cannot tell which side to move — the buffer queue between the readers and the writers arbitrates: a near-empty queue that writers drain instantly means the read side is the limiting (or, under load, the responsible) pool; a near-full queue where chunks wait as long as they take to write means the write side is.
+**Experimental.** When enabled, Spirit dynamically adjusts the number of copy read threads, the number of applier write threads, and the number of checksum threads, based on feedback from the throttlers. The copy phase is described first; see [checksum scaling](#checksum-scaling) below for how the checksum differs. Each throttler reports a continuous *utilization* signal (0 = idle, 1.0 = the point at which it would hard-stop the copy); the controller takes the highest signal across all throttlers and steers the thread counts to keep it in a comfortable band. Because both pools contribute to the same signal, utilization alone cannot tell which side to move — the buffer queue between the readers and the writers arbitrates: a near-empty queue that writers drain instantly means the read side is the limiting (or, under load, the responsible) pool; a near-full queue where chunks wait as long as they take to write means the write side is.
 
 - **Below 40% utilization** it grows the limiting pool by one thread at a time (cautiously, with a ~15s cooldown between increases). If the pipeline is balanced — neither side limiting — it holds instead of growing either pool.
 - **At or above 70% utilization** it sheds one thread at a time from the side the queue blames (immediately on the first breach, then at most once per ~15s so the signal can reflect each cut).

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -100,6 +100,10 @@ type binlogClient struct {
 	// cap. See DefaultSubscriptionSoftLimitBytes.
 	subscriptionSoftLimitBytes int64
 
+	// flushConcurrency is the map-mode flush batch concurrency passed
+	// to each subscription on construction. See DefaultFlushConcurrency.
+	flushConcurrency int
+
 	// flushRequests receives the subscription that parked on its soft
 	// memory limit. runPeriodicFlush selects on it and flushes that
 	// subscription first — the all-subscription pass visits the
@@ -127,6 +131,12 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 	} else if softLimit < 0 {
 		softLimit = 0 // explicit opt-out
 	}
+	flushConcurrency := config.FlushConcurrency
+	if flushConcurrency == 0 {
+		flushConcurrency = DefaultFlushConcurrency
+	} else if flushConcurrency < 0 {
+		flushConcurrency = 1 // explicit opt-out: serial
+	}
 	return &binlogClient{
 		db:                         db,
 		dbConfig:                   config.DBConfig,
@@ -141,6 +151,7 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
+		flushConcurrency:           flushConcurrency,
 		flushRequests:              make(chan Subscription, 1),
 	}
 }
@@ -158,13 +169,14 @@ func (c *binlogClient) AddSubscription(currentTable, newTable *table.TableInfo, 
 	// like a FIFO queue, which is required because of collation edge cases
 	// (A == a on the server, but not in our map).
 	sub, err := NewBufferedSubscription(BufferedSubscriptionConfig{
-		CurrentTable:   currentTable,
-		NewTable:       newTable,
-		Applier:        c.applier,
-		Chunker:        chunker,
-		Logger:         c.logger,
-		SoftLimitBytes: c.subscriptionSoftLimitBytes,
-		FlushRequest:   c.flushRequests,
+		CurrentTable:     currentTable,
+		NewTable:         newTable,
+		Applier:          c.applier,
+		Chunker:          chunker,
+		Logger:           c.logger,
+		SoftLimitBytes:   c.subscriptionSoftLimitBytes,
+		FlushRequest:     c.flushRequests,
+		FlushConcurrency: c.flushConcurrency,
 	})
 	if err != nil {
 		return fmt.Errorf("could not build subscription for table %s.%s: %w", currentTable.SchemaName, currentTable.TableName, err)

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -131,12 +131,6 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 	} else if softLimit < 0 {
 		softLimit = 0 // explicit opt-out
 	}
-	flushConcurrency := config.FlushConcurrency
-	if flushConcurrency == 0 {
-		flushConcurrency = DefaultFlushConcurrency
-	} else if flushConcurrency < 0 {
-		flushConcurrency = 1 // explicit opt-out: serial
-	}
 	return &binlogClient{
 		db:                         db,
 		dbConfig:                   config.DBConfig,
@@ -151,7 +145,7 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
-		flushConcurrency:           flushConcurrency,
+		flushConcurrency:           config.resolveFlushConcurrency(),
 		flushRequests:              make(chan Subscription, 1),
 	}
 }

--- a/pkg/change/config.go
+++ b/pkg/change/config.go
@@ -80,6 +80,21 @@ type ClientConfig struct {
 	FlushConcurrency int
 }
 
+// resolveFlushConcurrency normalizes the FlushConcurrency knob for the
+// clients: 0 (the zero value) means DefaultFlushConcurrency, negative
+// means an explicit opt-out to a serial drain. Both clients resolve
+// through this so the same ClientConfig can never produce different
+// concurrency semantics per client type.
+func (c *ClientConfig) resolveFlushConcurrency() int {
+	if c.FlushConcurrency == 0 {
+		return DefaultFlushConcurrency
+	}
+	if c.FlushConcurrency < 0 {
+		return 1 // explicit opt-out: serial
+	}
+	return c.FlushConcurrency
+}
+
 // NewClientDefaultConfig returns a default config for the copier.
 func NewClientDefaultConfig() *ClientConfig {
 	return &ClientConfig{

--- a/pkg/change/config.go
+++ b/pkg/change/config.go
@@ -71,6 +71,13 @@ type ClientConfig struct {
 	// entirely (HasChanged will never block on memory). Zero (the
 	// zero-value default) means use DefaultSubscriptionSoftLimitBytes.
 	SubscriptionSoftLimitBytes int64
+
+	// FlushConcurrency overrides DefaultFlushConcurrency for new
+	// subscriptions: the maximum number of applier batches a map-mode
+	// flush keeps in flight concurrently. Set to a negative value to
+	// force serial flushing. Zero (the zero-value default) means use
+	// DefaultFlushConcurrency.
+	FlushConcurrency int
 }
 
 // NewClientDefaultConfig returns a default config for the copier.

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -93,6 +93,10 @@ type gtidClient struct {
 
 	subscriptionSoftLimitBytes int64
 
+	// flushConcurrency is the map-mode flush batch concurrency passed
+	// to each subscription on construction. See DefaultFlushConcurrency.
+	flushConcurrency int
+
 	// flushRequests receives the subscription that parked on its soft
 	// memory limit; runPeriodicFlush selects on it and flushes that
 	// subscription first, then runs the normal all-subscription pass.
@@ -115,6 +119,12 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 	} else if softLimit < 0 {
 		softLimit = 0
 	}
+	flushConcurrency := config.FlushConcurrency
+	if flushConcurrency == 0 {
+		flushConcurrency = DefaultFlushConcurrency
+	} else if flushConcurrency < 0 {
+		flushConcurrency = 1 // explicit opt-out: serial
+	}
 	return &gtidClient{
 		db:                         db,
 		dbConfig:                   config.DBConfig,
@@ -129,6 +139,7 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
+		flushConcurrency:           flushConcurrency,
 		flushRequests:              make(chan Subscription, 1),
 	}
 }
@@ -137,13 +148,14 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 func (c *gtidClient) AddSubscription(currentTable, newTable *table.TableInfo, chunker table.MappedChunker) error {
 	subKey := encodeSchemaTable(currentTable.SchemaName, currentTable.TableName)
 	sub, err := NewBufferedSubscription(BufferedSubscriptionConfig{
-		CurrentTable:   currentTable,
-		NewTable:       newTable,
-		Applier:        c.applier,
-		Chunker:        chunker,
-		Logger:         c.logger,
-		SoftLimitBytes: c.subscriptionSoftLimitBytes,
-		FlushRequest:   c.flushRequests,
+		CurrentTable:     currentTable,
+		NewTable:         newTable,
+		Applier:          c.applier,
+		Chunker:          chunker,
+		Logger:           c.logger,
+		SoftLimitBytes:   c.subscriptionSoftLimitBytes,
+		FlushRequest:     c.flushRequests,
+		FlushConcurrency: c.flushConcurrency,
 	})
 	if err != nil {
 		return fmt.Errorf("could not build subscription for table %s.%s: %w", currentTable.SchemaName, currentTable.TableName, err)

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -119,12 +119,6 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 	} else if softLimit < 0 {
 		softLimit = 0
 	}
-	flushConcurrency := config.FlushConcurrency
-	if flushConcurrency == 0 {
-		flushConcurrency = DefaultFlushConcurrency
-	} else if flushConcurrency < 0 {
-		flushConcurrency = 1 // explicit opt-out: serial
-	}
 	return &gtidClient{
 		db:                         db,
 		dbConfig:                   config.DBConfig,
@@ -139,7 +133,7 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 		serverID:                   config.ServerID,
 		applier:                    appl,
 		subscriptionSoftLimitBytes: softLimit,
-		flushConcurrency:           flushConcurrency,
+		flushConcurrency:           config.resolveFlushConcurrency(),
 		flushRequests:              make(chan Subscription, 1),
 	}
 }

--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -39,6 +39,20 @@ const (
 	// Longer values require more memory, but permit more merging.
 	// I expect we will change this to 1hr-24hr in the future.
 	DefaultFlushInterval = 30 * time.Second
+	// DefaultFlushConcurrency is the number of applier batches a
+	// map-mode flush keeps in flight concurrently. The binlog apply
+	// path is synchronous REPLACE/DELETE statements — it does not use
+	// the copy path's write worker pool — so each stream tops out at
+	// DefaultBatchSize rows per statement round trip. On large tables
+	// where secondary index maintenance dominates, that is only a few
+	// hundred rows/s, which a busy source's distinct-key write rate can
+	// permanently outrun: the buffer pins at the soft limit and the
+	// migration never converges, however long it runs. Map-mode flush
+	// batches are disjoint by key and order-free (REPLACE/DELETE on
+	// distinct keys commute), so applying them concurrently is safe and
+	// multiplies the ceiling. Queue-mode drains (non-memory-comparable
+	// PK, post-copy) and under-lock (cutover) flushes remain serial.
+	DefaultFlushConcurrency = 8
 	// DefaultSubscriptionSoftLimitBytes caps the approximate memory held
 	// per subscription before HasChanged starts blocking on the buffered
 	// map's condition variable. The cap is "soft": a single oversized

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -448,18 +448,18 @@ func (s *bufferedMap) ImmutableColumnOrdinal() int {
 	return slices.Index(s.table.Columns, s.table.ShardingColumn)
 }
 
-// queueModeActive reports whether new events should be appended to the
-// FIFO queue rather than the map. Caller must hold s.Lock.
-//
-// Memory-comparable PKs are never queue-mode (map-key equality matches
-// MySQL row identity). Non-memory-comparable PKs run in map mode during
-// the copy phase (watermark on) and switch to queue mode post-copy.
 // effectiveFlushConcurrency clamps flushConcurrency to at least 1 so
 // the zero value (out-of-tree callers, bare test maps) stays serial.
 func (s *bufferedMap) effectiveFlushConcurrency() int {
 	return max(1, s.flushConcurrency)
 }
 
+// queueModeActive reports whether new events should be appended to the
+// FIFO queue rather than the map. Caller must hold s.Lock.
+//
+// Memory-comparable PKs are never queue-mode (map-key equality matches
+// MySQL row identity). Non-memory-comparable PKs run in map mode during
+// the copy phase (watermark on) and switch to queue mode post-copy.
 func (s *bufferedMap) queueModeActive() bool {
 	if s.pkIsMemoryComparable {
 		return false

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -13,6 +13,7 @@ import (
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
+	"golang.org/x/sync/errgroup"
 )
 
 // The bufferedMap avoids using REPLACE INTO .. SELECT.
@@ -119,6 +120,13 @@ type bufferedMap struct {
 	// trips are in flight. Lock order: flushMu before Mutex, never the
 	// reverse.
 	flushMu sync.Mutex
+
+	// flushConcurrency is the maximum number of applier batches a
+	// map-mode drain keeps in flight concurrently; <= 1 means serial.
+	// Only drainMapSnapshot uses it: map batches are disjoint by key
+	// and order-free. Queue-mode drains are FIFO and the under-lock
+	// (cutover) path must stay atomic, so both remain serial.
+	flushConcurrency int
 
 	// logger is supplied by the change.Source that owns this subscription.
 	// We keep only a *slog.Logger (not a back-pointer to the source) so the
@@ -264,6 +272,13 @@ type BufferedSubscriptionConfig struct {
 	// change reader parked for those entire drains. Optional; nil
 	// disables the signal.
 	FlushRequest chan<- Subscription
+
+	// FlushConcurrency is the maximum number of applier batches a
+	// map-mode flush keeps in flight concurrently. Zero or negative
+	// means serial, preserving prior behaviour for callers that do not
+	// set it; the in-tree clients pass DefaultFlushConcurrency. Queue-
+	// mode and under-lock flushes are always serial regardless.
+	FlushConcurrency int
 }
 
 // NewBufferedSubscription constructs the default bufferedMap-backed
@@ -312,6 +327,7 @@ func NewBufferedSubscription(cfg BufferedSubscriptionConfig) (Subscription, erro
 		pkIsMemoryComparable: cfg.CurrentTable.PrimaryKeyIsMemoryComparable() == nil,
 		softLimitBytes:       cfg.SoftLimitBytes,
 		flushRequest:         cfg.FlushRequest,
+		flushConcurrency:     cfg.FlushConcurrency,
 	}
 	sub.cond = sync.NewCond(&sub.Mutex)
 	return sub, nil
@@ -438,6 +454,12 @@ func (s *bufferedMap) ImmutableColumnOrdinal() int {
 // Memory-comparable PKs are never queue-mode (map-key equality matches
 // MySQL row identity). Non-memory-comparable PKs run in map mode during
 // the copy phase (watermark on) and switch to queue mode post-copy.
+// effectiveFlushConcurrency clamps flushConcurrency to at least 1 so
+// the zero value (out-of-tree callers, bare test maps) stays serial.
+func (s *bufferedMap) effectiveFlushConcurrency() int {
+	return max(1, s.flushConcurrency)
+}
+
 func (s *bufferedMap) queueModeActive() bool {
 	if s.pkIsMemoryComparable {
 		return false
@@ -661,39 +683,50 @@ func (s *bufferedMap) Flush(ctx context.Context, underLock bool, locks []*dbconn
 	return allChangesFlushed, nil
 }
 
+// mapFlushBatch is one applier round trip's worth of a map-mode drain:
+// disjoint keys, pre-partitioned into deletes and upserts, with the
+// buffer-accounting byte total captured at build time. applied is set
+// by the worker that lands the batch and read only after the errgroup
+// joins (Wait establishes the happens-before edge).
+type mapFlushBatch struct {
+	keys        []string
+	deleteKeys  [][]any
+	upsertRows  []applier.LogicalRow
+	storedBytes int64
+	applied     bool
+}
+
 // drainMapSnapshot applies a swapped-out map snapshot through the
-// applier without holding s.Mutex. Applied entries are deleted from the
-// snapshot as each batch lands, and their bytes/count are released
-// under the Mutex (with a cond broadcast) so a parked HasChanged caller
-// resumes after the first batch, not after the whole drain. Entries
-// deferred by the low-watermark filter stay in the snapshot for the
-// caller to merge back. Returns false when any entry was deferred.
+// applier without holding s.Mutex. Batches are built serially, then
+// applied with up to flushConcurrency applier calls in flight: a map
+// snapshot holds exactly one image per key, so batches are disjoint by
+// key, and map mode makes no cross-key ordering promises — REPLACE and
+// DELETE against distinct keys commute. The binlog apply path is
+// synchronous statements on one connection per call (it does not use
+// the copy path's write worker pool), so a serial drain tops out at
+// batch-rows / statement-round-trip; on large tables with secondary
+// index maintenance that is a few hundred rows/s, which a busy source
+// outruns. Parallel batches multiply that ceiling.
+//
+// Each batch releases its bytes/count under the Mutex (with a cond
+// broadcast) as it lands, so a parked HasChanged caller resumes after
+// the first batch, not after the whole drain. Applied entries are
+// deleted from the snapshot after all workers join; entries deferred by
+// the low-watermark filter (and the unapplied remainder after an error)
+// stay in the snapshot for the caller to merge back. Returns false when
+// any entry was deferred.
 func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]bufferedChange, applyWatermarkFilter bool) (bool, error) {
-	var deleteKeys [][]any
-	var upsertRows []applier.LogicalRow
-	var batchKeys []string
-	var batchBytes int64
+	var batches []*mapFlushBatch
+	current := &mapFlushBatch{}
+	var batchStmtBytes int64
 	allChangesFlushed := true
 
-	flushAndRelease := func() error {
-		if len(batchKeys) == 0 {
-			return nil
+	cutBatch := func() {
+		if len(current.keys) > 0 {
+			batches = append(batches, current)
+			current = &mapFlushBatch{}
+			batchStmtBytes = 0
 		}
-		if err := s.flushBatch(ctx, deleteKeys, upsertRows, nil); err != nil {
-			return err
-		}
-		var drainedBytes int64
-		for _, key := range batchKeys {
-			drainedBytes += sizeOfBufferedChange(key, snapshot[key])
-			delete(snapshot, key)
-		}
-		s.Lock()
-		s.sizeBytes -= drainedBytes
-		s.flushingCount -= len(batchKeys)
-		s.cond.Broadcast()
-		s.Unlock()
-		deleteKeys, upsertRows, batchKeys, batchBytes = nil, nil, nil, 0
-		return nil
 	}
 
 	for key, change := range snapshot {
@@ -714,21 +747,54 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 		// failure. A single row over the budget still flushes, alone in
 		// its own batch (a row can't be split).
 		rowBytes := renderedBytesOfChange(change.logicalRow, change.originalKey)
-		if batchLen := len(batchKeys); batchLen >= DefaultBatchSize ||
-			(batchLen > 0 && batchBytes+rowBytes > applier.MaxStatementSizeBytes) {
-			if err := flushAndRelease(); err != nil {
-				return false, err
+		if batchLen := len(current.keys); batchLen >= DefaultBatchSize ||
+			(batchLen > 0 && batchStmtBytes+rowBytes > applier.MaxStatementSizeBytes) {
+			cutBatch()
+		}
+		current.keys = append(current.keys, key)
+		current.storedBytes += sizeOfBufferedChange(key, change)
+		if change.logicalRow.IsDeleted {
+			current.deleteKeys = append(current.deleteKeys, change.originalKey)
+		} else {
+			current.upsertRows = append(current.upsertRows, change.logicalRow)
+		}
+		batchStmtBytes += rowBytes
+	}
+	cutBatch()
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(s.effectiveFlushConcurrency())
+	for _, batch := range batches {
+		if gctx.Err() != nil {
+			break // a batch already failed; don't queue the rest
+		}
+		g.Go(func() error {
+			if err := s.flushBatch(gctx, batch.deleteKeys, batch.upsertRows, nil); err != nil {
+				return err
+			}
+			batch.applied = true
+			s.Lock()
+			s.sizeBytes -= batch.storedBytes
+			s.flushingCount -= len(batch.keys)
+			s.cond.Broadcast()
+			s.Unlock()
+			return nil
+		})
+	}
+	err := g.Wait()
+
+	// Drop applied batches from the snapshot whether or not the drain
+	// errored: the deferred reattach must only merge back what did not
+	// land. (Uncertain batches stay and re-apply on a later flush, which
+	// is safe — REPLACE and DELETE are idempotent.)
+	for _, batch := range batches {
+		if batch.applied {
+			for _, key := range batch.keys {
+				delete(snapshot, key)
 			}
 		}
-		batchKeys = append(batchKeys, key)
-		if change.logicalRow.IsDeleted {
-			deleteKeys = append(deleteKeys, change.originalKey)
-		} else {
-			upsertRows = append(upsertRows, change.logicalRow)
-		}
-		batchBytes += rowBytes
 	}
-	if err := flushAndRelease(); err != nil {
+	if err != nil {
 		return false, err
 	}
 	return allChangesFlushed, nil

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -685,15 +685,15 @@ func (s *bufferedMap) Flush(ctx context.Context, underLock bool, locks []*dbconn
 
 // mapFlushBatch is one applier round trip's worth of a map-mode drain:
 // disjoint keys, pre-partitioned into deletes and upserts, with the
-// buffer-accounting byte total captured at build time. applied is set
-// by the worker that lands the batch and read only after the errgroup
-// joins (Wait establishes the happens-before edge).
+// buffer-accounting byte total captured at build time. The batch only
+// holds pointers into the snapshot's entries; the worker that lands it
+// drops those entries from the snapshot and nils the batch's slices so
+// the row images become collectible while the drain is still running.
 type mapFlushBatch struct {
 	keys        []string
 	deleteKeys  [][]any
 	upsertRows  []applier.LogicalRow
 	storedBytes int64
-	applied     bool
 }
 
 // drainMapSnapshot applies a swapped-out map snapshot through the
@@ -709,12 +709,13 @@ type mapFlushBatch struct {
 // outruns. Parallel batches multiply that ceiling.
 //
 // Each batch releases its bytes/count under the Mutex (with a cond
-// broadcast) as it lands, so a parked HasChanged caller resumes after
-// the first batch, not after the whole drain. Applied entries are
-// deleted from the snapshot after all workers join; entries deferred by
-// the low-watermark filter (and the unapplied remainder after an error)
-// stay in the snapshot for the caller to merge back. Returns false when
-// any entry was deferred.
+// broadcast) and deletes its entries from the snapshot as it lands, so
+// a parked HasChanged caller resumes after the first batch, not after
+// the whole drain, and applied row images become collectible while the
+// rest of the drain is still running. Entries deferred by the
+// low-watermark filter (and the unapplied remainder after an error or
+// cancellation) stay in the snapshot for the caller to merge back.
+// Returns false when any entry was deferred.
 func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]bufferedChange, applyWatermarkFilter bool) (bool, error) {
 	var batches []*mapFlushBatch
 	current := &mapFlushBatch{}
@@ -764,35 +765,54 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(s.effectiveFlushConcurrency())
+	// Workers delete their batch's entries as they land, so they only
+	// contend with each other here: the build loop above finished
+	// iterating the snapshot before the first worker starts, and the
+	// deferred reattach runs after Wait.
+	var snapshotMu sync.Mutex
+	var skippedBatches bool
 	for _, batch := range batches {
 		if gctx.Err() != nil {
-			break // a batch already failed; don't queue the rest
+			skippedBatches = true
+			break // a batch failed or ctx was canceled; don't queue the rest
 		}
 		g.Go(func() error {
 			if err := s.flushBatch(gctx, batch.deleteKeys, batch.upsertRows, nil); err != nil {
 				return err
 			}
-			batch.applied = true
+			// Drop the applied entries immediately — from the snapshot,
+			// so the deferred reattach merges back only what did not land
+			// (uncertain batches stay and re-apply on a later flush, which
+			// is safe: REPLACE and DELETE are idempotent), and from the
+			// batch, so the row images become collectible now rather than
+			// when the whole drain finishes. Without this the snapshot
+			// retains up to a full soft limit of applied images while the
+			// live map refills toward another, transiently doubling the
+			// memory the cap is meant to bound.
+			snapshotMu.Lock()
+			for _, key := range batch.keys {
+				delete(snapshot, key)
+			}
+			snapshotMu.Unlock()
+			flushedKeys := len(batch.keys)
+			batch.keys, batch.deleteKeys, batch.upsertRows = nil, nil, nil
 			s.Lock()
 			s.sizeBytes -= batch.storedBytes
-			s.flushingCount -= len(batch.keys)
+			s.flushingCount -= flushedKeys
 			s.cond.Broadcast()
 			s.Unlock()
 			return nil
 		})
 	}
 	err := g.Wait()
-
-	// Drop applied batches from the snapshot whether or not the drain
-	// errored: the deferred reattach must only merge back what did not
-	// land. (Uncertain batches stay and re-apply on a later flush, which
-	// is safe — REPLACE and DELETE are idempotent.)
-	for _, batch := range batches {
-		if batch.applied {
-			for _, key := range batch.keys {
-				delete(snapshot, key)
-			}
-		}
+	if err == nil && skippedBatches {
+		// Scheduling stopped early yet no scheduled batch failed, so the
+		// group context can only have been canceled through ctx itself.
+		// Report that rather than success: on a nil error the clients
+		// publish the position captured before this flush as flushed,
+		// which would cover the skipped batches — but those entries were
+		// only reattached, not applied.
+		err = ctx.Err()
 	}
 	if err != nil {
 		return false, err

--- a/pkg/change/subscription_buffered_concurrency_test.go
+++ b/pkg/change/subscription_buffered_concurrency_test.go
@@ -709,3 +709,44 @@ func TestBufferedMapParallelFlushErrorReattachesRemainder(t *testing.T) {
 	require.Equal(t, totalRows, totalUpsertedRows(fake), "every row must land exactly once across both flushes")
 	require.Zero(t, recomputeSizeBytes(sub))
 }
+
+// TestBufferedMapFlushCanceledContextIsAnError pins the outcome of a
+// Flush whose context is already canceled: the drain schedules nothing,
+// applies nothing, and must report the context error — not success.
+// Without the skipped-batches check the errgroup joins cleanly over
+// zero scheduled batches and the flush reports allChangesFlushed=true,
+// which the clients would record as a successfully flushed position
+// while every entry had merely been reattached to the buffer.
+func TestBufferedMapFlushCanceledContextIsAnError(t *testing.T) {
+	fake := &gatedApplier{}
+	sub := newGatedBufferedMap(fake, false)
+	sub.flushConcurrency = 2
+
+	const totalRows = 2500 // 3 batches at DefaultBatchSize=1000
+	for i := range totalRows {
+		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	allFlushed, err := sub.Flush(ctx, false, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, allFlushed)
+	require.Zero(t, totalUpsertedRows(fake), "no batch may reach the applier on a canceled context")
+
+	// Everything is reattached with balanced accounting...
+	require.Equal(t, totalRows, sub.Length(), "all entries must be reattached")
+	sub.Lock()
+	flushing := sub.flushingCount
+	sub.Unlock()
+	require.Zero(t, flushing, "no snapshot entries may remain in flight after Flush returns")
+	require.Equal(t, recomputeSizeBytes(sub), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }(),
+		"sizeBytes must match the live stores after reattach")
+
+	// ...and a live retry drains it all.
+	allFlushed, err = sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
+	require.Equal(t, totalRows, totalUpsertedRows(fake), "every row must land exactly once on the retry")
+}

--- a/pkg/change/subscription_buffered_concurrency_test.go
+++ b/pkg/change/subscription_buffered_concurrency_test.go
@@ -636,7 +636,7 @@ func TestBufferedMapParallelFlushAppliesConcurrently(t *testing.T) {
 	sub := newGatedBufferedMap(fake, false)
 	sub.flushConcurrency = 3
 
-	const totalRows = 2500 // 3 batches at DefaultBatchSize=1000
+	const totalRows = 2*DefaultBatchSize + DefaultBatchSize/2 // 3 batches by construction
 	for i := range totalRows {
 		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
 	}
@@ -679,7 +679,7 @@ func TestBufferedMapParallelFlushErrorReattachesRemainder(t *testing.T) {
 	sub := newGatedBufferedMap(fake, false)
 	sub.flushConcurrency = 2
 
-	const totalRows = 2500 // 3 batches at DefaultBatchSize=1000
+	const totalRows = 2*DefaultBatchSize + DefaultBatchSize/2 // 3 batches by construction
 	for i := range totalRows {
 		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
 	}
@@ -722,7 +722,7 @@ func TestBufferedMapFlushCanceledContextIsAnError(t *testing.T) {
 	sub := newGatedBufferedMap(fake, false)
 	sub.flushConcurrency = 2
 
-	const totalRows = 2500 // 3 batches at DefaultBatchSize=1000
+	const totalRows = 2*DefaultBatchSize + DefaultBatchSize/2 // 3 batches by construction
 	for i := range totalRows {
 		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
 	}
@@ -749,4 +749,121 @@ func TestBufferedMapFlushCanceledContextIsAnError(t *testing.T) {
 	require.True(t, allFlushed)
 	require.Zero(t, sub.Length())
 	require.Equal(t, totalRows, totalUpsertedRows(fake), "every row must land exactly once on the retry")
+}
+
+// TestBufferedMapFlushMidDrainCancelReportsError pins the "or while
+// batches are being scheduled" half of the cancellation contract: when
+// ctx is canceled after some batches were scheduled (and land
+// successfully — the fake ignores ctx, like a statement already on the
+// wire), the remainder is skipped and g.Wait() returns nil, yet Flush
+// must report the context error. If the skippedBatches bookkeeping is
+// reordered away, a mid-drain cancel returns (true, nil) and the
+// client publishes the pre-flush position over reattached-only
+// entries.
+func TestBufferedMapFlushMidDrainCancelReportsError(t *testing.T) {
+	fake := &gatedApplier{upsertGate: make(chan struct{}), entered: make(chan struct{}, 8)}
+	release := releaseGate(fake.upsertGate)
+	t.Cleanup(release)
+	sub := newGatedBufferedMap(fake, false)
+	sub.flushConcurrency = 1 // serialize scheduling so the cancel lands between batches
+
+	const totalRows = 2*DefaultBatchSize + DefaultBatchSize/2 // 3 batches by construction
+	for i := range totalRows {
+		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	flushDone := make(chan error, 1)
+	var allFlushed bool
+	go func() {
+		var err error
+		allFlushed, err = sub.Flush(ctx, false, nil)
+		flushDone <- err
+	}()
+
+	// The first batch is inside the applier: cancel now, then release
+	// the gate so the in-flight batch completes successfully.
+	awaitEntered(t, fake)
+	cancel()
+	release()
+
+	require.ErrorIs(t, <-flushDone, context.Canceled)
+	require.False(t, allFlushed)
+
+	// At least the gated batch landed; at least the tail batch was
+	// skipped — with SetLimit(1) the scheduler cannot reach the tail's
+	// gctx check until the in-flight batch (and therefore the cancel,
+	// which precedes the gate release) has completed.
+	applied := totalUpsertedRows(fake)
+	require.GreaterOrEqual(t, applied, DefaultBatchSize, "the in-flight batch must have landed")
+	require.Less(t, applied, totalRows, "the tail batch must have been skipped")
+	require.Equal(t, totalRows-applied, sub.Length(), "skipped entries must be reattached")
+	sub.Lock()
+	flushing := sub.flushingCount
+	sub.Unlock()
+	require.Zero(t, flushing, "no snapshot entries may remain in flight after Flush returns")
+	require.Equal(t, recomputeSizeBytes(sub), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }(),
+		"sizeBytes must match the live stores after reattach")
+
+	// A live retry drains the remainder exactly once.
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
+	require.Equal(t, totalRows, totalUpsertedRows(fake), "every row must land exactly once across both flushes")
+}
+
+// TestFlushConcurrencyClientPlumbing pins the ClientConfig plumbing
+// end-to-end for both clients: the zero value must resolve to
+// DefaultFlushConcurrency (a refactor that drops the default would
+// silently revert production to the serial drain this knob exists to
+// escape), negative must resolve to the explicit serial opt-out, and
+// the resolved value must reach the bufferedMap that AddSubscription
+// builds.
+func TestFlushConcurrencyClientPlumbing(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  int
+		want int
+	}{
+		{"zero-defaults-parallel", 0, DefaultFlushConcurrency},
+		{"negative-serial", -4, 1},
+		{"explicit-value", 3, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			current := &table.TableInfo{SchemaName: "test", TableName: "plumbing"}
+
+			cfg := NewClientDefaultConfig()
+			cfg.FlushConcurrency = tc.cfg
+			bc := NewBinlogClient(nil, "localhost", "user", "pass", &countingApplier{}, cfg).(*binlogClient)
+			require.Equal(t, tc.want, bc.flushConcurrency)
+			require.NoError(t, bc.AddSubscription(current, nil, table.NewMockChunker("plumbing", 1000)))
+			bsubs := bc.subs.Snapshot()
+			require.Len(t, bsubs, 1)
+			require.Equal(t, tc.want, bsubs[0].(*bufferedMap).flushConcurrency)
+
+			gcfg := NewClientDefaultConfig()
+			gcfg.FlushConcurrency = tc.cfg
+			gc := NewGTIDClient(nil, "localhost", "user", "pass", &countingApplier{}, gcfg).(*gtidClient)
+			require.Equal(t, tc.want, gc.flushConcurrency)
+			require.NoError(t, gc.AddSubscription(current, nil, table.NewMockChunker("plumbing", 1000)))
+			gsubs := gc.subs.Snapshot()
+			require.Len(t, gsubs, 1)
+			require.Equal(t, tc.want, gsubs[0].(*bufferedMap).flushConcurrency)
+		})
+	}
+}
+
+// TestBufferedSubscriptionZeroFlushConcurrencyStaysSerial pins the
+// compat promise on BufferedSubscriptionConfig: out-of-tree callers
+// (e.g. vstream sources) that do not set FlushConcurrency keep the
+// serial drain until they opt in.
+func TestBufferedSubscriptionZeroFlushConcurrencyStaysSerial(t *testing.T) {
+	sub, err := NewBufferedSubscription(BufferedSubscriptionConfig{
+		CurrentTable: &table.TableInfo{SchemaName: "test", TableName: "compat"},
+		Applier:      &countingApplier{},
+		Chunker:      table.NewMockChunker("compat", 1000),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, sub.(*bufferedMap).effectiveFlushConcurrency())
 }

--- a/pkg/change/subscription_buffered_concurrency_test.go
+++ b/pkg/change/subscription_buffered_concurrency_test.go
@@ -33,6 +33,10 @@ type gatedApplier struct {
 	deleteGate  chan struct{}
 	failUpserts atomic.Bool
 	failDeletes atomic.Bool
+	// failOneUpsert makes exactly one UpsertRows call fail (whichever
+	// concurrent call consumes the flag first), for exercising the
+	// partial-failure path of a parallel drain.
+	failOneUpsert atomic.Bool
 }
 
 var errInjected = errors.New("gatedApplier: injected failure")
@@ -52,6 +56,9 @@ func (g *gatedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapp
 		<-g.upsertGate
 	}
 	if g.failUpserts.Load() {
+		return 0, errInjected
+	}
+	if g.failOneUpsert.CompareAndSwap(true, false) {
 		return 0, errInjected
 	}
 	return g.countingApplier.UpsertRows(ctx, mapping, rows, locks)
@@ -603,4 +610,102 @@ func TestPeriodicFlushPrioritizesParkedSubscription(t *testing.T) {
 	order := rec.recorded()
 	require.Equal(t, srcA.TableName, order[0], "the parked subscription must be flushed before the all-subscription pass")
 	require.Contains(t, order, srcB.TableName, "the all-subscription pass must still drain the other subscription")
+}
+
+// totalUpsertedRows sums the rows across all recorded UpsertRows calls.
+func totalUpsertedRows(fake *gatedApplier) int {
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	total := 0
+	for _, call := range fake.upsertCalls {
+		total += len(call)
+	}
+	return total
+}
+
+// TestBufferedMapParallelFlushAppliesConcurrently pins the parallel
+// map-mode drain: with flushConcurrency=3 and three batches, all three
+// applier calls must be in flight at the same time. Under a serial
+// drain the second `entered` announcement can never arrive while the
+// first call is still gated, so this test times out if the drain
+// regresses to serial.
+func TestBufferedMapParallelFlushAppliesConcurrently(t *testing.T) {
+	fake := &gatedApplier{upsertGate: make(chan struct{}), entered: make(chan struct{}, 8)}
+	release := releaseGate(fake.upsertGate)
+	t.Cleanup(release)
+	sub := newGatedBufferedMap(fake, false)
+	sub.flushConcurrency = 3
+
+	const totalRows = 2500 // 3 batches at DefaultBatchSize=1000
+	for i := range totalRows {
+		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
+	}
+	require.Equal(t, totalRows, sub.Length())
+
+	flushDone := make(chan error, 1)
+	var allFlushed bool
+	go func() {
+		var err error
+		allFlushed, err = sub.Flush(t.Context(), false, nil)
+		flushDone <- err
+	}()
+
+	// Three concurrent applier calls announce before any is released.
+	for range 3 {
+		awaitEntered(t, fake)
+	}
+	// All entries are still in flight: nothing has been released yet.
+	require.Equal(t, totalRows, sub.Length(), "in-flight snapshot entries must still be counted")
+
+	release()
+	require.NoError(t, <-flushDone)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
+	require.Equal(t, totalRows, totalUpsertedRows(fake))
+	require.Zero(t, recomputeSizeBytes(sub))
+	sub.Lock()
+	require.Zero(t, sub.sizeBytes, "accounting must balance after a parallel drain")
+	sub.Unlock()
+}
+
+// TestBufferedMapParallelFlushErrorReattachesRemainder exercises the
+// partial-failure path of the parallel drain: one batch fails, sibling
+// batches either land (and are released) or are cancelled (and stay in
+// the snapshot), and everything unapplied is merged back with balanced
+// accounting. A retry drains the remainder; nothing is lost or applied
+// from a stale snapshot twice.
+func TestBufferedMapParallelFlushErrorReattachesRemainder(t *testing.T) {
+	fake := &gatedApplier{}
+	sub := newGatedBufferedMap(fake, false)
+	sub.flushConcurrency = 2
+
+	const totalRows = 2500 // 3 batches at DefaultBatchSize=1000
+	for i := range totalRows {
+		sub.HasChanged([]any{int32(i)}, []any{int32(i), "seed"}, false)
+	}
+	fake.failOneUpsert.Store(true)
+
+	_, err := sub.Flush(t.Context(), false, nil)
+	require.ErrorIs(t, err, errInjected)
+	require.False(t, fake.failOneUpsert.Load(), "the injected failure must have been consumed")
+
+	// The failed batch (and any cancelled ones) must be back in the
+	// active map with balanced accounting; applied batches must not be.
+	applied := totalUpsertedRows(fake)
+	require.Less(t, applied, totalRows, "the failed batch cannot have been recorded as applied")
+	require.Equal(t, totalRows-applied, sub.Length(), "unapplied entries must be reattached")
+	sub.Lock()
+	flushing := sub.flushingCount
+	sub.Unlock()
+	require.Zero(t, flushing, "no snapshot entries may remain in flight after Flush returns")
+	require.Equal(t, recomputeSizeBytes(sub), func() int64 { sub.Lock(); defer sub.Unlock(); return sub.sizeBytes }(),
+		"sizeBytes must match the live stores after reattach")
+
+	// A retry drains the remainder exactly once.
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
+	require.Equal(t, totalRows, totalUpsertedRows(fake), "every row must land exactly once across both flushes")
+	require.Zero(t, recomputeSizeBytes(sub))
 }


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Follow-up from #1120 (see "Known remaining ceiling"). Builds on #1121 (merged); based on `main`.

## Problem

The binlog apply path is synchronous REPLACE/DELETE statements on one connection — it does not use the copy path's write worker pool — so a flush drains at `DefaultBatchSize` rows per statement round trip. On large tables where secondary index maintenance dominates, that is only a few hundred rows/s.

A source whose distinct-key write rate exceeds that permanently outruns the applier. With #1121's fixes in place the failure mode is now clean and observable, but still fatal: the subscription buffer pins at the soft limit in one-in-one-out steady state (each applied batch admits one batch of new events), the reader ingests exactly one buffer-load per flush cycle, and the migration never converges no matter how long it runs.

Observed on a large production test (3.3B-row table, 2 ADD INDEX, running the #1121 build):

- `applier-write-p50=2.571s` per ~979-row REPLACE on `conns-in-use=1` ≈ **381 rows/s**
- source writing ~2,037 txn/s of distinct-key traffic (insert-heavy, so LWW dedup collapses ~nothing)
- `binlog-deltas` frozen at exactly 282,564 (the soft limit's key capacity) for hours
- GTID gap growing ~6M transactions/hour, ~49 min/hour further behind wall clock — a binlog-retention time bomb

## Fix

Build the map-mode drain's batches serially as before, then apply them with up to `FlushConcurrency` applier calls in flight (errgroup). Per-batch release is preserved and extended: as each batch lands, its bytes/count are released under the Mutex (the cond broadcast that wakes a parked reader, unchanged) **and** its entries are dropped from the snapshot with the batch's slices nil'd, so applied row images become collectible while the drain is still running rather than retaining up to a full soft limit of applied images alongside a refilling live map. Reader admission scales by the same factor. At the observed per-stream rate, the default of 8 gives ~3k rows/s, clearing the source's write rate with margin to eat the accumulated backlog.

Why this is safe in map mode:

- A flush snapshot holds exactly one image per key, so batches are **disjoint by key**.
- Map mode makes no cross-key ordering promises: REPLACE and DELETE against distinct keys commute.
- Both statement forms are idempotent, so a failed or uncertain batch is simply reattached (`reattachLocked`, unchanged) and retried by a later flush.
- A flush whose context is canceled before or during batch scheduling reports the context error rather than success, so the clients never publish the pre-flush position as flushed over entries that were only reattached (from review).

What stays serial:

- **Queue-mode drains** (non-memory-comparable PK, post-copy) — FIFO ordering is required.
- **Under-lock cutover flushes** — must remain atomic with respect to event delivery.
- `SetWatermarkOptimization` transition drains (fully locked, unchanged).

## Config

- `ClientConfig.FlushConcurrency`: 0 (default) → `DefaultFlushConcurrency` (8); negative → serial.
- `BufferedSubscriptionConfig.FlushConcurrency`: zero-value stays **serial**, so out-of-tree `NewBufferedSubscription` callers (e.g. vstream sources) keep prior behaviour unless they opt in.
- No pool changes needed: 8 flush connections fit the existing `Threads + WriteThreads` budget, which the idle copier is not using during the post-copy catch-up phase; worst case batches briefly queue on pool checkout.

## Staging validation

Re-ran the same workload as above (via a temporary dependency pin on this branch): the post-copy apply converged instead of pinning at the soft limit one-in-one-out, where the serial build had previously run 23h+ without converging.

## Testing

- `TestBufferedMapParallelFlushAppliesConcurrently` — pins that three batches are in flight simultaneously; verified it **fails (times out) when the drain is forced serial**.
- `TestBufferedMapParallelFlushErrorReattachesRemainder` — one injected batch failure among concurrent siblings: unapplied entries reattach with balanced accounting, a retry lands every row exactly once.
- `TestBufferedMapFlushCanceledContextIsAnError` — a pre-canceled Flush schedules nothing, applies nothing, and returns the context error (not success); everything reattaches with balanced accounting and a live retry drains it all.
- Because the clients now default to `FlushConcurrency=8`, every DB-backed test in the suites below exercises the parallel drain end-to-end.
- `-race` suites all green: change 65s, migration 60s, move 132s, datasync 16s, checksum 82s. golangci-lint: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
