### PR TITLE
build: bump Go 1.26.5 → 1.26.6 (fixes govulncheck)

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Checkout code
         uses: actions/checkout@v7
       - name: golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.26.5 as builder
+FROM golang:1.26.6 as builder
 
 RUN go install github.com/mfridman/tparse@latest
 
 # copy the installed tparse binary to the final image
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 COPY --from=builder /go/bin/tparse /usr/local/bin/tparse
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/block/spirit
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.16.0


### PR DESCRIPTION
Fixes the failing `govulncheck` CI job: [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) (crypto/tls) and [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) (encoding/asn1) are Go standard-library vulnerabilities fixed in go1.26.6.

Bumps every 1.26.5 pin:
- `go.mod` `go` directive (release workflow follows it via `go-version-file`)
- `.github/workflows/govulncheck.yml` and `linter.yml` `go-version`
- `Dockerfile` base images (`golang:1.26.6` is published)

Verified locally: `govulncheck ./...` on go1.26.6 reports 0 vulnerabilities affecting our code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)