### PR TITLE
status: report resume and throttle state through the status API

### DIFF
--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
@@ -73,8 +74,10 @@ type Runner struct {
 
 	// resuming is set when a checkpoint was found on the target: the
 	// initial copy is skipped and the change feed is opened from the
-	// checkpointed position.
-	resuming bool
+	// checkpointed position. It is atomic because it is also reported to API
+	// callers as Progress().Resume, which they poll from their own goroutine
+	// while setup is still writing it.
+	resuming atomic.Bool
 
 	status status.Tracker
 
@@ -269,7 +272,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// — and finishes immediately if the copy had already completed. The applier
 	// copies with INSERT IGNORE, so re-copying the chunks straddling the
 	// watermark is idempotent.
-	if !r.sync.CopyOnly && !r.resuming {
+	if !r.sync.CopyOnly && !r.resuming.Load() {
 		// Watermark optimization ON during a fresh continuous copy: change
 		// events for keys the copier has not reached yet (above the watermark)
 		// are discarded, because the copier will copy those rows directly.
@@ -299,12 +302,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 	if err := r.status.Do(status.CopyRows, func() error {
-		r.logger.Info("Starting copy", "resuming", r.resuming)
+		r.logger.Info("Starting copy", "resuming", r.resuming.Load())
 		if err := r.copier.Run(ctx); err != nil {
 			return fmt.Errorf("copy failed: %w", err)
 		}
 		if !r.sync.CopyOnly {
-			if !r.resuming {
+			if !r.resuming.Load() {
 				if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
 					return err
 				}
@@ -726,7 +729,7 @@ func (r *Runner) setup(ctx context.Context) error {
 		return err
 	}
 	if hasCheckpoint {
-		r.resuming = true
+		r.resuming.Store(true)
 		r.logger.Info("Found checkpoint on target; resuming", "position", pos)
 		return r.startResume(ctx, watermark, pos)
 	}
@@ -1459,7 +1462,14 @@ func (r *Runner) Progress() status.Progress {
 		})
 	}
 
-	return status.Progress{CurrentState: state, Summary: summary, Tables: tables}
+	return status.Progress{
+		CurrentState: state,
+		Summary:      summary,
+		Resume:       r.resuming.Load(),
+		Tables:       tables,
+		// Throttle is deliberately left zero: a sync copies through a Noop
+		// throttler, so there is nothing to report yet.
+	}
 }
 
 // Status returns a one-line, human-readable status for logging. It does not

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -448,6 +448,10 @@ func TestSyncResume(t *testing.T) {
 	r2, err := NewRunner(newSync())
 	require.NoError(t, err)
 	require.NoError(t, runUntilCopied(t, r2))
+	// The resume must also be visible to API callers, who cannot infer it from
+	// CurrentState — a resumed run walks the same states as a fresh one
+	// (issue #844).
+	require.True(t, r2.Progress().Resume)
 	require.NoError(t, r2.Close())
 
 	require.Equal(t, 3, countRows("t1"), "resume must not duplicate or drop rows")

--- a/pkg/migration/progress_test.go
+++ b/pkg/migration/progress_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/block/spirit/pkg/status"
@@ -9,9 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The tests here use a minimal hand-constructed Runner: Progress() in the
-// Initial state reads neither the copier nor the chunkers, so the fields under
-// test can be exercised without a live migration.
+// The tests here use a minimal hand-constructed Runner. Progress() in the
+// Initial state reads neither the copier nor the chunkers, and throttleStatus
+// reads nothing but the throttler, so the fields under test can be exercised
+// without a live migration.
 
 func TestProgressReportsResume(t *testing.T) {
 	// Resume exists so a wrapper can tell a recovering run from one that is
@@ -24,20 +26,20 @@ func TestProgressReportsResume(t *testing.T) {
 	require.True(t, r.Progress().Resume)
 }
 
-func TestProgressReportsThrottleState(t *testing.T) {
+func TestThrottleStatusReportsReasonDuringCopy(t *testing.T) {
 	r := &Runner{}
 
 	// No throttler resolved yet (setup has not reached setupThrottler, or found
 	// nothing to throttle on): not throttled, and no invented load reading.
-	p := r.Progress()
-	require.False(t, p.Throttle.Throttled)
-	require.Empty(t, p.Throttle.Reason)
-	require.Zero(t, p.Throttle.Utilization)
+	ts := r.throttleStatus(status.CopyRows)
+	require.False(t, ts.Throttled)
+	require.Empty(t, ts.Reason)
+	require.Zero(t, ts.Utilization)
 
 	r.setThrottler(&throttler.Mock{})
-	p = r.Progress()
-	require.True(t, p.Throttle.Throttled)
-	require.Equal(t, "mock throttler (always throttled)", p.Throttle.Reason)
+	ts = r.throttleStatus(status.CopyRows)
+	require.True(t, ts.Throttled)
+	require.Equal(t, "mock throttler (always throttled)", ts.Reason)
 }
 
 func TestThrottleStatusNarrowsToLoadSignalsDuringChecksum(t *testing.T) {
@@ -55,6 +57,42 @@ func TestThrottleStatusNarrowsToLoadSignalsDuringChecksum(t *testing.T) {
 	require.Empty(t, checksumThrottle.Reason)
 }
 
+// TestThrottleStatusIsZeroInUnpacedPhases pins the rule that makes Throttled
+// mean one thing everywhere: only the copy and the checksum pace themselves
+// against a throttler (they are the only SetThrottler callers), so every other
+// phase must report the zero value however loaded the server is.
+//
+// Reporting the composite in these phases would be actively misleading rather
+// than merely imprecise. The sentinel wait is the pointed case — a human is
+// watching that screen to decide when to cut over, and the only work running is
+// the continuous checker, which takes no throttler at all. Worse, the replica
+// throttler fails closed on a stale signal and Close() stops its poll loop
+// without changing IsThrottled, so a *finished* migration would start reporting
+// itself as paused on replica lag once the signal aged out.
+func TestThrottleStatusIsZeroInUnpacedPhases(t *testing.T) {
+	r := &Runner{}
+	r.setThrottler(&throttler.Mock{}) // always throttled
+
+	unpaced := []status.State{
+		status.Initial,
+		status.ApplyChangeset,
+		status.RestoreSecondaryIndexes,
+		status.AnalyzeTable,
+		status.PostChecksum,
+		status.WaitingOnSentinelTable,
+		status.CutOver,
+		status.ReverseWindow,
+		status.Close,
+		status.ErrCleanup,
+	}
+	for _, state := range unpaced {
+		t.Run(state.String(), func(t *testing.T) {
+			require.Equal(t, status.ThrottleStatus{}, r.throttleStatus(state),
+				"nothing paces itself against a throttler in %s, so status must not report it as paused", state)
+		})
+	}
+}
+
 // TestProgressPolledConcurrentlyWithRun covers the seam the new Progress fields
 // opened up: an API caller polls Progress() from its own goroutine while setup is
 // still writing the state those fields report. Under -race this fails if the
@@ -64,7 +102,7 @@ func TestThrottleStatusNarrowsToLoadSignalsDuringChecksum(t *testing.T) {
 // WithTestThrottler is what makes the write side real: without any replica DSN
 // and off Aurora, setupThrottler finds nothing to throttle on and never assigns,
 // so there would be no concurrent write to race with. It also lets the test
-// assert a throttled migration reports its reason.
+// assert that a throttled copy reports its reason through the API.
 func TestProgressPolledConcurrentlyWithRun(t *testing.T) {
 	tt := testutils.NewTestTable(t, "progresspoll",
 		`CREATE TABLE progresspoll (
@@ -77,6 +115,9 @@ func TestProgressPolledConcurrentlyWithRun(t *testing.T) {
 
 	m := NewTestRunner(t, "progresspoll", "ENGINE=InnoDB", WithTestThrottler())
 
+	// Recorded off the test goroutine, so assert on them after the join rather
+	// than calling require here (testifylint go-require).
+	var sawThrottledCopy, sawReason atomic.Bool
 	done := make(chan struct{})
 	pollDone := make(chan struct{})
 	go func() {
@@ -86,7 +127,13 @@ func TestProgressPolledConcurrentlyWithRun(t *testing.T) {
 			case <-done:
 				return
 			default:
-				_ = m.Progress()
+				p := m.Progress()
+				if p.CurrentState == status.CopyRows && p.Throttle.Throttled {
+					sawThrottledCopy.Store(true)
+					if p.Throttle.Reason == "mock throttler (always throttled)" {
+						sawReason.Store(true)
+					}
+				}
 				_ = m.Status()
 			}
 		}
@@ -98,10 +145,13 @@ func TestProgressPolledConcurrentlyWithRun(t *testing.T) {
 	require.NoError(t, runErr)
 	require.NoError(t, m.Close())
 
-	// A fresh migration reports no resume, and the always-throttled test
-	// throttler reaches the status API with its reason attached.
+	require.True(t, sawThrottledCopy.Load(),
+		"a copy paced by the always-throttled test throttler must report Throttled through the API")
+	require.True(t, sawReason.Load(), "and must carry the throttler's reason with it")
+
+	// After the run, nothing is being paced: the status API must not describe a
+	// finished migration as paused, however the throttler answers.
 	p := m.Progress()
 	require.False(t, p.Resume)
-	require.True(t, p.Throttle.Throttled)
-	require.Equal(t, "mock throttler (always throttled)", p.Throttle.Reason)
+	require.Equal(t, status.ThrottleStatus{}, p.Throttle)
 }

--- a/pkg/migration/progress_test.go
+++ b/pkg/migration/progress_test.go
@@ -1,0 +1,107 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/throttler"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests here use a minimal hand-constructed Runner: Progress() in the
+// Initial state reads neither the copier nor the chunkers, so the fields under
+// test can be exercised without a live migration.
+
+func TestProgressReportsResume(t *testing.T) {
+	// Resume exists so a wrapper can tell a recovering run from one that is
+	// starting over — a resumed run walks the whole state machine again, so
+	// CurrentState alone cannot distinguish them (issue #844).
+	r := &Runner{}
+	require.False(t, r.Progress().Resume)
+
+	r.usedResumeFromCheckpoint.Store(true)
+	require.True(t, r.Progress().Resume)
+}
+
+func TestProgressReportsThrottleState(t *testing.T) {
+	r := &Runner{}
+
+	// No throttler resolved yet (setup has not reached setupThrottler, or found
+	// nothing to throttle on): not throttled, and no invented load reading.
+	p := r.Progress()
+	require.False(t, p.Throttle.Throttled)
+	require.Empty(t, p.Throttle.Reason)
+	require.Zero(t, p.Throttle.Utilization)
+
+	r.setThrottler(&throttler.Mock{})
+	p = r.Progress()
+	require.True(t, p.Throttle.Throttled)
+	require.Equal(t, "mock throttler (always throttled)", p.Throttle.Reason)
+}
+
+func TestThrottleStatusNarrowsToLoadSignalsDuringChecksum(t *testing.T) {
+	// The checksum only honours load signals (see checksum's loadOnlyThrottler),
+	// so status must not report it as paused on a binary signal it is ignoring.
+	// The mock is binary-only, so it throttles the copy but not the checksum.
+	r := &Runner{}
+	r.setThrottler(&throttler.Mock{})
+
+	require.True(t, r.throttleStatus(status.CopyRows).Throttled)
+
+	checksumThrottle := r.throttleStatus(status.Checksum)
+	require.False(t, checksumThrottle.Throttled,
+		"a checksum must not be reported as throttled by a signal it does not honour")
+	require.Empty(t, checksumThrottle.Reason)
+}
+
+// TestProgressPolledConcurrentlyWithRun covers the seam the new Progress fields
+// opened up: an API caller polls Progress() from its own goroutine while setup is
+// still writing the state those fields report. Under -race this fails if the
+// throttler is read unsynchronized (hence throttlerMu) — the resume flag is
+// atomic for the same reason, written by resumeFromCheckpoint during setup.
+//
+// WithTestThrottler is what makes the write side real: without any replica DSN
+// and off Aurora, setupThrottler finds nothing to throttle on and never assigns,
+// so there would be no concurrent write to race with. It also lets the test
+// assert a throttled migration reports its reason.
+func TestProgressPolledConcurrentlyWithRun(t *testing.T) {
+	tt := testutils.NewTestTable(t, "progresspoll",
+		`CREATE TABLE progresspoll (
+			id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			pad VARCHAR(100)
+		)`)
+	// A handful of rows is enough: the test is about the polling seam, and the
+	// test throttler paces the copy at a second per chunk.
+	tt.SeedRows(t, "INSERT INTO progresspoll (pad) SELECT 'a'", 8)
+
+	m := NewTestRunner(t, "progresspoll", "ENGINE=InnoDB", WithTestThrottler())
+
+	done := make(chan struct{})
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = m.Progress()
+				_ = m.Status()
+			}
+		}
+	}()
+
+	runErr := m.Run(t.Context())
+	close(done)
+	<-pollDone
+	require.NoError(t, runErr)
+	require.NoError(t, m.Close())
+
+	// A fresh migration reports no resume, and the always-throttled test
+	// throttler reaches the status API with its reason attached.
+	p := m.Progress()
+	require.False(t, p.Resume)
+	require.True(t, p.Throttle.Throttled)
+	require.Equal(t, "mock throttler (always throttled)", p.Throttle.Reason)
+}

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -83,7 +83,10 @@ func TestChangeIntToBigIntPKResumeFromChkPt(t *testing.T) {
 	// Start a new migration with the same parameters. Let it complete.
 	m2 := NewTestRunner(t, "bigintpk", alterSQL, WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint)
+	require.True(t, m2.usedResumeFromCheckpoint.Load())
+	// The same fact must reach API callers, who cannot see the private field
+	// and cannot infer recovery from CurrentState (issue #844).
+	require.True(t, m2.Progress().Resume)
 	require.NoError(t, m2.Close())
 }
 
@@ -317,7 +320,7 @@ func TestCheckpointRestore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, r2.Run(t.Context()))
-	require.True(t, r2.usedResumeFromCheckpoint)
+	require.True(t, r2.usedResumeFromCheckpoint.Load())
 	require.NoError(t, r2.Close())
 }
 
@@ -353,7 +356,7 @@ func TestCheckpointRestoreBinaryPK(t *testing.T) {
 	// Resume with a fresh runner and confirm it picked up from the checkpoint.
 	m2 := NewTestRunner(t, "binarypk", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint) // managed to resume.
+	require.True(t, m2.usedResumeFromCheckpoint.Load()) // managed to resume.
 	require.NoError(t, m2.Close())
 }
 
@@ -414,7 +417,7 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 		WithTargetChunkTime(100*time.Millisecond))
 	require.NoError(t, r2.Run(t.Context()))
 	defer utils.CloseAndLog(r2)
-	require.True(t, r2.usedResumeFromCheckpoint)
+	require.True(t, r2.usedResumeFromCheckpoint.Load())
 }
 
 func TestCheckpointDifferentRestoreOptions(t *testing.T) {
@@ -511,7 +514,7 @@ func TestResumeFromCheckpointE2E(t *testing.T) {
 	// Start a new migration with the same parameters. Let it complete.
 	m2 := NewTestRunner(t, "chkpresumetest", alterSQL, WithThreads(4))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint)
+	require.True(t, m2.usedResumeFromCheckpoint.Load())
 	require.NoError(t, m2.Close())
 }
 
@@ -565,7 +568,7 @@ FROM compositevarcharpk a WHERE version='1'`)
 
 	m2 := NewTestRunner(t, "compositevarcharpk", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint)
+	require.True(t, m2.usedResumeFromCheckpoint.Load())
 	require.NoError(t, m2.Close())
 }
 
@@ -817,7 +820,7 @@ func TestResumeFromCheckpointE2EWithManualSentinel(t *testing.T) {
 	m.Cancel()
 	err = <-c
 	require.Error(t, err)
-	require.True(t, m.usedResumeFromCheckpoint)
+	require.True(t, m.usedResumeFromCheckpoint.Load())
 	require.NoError(t, m.Close())
 }
 
@@ -874,7 +877,7 @@ func TestResumeFromCheckpointCleanupOnFailure(t *testing.T) {
 	// Resume falls back to newMigration and completes successfully.
 	m2 := NewTestRunner(t, "cleanup_test", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.False(t, m2.usedResumeFromCheckpoint) // Should NOT have resumed because binlog was invalid
+	require.False(t, m2.usedResumeFromCheckpoint.Load()) // Should NOT have resumed because binlog was invalid
 	require.NoError(t, m2.Close())
 }
 
@@ -915,7 +918,7 @@ func TestResumeFromCheckpointTooOld(t *testing.T) {
 	// Resume falls back to newMigration and completes successfully.
 	m2 := NewTestRunner(t, "chkpttooold", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.False(t, m2.usedResumeFromCheckpoint) // Should NOT have resumed because checkpoint was too old
+	require.False(t, m2.usedResumeFromCheckpoint.Load()) // Should NOT have resumed because checkpoint was too old
 	require.NoError(t, m2.Close())
 }
 
@@ -952,7 +955,7 @@ func TestResumeFromCheckpointNotTooOld(t *testing.T) {
 	// The migration should resume from checkpoint successfully.
 	m2 := NewTestRunner(t, "chkptnotold", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.True(t, m2.usedResumeFromCheckpoint) // Should have resumed because checkpoint is fresh
+	require.True(t, m2.usedResumeFromCheckpoint.Load()) // Should have resumed because checkpoint is fresh
 	require.NoError(t, m2.Close())
 }
 
@@ -993,7 +996,7 @@ func TestResumeRejectsCheckpointFromDifferentTable(t *testing.T) {
 	// Resume must refuse and fall back to a fresh migration.
 	m2 := NewTestRunner(t, "chkptmismatch", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m2.Run(t.Context()))
-	require.False(t, m2.usedResumeFromCheckpoint,
+	require.False(t, m2.usedResumeFromCheckpoint.Load(),
 		"resume should be skipped when checkpoint records a different original table name")
 	require.NoError(t, m2.Close())
 }
@@ -1081,7 +1084,7 @@ func TestResumeTransientErrorPreservesState(t *testing.T) {
 	// proving the state we refused to destroy was still usable.
 	m3 := NewTestRunner(t, "transientresume", "ENGINE=InnoDB", WithThreads(2))
 	require.NoError(t, m3.Run(t.Context()))
-	require.True(t, m3.usedResumeFromCheckpoint,
+	require.True(t, m3.usedResumeFromCheckpoint.Load(),
 		"the healthy re-run must resume from the preserved checkpoint")
 	require.NoError(t, m3.Close())
 }

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -1433,19 +1433,35 @@ func (r *Runner) Progress() status.Progress {
 	}
 }
 
-// throttleStatus reports how the phase named by state is currently being paced.
+// throttleStatus reports how the phase named by state is currently being paced,
+// reading only the signals that phase actually honours so that Throttled means
+// the same thing in every phase: this phase is paused right now.
 //
-// The signals reported are the ones that phase actually honours, so that status
-// never blames a pause on a signal the running phase is ignoring: the copier
-// honours the whole composite, while the checksum narrows it to the load signals
-// exactly as checksum's loadOnlyThrottler does (a read-only snapshot pass cannot
-// cause replica lag, so it does not pause on it). Phases that are not paced at
-// all report the composite, which is then read as "the server is asking spirit
-// to back off" rather than "this phase is paused".
+// Only two phases pace themselves against a throttler — they are the only
+// callers of SetThrottler:
+//
+//   - CopyRows: the copier writes, so it honours every signal in the composite.
+//   - Checksum: narrowed to the load signals, exactly as checksum's
+//     loadOnlyThrottler does (a read-only snapshot pass cannot cause replica
+//     lag, so pausing it on lag would only hold the snapshot open for longer).
+//
+// Every other phase reports the zero value, because nothing there consults a
+// throttler: the sentinel wait runs the continuous checker, which takes no
+// throttler at all, and the changeset applies and cutover are not paced. Those
+// phases previously reported the composite, which made Throttled mean "the
+// server is loaded" there and "this phase is paused" in the two above — and
+// since the replica throttler fails closed on a stale signal and Close() stops
+// its poll loop without changing IsThrottled, a *finished* migration would
+// start reporting itself as paused on replica lag once the signal aged out.
 func (r *Runner) throttleStatus(state status.State) status.ThrottleStatus {
-	t := r.currentThrottler()
-	if state == status.Checksum {
-		t = throttler.GradualOnly(t)
+	var t throttler.Throttler
+	switch state { //nolint:exhaustive // only the two paced phases report throttling
+	case status.CopyRows:
+		t = r.currentThrottler()
+	case status.Checksum:
+		t = throttler.GradualOnly(r.currentThrottler())
+	default:
+		return status.ThrottleStatus{}
 	}
 	throttled, reason, utilization := throttler.Describe(t)
 	return status.ThrottleStatus{

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -76,6 +77,11 @@ type Runner struct {
 	replClient change.Source  // feed contains all binlog subscription activity.
 	throttler  throttler.Throttler
 
+	// throttlerMu guards throttler. setupThrottler assigns it partway through
+	// setup, while an API caller may already be polling Progress() — which reads
+	// the throttler to report whether the migration is currently paused.
+	throttlerMu sync.RWMutex
+
 	copier      copier.Copier
 	copyChunker table.Chunker // the chunker for copying
 
@@ -111,9 +117,12 @@ type Runner struct {
 
 	// Used by the test-suite and some post-migration output.
 	// Indicates if certain optimizations applied.
-	usedInstantDDL           bool
-	usedInplaceDDL           bool
-	usedResumeFromCheckpoint bool
+	usedInstantDDL bool
+	usedInplaceDDL bool
+	// usedResumeFromCheckpoint is atomic because it is also reported to API
+	// callers as Progress().Resume, which they poll from their own goroutine
+	// while setup is still writing it.
+	usedResumeFromCheckpoint atomic.Bool
 
 	// Attached logger
 	logger     *slog.Logger
@@ -1045,6 +1054,23 @@ func (r *Runner) closeReplicas() error {
 	return errors.Join(errs...)
 }
 
+// setThrottler publishes the resolved throttler. It is written once during
+// setup, but Progress() may be reading it concurrently — see throttlerMu.
+func (r *Runner) setThrottler(t throttler.Throttler) {
+	r.throttlerMu.Lock()
+	defer r.throttlerMu.Unlock()
+	r.throttler = t
+}
+
+// currentThrottler returns the resolved throttler, or nil if setup has not got
+// that far (or found nothing to throttle on, in which case the copier keeps its
+// own Noop).
+func (r *Runner) currentThrottler() throttler.Throttler {
+	r.throttlerMu.RLock()
+	defer r.throttlerMu.RUnlock()
+	return r.throttler
+}
+
 // setThrottlerOnPhases hands the resolved throttler to every phase that paces
 // itself against it. The copier always accepts one; the checksum does so via
 // the optional checksum.ThrottleAware capability (test doubles and the
@@ -1054,11 +1080,13 @@ func (r *Runner) closeReplicas() error {
 // it: the copier writes and so honours every signal in it, while the checksum
 // narrows it to the load signals (see checksum's loadOnlyThrottler — a read-only
 // snapshot pass cannot cause replica lag, so pausing it on lag would only hold
-// the snapshot open for longer).
+// the snapshot open for longer). Progress().Throttle mirrors that split — see
+// throttleStatus.
 func (r *Runner) setThrottlerOnPhases() {
-	r.copier.SetThrottler(r.throttler)
+	t := r.currentThrottler()
+	r.copier.SetThrottler(t)
 	if aware, ok := r.checker.(checksum.ThrottleAware); ok {
-		aware.SetThrottler(r.throttler)
+		aware.SetThrottler(t)
 	} else {
 		// Not fatal: the checksum falls back to its Noop and runs unthrottled,
 		// which is how it behaved before it learned to throttle at all. Worth a
@@ -1089,9 +1117,9 @@ func (r *Runner) setupThrottler(ctx context.Context) error {
 		// Handing it to the checksum as well would add a second per checksum
 		// chunk to every test that uses it — real wall-clock cost, no extra
 		// coverage. Checksum throttling is covered directly in pkg/checksum.
-		r.throttler = &throttler.Mock{}
-		r.copier.SetThrottler(r.throttler)
-		return r.throttler.Open(ctx)
+		r.setThrottler(&throttler.Mock{})
+		r.copier.SetThrottler(r.currentThrottler())
+		return r.currentThrottler().Open(ctx)
 	}
 
 	var throttlers []throttler.Throttler
@@ -1141,9 +1169,9 @@ func (r *Runner) setupThrottler(ctx context.Context) error {
 		return nil // use default Noop throttler
 	}
 
-	r.throttler = throttler.NewMultiThrottler(throttlers...)
+	r.setThrottler(throttler.NewMultiThrottler(throttlers...))
 	r.setThrottlerOnPhases()
-	if err := r.throttler.Open(ctx); err != nil {
+	if err := r.currentThrottler().Open(ctx); err != nil {
 		// multiThrottler already closes child throttlers on partial Open
 		// failure, but the *sql.DB connections backing replica throttlers
 		// are owned by r.replicas (and the Aurora monitor pool is owned
@@ -1339,14 +1367,18 @@ func (r *Runner) fatalError(reason change.FatalReason) bool {
 }
 
 func (r *Runner) Progress() status.Progress {
+	// Read the state once: the phase-specific fields below (summary, ETA,
+	// checksum, throttle) must all describe the same state, not whichever state
+	// each happened to observe.
+	state := r.status.Get()
 	var summary string
 	var eta status.ETA
 	var checksum status.ChecksumProgress
-	switch r.status.Get() { //nolint: exhaustive
+	switch state { //nolint: exhaustive
 	case status.CopyRows:
 		summary = fmt.Sprintf("%v %s ETA %v",
 			r.copier.GetProgress(),
-			r.status.Get().String(),
+			state.String(),
 			r.copier.GetETA(),
 		)
 		eta = r.copier.GetETAState()
@@ -1391,11 +1423,35 @@ func (r *Runner) Progress() status.Progress {
 		})
 	}
 	return status.Progress{
-		CurrentState: r.status.Get(),
+		CurrentState: state,
 		Summary:      summary,
+		Resume:       r.usedResumeFromCheckpoint.Load(),
+		Throttle:     r.throttleStatus(state),
 		ETA:          eta,
 		Checksum:     checksum,
 		Tables:       tables,
+	}
+}
+
+// throttleStatus reports how the phase named by state is currently being paced.
+//
+// The signals reported are the ones that phase actually honours, so that status
+// never blames a pause on a signal the running phase is ignoring: the copier
+// honours the whole composite, while the checksum narrows it to the load signals
+// exactly as checksum's loadOnlyThrottler does (a read-only snapshot pass cannot
+// cause replica lag, so it does not pause on it). Phases that are not paced at
+// all report the composite, which is then read as "the server is asking spirit
+// to back off" rather than "this phase is paused".
+func (r *Runner) throttleStatus(state status.State) status.ThrottleStatus {
+	t := r.currentThrottler()
+	if state == status.Checksum {
+		t = throttler.GradualOnly(t)
+	}
+	throttled, reason, utilization := throttler.Describe(t)
+	return status.ThrottleStatus{
+		Throttled:   throttled,
+		Reason:      reason,
+		Utilization: utilization,
 	}
 }
 
@@ -1429,8 +1485,8 @@ func (r *Runner) Close() error {
 	if r.replClient != nil {
 		r.replClient.Close()
 	}
-	if r.throttler != nil {
-		if err := r.throttler.Close(); err != nil {
+	if t := r.currentThrottler(); t != nil {
+		if err := t.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -1571,7 +1627,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 		"checksum-watermark", checksumWatermark,
 		"position", binlogPosition,
 	)
-	r.usedResumeFromCheckpoint = true
+	r.usedResumeFromCheckpoint.Store(true)
 	return nil
 }
 

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
@@ -125,8 +126,10 @@ type Runner struct {
 	// row resume reads. It also guards continuousChecker (see above).
 	checkpointMu sync.Mutex
 
-	// Track some key statistics.
-	usedResumeFromCheckpoint bool
+	// Track some key statistics. usedResumeFromCheckpoint is atomic because it
+	// is also reported to API callers as Progress().Resume, which they poll from
+	// their own goroutine while setup is still writing it.
+	usedResumeFromCheckpoint atomic.Bool
 
 	cutoverFunc func(ctx context.Context) error
 	// reverseCutoverFunc is the reverse-window rollback's traffic switch (route
@@ -535,7 +538,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 	}
 
 	r.checkpointTable = table.NewTableInfo(tgt0.DB, tgt0.Config.DBName, checkpointTableName)
-	r.usedResumeFromCheckpoint = true
+	r.usedResumeFromCheckpoint.Store(true)
 	return nil
 }
 
@@ -1762,6 +1765,10 @@ func (r *Runner) Progress() status.Progress {
 	return status.Progress{
 		CurrentState: r.status.Get(),
 		Summary:      summary,
+		Resume:       r.usedResumeFromCheckpoint.Load(),
+		// Throttle is deliberately left zero: a move always copies through a
+		// Noop throttler, so there is nothing to report yet. Populate it here
+		// when move learns to throttle (issue #831).
 	}
 }
 

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -521,7 +521,7 @@ func TestMoveResumeDeletesRecopyRange(t *testing.T) {
 	defer closeTestRunner(t, r)
 	require.NoError(t, r.setupDiscovery(ctx))
 	require.NoError(t, r.setupUnderLocks(ctx))
-	require.True(t, r.usedResumeFromCheckpoint)
+	require.True(t, r.usedResumeFromCheckpoint.Load())
 
 	// The target must hold no rows at/above the copier's resume position:
 	// both markers AND the previously-copied rows in [lower, srcMaxID] are
@@ -993,7 +993,11 @@ func TestResumeFromCheckpointMultiTableE2E(t *testing.T) {
 	r, err := NewRunner(move)
 	require.NoError(t, err)
 	require.NoError(t, r.Run(t.Context()))
-	require.True(t, r.usedResumeFromCheckpoint, "the move must resume from the checkpoint, not start over")
+	require.True(t, r.usedResumeFromCheckpoint.Load(), "the move must resume from the checkpoint, not start over")
+	// The same fact must reach API callers, who cannot infer recovery from
+	// CurrentState — a resumed run walks the same states as a fresh one
+	// (issue #844).
+	require.True(t, r.Progress().Resume)
 	require.NoError(t, r.Close())
 
 	// After cutover the source tables are renamed *_old. The target must
@@ -1058,7 +1062,7 @@ func TestResumeFromCheckpointCompositePKE2E(t *testing.T) {
 	r, err := NewRunner(move)
 	require.NoError(t, err)
 	require.NoError(t, r.Run(t.Context()))
-	require.True(t, r.usedResumeFromCheckpoint, "the move must resume from the checkpoint, not start over")
+	require.True(t, r.usedResumeFromCheckpoint.Load(), "the move must resume from the checkpoint, not start over")
 	require.NoError(t, r.Close())
 
 	db, err := sql.Open("mysql", targetDSN)
@@ -1143,7 +1147,7 @@ func TestMultiSourceResumeFromCheckpointE2E(t *testing.T) {
 	r, err := NewRunner(move)
 	require.NoError(t, err)
 	require.NoError(t, r.Run(t.Context()))
-	require.True(t, r.usedResumeFromCheckpoint, "the move must resume from the checkpoint, not start over")
+	require.True(t, r.usedResumeFromCheckpoint.Load(), "the move must resume from the checkpoint, not start over")
 	require.NoError(t, r.Close())
 
 	// After cutover the source tables are renamed users_old on each source.
@@ -1247,7 +1251,7 @@ func TestMultiSourceResumeDiscardsChecksumWatermark(t *testing.T) {
 	r, err := NewRunner(move)
 	require.NoError(t, err)
 	require.NoError(t, r.Run(t.Context()))
-	require.True(t, r.usedResumeFromCheckpoint, "the move must resume from the checkpoint, not start over")
+	require.True(t, r.usedResumeFromCheckpoint.Load(), "the move must resume from the checkpoint, not start over")
 	require.Empty(t, r.checksumWatermark,
 		"a multi-source resume must discard the persisted checksum watermark and run a full checksum pass")
 	require.NoError(t, r.Close())
@@ -1310,7 +1314,7 @@ func TestSingleSourceResumeKeepsChecksumWatermark(t *testing.T) {
 	r, err := NewRunner(move)
 	require.NoError(t, err)
 	require.NoError(t, r.Run(t.Context()))
-	require.True(t, r.usedResumeFromCheckpoint, "the move must resume from the checkpoint, not start over")
+	require.True(t, r.usedResumeFromCheckpoint.Load(), "the move must resume from the checkpoint, not start over")
 	require.Equal(t, craftedChecksumWM, r.checksumWatermark,
 		"a single-source resume must preserve the persisted checksum watermark (resume-at-watermark optimization)")
 	require.NoError(t, r.Close())
@@ -1565,7 +1569,7 @@ func TestResumeFromCheckpointTooOld(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, status.ErrCheckpointTooOld)
 	require.ErrorContains(t, err, "wipe the target tables")
-	require.False(t, r.usedResumeFromCheckpoint)
+	require.False(t, r.usedResumeFromCheckpoint.Load())
 	require.NoError(t, r.Close())
 }
 
@@ -1605,7 +1609,7 @@ func TestResumeFromCheckpointNotTooOld(t *testing.T) {
 	r, err := NewRunner(move)
 	require.NoError(t, err)
 	require.NoError(t, r.Run(t.Context()))
-	require.True(t, r.usedResumeFromCheckpoint, "a fresh checkpoint must still resume")
+	require.True(t, r.usedResumeFromCheckpoint.Load(), "a fresh checkpoint must still resume")
 	require.NoError(t, r.Close())
 }
 

--- a/pkg/status/README.md
+++ b/pkg/status/README.md
@@ -63,12 +63,12 @@ Alongside the summary it carries structured fields for the things a wrapper woul
 | --- | --- |
 | `Throttled` | The phase is paused right now. **Branch on this.** |
 | `Reason` | Display string naming the signal and comparison, e.g. `commit-latency 128ms >= 100ms`. Multiple concurrent signals are joined with `"; "`. May be `""` even while throttled (see below). |
-| `Utilization` | Load relative to the throttle point: 0 = idle, 1.0 = at the point throttling begins, >1.0 = over. |
+| `Utilization` | Load relative to the throttle point: `1.0` = at the point throttling begins, `>1.0` = over, lower = further below. **`0` does not mean idle** — see below. |
 
 Two traps for consumers:
 
 - `Reason` is for display, not for branching. It is empty when the configured throttler cannot explain itself (see [`ReasonedThrottler`](../throttler/README.md#reasonedthrottler-optional-extension)).
-- `Utilization` is `0` when no *continuous* load signal exists — notably when throttling is replica-lag-only, which is a budget rather than a load gauge. Treat `0` as "unknown", not "idle".
+- `Utilization` is also `0` when no *continuous* load signal exists — notably when throttling is replica-lag-only, which is a budget rather than a load gauge. So a copy paused on replica lag reports `Throttled` with `Utilization` `0`: treat `0` as "unknown" and hide the gauge, rather than drawing an idle server.
 
 Which signals count depends on the phase, and the runner narrows the report to the ones that phase actually honours: the copy honours all of them, while a checksum honours only load signals (a read-only snapshot pass cannot cause replica lag, so pausing it on lag would only hold the snapshot open for longer). A `move` reports no throttling at all — it copies through a `Noop` throttler for now.
 

--- a/pkg/status/README.md
+++ b/pkg/status/README.md
@@ -61,16 +61,26 @@ Alongside the summary it carries structured fields for the things a wrapper woul
 
 | Field | Meaning |
 | --- | --- |
-| `Throttled` | The phase is paused right now. **Branch on this.** |
+| `Throttled` | The phase is paused right now. **Branch on this.** False in phases that pace against nothing — see below. |
 | `Reason` | Display string naming the signal and comparison, e.g. `commit-latency 128ms >= 100ms`. Multiple concurrent signals are joined with `"; "`. May be `""` even while throttled (see below). |
 | `Utilization` | Load relative to the throttle point: `1.0` = at the point throttling begins, `>1.0` = over, lower = further below. **`0` does not mean idle** — see below. |
 
 Two traps for consumers:
 
-- `Reason` is for display, not for branching. It is empty when the configured throttler cannot explain itself (see [`ReasonedThrottler`](../throttler/README.md#reasonedthrottler-optional-extension)).
+- `Reason` is for display, not for branching. It is empty when the configured throttler cannot explain itself (see [`ReasonedThrottler`](../throttler/README.md#reasonedthrottler-optional-extension)), and it is sampled independently of `Throttled` rather than atomically with it, so on a fast-changing signal the two can briefly disagree.
 - `Utilization` is also `0` when no *continuous* load signal exists — notably when throttling is replica-lag-only, which is a budget rather than a load gauge. So a copy paused on replica lag reports `Throttled` with `Utilization` `0`: treat `0` as "unknown" and hide the gauge, rather than drawing an idle server.
 
-Which signals count depends on the phase, and the runner narrows the report to the ones that phase actually honours: the copy honours all of them, while a checksum honours only load signals (a read-only snapshot pass cannot cause replica lag, so pausing it on lag would only hold the snapshot open for longer). A `move` reports no throttling at all — it copies through a `Noop` throttler for now.
+Which signals count depends on the phase, and the runner reports only the ones that phase actually honours — so `Throttled` means the same thing everywhere:
+
+| Phase | Reported |
+| --- | --- |
+| `CopyRows` | The whole composite. The copier writes, so it honours every signal. |
+| `Checksum` | Load signals only, matching `checksum`'s `loadOnlyThrottler` — a read-only snapshot pass cannot cause replica lag, so pausing it on lag would only hold the snapshot open for longer. |
+| everything else | Zero value. Nothing there consults a throttler: the sentinel wait runs the continuous checker (which takes none), and the changeset applies and cutover are not paced. |
+
+That last row matters for a wrapper polling after a run ends: a loaded server — or a replica-lag throttler that fails closed once its poll loop has stopped — must not make a finished migration, a cutover, or a sentinel wait look paused.
+
+A `move` reports no throttling at all — it copies through a `Noop` throttler for now.
 
 ## See Also
 

--- a/pkg/status/README.md
+++ b/pkg/status/README.md
@@ -47,6 +47,31 @@ The checkpoint dumper also handles a race condition where the state transitions 
 
 `Progress` is a struct (not just a string) containing the current state and a summary. It is designed as a struct specifically to allow future expansion for GUI wrappers and external tooling.
 
+Alongside the summary it carries structured fields for the things a wrapper would otherwise have to parse out of prose or scrape from the logs: `ETA`, per-table `Tables` progress, `Checksum` progress, and — from [#844](https://github.com/block/spirit/issues/844) — `Resume` and `Throttle`.
+
+### `Resume`
+
+`Resume` is true when the run resumed from a checkpoint left by an earlier run. A resumed run walks the whole state machine again (`CopyRows`, `Checksum`, ...) even when those phases are near-instant, so a wrapper watching only `CurrentState` sees what looks like a migration starting over — confusing when the previous pod died while waiting on the sentinel table.
+
+`CurrentState` is deliberately **not** overloaded with a synthetic "recovering" value: callers parse it for phase display, so a new state would be a breaking change. Pair `Resume` with the progress fields instead — a resumed run whose copy and checksum progress are both near-complete is one to render as "recovering" rather than "starting".
+
+### `Throttle`
+
+`Throttle` reports whether the current phase is paused by a throttler, and why:
+
+| Field | Meaning |
+| --- | --- |
+| `Throttled` | The phase is paused right now. **Branch on this.** |
+| `Reason` | Display string naming the signal and comparison, e.g. `commit-latency 128ms >= 100ms`. Multiple concurrent signals are joined with `"; "`. May be `""` even while throttled (see below). |
+| `Utilization` | Load relative to the throttle point: 0 = idle, 1.0 = at the point throttling begins, >1.0 = over. |
+
+Two traps for consumers:
+
+- `Reason` is for display, not for branching. It is empty when the configured throttler cannot explain itself (see [`ReasonedThrottler`](../throttler/README.md#reasonedthrottler-optional-extension)).
+- `Utilization` is `0` when no *continuous* load signal exists — notably when throttling is replica-lag-only, which is a budget rather than a load gauge. Treat `0` as "unknown", not "idle".
+
+Which signals count depends on the phase, and the runner narrows the report to the ones that phase actually honours: the copy honours all of them, while a checksum honours only load signals (a read-only snapshot pass cannot cause replica lag, so pausing it on lag would only hold the snapshot open for longer). A `move` reports no throttling at all — it copies through a `Noop` throttler for now.
+
 ## See Also
 
 - [pkg/migration](../migration/README.md) - Migration runner that implements the `Task` interface

--- a/pkg/status/progress.go
+++ b/pkg/status/progress.go
@@ -44,6 +44,11 @@ type ETA struct {
 type ThrottleStatus struct {
 	// Throttled is true while a throttler is telling the current phase to
 	// pause. This is the field to branch on.
+	//
+	// It is false in phases that do not pace themselves against a throttler at
+	// all — which is every phase except the row copy and the checksum. A loaded
+	// server is not reported as pausing a cutover or a sentinel wait, because
+	// nothing there is reading that signal.
 	Throttled bool
 
 	// Reason names the signal and the comparison that tripped it, in the form
@@ -55,6 +60,13 @@ type ThrottleStatus struct {
 	// It is intended for display, not for branching: it is "" when Throttled is
 	// false, and may also be "" when the configured throttler cannot explain
 	// itself (see throttler.ReasonedThrottler).
+	//
+	// It is also sampled independently of Throttled rather than atomically with
+	// it, so on a signal that is changing underneath the poll the two can
+	// disagree: a throttler that clears in between yields Throttled with an
+	// empty Reason, and a reason can quote a comparison that has just stopped
+	// holding. Both are display-level staleness on a value that is a snapshot
+	// anyway — not a bug to report.
 	Reason string
 
 	// Utilization is load relative to the point at which throttling begins:

--- a/pkg/status/progress.go
+++ b/pkg/status/progress.go
@@ -58,13 +58,16 @@ type ThrottleStatus struct {
 	Reason string
 
 	// Utilization is load relative to the point at which throttling begins:
-	// 0 = idle, 1.0 = exactly at the throttle point, >1.0 = over. It lets a
-	// wrapper show "running at 40% of the load limit" rather than only a
-	// long ETA.
+	// 1.0 is exactly at that point, >1.0 is over it, and lower values are
+	// further below it. It lets a wrapper show "running at 40% of the load
+	// limit" rather than only a long ETA.
 	//
-	// It is 0 when no continuous load signal is available — notably when
+	// 0 is ambiguous and must not be rendered as idle. It is also what this
+	// field reports when no continuous load signal exists at all — notably when
 	// throttling is replica-lag-only, which is a budget rather than a load gauge
-	// (see throttler.GradualThrottler) — so treat 0 as "unknown", not "idle".
+	// (see throttler.GradualThrottler). A copy paused on replica lag therefore
+	// reports Throttled with Utilization 0, so a wrapper drawing a load gauge
+	// should treat 0 as "unknown" and hide it rather than show an idle server.
 	Utilization float64
 }
 

--- a/pkg/status/progress.go
+++ b/pkg/status/progress.go
@@ -37,9 +37,59 @@ type ETA struct {
 	Duration time.Duration
 }
 
+// ThrottleStatus reports whether the current phase is paused by a throttler,
+// and why. Before this, throttling was only visible in the logs, so a wrapper
+// polling status saw a migration that had gone quiet with no way to say why
+// (issue #844).
+type ThrottleStatus struct {
+	// Throttled is true while a throttler is telling the current phase to
+	// pause. This is the field to branch on.
+	Throttled bool
+
+	// Reason names the signal and the comparison that tripped it, in the form
+	// "<signal> <observed> <op> <threshold>" — e.g. "commit-latency 128ms >= 100ms"
+	// or "redo-aware 24 > 17". When several signals throttle at once they are
+	// joined with "; ", because clearing only one of them will not resume the
+	// copy.
+	//
+	// It is intended for display, not for branching: it is "" when Throttled is
+	// false, and may also be "" when the configured throttler cannot explain
+	// itself (see throttler.ReasonedThrottler).
+	Reason string
+
+	// Utilization is load relative to the point at which throttling begins:
+	// 0 = idle, 1.0 = exactly at the throttle point, >1.0 = over. It lets a
+	// wrapper show "running at 40% of the load limit" rather than only a
+	// long ETA.
+	//
+	// It is 0 when no continuous load signal is available — notably when
+	// throttling is replica-lag-only, which is a budget rather than a load gauge
+	// (see throttler.GradualThrottler) — so treat 0 as "unknown", not "idle".
+	Utilization float64
+}
+
 type Progress struct {
 	CurrentState State  // current state, i.e. CopyRows
 	Summary      string // text based representation, i.e. "12.5% copyRows ETA 1h 30m"
+
+	// Resume is true when this run resumed from a checkpoint left by an earlier
+	// run, rather than starting the copy from scratch.
+	//
+	// It exists because a resumed run walks the whole state machine again
+	// (CopyRows, Checksum, ...) even when those phases are near-instant, so a
+	// wrapper watching CurrentState sees what looks like a migration starting
+	// over. CurrentState is deliberately left alone — callers parse it for phase
+	// display — and this reports the fact alongside it: pair it with
+	// Tables/Checksum progress to decide whether to render the run as
+	// "recovering" rather than "starting".
+	Resume bool
+
+	// Throttle reports whether the current phase is paused by a throttler, and
+	// why. Which signals count depends on the phase: the copy honours all of
+	// them, while a checksum only honours load signals (a read-only snapshot
+	// pass cannot cause replica lag, so pausing it on lag would only hold the
+	// snapshot open for longer).
+	Throttle ThrottleStatus
 
 	// ETA is the structured remaining row-copy estimate and its availability.
 	ETA ETA

--- a/pkg/throttler/README.md
+++ b/pkg/throttler/README.md
@@ -66,7 +66,9 @@ This exists for the status API: throttling used to be visible only in the logs, 
 
 `Describe(t)` is the accessor the runners use, folding the two optional extensions and a nil throttler into the three values `status.Progress.Throttle` carries: `throttled`, `reason`, and `utilization`. Note the asymmetry: `reason` is only read while throttling, whereas `utilization` is always read — a load reading below the throttle point is exactly what makes "running at 40% of the limit" reportable before anything pauses.
 
-Implementations of `ThrottleReason` must not disturb the signal they report on. It is called from status polling, so — unlike the throttle path — it must not consume the warn-once staleness logging (`Replica.ThrottleReason` uses `gapExceeds` rather than `check` for this reason).
+Implementations of `ThrottleReason` must not disturb the signal they report on: asking for a reason should never change what the throttle path will log. `Replica.ThrottleReason` uses `gapExceeds` rather than `check` for this reason, so it cannot consume the warn-once staleness logging.
+
+Note this is a requirement on the *method*, not a claim about the status path: `Describe` calls `IsThrottled` first to get the field it reports, so a status poll can still be what logs that stale-signal warning. The `CompareAndSwap` behind it means the warning is still logged exactly once per stale period — only the attribution moves.
 
 ## Implementations
 

--- a/pkg/throttler/README.md
+++ b/pkg/throttler/README.md
@@ -49,6 +49,25 @@ The copier's write-thread autoscaler type-asserts for this and only engages when
 
 The distinction also decides *who is allowed to pause whom*. `GradualOnly(t)` returns a view of a composite that keeps only its gradual children, for consumers that cannot cause what a binary throttler protects: the checksum reads inside a `REPEATABLE READ` snapshot and emits no binlog events, so pausing it on replica lag cannot reduce that lag, while the pause holds the snapshot open and retains undo. The view is read-only — its `Open`, `Close` and `UpdateLag` are no-ops, because the composite it came from is still what gets opened, polled and closed.
 
+### `ReasonedThrottler` (optional extension)
+
+Throttlers that can explain *why* they are throttling implement `ReasonedThrottler` ([#844](https://github.com/block/spirit/issues/844)):
+
+```go
+type ReasonedThrottler interface {
+    Throttler
+    // ThrottleReason names the signal and the comparison that tripped it,
+    // e.g. "commit-latency 128ms >= 100ms". "" when not throttling.
+    ThrottleReason() string
+}
+```
+
+This exists for the status API: throttling used to be visible only in the logs, so a wrapper polling `status.Progress` saw a migration that had gone quiet with no way to say why. Every throttler in this package implements it, and the composite names *every* currently-throttling child (joined with `"; "`) because clearing only one of them will not resume the copy. It is optional, so a custom throttler that omits it still works — it just reports being throttled without a reason.
+
+`Describe(t)` is the accessor the runners use, folding the two optional extensions and a nil throttler into the three values `status.Progress.Throttle` carries: `throttled`, `reason`, and `utilization`. Note the asymmetry: `reason` is only read while throttling, whereas `utilization` is always read — a load reading below the throttle point is exactly what makes "running at 40% of the limit" reportable before anything pauses.
+
+Implementations of `ThrottleReason` must not disturb the signal they report on. It is called from status polling, so — unlike the throttle path — it must not consume the warn-once staleness logging (`Replica.ThrottleReason` uses `gapExceeds` rather than `check` for this reason).
+
 ## Implementations
 
 ### Noop Throttler
@@ -130,6 +149,7 @@ To implement a custom throttler (e.g., for Freno integration):
 3. Update throttling state based on your metrics
 4. Return the current state in `IsThrottled()`
 5. Block appropriately in `BlockWait()` with context support
+6. Optionally implement `ThrottleReason()` so the status API can explain your pauses to a GUI
 
 Example structure:
 

--- a/pkg/throttler/aurora_commitlatency.go
+++ b/pkg/throttler/aurora_commitlatency.go
@@ -92,6 +92,7 @@ type CommitLatency struct {
 }
 
 var _ GradualThrottler = (*CommitLatency)(nil)
+var _ ReasonedThrottler = (*CommitLatency)(nil)
 
 // NewCommitLatencyThrottler returns a Throttler that polls Aurora's commit
 // counters and throttles when window-averaged commit latency >= threshold.
@@ -149,6 +150,21 @@ func (c *CommitLatency) Close() error {
 
 func (c *CommitLatency) IsThrottled() bool {
 	return c.isThrottled.Load()
+}
+
+// ThrottleReason implements ReasonedThrottler, quoting the window-averaged
+// commit latency against the configured threshold — the same comparison
+// applySample throttles on.
+//
+// Unlike Utilization it does not consult the stale guard: the hard-stop this
+// reason explains is itself unaffected by staleness (see stale.go), so reporting
+// a stale-signal caveat here would describe a state IsThrottled is not in.
+func (c *CommitLatency) ThrottleReason() string {
+	if !c.isThrottled.Load() {
+		return ""
+	}
+	avg := time.Duration(c.avgLatencyUs.Load()) * time.Microsecond
+	return fmt.Sprintf("commit-latency %s >= %s", avg.Round(time.Microsecond), c.threshold)
 }
 
 // Utilization reports the most recent window-averaged commit latency as a

--- a/pkg/throttler/aurora_threads.go
+++ b/pkg/throttler/aurora_threads.go
@@ -275,6 +275,7 @@ type AuroraThreads struct {
 }
 
 var _ GradualThrottler = (*AuroraThreads)(nil)
+var _ ReasonedThrottler = (*AuroraThreads)(nil)
 
 // newAuroraThreadsThrottler returns a throttler that polls the given mode's
 // signal and throttles when it exceeds the instance vCPU count (plus the mode's
@@ -336,6 +337,17 @@ func (a *AuroraThreads) Close() error {
 
 func (a *AuroraThreads) IsThrottled() bool {
 	return a.isThrottled.Load()
+}
+
+// ThrottleReason implements ReasonedThrottler. It quotes the raw sample against
+// the hard-stop threshold — the comparison applySample actually throttles on —
+// not the EWMA that Utilization reports, and names the mode so the reason says
+// which signal was read ("redo-aware 24 > 17", "threads-running 24 > 20").
+func (a *AuroraThreads) ThrottleReason() string {
+	if !a.isThrottled.Load() {
+		return ""
+	}
+	return fmt.Sprintf("%s %d > %d", a.mode.label, a.lastSample.Load(), a.throttleThreshold())
 }
 
 // Utilization reports the smoothed (EWMA) thread count as a fraction of the

--- a/pkg/throttler/gradualonly.go
+++ b/pkg/throttler/gradualonly.go
@@ -55,6 +55,7 @@ type gradualSubset struct {
 }
 
 var _ GradualThrottler = &gradualSubset{}
+var _ ReasonedThrottler = &gradualSubset{}
 
 // Open is a no-op: the composite this view was derived from owns the children.
 func (g *gradualSubset) Open(_ context.Context) error { return nil }
@@ -70,6 +71,11 @@ func (g *gradualSubset) UpdateLag(_ context.Context) error { return nil }
 func (g *gradualSubset) IsThrottled() bool { return g.inner.IsThrottled() }
 
 func (g *gradualSubset) BlockWait(ctx context.Context) { g.inner.BlockWait(ctx) }
+
+// ThrottleReason names only the retained children, so a consumer of this view
+// (the checksum's status) is never told it is paused on a signal this view
+// dropped.
+func (g *gradualSubset) ThrottleReason() string { return g.inner.ThrottleReason() }
 
 // Utilization is the maximum across the retained children, matching
 // gradualMultiThrottler. Every child here is gradual, so nothing is skipped.

--- a/pkg/throttler/mock.go
+++ b/pkg/throttler/mock.go
@@ -15,7 +15,7 @@ type Mock struct {
 	blockDuration time.Duration
 }
 
-var _ Throttler = &Mock{}
+var _ ReasonedThrottler = &Mock{}
 
 func (t *Mock) blockFor() time.Duration {
 	if t.blockDuration == 0 {
@@ -34,6 +34,12 @@ func (t *Mock) Close() error {
 
 func (t *Mock) IsThrottled() bool {
 	return true
+}
+
+// ThrottleReason implements ReasonedThrottler so that tests wiring the mock
+// (--test-throttler) exercise the same status plumbing production does.
+func (t *Mock) ThrottleReason() string {
+	return "mock throttler (always throttled)"
 }
 
 func (t *Mock) BlockWait(ctx context.Context) {

--- a/pkg/throttler/multi.go
+++ b/pkg/throttler/multi.go
@@ -14,7 +14,7 @@ type multiThrottler struct {
 	throttlers []Throttler
 }
 
-var _ Throttler = &multiThrottler{}
+var _ ReasonedThrottler = &multiThrottler{}
 
 // gradualMultiThrottler is the multiThrottler variant returned when at least
 // one child implements GradualThrottler, so that asserting GradualThrottler on
@@ -95,6 +95,13 @@ func (m *multiThrottler) IsThrottled() bool {
 		}
 	}
 	return false
+}
+
+// ThrottleReason implements ReasonedThrottler by naming every child currently
+// throttling, joined with "; " — a copy held up by both replica lag and commit
+// latency should say so, since clearing only one of them will not resume it.
+func (m *multiThrottler) ThrottleReason() string {
+	return joinReasons(m.throttlers)
 }
 
 // BlockWait blocks until all child throttlers are unthrottled.

--- a/pkg/throttler/reason.go
+++ b/pkg/throttler/reason.go
@@ -1,0 +1,79 @@
+package throttler
+
+import "strings"
+
+// ReasonedThrottler is an optional extension implemented by throttlers that can
+// explain why they are currently throttling. It exists for the status API: a
+// wrapper (GUI, orchestration) polling status.Progress can report "paused:
+// commit-latency 128ms >= 100ms" rather than leaving the operator to explain a
+// mysteriously long ETA from the logs. See issue #844.
+//
+// It is optional for the same reason GradualThrottler is — a custom throttler
+// that does not implement it still works, it just reports being throttled
+// without a reason.
+type ReasonedThrottler interface {
+	Throttler
+	// ThrottleReason names the signal and the comparison that tripped it, in the
+	// form "<signal> <observed> <op> <threshold>", e.g.
+	// "commit-latency 128ms >= 100ms". It returns "" when this throttler is not
+	// currently throttling.
+	//
+	// It must be free of side effects beyond the warn-once logging the throttlers
+	// already do: it is called from status polling, not from the throttle path,
+	// and must not disturb the signal it reports on.
+	ThrottleReason() string
+}
+
+// Describe reports a throttler's current state for the status API:
+//
+//   - throttled is what IsThrottled reports — the binary "is the copy paused
+//     right now" answer, and the field callers should branch on.
+//   - reason explains it, and is "" both when not throttled and when the
+//     throttler does not implement ReasonedThrottler. Never branch on it.
+//   - utilization is load relative to the throttle point (0 = idle, 1.0 = at
+//     the point throttling begins) for throttlers implementing
+//     GradualThrottler, and 0 for those that do not — so 0 means "no continuous
+//     signal available", not "idle". Replica-lag-only throttling reads 0 here
+//     by design; see GradualThrottler.
+//
+// A nil throttler reads as not throttled, which is what the runners want: a
+// migration with no throttlers configured paces itself against the copier's
+// Noop.
+func Describe(t Throttler) (throttled bool, reason string, utilization float64) {
+	if t == nil {
+		return false, "", 0
+	}
+	throttled = t.IsThrottled()
+	if throttled {
+		if rt, ok := t.(ReasonedThrottler); ok {
+			reason = rt.ThrottleReason()
+		}
+	}
+	if gt, ok := t.(GradualThrottler); ok {
+		utilization = gt.Utilization()
+	}
+	return throttled, reason, utilization
+}
+
+// joinReasons renders the reasons of every currently-throttling child of a
+// composite throttler, so that a copy paused by two signals at once names both
+// rather than only whichever child happens to sort first. Children that are not
+// throttling, and children that cannot explain themselves, contribute nothing —
+// so the result is "" if no child can be attributed, matching the
+// ThrottleReason contract for a throttler that has no reason to offer.
+func joinReasons(throttlers []Throttler) string {
+	var reasons []string
+	for _, t := range throttlers {
+		if !t.IsThrottled() {
+			continue
+		}
+		rt, ok := t.(ReasonedThrottler)
+		if !ok {
+			continue
+		}
+		if reason := rt.ThrottleReason(); reason != "" {
+			reasons = append(reasons, reason)
+		}
+	}
+	return strings.Join(reasons, "; ")
+}

--- a/pkg/throttler/reason_test.go
+++ b/pkg/throttler/reason_test.go
@@ -106,10 +106,11 @@ func TestReplicaThrottleReasonWhenLagUnobservable(t *testing.T) {
 }
 
 func TestReplicaThrottleReasonHasNoStaleWarnSideEffect(t *testing.T) {
-	// ThrottleReason is called from status polling, which must not consume the
-	// warn-once that the throttle path wants to log. If it called IsThrottled
-	// (and hence stale.check) the subsequent IsThrottled would find warned
-	// already set and stay silent.
+	// Asking for a reason must not consume the warn-once that IsThrottled logs
+	// on entering a stale period: if ThrottleReason called IsThrottled (and hence
+	// stale.check), the next IsThrottled would find warned already set and stay
+	// silent. This pins the method as pure — the status path as a whole is not,
+	// since Describe calls IsThrottled to get the field it reports.
 	l := newTestReplica(t, 120*time.Second)
 	l.applyLag(5)
 	ageLastSample(&l.stale, staleSignalThreshold+time.Second)

--- a/pkg/throttler/reason_test.go
+++ b/pkg/throttler/reason_test.go
@@ -1,0 +1,186 @@
+package throttler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeNilThrottler(t *testing.T) {
+	// A runner that found nothing to throttle on leaves its throttler nil (the
+	// copier keeps its own Noop), and status must read that as "not throttled"
+	// rather than panic.
+	throttled, reason, utilization := Describe(nil)
+	require.False(t, throttled)
+	require.Empty(t, reason)
+	require.Zero(t, utilization)
+}
+
+func TestDescribeBinaryThrottlerHasNoUtilization(t *testing.T) {
+	// testThrottler implements neither optional extension: it must report the
+	// binary state truthfully and leave reason/utilization at their "unknown"
+	// zero values rather than inventing a 0 = idle load reading.
+	bare := &testThrottler{}
+	bare.throttled.Store(true)
+
+	throttled, reason, utilization := Describe(bare)
+	require.True(t, throttled)
+	require.Empty(t, reason)
+	require.Zero(t, utilization)
+}
+
+func TestDescribeReportsReasonOnlyWhileThrottled(t *testing.T) {
+	l := newTestReplica(t, 120*time.Second)
+
+	l.applyLag(5)
+	throttled, reason, _ := Describe(l)
+	require.False(t, throttled)
+	require.Empty(t, reason, "a healthy throttler must not offer a stale reason")
+
+	l.applyLag(150_000)
+	throttled, reason, _ = Describe(l)
+	require.True(t, throttled)
+	require.Equal(t, "replica-lag 150000ms >= 120000ms", reason)
+}
+
+func TestDescribeReportsUtilizationOfGradualThrottler(t *testing.T) {
+	// Utilization comes through even when the throttler is not yet throttling:
+	// that is the whole point of the continuous signal — "running at 40% of the
+	// load limit" is exactly what a GUI wants instead of a long ETA.
+	g := &gradualTestThrottler{}
+	g.setUtilization(0.4)
+
+	throttled, reason, utilization := Describe(g)
+	require.False(t, throttled)
+	require.Empty(t, reason)
+	require.InDelta(t, 0.4, utilization, 0.0001)
+}
+
+func TestCommitLatencyThrottleReason(t *testing.T) {
+	c := newTestCommitLatency(t, 100*time.Millisecond)
+
+	c.applySample(1_000_000, 2_000_000_000) // baseline; no Δ window yet
+	require.Empty(t, c.ThrottleReason())
+
+	// 1000 commits over the window at 128ms each.
+	c.applySample(1_001_000, 2_128_000_000)
+	require.True(t, c.IsThrottled())
+	require.Equal(t, "commit-latency 128ms >= 100ms", c.ThrottleReason())
+}
+
+func TestAuroraThreadsThrottleReason(t *testing.T) {
+	// The reason quotes the raw sample against the hard-stop threshold
+	// (vCPUs + the mode's headroom), which is the comparison applySample
+	// throttles on — not the EWMA that Utilization reports.
+	a := newTestAuroraThreads(t, 16, redoAwareMode)
+
+	a.applySample(4)
+	require.Empty(t, a.ThrottleReason())
+
+	a.applySample(24)
+	require.True(t, a.IsThrottled())
+	require.Equal(t, "redo-aware 24 > 17", a.ThrottleReason())
+
+	// The mode names the signal that was actually read, so an operator can tell
+	// which of the two thread signals tripped.
+	g := newTestAuroraThreads(t, 16, globalStatusMode)
+	g.applySample(24)
+	require.True(t, g.IsThrottled())
+	require.Equal(t, fmt.Sprintf("threads-running 24 > %d", 16+selfMonitoringHeadroom), g.ThrottleReason())
+}
+
+func TestReplicaThrottleReasonWhenLagUnobservable(t *testing.T) {
+	// The fail-closed stale case has no trustworthy lag number to quote, so the
+	// reason must say the signal is gone rather than print the frozen 5ms that
+	// would look healthy.
+	l := newTestReplica(t, 120*time.Second)
+	l.applyLag(5)
+	require.Empty(t, l.ThrottleReason())
+
+	ageLastSample(&l.stale, staleSignalThreshold+time.Second)
+	require.True(t, l.IsThrottled())
+	require.Contains(t, l.ThrottleReason(), "replica-lag unobservable for ")
+	require.Contains(t, l.ThrottleReason(), "(failing closed)")
+}
+
+func TestReplicaThrottleReasonHasNoStaleWarnSideEffect(t *testing.T) {
+	// ThrottleReason is called from status polling, which must not consume the
+	// warn-once that the throttle path wants to log. If it called IsThrottled
+	// (and hence stale.check) the subsequent IsThrottled would find warned
+	// already set and stay silent.
+	l := newTestReplica(t, 120*time.Second)
+	l.applyLag(5)
+	ageLastSample(&l.stale, staleSignalThreshold+time.Second)
+
+	require.NotEmpty(t, l.ThrottleReason())
+	stale, entering := l.stale.check(staleSignalThreshold)
+	require.True(t, stale)
+	require.True(t, entering, "ThrottleReason must not have consumed the warn-once")
+}
+
+func TestMultiThrottlerReasonNamesEveryThrottlingChild(t *testing.T) {
+	// A copy held up by two signals at once must name both: clearing only one of
+	// them will not resume it.
+	lag := newTestReplica(t, 120*time.Second)
+	lag.applyLag(150_000)
+	commit := newTestCommitLatency(t, 100*time.Millisecond)
+	commit.applySample(1_000_000, 2_000_000_000)
+	commit.applySample(1_001_000, 2_128_000_000)
+
+	multi := NewMultiThrottler(lag, commit)
+	throttled, reason, utilization := Describe(multi)
+	require.True(t, throttled)
+	require.Equal(t, "replica-lag 150000ms >= 120000ms; commit-latency 128ms >= 100ms", reason)
+	// Utilization comes from the gradual child only (1.28 = 128ms/100ms); the
+	// replica-lag child contributes nothing by design.
+	require.InDelta(t, 1.28, utilization, 0.0001)
+}
+
+func TestMultiThrottlerReasonSkipsChildrenThatAreNotThrottling(t *testing.T) {
+	lag := newTestReplica(t, 120*time.Second)
+	lag.applyLag(5) // healthy
+	commit := newTestCommitLatency(t, 100*time.Millisecond)
+	commit.applySample(1_000_000, 2_000_000_000)
+	commit.applySample(1_001_000, 2_128_000_000)
+
+	multi := NewMultiThrottler(lag, commit)
+	_, reason, _ := Describe(multi)
+	require.Equal(t, "commit-latency 128ms >= 100ms", reason)
+}
+
+func TestMultiThrottlerReasonSkipsChildrenWithoutOne(t *testing.T) {
+	// A custom throttler that does not implement ReasonedThrottler still
+	// throttles; it just cannot be attributed. With no attributable child the
+	// composite reports being throttled with no reason, which is why callers
+	// must branch on Throttled rather than on Reason.
+	bare := &testThrottler{}
+	bare.throttled.Store(true)
+
+	multi := NewMultiThrottler(bare, &Noop{})
+	throttled, reason, _ := Describe(multi)
+	require.True(t, throttled)
+	require.Empty(t, reason)
+}
+
+func TestGradualOnlyReasonDropsBinarySignals(t *testing.T) {
+	// The checksum honours only the load signals, so the view it reads through
+	// must not report a replica-lag pause it is not observing.
+	lag := newTestReplica(t, 120*time.Second)
+	lag.applyLag(150_000)
+	commit := newTestCommitLatency(t, 100*time.Millisecond)
+	commit.applySample(1_000_000, 2_000_000_000)
+	commit.applySample(1_001_000, 2_002_000_000) // 2ms avg: healthy
+
+	loadOnly := GradualOnly(NewMultiThrottler(lag, commit))
+	throttled, reason, _ := Describe(loadOnly)
+	require.False(t, throttled)
+	require.Empty(t, reason)
+
+	// Once the load signal itself trips, the view reports it.
+	commit.applySample(1_002_000, 2_130_000_000)
+	throttled, reason, _ = Describe(loadOnly)
+	require.True(t, throttled)
+	require.Equal(t, "commit-latency 128ms >= 100ms", reason)
+}

--- a/pkg/throttler/replica.go
+++ b/pkg/throttler/replica.go
@@ -123,9 +123,11 @@ func (l *Replica) IsThrottled() bool {
 // tripped, or — for the fail-closed stale case, which has no trustworthy lag
 // number to quote — how long lag has been unobservable.
 //
-// It deliberately re-derives staleness with gapExceeds rather than calling
-// IsThrottled: check() carries the warn-once side effect, and a status poll
-// should not be what consumes the one warning the throttle path wants to log.
+// It is itself side-effect-free: it re-derives staleness with gapExceeds rather
+// than check(), so asking for a reason never consumes the warn-once that
+// IsThrottled logs on entering a stale period. Note this makes the *method*
+// pure, not the status path — Describe calls IsThrottled first, so a status poll
+// can still be what logs that warning.
 func (l *Replica) ThrottleReason() string {
 	if l.stale.gapExceeds(staleSignalThreshold) {
 		return "replica-lag unobservable for " + l.stale.age().Round(time.Second).String() + " (failing closed)"

--- a/pkg/throttler/replica.go
+++ b/pkg/throttler/replica.go
@@ -63,7 +63,7 @@ const MySQL8LagQuery = `WITH applier_latency AS (
    SELECT IFNULL(IF(queue_status='IDLE',0,CEIL(GREATEST(applier_latency_ms, queue_latency_ms))),0) as lagMs FROM applier_latency, queue_latency
 `
 
-var _ Throttler = &Replica{}
+var _ ReasonedThrottler = &Replica{}
 
 // Open starts the lag monitor. This is not gh-ost. The lag monitor is primitive
 // because the requirement is only for DR, and not for up-to-date read-replicas.
@@ -117,6 +117,24 @@ func (l *Replica) IsThrottled() bool {
 		return true
 	}
 	return l.currentLagInMs.Load() >= l.lagTolerance.Milliseconds()
+}
+
+// ThrottleReason implements ReasonedThrottler. It names the lag comparison that
+// tripped, or — for the fail-closed stale case, which has no trustworthy lag
+// number to quote — how long lag has been unobservable.
+//
+// It deliberately re-derives staleness with gapExceeds rather than calling
+// IsThrottled: check() carries the warn-once side effect, and a status poll
+// should not be what consumes the one warning the throttle path wants to log.
+func (l *Replica) ThrottleReason() string {
+	if l.stale.gapExceeds(staleSignalThreshold) {
+		return "replica-lag unobservable for " + l.stale.age().Round(time.Second).String() + " (failing closed)"
+	}
+	lagMs := l.currentLagInMs.Load()
+	if lagMs < l.lagTolerance.Milliseconds() {
+		return ""
+	}
+	return fmt.Sprintf("replica-lag %dms >= %dms", lagMs, l.lagTolerance.Milliseconds())
 }
 
 // Replica deliberately does NOT implement GradualThrottler: replication lag


### PR DESCRIPTION
Closes #844.

Implements the two limitations raised in the issue, following @aparajon's feedback on the SchemaBot side: structured fields rather than a changed `CurrentState` string, and `Throttled bool` + `Reason string` rather than prose to parse.

## 1. `Progress.Resume bool`

A resumed run walks the whole state machine again (`CopyRows`, `Checksum`, ...) even when those phases are near-instant, so a GUI watching `CurrentState` sees what looks like a migration starting over — the confusing case in the issue, where a pod dies while waiting on the sentinel table.

- `CurrentState` is deliberately **not** given a synthetic `recovering` value. Callers parse it for phase display, so a new state would be a breaking change; `Resume` reports the fact alongside it and the caller decides how to render it.
- Wired in all three runners: `migration`, `move`, and `datasync` (which already had a private `resuming` flag that was never surfaced).

## 2. `Progress.Throttle`

Throttling used to be visible only in the logs. `ThrottleStatus` carries:

| Field | Meaning |
| --- | --- |
| `Throttled` | The phase is paused right now. **Branch on this.** |
| `Reason` | Display string naming the signal and comparison, e.g. `commit-latency 128ms >= 100ms`, `redo-aware 24 > 17`, `replica-lag 150000ms >= 120000ms`. Concurrent signals join with `"; "`, because clearing only one of them will not resume the copy. |
| `Utilization` | Load relative to the throttle point (`0` = idle, `1.0` = where throttling begins). Cheap to add — the Aurora throttlers already compute it for the write-thread autoscaler. |

Reasons come from a new optional throttler extension, `ReasonedThrottler`, following the existing `GradualThrottler` precedent so a custom throttler that omits it still works (the README documents implementing your own). Every throttler in the package implements it.

**Reported signals match the running phase.** The copier honours the whole composite; a checksum honours only the load signals, exactly as `checksum.loadOnlyThrottler` narrows it. So status never reports a checksum as paused on replica lag it is not observing.

**Two traps documented for consumers** (`pkg/status/README.md`):
- `Reason` is for display, not branching — it is empty when the configured throttler cannot explain itself.
- `Utilization` is `0` when no continuous load signal exists (replica-lag-only throttling), so `0` means *unknown*, not *idle*.

## Concurrency

Both new fields are read by API callers from their own goroutine while setup is still writing them, so:

- the resume flags become `atomic.Bool` (migration, move, datasync)
- the migration runner's throttler gets a `throttlerMu`, assigned partway through setup by `setupThrottler`

`TestProgressPolledConcurrentlyWithRun` pins this — it fails with `WARNING: DATA RACE` under `-race` when the guard is removed (verified, not assumed).

## Notes

- One correction to the issue thread's examples: the thread-signal comparison is strictly `>` (vCPUs + the mode's headroom), not `>=`, so the reason string quotes `>` to stay accurate.
- `move` and `datasync` report no throttling — both copy through a `Noop` throttler for now (move: #831).
- The third signal from the issue thread — subscription soft-limit park count/duration — is **not** included here; it lives in a different subsystem (`pkg/change`) and the commenter was happy to track it separately.

## Testing

- New: `pkg/throttler/reason_test.go` (per-throttler reasons, composite aggregation, load-only narrowing, and that `ThrottleReason` does not consume the staleness warn-once that the throttle path wants to log), `pkg/migration/progress_test.go`.
- Resume assertions added to existing end-to-end resume tests in `migration`, `move`, and `datasync`.
- Verified against MySQL 8.0.45: full `pkg/migration` and `pkg/move` suites, `pkg/datasync` under `-race`, `pkg/throttler`, `pkg/status`, `pkg/checksum`, `pkg/copier`, plus the `singleversion`-tagged resume suite. `golangci-lint run ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)