### PR TITLE
change: de-flake TestPeriodicFlushPrioritizesParkedSubscription

### DIFF
--- a/pkg/change/subscription_buffered_concurrency_test.go
+++ b/pkg/change/subscription_buffered_concurrency_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -603,13 +604,16 @@ func TestPeriodicFlushPrioritizesParkedSubscription(t *testing.T) {
 		return subA.timesParked.Load() >= 1
 	}, 10*time.Second, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
 
-	// The priority flush drains A; the follow-up pass drains B.
+	// The priority flush drains A; the follow-up pass drains B. Gate on B
+	// specifically rather than on a bare count: the all-subscription pass
+	// walks the registry in map order, so it can drain A a second time
+	// (the 'parked' insert buffers once the park releases) before it ever
+	// reaches B, and a count of two would then snapshot [A, A].
 	require.Eventually(t, func() bool {
-		return len(rec.recorded()) >= 2
-	}, 15*time.Second, 50*time.Millisecond, "park-requested flush did not reach the applier")
+		return slices.Contains(rec.recorded(), srcB.TableName)
+	}, 15*time.Second, 50*time.Millisecond, "the all-subscription pass must still drain the other subscription")
 	order := rec.recorded()
 	require.Equal(t, srcA.TableName, order[0], "the parked subscription must be flushed before the all-subscription pass")
-	require.Contains(t, order, srcB.TableName, "the all-subscription pass must still drain the other subscription")
 }
 
 // totalUpsertedRows sums the rows across all recorded UpsertRows calls.


### PR DESCRIPTION
Fixes #1133.

`TestPeriodicFlushPrioritizesParkedSubscription` gated on `len(rec.recorded()) >= 2`, which assumed the two recorded flushes were A (the priority flush on the park signal) and B (the follow-up all-subscription pass). They need not be.

`flush` walks `c.subs.Snapshot()` (`pkg/change/binlog.go:1102`), and `Snapshot` builds its slice by ranging a map (`pkg/change/subscription_registry.go:56`), so the pass visits the registry in nondeterministic order. Table A still has a buffered row when the pass starts — the `'parked'` insert buffers once the park releases — so when the order is `[A, B]` the pass drains A a second time, the count reaches two, and `rec.recorded()` is snapshotted before B is ever visited. The trailing `require.Contains` then fails on `[A, A]`:

```
Error: []string{"..._caacd0_a", "..._caacd0_a"} does not contain "..._caacd0_b"
```

Roughly half the runs. It took down both the 8.4 GA and 8.0.42 jobs on #1131, a docs/flags change that touches nothing in `pkg/change`.

## Fix

Gate on B appearing rather than on a bare count:

```go
require.Eventually(t, func() bool {
    return slices.Contains(rec.recorded(), srcB.TableName)
}, 15*time.Second, 50*time.Millisecond, "the all-subscription pass must still drain the other subscription")
order := rec.recorded()
require.Equal(t, srcA.TableName, order[0], "the parked subscription must be flushed before the all-subscription pass")
```

That still pins both properties the test cares about — A is flushed first (the priority), and B is eventually drained by the all-subscription pass — and makes the old trailing `require.Contains` redundant. Test-only; production behaviour is unchanged.

## Testing

`go vet` clean. The fixed test passes 10/10 under `-count=10`.

I also ran the pre-fix version 20 times locally to reproduce the flake and it passed 20/20 — the failure needs A's `'parked'` row to still be buffered when the pass runs, which local timing doesn't produce. So the local runs confirm the new gate is stable but don't independently reproduce the CI failure; the diagnosis rests on the code reading above plus the two CI runs linked in #1133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
