### PR TITLE
feat(status): expose authoritative workflow events

### DIFF
--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -28,20 +28,22 @@ import (
 type buffered struct {
 	sync.Mutex
 
-	applier       applier.Applier
-	chunker       table.Chunker
-	concurrency   int
-	rowsPerSecond atomic.Uint64
-	chunkSize     atomic.Uint64 // size of the most recently claimed chunk; see Copier.ChunkSize
-	isInvalid     atomic.Bool
-	errMu         sync.Mutex // guards firstErr
-	firstErr      error      // first error that invalidated the copy (any goroutine)
-	startTime     time.Time
-	throttler     throttler.Throttler
-	dbConfig      *dbconn.DBConfig
-	logger        *slog.Logger
-	metricsSink   metrics.Sink
-	autoscale     AutoscaleConfig
+	applier         applier.Applier
+	chunker         table.Chunker
+	concurrency     int
+	rowsPerSecond   atomic.Uint64
+	chunkSize       atomic.Uint64 // size of the most recently claimed chunk; see Copier.ChunkSize
+	isInvalid       atomic.Bool
+	errMu           sync.Mutex // guards firstErr
+	firstErr        error      // first error that invalidated the copy (any goroutine)
+	completedRows   atomic.Uint64
+	completedChunks atomic.Uint64
+	startTime       time.Time
+	throttler       throttler.Throttler
+	dbConfig        *dbconn.DBConfig
+	logger          *slog.Logger
+	metricsSink     metrics.Sink
+	autoscale       AutoscaleConfig
 
 	// Read-worker pool management, symmetric with the applier's write-worker
 	// pool (SetWriteWorkers/ActiveWriteWorkers). concurrency above is the
@@ -111,6 +113,7 @@ func (c *buffered) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 		}
 		totalTime := time.Since(startTime)
 		c.chunker.Feedback(chunk, totalTime, uint64(affectedRows))
+		c.recordCompletedChunk(uint64(affectedRows))
 		if metricsErr := c.sendMetrics(ctx, totalTime, chunk.ChunkSize, uint64(affectedRows)); metricsErr != nil {
 			// Metrics failures don't fail the copy; log and continue.
 			c.logger.Error("error sending metrics from copier", "error", metricsErr)
@@ -254,6 +257,8 @@ func (c *buffered) Run(ctx context.Context) error {
 	c.Lock()
 	c.startTime = time.Now()
 	c.Unlock()
+	c.completedRows.Store(0)
+	c.completedChunks.Store(0)
 	go c.estimateRowsPerSecondLoop(ctx) // estimate rows while copying
 
 	// Start the applier
@@ -426,6 +431,7 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 			totalTime := time.Since(chunkStartTime)
 			c.logger.Debug("readWorker chunk is empty, sending immediate feedback", "chunk", chunk.String())
 			c.chunker.Feedback(chunk, totalTime, 0)
+			c.recordCompletedChunk(0)
 
 			// Send metrics for empty chunk
 			err := c.sendMetrics(ctx, totalTime, chunk.ChunkSize, 0)
@@ -467,6 +473,7 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 
 			// Send feedback to chunker with total processing time
 			c.chunker.Feedback(capturedChunk, totalTime, uint64(affectedRows))
+			c.recordCompletedChunk(uint64(affectedRows))
 
 			// Send metrics with total processing time
 			metricsErr := c.sendMetrics(ctx, totalTime, capturedChunk.ChunkSize, uint64(affectedRows))
@@ -719,6 +726,15 @@ func (c *buffered) sendMetrics(ctx context.Context, processingTime time.Duration
 // GetChunker returns the chunker for accessing progress information
 func (c *buffered) GetChunker() table.Chunker {
 	return c.chunker
+}
+
+func (c *buffered) recordCompletedChunk(affectedRows uint64) {
+	c.completedRows.Add(affectedRows)
+	c.completedChunks.Add(1)
+}
+
+func (c *buffered) CompletedWork() (uint64, uint64) {
+	return c.completedRows.Load(), c.completedChunks.Load()
 }
 
 func (c *buffered) GetThrottler() throttler.Throttler {

--- a/pkg/copier/completed_work_test.go
+++ b/pkg/copier/completed_work_test.go
@@ -1,0 +1,27 @@
+package copier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type copierWithoutCompletedWork struct{ Copier }
+
+func TestCompletedWorkCountsAffectedRowsAndZeroRowChunks(t *testing.T) {
+	bufferedCopier := &buffered{}
+	bufferedCopier.recordCompletedChunk(12)
+	bufferedCopier.recordCompletedChunk(0)
+	bufferedCopier.recordCompletedChunk(0)
+	rows, chunks, available := CompletedWork(bufferedCopier)
+	require.True(t, available)
+	require.Equal(t, uint64(12), rows)
+	require.Equal(t, uint64(3), chunks)
+}
+
+func TestCompletedWorkUnavailableForCopierWithoutCapability(t *testing.T) {
+	rows, chunks, available := CompletedWork(&copierWithoutCompletedWork{})
+	require.False(t, available)
+	require.Zero(t, rows)
+	require.Zero(t, chunks)
+}

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -91,6 +91,24 @@ type ChunkCopier interface {
 	CopyChunk(ctx context.Context, chunk *table.Chunk) error
 }
 
+// CompletedWorkReporter is an optional capability implemented by copiers that
+// can report exact terminal aggregate work.
+type CompletedWorkReporter interface {
+	CompletedWork() (rows uint64, chunks uint64)
+}
+
+// CompletedWork returns authoritative aggregate rows and chunks completed by a
+// built-in copier. The boolean is false for Copier implementations that do not
+// implement CompletedWorkReporter.
+func CompletedWork(c Copier) (rows uint64, chunks uint64, available bool) {
+	reporter, ok := c.(CompletedWorkReporter)
+	if !ok {
+		return 0, 0, false
+	}
+	rows, chunks = reporter.CompletedWork()
+	return rows, chunks, true
+}
+
 type CopierConfig struct {
 	Concurrency int
 	Throttler   throttler.Throttler

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -306,7 +306,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := r.status.Do(status.CopyRows, func() error {
+	if err := r.status.Do(ctx, status.CopyRows, func() error {
 		r.logger.Info("Starting copy", "resuming", r.resuming.Load())
 		if err := r.copier.Run(ctx); err != nil {
 			return fmt.Errorf("copy failed: %w", err)
@@ -333,7 +333,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// the post-copy checksum walks it (copy-only). Always called — it is a
 	// no-op when nothing was deferred and resume-safe; see
 	// restoreSecondaryIndexes.
-	if err := r.status.Do(status.RestoreSecondaryIndexes, func() error {
+	if err := r.status.Do(ctx, status.RestoreSecondaryIndexes, func() error {
 		return r.restoreSecondaryIndexes(ctx)
 	}); err != nil {
 		return fmt.Errorf("failed to restore secondary indexes: %w", err)
@@ -351,13 +351,13 @@ func (r *Runner) Run(ctx context.Context) error {
 			r.logger.Warn("post-copy checkpoint write failed", "error", err)
 		}
 		r.logger.Info("Copy complete; entering continuous checksum (CopyOnly mode)")
-		return r.status.Do(status.ApplyChangeset, func() error {
+		return r.status.Do(ctx, status.ApplyChangeset, func() error {
 			return r.runCopyOnlyChecksum(ctx)
 		})
 	}
 
 	r.logger.Info("Copy complete; entering continuous sync")
-	return r.status.Do(status.ApplyChangeset, func() error {
+	return r.status.Do(ctx, status.ApplyChangeset, func() error {
 		return r.runContinuous(ctx)
 	})
 }

--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/block/spirit/pkg/dbconn"
@@ -179,6 +180,9 @@ func (c *tableChange) attemptMySQLDDL(ctx context.Context) error {
 		c.runner.usedInstantDDL = true // success
 		return nil
 	}
+	if dbconn.IsConnectionLossError(err) {
+		return errors.Join(err, errDirectDDLOwnershipAmbiguous)
+	}
 
 	// Many "inplace" operations (such as adding an index)
 	// are only online-safe to do in Aurora GLOBAL
@@ -193,6 +197,9 @@ func (c *tableChange) attemptMySQLDDL(ctx context.Context) error {
 		if err == nil {
 			c.runner.usedInplaceDDL = true // success
 			return nil
+		}
+		if dbconn.IsConnectionLossError(err) {
+			return errors.Join(err, errDirectDDLOwnershipAmbiguous)
 		}
 	}
 	c.runner.logger.Info("unable to use INPLACE", "error", err)

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -32,6 +32,8 @@ const (
 	cutoverUnlockTimeout = 30 * time.Second
 )
 
+var errCutoverOwnershipAmbiguous = errors.New("cutover rename may have committed; verify table ownership manually")
+
 type CutOver struct {
 	db       *sql.DB
 	feed     change.Source
@@ -43,6 +45,9 @@ type CutOver struct {
 	// that died after the server committed the RENAME TABLE but before the
 	// client read the OK packet.
 	testInjectRenameError error
+	// testAfterRenameError runs immediately before testInjectRenameError is
+	// returned. It lets tests make the subsequent ownership check unavailable.
+	testAfterRenameError func()
 }
 
 type cutoverConfig struct {
@@ -102,7 +107,7 @@ func (c *CutOver) Run(ctx context.Context) error {
 	renameMayHaveCommitted := false
 	for i := range max(1, c.dbConfig.MaxRetries) {
 		if ctx.Err() != nil {
-			return errors.Join(append(attemptErrs, ctx.Err())...)
+			return joinCutoverErrors(attemptErrs, ctx.Err(), renameMayHaveCommitted)
 		}
 		if i > 0 {
 			// Exponential backoff between attempts. Without this a
@@ -113,7 +118,7 @@ func (c *CutOver) Run(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				timer.Stop()
-				return errors.Join(append(attemptErrs, ctx.Err())...)
+				return joinCutoverErrors(attemptErrs, ctx.Err(), renameMayHaveCommitted)
 			case <-timer.C:
 			}
 			backoff *= 2
@@ -133,7 +138,7 @@ func (c *CutOver) Run(ctx context.Context) error {
 		// since we will need to catch up again with the lock held
 		// and we want to minimize that.
 		if err := c.feed.Flush(ctx); err != nil {
-			return errors.Join(append(attemptErrs, err)...)
+			return joinCutoverErrors(attemptErrs, err, renameMayHaveCommitted)
 		}
 		// We use maxCutoverRetries as our retrycount, but nested
 		// within c.algorithmX() it may also have a retry for the specific statement
@@ -182,7 +187,19 @@ func (c *CutOver) Run(ctx context.Context) error {
 		return nil
 	}
 	c.logger.Error("cutover failed, and retries exhausted")
-	return errors.Join(attemptErrs...)
+	return joinCutoverErrors(attemptErrs, nil, renameMayHaveCommitted)
+}
+
+func joinCutoverErrors(attemptErrs []error, terminalErr error, ownershipAmbiguous bool) error {
+	errs := make([]error, 0, len(attemptErrs)+2)
+	errs = append(errs, attemptErrs...)
+	if terminalErr != nil {
+		errs = append(errs, terminalErr)
+	}
+	if ownershipAmbiguous {
+		errs = append(errs, errCutoverOwnershipAmbiguous)
+	}
+	return errors.Join(errs...)
 }
 
 // confirmRenameCompleted wraps renameCompleted with logging for use in the
@@ -320,6 +337,9 @@ func (c *CutOver) executeRenameUnderLock(ctx context.Context, tablesToLock []*ta
 	if c.testInjectRenameError != nil {
 		// Test-only seam: the rename was committed by the server, but we
 		// pretend the client never read the OK packet.
+		if c.testAfterRenameError != nil {
+			c.testAfterRenameError()
+		}
 		return c.testInjectRenameError
 	}
 	return nil

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -269,50 +269,7 @@ func TestCutoverRenameCompletedDetection(t *testing.T) {
 // retrying into ER_NO_SUCH_TABLE failures.
 func TestCutoverConnectionLossAfterRenameCommitted(t *testing.T) {
 	t.Parallel()
-	testutils.NewTestTable(t, "cutoverconnloss", `CREATE TABLE cutoverconnloss (
-		id int(11) NOT NULL AUTO_INCREMENT,
-		name varchar(255) NOT NULL,
-		PRIMARY KEY (id)
-	)`)
-	testutils.RunSQL(t, `CREATE TABLE _cutoverconnloss_new (
-		id int(11) NOT NULL AUTO_INCREMENT,
-		name varchar(255) NOT NULL,
-		PRIMARY KEY (id)
-	)`)
-	testutils.RunSQL(t, `CREATE TABLE _cutoverconnloss_chkpnt (a int)`) // for binlog advancement
-	// Two rows in the original table so post-cutover state is distinguishable.
-	testutils.RunSQL(t, `INSERT INTO cutoverconnloss VALUES (1, 2), (2, 2)`)
-
-	cfg, err := mysql.ParseDSN(testutils.DSN())
-	require.NoError(t, err)
-
-	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
-	require.NoError(t, err)
-	defer utils.CloseAndLog(db)
-
-	t1 := table.NewTableInfo(db, cfg.DBName, "cutoverconnloss")
-	require.NoError(t, t1.SetInfo(t.Context()))
-	t1new := table.NewTableInfo(db, cfg.DBName, "_cutoverconnloss_new")
-	logger := slog.Default()
-	feed := change.NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd, applier.NewSingleTargetForTest(t, db), change.NewClientDefaultConfig())
-	defer feed.Close()
-	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t1new})
-	require.NoError(t, err)
-	require.NoError(t, feed.AddSubscription(t1, t1new, chunker))
-	require.NoError(t, feed.Start(t.Context()))
-
-	cutover, err := NewCutOver(db, []*cutoverConfig{
-		{
-			table:        t1,
-			newTable:     t1new,
-			oldTableName: "_cutoverconnloss_old",
-		},
-	}, feed, dbconn.NewDBConfig(), logger)
-	require.NoError(t, err)
-	// Simulate the server committing the rename while the client's
-	// connection dies before the OK packet is read. mysql.ErrInvalidConn is
-	// exactly what go-sql-driver returns when a connection dies mid-statement.
-	cutover.testInjectRenameError = mysql.ErrInvalidConn
+	cutover, db, dbName := newConnectionLossCutover(t, "cutoverconnloss")
 
 	require.NoError(t, cutover.Run(t.Context()),
 		"a rename committed by the server must be reported as success despite the connection loss")
@@ -327,8 +284,73 @@ func TestCutoverConnectionLossAfterRenameCommitted(t *testing.T) {
 	require.Equal(t, 2, count)
 	require.NoError(t, db.QueryRowContext(t.Context(),
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = '_cutoverconnloss_new'",
-		cfg.DBName).Scan(&count))
+		dbName).Scan(&count))
 	require.Equal(t, 0, count)
+}
+
+func TestCutoverConnectionLossWithUnavailableOwnershipCheck(t *testing.T) {
+	t.Parallel()
+	cutover, _, _ := newConnectionLossCutover(t, "cutoverconnunknown")
+	ctx, cancel := context.WithCancel(t.Context())
+	cutover.testAfterRenameError = cancel
+
+	err := cutover.Run(ctx)
+
+	require.ErrorIs(t, err, errCutoverOwnershipAmbiguous)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func newConnectionLossCutover(t *testing.T, tableName string) (*CutOver, *sql.DB, string) {
+	t.Helper()
+	newTableName := "_" + tableName + "_new"
+	oldTableName := "_" + tableName + "_old"
+	checkpointTableName := "_" + tableName + "_chkpnt"
+	testutils.NewTestTable(t, tableName, fmt.Sprintf(`CREATE TABLE %s (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`, tableName))
+	testutils.RunSQL(t, fmt.Sprintf(`CREATE TABLE %s (
+		id int(11) NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`, newTableName))
+	testutils.RunSQL(t, fmt.Sprintf("CREATE TABLE %s (a int)", checkpointTableName))
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s VALUES (1, 2), (2, 2)", tableName))
+
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+
+	original := table.NewTableInfo(db, cfg.DBName, tableName)
+	require.NoError(t, original.SetInfo(t.Context()))
+	replacement := table.NewTableInfo(db, cfg.DBName, newTableName)
+	feed := change.NewBinlogClient(
+		db,
+		cfg.Addr,
+		cfg.User,
+		cfg.Passwd,
+		applier.NewSingleTargetForTest(t, db),
+		change.NewClientDefaultConfig(),
+	)
+	t.Cleanup(feed.Close)
+	chunker, err := table.NewChunker(original, table.ChunkerConfig{NewTable: replacement})
+	require.NoError(t, err)
+	require.NoError(t, feed.AddSubscription(original, replacement, chunker))
+	require.NoError(t, feed.Start(t.Context()))
+
+	cutover, err := NewCutOver(db, []*cutoverConfig{{
+		table:        original,
+		newTable:     replacement,
+		oldTableName: oldTableName,
+	}}, feed, dbconn.NewDBConfig(), slog.Default())
+	require.NoError(t, err)
+	// Simulate the server committing the rename while the client's connection
+	// dies before the OK packet is read.
+	cutover.testInjectRenameError = mysql.ErrInvalidConn
+	return cutover, db, cfg.DBName
 }
 
 // TestCutoverDeterministicErrorDoesNotVerify is the negative counterpart of

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -502,13 +502,14 @@ func (r *Runner) Run(ctx context.Context) error {
 			}
 		}
 		if err := cutover.Run(ctx); err != nil {
-			return fmt.Errorf("cutover failed: %w", err)
+			return r.wrapCutoverError(ctx, err)
 		}
 		r.status.DurableMutation(ctx)
 		return nil
 	}); err != nil {
 		return err
 	}
+
 	if !r.migration.SkipDropAfterCutover {
 		for _, change := range r.changes {
 			if err := change.dropOldTable(ctx); err != nil {
@@ -549,6 +550,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+func (r *Runner) wrapCutoverError(ctx context.Context, err error) error {
+	if errors.Is(err, errCutoverOwnershipAmbiguous) {
+		r.status.Terminal(ctx, status.WorkflowTerminalOwnershipAmbiguous)
+	}
+	return fmt.Errorf("cutover failed: %w", err)
 }
 
 // postCopyPhase runs the work that happens between copy-rows and the

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -397,7 +397,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// of migrations usually spend time. It is not strictly necessary,
 	// but we always recopy the last-bit, even if we are resuming
 	// partially through the checksum.
-	if err := r.status.Do(status.CopyRows, func() error {
+	if err := r.status.Do(ctx, status.CopyRows, func() error {
 		return r.copier.Run(ctx)
 	}); err != nil {
 		return err
@@ -434,7 +434,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		// watermark invalidation are migration-specific — invalidateChecksumWatermark
 		// scopes its UPDATE by statement because the checkpoint table is shared in
 		// multi-table mode — so they are injected as callbacks. See pkg/sentinel.
-		if err := r.status.Do(status.WaitingOnSentinelTable, func() error {
+		if err := r.status.Do(ctx, status.WaitingOnSentinelTable, func() error {
 			return sentinel.Wait(ctx, sentinel.WaitConfig{
 				Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.db) },
 				RunChecksum:         r.runContinuousChecksum,
@@ -451,7 +451,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	// It's time for the final cut-over, where
 	// the tables are swapped under a lock.
-	if err := r.status.Do(status.CutOver, func() error {
+	if err := r.status.Do(ctx, status.CutOver, func() error {
 		cutoverCfg := []*cutoverConfig{}
 		for _, change := range r.changes {
 			cutoverCfg = append(cutoverCfg, &cutoverConfig{
@@ -530,7 +530,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// We want it disabled for ANALYZE TABLE and acquiring a table lock
 	// *but* it will be started again briefly inside of the checksum
 	// runner to ensure that the lag does not grow too long.
-	if err := r.status.Do(status.ApplyChangeset, func() error {
+	if err := r.status.Do(ctx, status.ApplyChangeset, func() error {
 		r.replClient.StopPeriodicFlush()
 		return r.replClient.Flush(ctx)
 	}); err != nil {
@@ -541,7 +541,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// This is required so on cutover plans don't go sideways, which
 	// is at elevated risk because the batch loading can cause statistics
 	// to be out of date.
-	if err := r.status.Do(status.AnalyzeTable, func() error {
+	if err := r.status.Do(ctx, status.AnalyzeTable, func() error {
 		r.logger.Info("Running ANALYZE TABLE")
 		for _, change := range r.changes {
 			if err := dbconn.Exec(ctx, r.db, "ANALYZE TABLE %n.%n", change.newTable.SchemaName, change.newTable.TableName); err != nil {
@@ -1683,7 +1683,7 @@ func (r *Runner) initChunkers() error {
 
 // checksum creates the checksum which opens the read view
 func (r *Runner) checksum(ctx context.Context) error {
-	if err := r.status.Do(status.Checksum, func() error {
+	if err := r.status.Do(ctx, status.Checksum, func() error {
 		// The checksum keeps the pool threads open, so we need to extend
 		// by more than +1 on threads as we did previously. We have:
 		// - background flushing
@@ -1720,7 +1720,7 @@ func (r *Runner) checksum(ctx context.Context) error {
 	// A long checksum extends the binlog deltas
 	// So if we've called this optional checksum, we need one more state
 	// of applying the binlog deltas.
-	return r.status.Do(status.PostChecksum, func() error {
+	return r.status.Do(ctx, status.PostChecksum, func() error {
 		return r.replClient.Flush(ctx)
 	})
 }

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -42,6 +42,8 @@ var (
 	// checksum.DefaultContinuousRetryDelay), so they are shared with move/sync.
 )
 
+var errDirectDDLOwnershipAmbiguous = errors.New("direct DDL may have committed; verify table ownership manually")
+
 // continuousDivergenceReporter is the minimal view of the sentinel-wait
 // continuous checker that the checkpoint machinery needs: "has this checker
 // observed any divergence?". Both the production *checksum.ContinuousChecker
@@ -327,7 +329,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			// '100%new') that must not be format-interpreted.
 			err := dbconn.Exec(ctx, r.db, "%r", sqlescape.RawSQL(r.changes[0].stmt.Statement))
 			if err != nil {
-				return err
+				return r.reportDirectDDLError(ctx, err)
 			}
 			r.status.DurableMutation(ctx)
 			r.logger.Info("apply complete")
@@ -403,6 +405,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		)
 		r.status.DurableMutation(ctx)
 		return nil // success!
+	}
+	if errors.Is(err, errDirectDDLOwnershipAmbiguous) {
+		return r.reportDirectDDLError(ctx, err)
 	}
 
 	// Perform preflight basic checks.
@@ -556,6 +561,16 @@ func (r *Runner) wrapCutoverError(ctx context.Context, err error) error {
 		r.status.Terminal(ctx, status.WorkflowTerminalOwnershipAmbiguous)
 	}
 	return fmt.Errorf("cutover failed: %w", err)
+}
+
+func (r *Runner) reportDirectDDLError(ctx context.Context, err error) error {
+	if dbconn.IsConnectionLossError(err) && !errors.Is(err, errDirectDDLOwnershipAmbiguous) {
+		err = errors.Join(err, errDirectDDLOwnershipAmbiguous)
+	}
+	if errors.Is(err, errDirectDDLOwnershipAmbiguous) {
+		r.status.Terminal(ctx, status.WorkflowTerminalOwnershipAmbiguous)
+	}
+	return err
 }
 
 // postCopyPhase runs the work that happens between copy-rows and the

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -329,6 +329,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+			r.status.DurableMutation(ctx)
 			r.logger.Info("apply complete")
 			return nil
 		}
@@ -400,6 +401,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			"instant-ddl", r.usedInstantDDL,
 			"inplace-ddl", r.usedInplaceDDL,
 		)
+		r.status.DurableMutation(ctx)
 		return nil // success!
 	}
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -227,6 +227,12 @@ func (r *Runner) SetLogger(logger *slog.Logger) {
 	r.logger = logger
 }
 
+// SetWorkflowObserver installs the optional typed workflow observer. It must be
+// called before Run. A nil observer disables workflow observation.
+func (r *Runner) SetWorkflowObserver(observer status.WorkflowObserver) {
+	r.status.SetObserver(observer)
+}
+
 // attemptMySQLDDL tries to perform the DDL using MySQL's built-in
 // either with INSTANT or known safe INPLACE operations.
 func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
@@ -234,6 +240,27 @@ func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
 		return errors.New("attemptMySQLDDL only supports single-table changes")
 	}
 	return r.changes[0].attemptMySQLDDL(ctx)
+}
+
+func (r *Runner) runCopy(ctx context.Context) error {
+	if r.status.HasObserver() {
+		defer func() {
+			rows, chunks, available := copier.CompletedWork(r.copier)
+			if available {
+				r.status.RecordCompletedWork(ctx, rows, chunks)
+			}
+		}()
+	}
+	return r.status.Do(ctx, status.CopyRows, func() error {
+		err := r.copier.Run(ctx)
+		if err == nil && ctx.Err() != nil {
+			chunker := r.copier.GetChunker()
+			if chunker == nil || !chunker.IsRead() {
+				return ctx.Err()
+			}
+		}
+		return err
+	})
 }
 
 func (r *Runner) Run(ctx context.Context) error {
@@ -397,9 +424,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// of migrations usually spend time. It is not strictly necessary,
 	// but we always recopy the last-bit, even if we are resuming
 	// partially through the checksum.
-	if err := r.status.Do(ctx, status.CopyRows, func() error {
-		return r.copier.Run(ctx)
-	}); err != nil {
+	if err := r.runCopy(ctx); err != nil {
 		return err
 	}
 	r.logger.Info("copy rows complete")
@@ -433,14 +458,16 @@ func (r *Runner) Run(ctx context.Context) error {
 		// lives in the sentinel package). The continuous-checksum lifecycle and
 		// watermark invalidation are migration-specific — invalidateChecksumWatermark
 		// scopes its UPDATE by statement because the checkpoint table is shared in
-		// multi-table mode — so they are injected as callbacks. See pkg/sentinel.
-		if err := r.status.Do(ctx, status.WaitingOnSentinelTable, func() error {
-			return sentinel.Wait(ctx, sentinel.WaitConfig{
-				Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.db) },
-				RunChecksum:         r.runContinuousChecksum,
-				InvalidateWatermark: r.invalidateChecksumWatermark,
-				Logger:              r.logger,
-			})
+		// multi-table mode — so they are injected as callbacks. RunWait brackets
+		// only an observed sentinel; an absent optional sentinel emits no phase.
+		if err := sentinel.Wait(ctx, sentinel.WaitConfig{
+			Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.db) },
+			RunChecksum:         r.runContinuousChecksum,
+			InvalidateWatermark: r.invalidateChecksumWatermark,
+			Logger:              r.logger,
+			RunWait: func(wait func() error) error {
+				return r.status.Do(ctx, status.WaitingOnSentinelTable, wait)
+			},
 		}); err != nil {
 			return err
 		}
@@ -475,6 +502,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		if err := cutover.Run(ctx); err != nil {
 			return fmt.Errorf("cutover failed: %w", err)
 		}
+		r.status.DurableMutation(ctx)
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/migration/workflow_test.go
+++ b/pkg/migration/workflow_test.go
@@ -220,3 +220,18 @@ func TestMigrationWorkflowReportsDurableMutationBeforeCleanup(t *testing.T) {
 	require.Equal(t, 1, indexCount)
 	require.NoError(t, r.Close())
 }
+
+func TestMigrationWorkflowReportsAmbiguousCutoverOwnership(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{}
+	r.SetWorkflowObserver(observer)
+	cause := errors.New("connection lost after rename")
+
+	err := r.wrapCutoverError(t.Context(), errors.Join(cause, errCutoverOwnershipAmbiguous))
+
+	require.ErrorIs(t, err, cause)
+	events, _ := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{{
+		TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous,
+	}}, events)
+}

--- a/pkg/migration/workflow_test.go
+++ b/pkg/migration/workflow_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/block/spirit/pkg/status"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -230,6 +231,21 @@ func TestMigrationWorkflowReportsAmbiguousCutoverOwnership(t *testing.T) {
 	err := r.wrapCutoverError(t.Context(), errors.Join(cause, errCutoverOwnershipAmbiguous))
 
 	require.ErrorIs(t, err, cause)
+	events, _ := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{{
+		TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous,
+	}}, events)
+}
+
+func TestMigrationWorkflowReportsAmbiguousDirectDDLOwnership(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{}
+	r.SetWorkflowObserver(observer)
+
+	err := r.reportDirectDDLError(t.Context(), mysql.ErrInvalidConn)
+
+	require.ErrorIs(t, err, mysql.ErrInvalidConn)
+	require.ErrorIs(t, err, errDirectDDLOwnershipAmbiguous)
 	events, _ := observer.snapshot()
 	require.Equal(t, []status.WorkflowEvent{{
 		TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous,

--- a/pkg/migration/workflow_test.go
+++ b/pkg/migration/workflow_test.go
@@ -1,0 +1,182 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/block/spirit/pkg/copier"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingWorkflowObserver struct {
+	mu       sync.Mutex
+	events   []status.WorkflowEvent
+	contexts []context.Context
+}
+
+func (o *recordingWorkflowObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.contexts = append(o.contexts, ctx)
+	o.events = append(o.events, event)
+}
+
+func (o *recordingWorkflowObserver) snapshot() ([]status.WorkflowEvent, []context.Context) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]status.WorkflowEvent(nil), o.events...), append([]context.Context(nil), o.contexts...)
+}
+
+type workflowChunker struct {
+	table.Chunker
+	read bool
+}
+
+func (c *workflowChunker) IsRead() bool { return c.read }
+
+type workflowCopier struct {
+	copier.Copier
+	runErr               error
+	chunker              table.Chunker
+	rows                 uint64
+	chunks               uint64
+	panicOnCompletedWork bool
+}
+
+func (c *workflowCopier) Run(context.Context) error { return c.runErr }
+func (c *workflowCopier) GetChunker() table.Chunker { return c.chunker }
+func (c *workflowCopier) CompletedWork() (uint64, uint64) {
+	if c.panicOnCompletedWork {
+		panic("CompletedWork queried without an observer")
+	}
+	return c.rows, c.chunks
+}
+
+type cancelMigrationObserver struct {
+	recordingWorkflowObserver
+	cancel            context.CancelFunc
+	cancelOnCopyStart bool
+	cancelOnMutation  bool
+}
+
+func (o *cancelMigrationObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.recordingWorkflowObserver.ObserveWorkflow(ctx, event)
+	if (o.cancelOnCopyStart && event.State == status.CopyRows && event.Transition == status.WorkflowTransitionStarted) ||
+		(o.cancelOnMutation && event.DurableMutation) {
+		o.cancel()
+	}
+}
+
+func TestMigrationWorkflowCopyEventsAndTotals(t *testing.T) {
+	ctx := t.Context()
+	observer := &recordingWorkflowObserver{}
+	r := &Runner{copier: &workflowCopier{
+		chunker: &workflowChunker{read: true},
+		rows:    42,
+		chunks:  7,
+	}}
+	r.SetWorkflowObserver(observer)
+
+	require.NoError(t, r.runCopy(ctx))
+
+	events, contexts := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.CopyRows, Transition: status.WorkflowTransitionStarted},
+		{State: status.CopyRows, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeSucceeded},
+		{
+			State:           status.CopyRows,
+			Totals:          status.WorkflowTotals{CompletedRows: 42, CompletedChunks: 7},
+			TotalsAvailable: true,
+		},
+	}, events)
+	require.Len(t, contexts, len(events))
+	for _, observedCtx := range contexts {
+		require.Equal(t, ctx, observedCtx)
+	}
+}
+
+func TestMigrationWorkflowCopyCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	observer := &cancelMigrationObserver{cancel: cancel, cancelOnCopyStart: true}
+	r := &Runner{copier: &workflowCopier{}}
+	r.SetWorkflowObserver(observer)
+
+	require.ErrorIs(t, r.runCopy(ctx), context.Canceled)
+	events, _ := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.CopyRows, Transition: status.WorkflowTransitionStarted},
+		{State: status.CopyRows, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeCancelled},
+		{State: status.CopyRows, TotalsAvailable: true},
+	}, events)
+}
+
+func TestMigrationWorkflowCompletedWorkCapabilityIsConditional(t *testing.T) {
+	t.Run("nil observer skips capability", func(t *testing.T) {
+		r := &Runner{copier: &workflowCopier{panicOnCompletedWork: true}}
+		require.NotPanics(t, func() {
+			require.NoError(t, r.runCopy(t.Context()))
+		})
+	})
+
+	t.Run("failed copy retains completed work", func(t *testing.T) {
+		copyErr := errors.New("copy failed")
+		observer := &recordingWorkflowObserver{}
+		r := &Runner{copier: &workflowCopier{runErr: copyErr, rows: 8, chunks: 2}}
+		r.SetWorkflowObserver(observer)
+
+		require.ErrorIs(t, r.runCopy(t.Context()), copyErr)
+		events, _ := observer.snapshot()
+		require.Equal(t, status.WorkflowOutcomeFailed, events[1].Outcome)
+		require.Equal(t, status.WorkflowEvent{
+			State:           status.CopyRows,
+			Totals:          status.WorkflowTotals{CompletedRows: 8, CompletedChunks: 2},
+			TotalsAvailable: true,
+		}, events[2])
+	})
+}
+
+func TestMigrationWorkflowReportsDurableMutationBeforeCleanup(t *testing.T) {
+	dbName, _ := testutils.CreateUniqueTestDatabase(t)
+	const tableName = "observed_empty_cutover"
+	testutils.RunSQLInDatabase(t, dbName, fmt.Sprintf(`CREATE TABLE %s (
+		pk int UNSIGNED NOT NULL,
+		PRIMARY KEY(pk)
+	)`, tableName))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	observer := &cancelMigrationObserver{cancel: cancel, cancelOnMutation: true}
+	r := NewTestRunner(t, tableName, "ADD INDEX observed_idx (pk)", WithDBName(dbName), WithRespectSentinel())
+	r.SetWorkflowObserver(observer)
+
+	err := r.Run(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	events, _ := observer.snapshot()
+	mutationIndex := -1
+	cutoverFinishIndex := -1
+	for i, event := range events {
+		if event.DurableMutation {
+			mutationIndex = i
+		}
+		if event.State == status.CutOver && event.Transition == status.WorkflowTransitionFinished {
+			cutoverFinishIndex = i
+		}
+		require.NotEqual(t, status.WaitingOnSentinelTable, event.State, "an absent optional sentinel must not emit a phase")
+	}
+	require.NotEqual(t, -1, mutationIndex)
+	require.Greater(t, cutoverFinishIndex, mutationIndex, "durable mutation must be emitted inside the cutover bracket")
+
+	var indexCount int
+	require.NoError(t, r.db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE TABLE_SCHEMA=? AND TABLE_NAME=? AND INDEX_NAME='observed_idx'
+	`, dbName, tableName).Scan(&indexCount))
+	require.Equal(t, 1, indexCount)
+	require.NoError(t, r.Close())
+}

--- a/pkg/migration/workflow_test.go
+++ b/pkg/migration/workflow_test.go
@@ -141,6 +141,46 @@ func TestMigrationWorkflowCompletedWorkCapabilityIsConditional(t *testing.T) {
 	})
 }
 
+func TestMigrationWorkflowReportsDirectDDLMutation(t *testing.T) {
+	dbName, _ := testutils.CreateUniqueTestDatabase(t)
+	testutils.RunSQLInDatabase(t, dbName, `CREATE TABLE direct_ddl_observer (
+		id bigint unsigned NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+
+	t.Run("instant alter", func(t *testing.T) {
+		observer := &recordingWorkflowObserver{}
+		r := NewTestRunnerFromStatement(
+			t,
+			"ALTER TABLE direct_ddl_observer ADD COLUMN observed INT",
+			WithDBName(dbName),
+			WithThreads(1),
+		)
+		r.SetWorkflowObserver(observer)
+
+		require.NoError(t, r.Run(t.Context()))
+		require.True(t, r.usedInstantDDL)
+		events, _ := observer.snapshot()
+		require.Equal(t, []status.WorkflowEvent{{DurableMutation: true}}, events)
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("direct statement", func(t *testing.T) {
+		observer := &recordingWorkflowObserver{}
+		r := NewTestRunnerFromStatement(
+			t,
+			"CREATE TABLE direct_statement_observer (id INT PRIMARY KEY)",
+			WithDBName(dbName),
+		)
+		r.SetWorkflowObserver(observer)
+
+		require.NoError(t, r.Run(t.Context()))
+		events, _ := observer.snapshot()
+		require.Equal(t, []status.WorkflowEvent{{DurableMutation: true}}, events)
+		require.NoError(t, r.Close())
+	})
+}
+
 func TestMigrationWorkflowReportsDurableMutationBeforeCleanup(t *testing.T) {
 	dbName, _ := testutils.CreateUniqueTestDatabase(t)
 	const tableName = "observed_empty_cutover"

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -27,6 +27,11 @@ var renameRetryWait = 1 * time.Second
 // that state cannot converge, so the retry loop aborts immediately.
 var errRenameRollbackFailed = errors.New("rename rollback failed")
 
+// errRenameOwnershipAmbiguous marks a connection loss during a rename. The
+// server may have committed the atomic statement before the client lost its
+// acknowledgement, so retrying cannot safely infer current ownership.
+var errRenameOwnershipAmbiguous = errors.New("rename ownership ambiguous")
+
 // CutoverResult reports whether a caller-owned forward cutover callback made a
 // durable ownership or topology mutation, even when it also returned an error.
 type CutoverResult struct {
@@ -141,6 +146,11 @@ func (c *CutOver) runWithRetries(ctx context.Context, runAttempt func(attempt in
 		}
 		err = runAttempt(attempt)
 		if err != nil {
+			if errors.Is(err, errRenameRollbackFailed) || errors.Is(err, errRenameOwnershipAmbiguous) {
+				c.logger.Error("cutover rename left ownership unresolved; not retrying",
+					"error", err.Error())
+				return fmt.Errorf("cutover rename left ownership unresolved; manual intervention required: %w", err)
+			}
 			if c.cutoverFuncMutated && !c.cutoverFuncSucceeded {
 				c.logger.Error("cutover callback failed after reporting a durable mutation; not retrying",
 					"error", err.Error())
@@ -270,8 +280,9 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 			c.stopSourceFeeds()
 			return nil
 		}
-		if errors.Is(err, errRenameRollbackFailed) {
-			// The sources are partially renamed; retrying cannot converge.
+		if errors.Is(err, errRenameRollbackFailed) || errors.Is(err, errRenameOwnershipAmbiguous) {
+			// The sources are partially renamed or the failed rename may have
+			// committed; retrying cannot safely converge.
 			return err
 		}
 		c.logger.Warn("rename failed", "error", err.Error())
@@ -324,6 +335,10 @@ func (c *CutOver) renameAllSources(ctx context.Context, sourceLocks []*dbconn.Ta
 			if len(rollbackErrors) > 0 {
 				return fmt.Errorf("%w: rename failed on source %d and rollback also failed (%s): %w",
 					errRenameRollbackFailed, i, strings.Join(rollbackErrors, "; "), err)
+			}
+			if dbconn.IsConnectionLossError(err) {
+				return fmt.Errorf("%w: rename outcome is unknown on source %d: %w",
+					errRenameOwnershipAmbiguous, i, err)
 			}
 			return fmt.Errorf("rename failed on source %d, rolled back %d completed renames: %w",
 				i, len(completedRenames), err)

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -27,6 +27,15 @@ var renameRetryWait = 1 * time.Second
 // that state cannot converge, so the retry loop aborts immediately.
 var errRenameRollbackFailed = errors.New("rename rollback failed")
 
+// CutoverResult reports whether a caller-owned forward cutover callback made a
+// durable ownership or topology mutation, even when it also returned an error.
+type CutoverResult struct {
+	DurableMutation bool
+}
+
+// CutoverResultCallback is the result-bearing form of a forward cutover callback.
+type CutoverResultCallback func(context.Context) (CutoverResult, error)
+
 // CutOverSource holds per-source state needed for the cutover.
 type CutOverSource struct {
 	DB         *sql.DB
@@ -35,16 +44,16 @@ type CutOverSource struct {
 }
 
 type CutOver struct {
-	sources     []CutOverSource
-	cutoverFunc func(ctx context.Context) error
-	dbConfig    *dbconn.DBConfig
-	logger      *slog.Logger
-	// cutoverFuncSucceeded tracks whether cutoverFunc has been invoked and
-	// returned nil. The cutover function is a caller-supplied traffic switch
-	// (e.g. a Vitess routing change) and is not assumed to be idempotent:
-	// once it has succeeded it must never be invoked again, and retrying
-	// any later step must not reopen the window where straggler writes to
-	// the (now stale) source could be replayed over newer rows on the target.
+	sources            []CutOverSource
+	cutoverFunc        func(ctx context.Context) error
+	cutoverResultFunc  CutoverResultCallback
+	cutoverFuncMutated bool
+	dbConfig           *dbconn.DBConfig
+	logger             *slog.Logger
+	// cutoverFuncSucceeded tracks whether the cutover callback has returned nil.
+	// The callback is a caller-supplied traffic switch (e.g. a Vitess routing
+	// change) and is not assumed to be idempotent: once it has succeeded or
+	// reported a durable mutation it must never be invoked again.
 	cutoverFuncSucceeded bool
 
 	// postSwitch, when set, runs once under the source locks after the traffic
@@ -62,6 +71,13 @@ type CutOver struct {
 // traffic switch and before the source rename. See CutOver.postSwitch.
 func (c *CutOver) SetPostSwitch(fn func(ctx context.Context) error) {
 	c.postSwitch = fn
+}
+
+// SetCutoverWithResult installs a result-bearing forward cutover callback.
+// It is mutually exclusive with the legacy error-only callback.
+func (c *CutOver) SetCutoverWithResult(fn CutoverResultCallback) {
+	c.cutoverFunc = nil
+	c.cutoverResultFunc = fn
 }
 
 // NewCutOver creates a new CutOver that handles multiple sources.
@@ -103,11 +119,7 @@ func NewCutOver(sources []CutOverSource, cutoverFunc func(ctx context.Context) e
 }
 
 func (c *CutOver) Run(ctx context.Context) error {
-	var err error
-	for attempt := range c.dbConfig.MaxRetries {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
+	return c.runWithRetries(ctx, func(attempt int) error {
 		// Flush all sources before attempting the cutover.
 		for i, src := range c.sources {
 			if err := src.ReplClient.Flush(ctx); err != nil {
@@ -117,8 +129,23 @@ func (c *CutOver) Run(ctx context.Context) error {
 		c.logger.Warn("Attempting final cut over operation",
 			"attempt", attempt+1,
 			"max-retries", c.dbConfig.MaxRetries)
-		err = c.algorithmCutover(ctx)
+		return c.algorithmCutover(ctx)
+	})
+}
+
+func (c *CutOver) runWithRetries(ctx context.Context, runAttempt func(attempt int) error) error {
+	var err error
+	for attempt := range c.dbConfig.MaxRetries {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		err = runAttempt(attempt)
 		if err != nil {
+			if c.cutoverFuncMutated && !c.cutoverFuncSucceeded {
+				c.logger.Error("cutover callback failed after reporting a durable mutation; not retrying",
+					"error", err.Error())
+				return fmt.Errorf("cutover callback reported a durable ownership or topology mutation before failing; manual intervention required: %w", err)
+			}
 			if c.cutoverFuncSucceeded {
 				// The traffic switch has already succeeded, so traffic may be
 				// on the target. Another attempt would have released the
@@ -141,6 +168,25 @@ func (c *CutOver) Run(ctx context.Context) error {
 	}
 	c.logger.Error("cutover failed, and retries exhausted")
 	return err
+}
+
+func (c *CutOver) runCutoverCallback(ctx context.Context) error {
+	if c.cutoverFuncSucceeded || (c.cutoverResultFunc == nil && c.cutoverFunc == nil) {
+		return nil
+	}
+	c.logger.Info("Running cutover function")
+	if c.cutoverResultFunc != nil {
+		result, err := c.cutoverResultFunc(ctx)
+		c.cutoverFuncMutated = c.cutoverFuncMutated || result.DurableMutation
+		if err != nil {
+			return err
+		}
+	} else if err := c.cutoverFunc(ctx); err != nil {
+		return err
+	}
+	c.cutoverFuncSucceeded = true
+	c.logger.Info("Cutover function complete")
+	return nil
 }
 
 func (c *CutOver) algorithmCutover(ctx context.Context) error {
@@ -177,16 +223,8 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 		}
 	}
 
-	// Run the cutover function (Vitess coordination). It is invoked at most
-	// once per CutOver: the traffic switch is not assumed to be idempotent,
-	// so if a later step fails the retry must never re-run it.
-	if c.cutoverFunc != nil && !c.cutoverFuncSucceeded {
-		c.logger.Info("Running cutover function")
-		if err := c.cutoverFunc(ctx); err != nil {
-			return err
-		}
-		c.cutoverFuncSucceeded = true
-		c.logger.Info("Cutover function complete")
+	if err := c.runCutoverCallback(ctx); err != nil {
+		return err
 	}
 
 	// Reverse-window hook: after the traffic switch and before retiring the

--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -32,10 +32,12 @@ var errRenameRollbackFailed = errors.New("rename rollback failed")
 // acknowledgement, so retrying cannot safely infer current ownership.
 var errRenameOwnershipAmbiguous = errors.New("rename ownership ambiguous")
 
-// CutoverResult reports whether a caller-owned forward cutover callback made a
-// durable ownership or topology mutation, even when it also returned an error.
+// CutoverResult reports authoritative evidence from a caller-owned forward
+// cutover callback, including failures after a durable mutation and failures
+// whose mutation outcome cannot be determined.
 type CutoverResult struct {
-	DurableMutation bool
+	DurableMutation    bool
+	OwnershipAmbiguous bool
 }
 
 // CutoverResultCallback is the result-bearing form of a forward cutover callback.
@@ -49,16 +51,18 @@ type CutOverSource struct {
 }
 
 type CutOver struct {
-	sources            []CutOverSource
-	cutoverFunc        func(ctx context.Context) error
-	cutoverResultFunc  CutoverResultCallback
-	cutoverFuncMutated bool
-	dbConfig           *dbconn.DBConfig
-	logger             *slog.Logger
+	sources              []CutOverSource
+	cutoverFunc          func(ctx context.Context) error
+	cutoverResultFunc    CutoverResultCallback
+	cutoverFuncMutated   bool
+	cutoverFuncAmbiguous bool
+	dbConfig             *dbconn.DBConfig
+	logger               *slog.Logger
 	// cutoverFuncSucceeded tracks whether the cutover callback has returned nil.
 	// The callback is a caller-supplied traffic switch (e.g. a Vitess routing
-	// change) and is not assumed to be idempotent: once it has succeeded or
-	// reported a durable mutation it must never be invoked again.
+	// change) and is not assumed to be idempotent: once it has succeeded,
+	// reported a durable mutation, or reported ambiguity it must never be
+	// invoked again.
 	cutoverFuncSucceeded bool
 
 	// postSwitch, when set, runs once under the source locks after the traffic
@@ -151,6 +155,11 @@ func (c *CutOver) runWithRetries(ctx context.Context, runAttempt func(attempt in
 					"error", err.Error())
 				return fmt.Errorf("cutover rename left ownership unresolved; manual intervention required: %w", err)
 			}
+			if c.cutoverFuncAmbiguous && !c.cutoverFuncSucceeded {
+				c.logger.Error("cutover callback failed with ambiguous ownership; not retrying",
+					"error", err.Error())
+				return fmt.Errorf("cutover callback left ownership ambiguous; manual intervention required: %w", err)
+			}
 			if c.cutoverFuncMutated && !c.cutoverFuncSucceeded {
 				c.logger.Error("cutover callback failed after reporting a durable mutation; not retrying",
 					"error", err.Error())
@@ -188,6 +197,7 @@ func (c *CutOver) runCutoverCallback(ctx context.Context) error {
 	if c.cutoverResultFunc != nil {
 		result, err := c.cutoverResultFunc(ctx)
 		c.cutoverFuncMutated = c.cutoverFuncMutated || result.DurableMutation
+		c.cutoverFuncAmbiguous = c.cutoverFuncAmbiguous || (err != nil && result.OwnershipAmbiguous)
 		if err != nil {
 			return err
 		}

--- a/pkg/move/cutover_test.go
+++ b/pkg/move/cutover_test.go
@@ -98,6 +98,25 @@ func TestNewCutOverValidation(t *testing.T) {
 	require.ErrorContains(t, err, "MaxRetries must be at least 1")
 }
 
+func TestCutOverDoesNotRetryUnresolvedRenameOwnership(t *testing.T) {
+	for _, marker := range []error{errRenameRollbackFailed, errRenameOwnershipAmbiguous} {
+		t.Run(marker.Error(), func(t *testing.T) {
+			cfg := dbconn.NewDBConfig()
+			cfg.MaxRetries = 3
+			cutover := &CutOver{dbConfig: cfg, logger: slog.Default()}
+			attempts := 0
+
+			err := cutover.runWithRetries(t.Context(), func(int) error {
+				attempts++
+				return marker
+			})
+
+			require.ErrorIs(t, err, marker)
+			require.Equal(t, 1, attempts)
+		})
+	}
+}
+
 // TestCutOverSingleSource tests the cutover flow with a single source,
 // verifying table rename and cutoverFunc callback.
 // Note: multi-source cutover cannot be tested with a single MySQL server

--- a/pkg/move/cutover_test.go
+++ b/pkg/move/cutover_test.go
@@ -305,13 +305,15 @@ func TestCutOverFuncCalledOnceAcrossRenameRetry(t *testing.T) {
 func TestCutOverResultControlsRetry(t *testing.T) {
 	callbackErr := errors.New("cutover callback failed")
 	for _, tt := range []struct {
-		name            string
-		durableMutation bool
-		wantCalls       int
-		wantErr         bool
+		name               string
+		durableMutation    bool
+		ownershipAmbiguous bool
+		wantCalls          int
+		wantErr            bool
 	}{
-		{name: "retry before durable mutation", wantCalls: 2},
+		{name: "retry before authoritative evidence", wantCalls: 2},
 		{name: "abort after durable mutation", durableMutation: true, wantCalls: 1, wantErr: true},
+		{name: "abort after ambiguous outcome", ownershipAmbiguous: true, wantCalls: 1, wantErr: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			dbConfig := dbconn.NewDBConfig()
@@ -321,7 +323,10 @@ func TestCutOverResultControlsRetry(t *testing.T) {
 			cutover.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
 				callbackCalls++
 				if callbackCalls == 1 {
-					return CutoverResult{DurableMutation: tt.durableMutation}, callbackErr
+					return CutoverResult{
+						DurableMutation:    tt.durableMutation,
+						OwnershipAmbiguous: tt.ownershipAmbiguous,
+					}, callbackErr
 				}
 				return CutoverResult{}, nil
 			})
@@ -333,12 +338,14 @@ func TestCutOverResultControlsRetry(t *testing.T) {
 			if tt.wantErr {
 				require.ErrorIs(t, err, callbackErr)
 				require.ErrorContains(t, err, "manual intervention required")
-				require.True(t, cutover.cutoverFuncMutated)
+				require.Equal(t, tt.durableMutation, cutover.cutoverFuncMutated)
+				require.Equal(t, tt.ownershipAmbiguous, cutover.cutoverFuncAmbiguous)
 				require.False(t, cutover.cutoverFuncSucceeded)
 				return
 			}
 			require.NoError(t, err)
 			require.False(t, cutover.cutoverFuncMutated)
+			require.False(t, cutover.cutoverFuncAmbiguous)
 			require.True(t, cutover.cutoverFuncSucceeded)
 		})
 	}

--- a/pkg/move/cutover_test.go
+++ b/pkg/move/cutover_test.go
@@ -2,6 +2,7 @@ package move
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -280,4 +281,46 @@ func TestCutOverFuncCalledOnceAcrossRenameRetry(t *testing.T) {
 
 	_, err = srcDB.ExecContext(ctx, "SELECT 1 FROM t1")
 	require.Error(t, err, "t1 should not exist after rename")
+}
+
+func TestCutOverResultControlsRetry(t *testing.T) {
+	callbackErr := errors.New("cutover callback failed")
+	for _, tt := range []struct {
+		name            string
+		durableMutation bool
+		wantCalls       int
+		wantErr         bool
+	}{
+		{name: "retry before durable mutation", wantCalls: 2},
+		{name: "abort after durable mutation", durableMutation: true, wantCalls: 1, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dbConfig := dbconn.NewDBConfig()
+			dbConfig.MaxRetries = 3
+			cutover := &CutOver{dbConfig: dbConfig, logger: slog.Default()}
+			callbackCalls := 0
+			cutover.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+				callbackCalls++
+				if callbackCalls == 1 {
+					return CutoverResult{DurableMutation: tt.durableMutation}, callbackErr
+				}
+				return CutoverResult{}, nil
+			})
+
+			err := cutover.runWithRetries(t.Context(), func(int) error {
+				return cutover.runCutoverCallback(t.Context())
+			})
+			require.Equal(t, tt.wantCalls, callbackCalls)
+			if tt.wantErr {
+				require.ErrorIs(t, err, callbackErr)
+				require.ErrorContains(t, err, "manual intervention required")
+				require.True(t, cutover.cutoverFuncMutated)
+				require.False(t, cutover.cutoverFuncSucceeded)
+				return
+			}
+			require.NoError(t, err)
+			require.False(t, cutover.cutoverFuncMutated)
+			require.True(t, cutover.cutoverFuncSucceeded)
+		})
+	}
 }

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -328,6 +328,12 @@ func TestRecordForwardCutoverFailure(t *testing.T) {
 			err:     errRenameRollbackFailed,
 			want:    true,
 		},
+		{
+			name:    "unacknowledged source rename",
+			cutover: &CutOver{},
+			err:     errRenameOwnershipAmbiguous,
+			want:    true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			runner := &Runner{}

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -266,9 +266,10 @@ func TestForwardCutoverCallbackConfiguration(t *testing.T) {
 	require.Nil(t, runner.cutoverResultFunc)
 
 	result, err := runner.runForwardCutoverCallback(t.Context())
-	require.Equal(t, CutoverResult{}, result)
+	require.Equal(t, CutoverResult{OwnershipAmbiguous: true}, result)
 	require.ErrorIs(t, err, legacyErr)
 	require.Equal(t, 1, legacyCalls)
+	require.True(t, runner.ownershipAmbiguous)
 
 	runner.SetCutoverWithResult(nil)
 	require.Nil(t, runner.cutoverFunc)
@@ -332,6 +333,12 @@ func TestRecordForwardCutoverFailure(t *testing.T) {
 			name:    "unacknowledged source rename",
 			cutover: &CutOver{},
 			err:     errRenameOwnershipAmbiguous,
+			want:    true,
+		},
+		{
+			name:    "ambiguous external cutover",
+			cutover: &CutOver{cutoverFuncAmbiguous: true},
+			err:     ordinaryErr,
 			want:    true,
 		},
 	} {

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -251,6 +251,7 @@ func TestEmptyDatabaseMoveWithCutoverResult(t *testing.T) {
 
 	require.ErrorIs(t, runner.Run(t.Context()), callbackErr)
 	require.Equal(t, 1, callbackCalls)
+	require.True(t, runner.ownershipAmbiguous)
 }
 
 func TestForwardCutoverCallbackConfiguration(t *testing.T) {
@@ -284,10 +285,56 @@ func TestForwardCutoverCallbackConfiguration(t *testing.T) {
 	result, err = runner.runForwardCutoverCallback(t.Context())
 	require.Equal(t, wantResult, result)
 	require.ErrorIs(t, err, resultErr)
+	require.True(t, runner.ownershipAmbiguous)
 
 	runner.SetCutover(nil)
 	require.Nil(t, runner.cutoverFunc)
 	require.Nil(t, runner.cutoverResultFunc)
+}
+
+func TestRecordForwardCutoverFailure(t *testing.T) {
+	ordinaryErr := errors.New("cutover failed")
+	for _, tt := range []struct {
+		name    string
+		cutover *CutOver
+		err     error
+		want    bool
+	}{
+		{
+			name:    "pre-mutation failure",
+			cutover: &CutOver{},
+			err:     ordinaryErr,
+		},
+		{
+			name:    "reverse checkpoint alone",
+			cutover: &CutOver{postSwitchDone: true},
+			err:     ordinaryErr,
+		},
+		{
+			name:    "successful external cutover",
+			cutover: &CutOver{cutoverFuncSucceeded: true},
+			err:     ordinaryErr,
+			want:    true,
+		},
+		{
+			name:    "reported external mutation",
+			cutover: &CutOver{cutoverFuncMutated: true},
+			err:     ordinaryErr,
+			want:    true,
+		},
+		{
+			name:    "partial source rename",
+			cutover: &CutOver{},
+			err:     errRenameRollbackFailed,
+			want:    true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &Runner{}
+			runner.recordForwardCutoverFailure(tt.cutover, tt.err)
+			require.Equal(t, tt.want, runner.ownershipAmbiguous)
+		})
+	}
 }
 
 // TestMoveReservedWordPK is a regression test for issue #828. Moving a

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -3,6 +3,7 @@ package move
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -216,6 +217,77 @@ func TestEmptyDatabaseMove(t *testing.T) {
 
 	// Clean up
 	require.NoError(t, runner.Close())
+}
+
+func TestEmptyDatabaseMoveWithCutoverResult(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+
+	src := cfg.Clone()
+	src.DBName = "source_empty_result"
+	dest := cfg.Clone()
+	dest.DBName = "dest_empty_result"
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS source_empty_result")
+	testutils.RunSQL(t, "CREATE DATABASE source_empty_result")
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS dest_empty_result")
+	testutils.RunSQL(t, "CREATE DATABASE dest_empty_result")
+
+	runner, err := NewRunner(&Move{
+		SourceDSN:       src.FormatDSN(),
+		TargetDSN:       dest.FormatDSN(),
+		TargetChunkTime: 5 * time.Second,
+		Threads:         4,
+		WriteThreads:    4,
+	})
+	require.NoError(t, err)
+	defer utils.CloseAndLog(runner)
+
+	callbackErr := errors.New("result-bearing cutover failed")
+	callbackCalls := 0
+	runner.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+		callbackCalls++
+		return CutoverResult{DurableMutation: true}, callbackErr
+	})
+
+	require.ErrorIs(t, runner.Run(t.Context()), callbackErr)
+	require.Equal(t, 1, callbackCalls)
+}
+
+func TestForwardCutoverCallbackConfiguration(t *testing.T) {
+	runner := &Runner{}
+	legacyErr := errors.New("legacy cutover failed")
+	legacyCalls := 0
+	runner.SetCutover(func(context.Context) error {
+		legacyCalls++
+		return legacyErr
+	})
+	require.NotNil(t, runner.cutoverFunc)
+	require.Nil(t, runner.cutoverResultFunc)
+
+	result, err := runner.runForwardCutoverCallback(t.Context())
+	require.Equal(t, CutoverResult{}, result)
+	require.ErrorIs(t, err, legacyErr)
+	require.Equal(t, 1, legacyCalls)
+
+	runner.SetCutoverWithResult(nil)
+	require.Nil(t, runner.cutoverFunc)
+	require.Nil(t, runner.cutoverResultFunc)
+
+	resultErr := errors.New("result cutover failed")
+	wantResult := CutoverResult{DurableMutation: true}
+	runner.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+		return wantResult, resultErr
+	})
+	require.Nil(t, runner.cutoverFunc)
+	require.NotNil(t, runner.cutoverResultFunc)
+
+	result, err = runner.runForwardCutoverCallback(t.Context())
+	require.Equal(t, wantResult, result)
+	require.ErrorIs(t, err, resultErr)
+
+	runner.SetCutover(nil)
+	require.Nil(t, runner.cutoverFunc)
+	require.Nil(t, runner.cutoverResultFunc)
 }
 
 // TestMoveReservedWordPK is a regression test for issue #828. Moving a

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -349,6 +349,9 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 		for _, t := range r.sourceTables {
 			oldName := check.CutoverOldName(t.TableName)
 			if err := dbconn.Exec(ctx, s.db, "RENAME TABLE %n TO %n", oldName, t.TableName); err != nil {
+				if dbconn.IsConnectionLossError(err) {
+					r.ownershipAmbiguous = true
+				}
 				return fmt.Errorf("reverse cutover: un-retire source %d table %q: %w", si, t.TableName, err)
 			}
 			r.ownershipAmbiguous = true
@@ -371,6 +374,9 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 			revertName := check.RevertRetiredName(t.TableName)
 			stmt := sqlescape.MustEscapeSQL("RENAME TABLE %n TO %n", t.TableName, revertName)
 			if err := locks[i].ExecUnderLock(ctx, stmt); err != nil {
+				if dbconn.IsConnectionLossError(err) {
+					r.ownershipAmbiguous = true
+				}
 				return fmt.Errorf("reverse cutover: retire target %d table %q: %w", i, t.TableName, err)
 			}
 		}

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -21,8 +21,9 @@ import (
 // the copy phase — the only value migration/datasync ever write, and what a
 // normal move writes right up to (and including) its cutover.
 const (
-	phaseReverseWindow = "reverse_window" // forward cutover done, reverse feed live
-	phaseReverting     = "reverting"      // reverse cutover under way
+	phaseReverseWindow    = "reverse_window"    // forward cutover done, reverse feed live
+	phaseReverting        = "reverting"         // reverse cutover crossed its first mutation boundary
+	phaseReverseFinalized = "reverse_finalized" // source ownership restored; cleanup may remain
 )
 
 // reverseWindowPollInterval is how often the window loop checks for a revert
@@ -92,10 +93,22 @@ type reverseWindow struct {
 	feed *ReverseFeed
 	// watched[i] is target i's real-name tables, used to lock and then retire
 	// the targets during a reverse cutover.
-	watched [][]*table.TableInfo
+	watched        [][]*table.TableInfo
+	persistPhase   func(context.Context, string) error
+	dropMarker     func(context.Context) error
+	dropCheckpoint func(context.Context) error
 }
 
-func newReverseWindow(r *Runner) *reverseWindow { return &reverseWindow{r: r} }
+func newReverseWindow(r *Runner) *reverseWindow {
+	return &reverseWindow{
+		r: r,
+		persistPhase: func(ctx context.Context, phase string) error {
+			return r.checkpointTbl().Write(ctx, checkpoint.Record{Phase: phase, CutoverAt: r.cutoverAt})
+		},
+		dropMarker:     func(ctx context.Context) error { return dropRevertMarker(ctx, r.targets[0].DB) },
+		dropCheckpoint: func(ctx context.Context) error { return r.checkpointTbl().Drop(ctx) },
+	}
+}
 
 // run holds the window and performs the terminal action. It owns the feed's
 // lifecycle.
@@ -271,10 +284,10 @@ func (w *reverseWindow) revertRequested(ctx context.Context) (bool, error) {
 // checkpoint is dropped. The reverse feed is stopped.
 func (w *reverseWindow) completeForward(ctx context.Context) error {
 	w.feed.Close()
-	if err := dropRevertMarker(ctx, w.r.targets[0].DB); err != nil {
+	if err := w.dropMarker(ctx); err != nil {
 		return fmt.Errorf("reverse window: drop revert marker on complete-forward: %w", err)
 	}
-	if err := w.r.checkpointTbl().Drop(ctx); err != nil {
+	if err := w.dropCheckpoint(ctx); err != nil {
 		return fmt.Errorf("reverse window: drop checkpoint on complete-forward: %w", err)
 	}
 	w.r.logger.Info("reverse window complete; move finalized forward (source retired)")
@@ -287,11 +300,6 @@ func (w *reverseWindow) completeForward(ctx context.Context) error {
 // traffic returns to them.
 func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 	r := w.r
-
-	// Record that we are rolling back (best-effort; for a future resume).
-	if err := r.checkpointTbl().Write(ctx, checkpoint.Record{Phase: phaseReverting, CutoverAt: r.cutoverAt}); err != nil {
-		r.logger.Warn("could not persist reverting phase; continuing", "error", err)
-	}
 
 	// Clear any stale _revert tables on the targets before the retire (step 5)
 	// renames each target table to its _revert form — a leftover from a prior
@@ -326,6 +334,13 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 	}
 	w.feed.Close()
 
+	// Persist the ambiguous ownership boundary immediately before the first
+	// source rename. Fail closed: proceeding without this durable fact could
+	// make a restart mistake a partially reverted move for a live window.
+	if err := w.persistPhase(ctx, phaseReverting); err != nil {
+		return fmt.Errorf("reverse cutover: persist reverting phase: %w", err)
+	}
+
 	// 3. Un-retire the source: rename its _old tables back to their real names
 	//    (on every source shard) so it can serve again. The feed is stopped, so
 	//    nothing writes them.
@@ -336,6 +351,7 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 			if err := dbconn.Exec(ctx, s.db, "RENAME TABLE %n TO %n", oldName, t.TableName); err != nil {
 				return fmt.Errorf("reverse cutover: un-retire source %d table %q: %w", si, t.TableName, err)
 			}
+			r.ownershipAmbiguous = true
 		}
 	}
 
@@ -360,11 +376,23 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 		}
 	}
 
-	// 6. Drop the revert marker and the checkpoint.
-	if err := dropRevertMarker(ctx, r.targets[0].DB); err != nil {
+	return w.finalizeReverse(ctx)
+}
+
+// finalizeReverse records definitive reverse ownership before fallible
+// persistence and cleanup. Once every former target has been retired, no
+// remaining operation can move ownership away from the restored source.
+func (w *reverseWindow) finalizeReverse(ctx context.Context) error {
+	r := w.r
+	r.ownershipAmbiguous = false
+	r.reverseFinalized = true
+	if err := w.persistPhase(ctx, phaseReverseFinalized); err != nil {
+		return fmt.Errorf("reverse cutover: persist finalized phase: %w", err)
+	}
+	if err := w.dropMarker(ctx); err != nil {
 		return fmt.Errorf("reverse cutover: drop revert marker: %w", err)
 	}
-	if err := r.checkpointTbl().Drop(ctx); err != nil {
+	if err := w.dropCheckpoint(ctx); err != nil {
 		return fmt.Errorf("reverse cutover: drop checkpoint: %w", err)
 	}
 	r.logger.Info("reverse cutover complete; move rolled back to source")

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -130,7 +130,7 @@ func (w *reverseWindow) run(ctx context.Context) error {
 		revertMarkerName, revertLoc),
 		"window", r.move.ReverseWindow, "deadline", deadline, "reverse_sources", len(r.targets))
 
-	return r.status.Do(status.ReverseWindow, func() error {
+	return r.status.Do(ctx, status.ReverseWindow, func() error {
 		ticker := time.NewTicker(reverseWindowPollInterval)
 		defer ticker.Stop()
 		for {

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -294,6 +294,8 @@ func TestMoveReverseWindowResumesAfterKill(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer utils.CloseAndLog(run2)
+	observer := &recordingMoveWorkflowObserver{}
+	run2.SetWorkflowObserver(observer)
 	run2.SetCutover(func(context.Context) error {
 		t.Error("resume must NOT run the forward cutover again (it re-copied instead of resuming)")
 		return nil
@@ -317,6 +319,9 @@ func TestMoveReverseWindowResumesAfterKill(t *testing.T) {
 	require.True(t, reverseCutoverCalled, "resumed window must be able to roll back")
 	require.True(t, tableExists(t, ctl, "rwrk_src", "t1"), "source un-retired after rollback")
 	require.True(t, tableExists(t, ctl, "rwrk_dst", "t1_revert"), "target retired to _revert after rollback")
+	events, _ := observer.snapshot()
+	require.Contains(t, events, status.WorkflowEvent{DurableMutation: true},
+		"a resumed post-cutover run must report the mutation inherited from its checkpoint")
 	require.False(t, tableExists(t, ctl, "rwrk_dst", "t1"), "target real table gone after rollback")
 }
 

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -148,6 +148,8 @@ func TestMoveReverseWindowRevert(t *testing.T) {
 	runner, err := NewRunner(m)
 	require.NoError(t, err)
 	defer utils.CloseAndLog(runner)
+	observer := &recordingMoveWorkflowObserver{}
+	runner.SetWorkflowObserver(observer)
 
 	var reverseCutoverCalled bool
 	runner.SetCutover(func(context.Context) error { return nil })
@@ -171,6 +173,15 @@ func TestMoveReverseWindowRevert(t *testing.T) {
 	}
 
 	require.True(t, reverseCutoverCalled, "reverse cutover func must run on revert")
+	events, _ := observer.snapshot()
+	require.Equal(t, status.WorkflowEvent{
+		TerminalOwnership: status.WorkflowTerminalOwnershipReverseFinalized,
+	}, events[len(events)-1])
+	require.Contains(t, events, status.WorkflowEvent{
+		State:      status.ReverseWindow,
+		Transition: status.WorkflowTransitionFinished,
+		Outcome:    status.WorkflowOutcomeSucceeded,
+	})
 	// Source un-retired and serving, with the window's write flowed back.
 	require.True(t, tableExists(t, ctl, "rwrv_src", "t1"), "source should be un-retired")
 	require.False(t, tableExists(t, ctl, "rwrv_src", "t1_old"), "source _old should be gone after un-retire")

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -10,6 +10,7 @@ package move
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -585,4 +586,78 @@ func TestMoveReverseWindowNMResumesAfterKill(t *testing.T) {
 	for _, tgt := range []string{f.tgtEvenName, f.tgtOddName} {
 		require.True(t, tableExists(t, f.ctl, tgt, "users_revert"), "target %s retired to _revert", tgt)
 	}
+}
+
+func TestFinalizeReversePersistsOwnershipBeforeCleanup(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	for _, tt := range []struct {
+		name           string
+		dropMarker     func(context.Context) error
+		dropCheckpoint func(context.Context) error
+		wantOrder      []string
+	}{
+		{
+			name:           "revert marker",
+			dropMarker:     func(context.Context) error { return cleanupErr },
+			dropCheckpoint: func(context.Context) error { return nil },
+			wantOrder:      []string{"persist", "marker"},
+		},
+		{
+			name:           "checkpoint",
+			dropMarker:     func(context.Context) error { return nil },
+			dropCheckpoint: func(context.Context) error { return cleanupErr },
+			wantOrder:      []string{"persist", "marker", "checkpoint"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Runner{ownershipAmbiguous: true}
+			var order []string
+			w := &reverseWindow{
+				r: r,
+				persistPhase: func(_ context.Context, phase string) error {
+					require.Equal(t, phaseReverseFinalized, phase)
+					order = append(order, "persist")
+					return nil
+				},
+				dropMarker: func(ctx context.Context) error {
+					order = append(order, "marker")
+					return tt.dropMarker(ctx)
+				},
+				dropCheckpoint: func(ctx context.Context) error {
+					order = append(order, "checkpoint")
+					return tt.dropCheckpoint(ctx)
+				},
+			}
+
+			require.ErrorIs(t, w.finalizeReverse(t.Context()), cleanupErr)
+			require.True(t, r.reverseFinalized)
+			require.False(t, r.ownershipAmbiguous)
+			require.Equal(t, tt.wantOrder, order)
+		})
+	}
+}
+
+func TestFinalizeReverseFailsClosedWhenOwnershipCannotBePersisted(t *testing.T) {
+	persistErr := errors.New("persist failed")
+	r := &Runner{ownershipAmbiguous: true}
+	cleanupCalled := false
+	w := &reverseWindow{
+		r: r,
+		persistPhase: func(context.Context, string) error {
+			return persistErr
+		},
+		dropMarker: func(context.Context) error {
+			cleanupCalled = true
+			return nil
+		},
+		dropCheckpoint: func(context.Context) error {
+			cleanupCalled = true
+			return nil
+		},
+	}
+
+	require.ErrorIs(t, w.finalizeReverse(t.Context()), persistErr)
+	require.True(t, r.reverseFinalized)
+	require.False(t, r.ownershipAmbiguous)
+	require.False(t, cleanupCalled)
 }

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1861,11 +1861,16 @@ func (r *Runner) runForwardCutoverCallback(ctx context.Context) (CutoverResult, 
 		result, err = r.cutoverResultFunc(ctx)
 	case r.cutoverFunc != nil:
 		err = r.cutoverFunc(ctx)
+		if err != nil {
+			// The legacy callback cannot report whether it mutated before
+			// failing. Do not retry an unknown traffic-switch outcome.
+			result.OwnershipAmbiguous = true
+		}
 	}
 	if result.DurableMutation {
 		r.status.DurableMutation(ctx)
 	}
-	if err != nil && result.DurableMutation {
+	if err != nil && (result.DurableMutation || result.OwnershipAmbiguous) {
 		r.ownershipAmbiguous = true
 	}
 	return result, err
@@ -1875,6 +1880,7 @@ func (r *Runner) recordForwardCutoverFailure(cutover *CutOver, err error) {
 	r.ownershipAmbiguous = r.ownershipAmbiguous ||
 		cutover.cutoverFuncSucceeded ||
 		cutover.cutoverFuncMutated ||
+		cutover.cutoverFuncAmbiguous ||
 		errors.Is(err, errRenameRollbackFailed) ||
 		errors.Is(err, errRenameOwnershipAmbiguous)
 }

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1163,7 +1163,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		// cutover callback still runs through the same result-bearing helper as
 		// the full cutover path.
 		r.logger.Info("No tables to copy, proceeding directly to cutover")
-		if err := r.status.Do(status.CutOver, func() error {
+		if err := r.status.Do(ctx, status.CutOver, func() error {
 			_, err := r.runForwardCutoverCallback(ctx)
 			return err
 		}); err != nil {
@@ -1210,7 +1210,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.status.Do(status.CopyRows, func() error {
+	if err := r.status.Do(ctx, status.CopyRows, func() error {
 		return r.copier.Run(ctx)
 	}); err != nil {
 		return err
@@ -1243,7 +1243,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// watermark invalidation are move-specific (multi-source feeds;
 	// invalidateChecksumWatermark blanks the whole per-move checkpoint table),
 	// so they are injected as callbacks. See pkg/sentinel.
-	if err := r.status.Do(status.WaitingOnSentinelTable, func() error {
+	if err := r.status.Do(ctx, status.WaitingOnSentinelTable, func() error {
 		return sentinel.Wait(ctx, sentinel.WaitConfig{
 			Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
 			RunChecksum:         r.runContinuousChecksum,
@@ -1262,7 +1262,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	r.logger.Info("Sentinel released, starting cutover")
 	// Create a cutover.
-	if err := r.status.Do(status.CutOver, func() error {
+	if err := r.status.Do(ctx, status.CutOver, func() error {
 		cutoverSources := make([]CutOverSource, len(r.sources))
 		for i := range r.sources {
 			cutoverSources[i] = CutOverSource{
@@ -1671,7 +1671,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// pkg/change/subscription_buffered.go), unread binlog would pile up
 	// server-side, and a source purging binlogs past the reader's position
 	// during an hours-long index build would fail the move fatally.
-	if err := r.status.Do(status.ApplyChangeset, func() error {
+	if err := r.status.Do(ctx, status.ApplyChangeset, func() error {
 		return r.flushAllReplClients(ctx)
 	}); err != nil {
 		return err
@@ -1680,7 +1680,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// Restore secondary indexes if they were deferred during table creation.
 	// This is always called (not conditional on DeferSecondaryIndexes) to handle
 	// checkpoint resume scenarios where indexes may have been deferred in a previous run.
-	if err := r.status.Do(status.RestoreSecondaryIndexes, func() error {
+	if err := r.status.Do(ctx, status.RestoreSecondaryIndexes, func() error {
 		return r.restoreSecondaryIndexes(ctx)
 	}); err != nil {
 		return err
@@ -1690,7 +1690,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// This is required so on cutover plans don't go sideways, which
 	// is at elevated risk because the batch loading can cause statistics
 	// to be out of date.
-	if err := r.status.Do(status.AnalyzeTable, func() error {
+	if err := r.status.Do(ctx, status.AnalyzeTable, func() error {
 		r.logger.Info("Running ANALYZE TABLE")
 		for _, target := range r.targets {
 			for _, tbl := range r.sourceTables {
@@ -1761,7 +1761,7 @@ func (r *Runner) postCopyPhase(ctx context.Context) error {
 	// repair) or resumes safely from a watermark that came from a clean
 	// pass. See pkg/migration/runner.go DumpCheckpoint for the full
 	// rationale.
-	return r.status.Do(status.Checksum, func() error {
+	return r.status.Do(ctx, status.Checksum, func() error {
 		return r.checker.Run(ctx)
 	})
 }

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -824,12 +824,15 @@ func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
 	}
 	switch rec.Phase {
 	case phaseReverseWindow:
+		r.status.DurableMutation(ctx)
 		r.logger.Warn("resuming an interrupted reverse window from checkpoint", "cutover_at", rec.CutoverAt)
 		return true, r.resumeReverseWindow(ctx, rec)
 	case phaseReverting:
+		r.status.DurableMutation(ctx)
 		r.ownershipAmbiguous = true
 		return true, fmt.Errorf("a reverse cutover was interrupted (checkpoint phase=%q); resuming a partial rollback is not yet supported — complete it manually", rec.Phase)
 	case phaseReverseFinalized:
+		r.status.DurableMutation(ctx)
 		// Ownership is already definitive. Retry only the idempotent cleanup
 		// that may have failed after the phase was durably persisted.
 		return true, newReverseWindow(r).finalizeReverse(ctx)

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -216,6 +216,44 @@ func NewRunner(m *Move) (*Runner, error) {
 	return r, nil
 }
 
+// SetWorkflowObserver installs the optional typed workflow observer. It must be
+// called before Run. A nil observer disables workflow observation.
+func (r *Runner) SetWorkflowObserver(observer status.WorkflowObserver) {
+	r.status.SetObserver(observer)
+}
+
+func (r *Runner) runCopy(ctx context.Context) error {
+	if r.status.HasObserver() {
+		defer func() {
+			rows, chunks, available := copier.CompletedWork(r.copier)
+			if available {
+				r.status.RecordCompletedWork(ctx, rows, chunks)
+			}
+		}()
+	}
+	return r.status.Do(ctx, status.CopyRows, func() error {
+		err := r.copier.Run(ctx)
+		if err == nil && ctx.Err() != nil {
+			chunker := r.copier.GetChunker()
+			if chunker == nil || !chunker.IsRead() {
+				return ctx.Err()
+			}
+		}
+		return err
+	})
+}
+
+func (r *Runner) terminalOwnership() status.WorkflowTerminalOwnership {
+	switch {
+	case r.reverseFinalized:
+		return status.WorkflowTerminalOwnershipReverseFinalized
+	case r.ownershipAmbiguous:
+		return status.WorkflowTerminalOwnershipAmbiguous
+	default:
+		return 0
+	}
+}
+
 func (r *Runner) Close() error {
 	// Cancel the runner context so background goroutines (status.WatchTask)
 	// observe ctx.Done() and exit. Idempotent.
@@ -1025,6 +1063,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.status.Begin()
 	r.reverseFinalized = false
 	r.ownershipAmbiguous = false
+	defer func() {
+		r.status.Terminal(ctx, r.terminalOwnership())
+	}()
 	bi := buildinfo.Get()
 	r.logger.Info("Starting table move",
 		"version", bi.Version,
@@ -1210,9 +1251,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.status.Do(ctx, status.CopyRows, func() error {
-		return r.copier.Run(ctx)
-	}); err != nil {
+	if err := r.runCopy(ctx); err != nil {
 		return err
 	}
 
@@ -1242,14 +1281,16 @@ func (r *Runner) Run(ctx context.Context) error {
 	// lives in the sentinel package). The continuous-checksum lifecycle and
 	// watermark invalidation are move-specific (multi-source feeds;
 	// invalidateChecksumWatermark blanks the whole per-move checkpoint table),
-	// so they are injected as callbacks. See pkg/sentinel.
-	if err := r.status.Do(ctx, status.WaitingOnSentinelTable, func() error {
-		return sentinel.Wait(ctx, sentinel.WaitConfig{
-			Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
-			RunChecksum:         r.runContinuousChecksum,
-			InvalidateWatermark: r.invalidateChecksumWatermark,
-			Logger:              r.logger,
-		})
+	// so they are injected as callbacks. RunWait brackets only an observed
+	// sentinel; an absent optional sentinel emits no phase.
+	if err := sentinel.Wait(ctx, sentinel.WaitConfig{
+		Exists:              func(ctx context.Context) (bool, error) { return sentinel.Exists(ctx, r.targets[0].DB) },
+		RunChecksum:         r.runContinuousChecksum,
+		InvalidateWatermark: r.invalidateChecksumWatermark,
+		Logger:              r.logger,
+		RunWait: func(wait func() error) error {
+			return r.status.Do(ctx, status.WaitingOnSentinelTable, wait)
+		},
 	}); err != nil {
 		return err
 	}
@@ -1295,6 +1336,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			return err
 		}
 		r.ownershipAmbiguous = false
+		r.status.DurableMutation(ctx)
 		return nil
 	}); err != nil {
 		return err
@@ -1816,6 +1858,9 @@ func (r *Runner) runForwardCutoverCallback(ctx context.Context) (CutoverResult, 
 		result, err = r.cutoverResultFunc(ctx)
 	case r.cutoverFunc != nil:
 		err = r.cutoverFunc(ctx)
+	}
+	if result.DurableMutation {
+		r.status.DurableMutation(ctx)
 	}
 	if err != nil && result.DurableMutation {
 		r.ownershipAmbiguous = true

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -173,6 +173,11 @@ type Runner struct {
 	// (stopWatchTask) so the reverse window is the sole writer of the checkpoint
 	// row.
 	bgCancel context.CancelFunc
+
+	// reverseFinalized and ownershipAmbiguous retain terminal ownership evidence
+	// across fallible cleanup so callers never have to infer it from an error.
+	reverseFinalized   bool
+	ownershipAmbiguous bool
 }
 
 var _ status.Task = (*Runner)(nil)
@@ -784,7 +789,12 @@ func (r *Runner) maybeResumeReverseWindow(ctx context.Context) (bool, error) {
 		r.logger.Warn("resuming an interrupted reverse window from checkpoint", "cutover_at", rec.CutoverAt)
 		return true, r.resumeReverseWindow(ctx, rec)
 	case phaseReverting:
+		r.ownershipAmbiguous = true
 		return true, fmt.Errorf("a reverse cutover was interrupted (checkpoint phase=%q); resuming a partial rollback is not yet supported — complete it manually", rec.Phase)
+	case phaseReverseFinalized:
+		// Ownership is already definitive. Retry only the idempotent cleanup
+		// that may have failed after the phase was durably persisted.
+		return true, newReverseWindow(r).finalizeReverse(ctx)
 	default:
 		return false, nil // phase "" (copy) — the normal flow handles resume/fresh
 	}
@@ -1013,6 +1023,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
 	r.status.Begin()
+	r.reverseFinalized = false
+	r.ownershipAmbiguous = false
 	bi := buildinfo.Get()
 	r.logger.Info("Starting table move",
 		"version", bi.Version,
@@ -1278,7 +1290,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		if err := r.assertNoRevertMarker(ctx, "pre-cutover"); err != nil {
 			return err
 		}
-		return cutover.Run(ctx)
+		if err := cutover.Run(ctx); err != nil {
+			r.recordForwardCutoverFailure(cutover, err)
+			return err
+		}
+		r.ownershipAmbiguous = false
+		return nil
 	}); err != nil {
 		return err
 	}
@@ -1792,13 +1809,25 @@ func (r *Runner) analyzeTable(ctx context.Context, db *sql.DB, tableName string)
 // configured and always returns the result-bearing form used by both runner
 // cutover paths.
 func (r *Runner) runForwardCutoverCallback(ctx context.Context) (CutoverResult, error) {
-	if r.cutoverResultFunc != nil {
-		return r.cutoverResultFunc(ctx)
+	var result CutoverResult
+	var err error
+	switch {
+	case r.cutoverResultFunc != nil:
+		result, err = r.cutoverResultFunc(ctx)
+	case r.cutoverFunc != nil:
+		err = r.cutoverFunc(ctx)
 	}
-	if r.cutoverFunc != nil {
-		return CutoverResult{}, r.cutoverFunc(ctx)
+	if err != nil && result.DurableMutation {
+		r.ownershipAmbiguous = true
 	}
-	return CutoverResult{}, nil
+	return result, err
+}
+
+func (r *Runner) recordForwardCutoverFailure(cutover *CutOver, err error) {
+	r.ownershipAmbiguous = r.ownershipAmbiguous ||
+		cutover.cutoverFuncSucceeded ||
+		cutover.cutoverFuncMutated ||
+		errors.Is(err, errRenameRollbackFailed)
 }
 
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1875,7 +1875,8 @@ func (r *Runner) recordForwardCutoverFailure(cutover *CutOver, err error) {
 	r.ownershipAmbiguous = r.ownershipAmbiguous ||
 		cutover.cutoverFuncSucceeded ||
 		cutover.cutoverFuncMutated ||
-		errors.Is(err, errRenameRollbackFailed)
+		errors.Is(err, errRenameRollbackFailed) ||
+		errors.Is(err, errRenameOwnershipAmbiguous)
 }
 
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -137,7 +137,8 @@ type Runner struct {
 	// their own goroutine while setup is still writing it.
 	usedResumeFromCheckpoint atomic.Bool
 
-	cutoverFunc func(ctx context.Context) error
+	cutoverFunc       func(ctx context.Context) error
+	cutoverResultFunc CutoverResultCallback
 	// reverseCutoverFunc is the reverse-window rollback's traffic switch (route
 	// back to the source). Set via SetReverseCutover; used only when
 	// move.ReverseWindow > 0 and a revert is requested during the window.
@@ -1145,20 +1146,14 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	if len(r.sourceTables) == 0 {
 		// Because this is called from orchestration, there might be a bug where
-		// it is asked to move *no tables*. Since there are no tables,
-		// there is no:
-		// - copier, replication changes
-		// - advisory lock
-		// - cutover step
-		//
-		// But the caller will still want their cutoverFunc called. So we do that
-		// and then exit.
+		// it is asked to move *no tables*. Since there are no tables, there is no
+		// copier, replication, advisory lock, or physical cutover. The caller's
+		// cutover callback still runs through the same result-bearing helper as
+		// the full cutover path.
 		r.logger.Info("No tables to copy, proceeding directly to cutover")
 		if err := r.status.Do(status.CutOver, func() error {
-			if r.cutoverFunc == nil {
-				return nil
-			}
-			return r.cutoverFunc(ctx)
+			_, err := r.runForwardCutoverCallback(ctx)
+			return err
 		}); err != nil {
 			return err
 		}
@@ -1264,9 +1259,12 @@ func (r *Runner) Run(ctx context.Context) error {
 				Tables:     r.sources[i].tables,
 			}
 		}
-		cutover, err := NewCutOver(cutoverSources, r.cutoverFunc, r.dbConfig, r.logger)
+		cutover, err := NewCutOver(cutoverSources, nil, r.dbConfig, r.logger)
 		if err != nil {
 			return err
+		}
+		if r.cutoverResultFunc != nil || r.cutoverFunc != nil {
+			cutover.SetCutoverWithResult(r.runForwardCutoverCallback)
 		}
 		if r.move.ReverseWindow > 0 {
 			// Under the cutover lock, right after the traffic switch, capture the
@@ -1790,8 +1788,29 @@ func (r *Runner) analyzeTable(ctx context.Context, db *sql.DB, tableName string)
 	return rows.Err()
 }
 
+// runForwardCutoverCallback invokes whichever mutually exclusive callback was
+// configured and always returns the result-bearing form used by both runner
+// cutover paths.
+func (r *Runner) runForwardCutoverCallback(ctx context.Context) (CutoverResult, error) {
+	if r.cutoverResultFunc != nil {
+		return r.cutoverResultFunc(ctx)
+	}
+	if r.cutoverFunc != nil {
+		return CutoverResult{}, r.cutoverFunc(ctx)
+	}
+	return CutoverResult{}, nil
+}
+
 func (r *Runner) SetCutover(cutover func(ctx context.Context) error) {
+	r.cutoverResultFunc = nil
 	r.cutoverFunc = cutover
+}
+
+// SetCutoverWithResult installs a result-bearing forward cutover callback.
+// It is mutually exclusive with SetCutover; the most recent setter wins.
+func (r *Runner) SetCutoverWithResult(cutover CutoverResultCallback) {
+	r.cutoverFunc = nil
+	r.cutoverResultFunc = cutover
 }
 
 // SetReverseCutover registers the rollback traffic switch used if a revert is

--- a/pkg/move/workflow_test.go
+++ b/pkg/move/workflow_test.go
@@ -1,0 +1,197 @@
+package move
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/copier"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingMoveWorkflowObserver struct {
+	mu       sync.Mutex
+	events   []status.WorkflowEvent
+	contexts []context.Context
+}
+
+func (o *recordingMoveWorkflowObserver) ObserveWorkflow(ctx context.Context, event status.WorkflowEvent) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.contexts = append(o.contexts, ctx)
+	o.events = append(o.events, event)
+}
+
+func (o *recordingMoveWorkflowObserver) snapshot() ([]status.WorkflowEvent, []context.Context) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]status.WorkflowEvent(nil), o.events...), append([]context.Context(nil), o.contexts...)
+}
+
+type workflowMoveCopier struct {
+	copier.Copier
+	runErr               error
+	chunker              table.Chunker
+	rows                 uint64
+	chunks               uint64
+	panicOnCompletedWork bool
+}
+
+func (c *workflowMoveCopier) Run(context.Context) error { return c.runErr }
+func (c *workflowMoveCopier) GetChunker() table.Chunker { return c.chunker }
+func (c *workflowMoveCopier) CompletedWork() (uint64, uint64) {
+	if c.panicOnCompletedWork {
+		panic("CompletedWork queried without an observer")
+	}
+	return c.rows, c.chunks
+}
+
+func newWorkflowMoveRunner(t *testing.T, prefix string, withTable bool) *Runner {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	sourceName := prefix + "_src"
+	targetName := prefix + "_dst"
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+sourceName)
+	testutils.RunSQL(t, "CREATE DATABASE "+sourceName)
+	testutils.RunSQL(t, "DROP DATABASE IF EXISTS "+targetName)
+	testutils.RunSQL(t, "CREATE DATABASE "+targetName)
+	if withTable {
+		testutils.RunSQL(t, "CREATE TABLE "+sourceName+".t1 (id INT PRIMARY KEY, val VARCHAR(32))")
+		testutils.RunSQL(t, "INSERT INTO "+sourceName+".t1 VALUES (1, 'one'), (2, 'two'), (3, 'three')")
+	}
+	source := cfg.Clone()
+	source.DBName = sourceName
+	target := cfg.Clone()
+	target.DBName = targetName
+	r, err := NewRunner(&Move{
+		SourceDSN:       source.FormatDSN(),
+		TargetDSN:       target.FormatDSN(),
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         1,
+		WriteThreads:    1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(r) })
+	return r
+}
+
+func TestMoveWorkflowOrderedPhasesTotalsAndMutation(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(t.Context(), contextKey{}, "move")
+	observer := &recordingMoveWorkflowObserver{}
+	r := newWorkflowMoveRunner(t, "workflow_order", true)
+	r.SetWorkflowObserver(observer)
+
+	require.NoError(t, r.Run(ctx))
+
+	events, contexts := observer.snapshot()
+	type transition struct {
+		state      status.State
+		transition status.WorkflowTransition
+		outcome    status.WorkflowOutcome
+	}
+	var transitions []transition
+	var totals []status.WorkflowTotals
+	mutationIndex := -1
+	cutoverFinishIndex := -1
+	for i, event := range events {
+		if event.Transition != 0 {
+			transitions = append(transitions, transition{event.State, event.Transition, event.Outcome})
+		}
+		if event.TotalsAvailable {
+			totals = append(totals, event.Totals)
+		}
+		if event.DurableMutation {
+			mutationIndex = i
+		}
+		if event.State == status.CutOver && event.Transition == status.WorkflowTransitionFinished {
+			cutoverFinishIndex = i
+		}
+		require.Zero(t, event.TerminalOwnership)
+		require.NotEqual(t, status.WaitingOnSentinelTable, event.State, "an absent optional sentinel must not emit a phase")
+	}
+	require.Equal(t, []transition{
+		{status.CopyRows, status.WorkflowTransitionStarted, 0},
+		{status.CopyRows, status.WorkflowTransitionFinished, status.WorkflowOutcomeSucceeded},
+		{status.ApplyChangeset, status.WorkflowTransitionStarted, 0},
+		{status.ApplyChangeset, status.WorkflowTransitionFinished, status.WorkflowOutcomeSucceeded},
+		{status.RestoreSecondaryIndexes, status.WorkflowTransitionStarted, 0},
+		{status.RestoreSecondaryIndexes, status.WorkflowTransitionFinished, status.WorkflowOutcomeSucceeded},
+		{status.AnalyzeTable, status.WorkflowTransitionStarted, 0},
+		{status.AnalyzeTable, status.WorkflowTransitionFinished, status.WorkflowOutcomeSucceeded},
+		{status.Checksum, status.WorkflowTransitionStarted, 0},
+		{status.Checksum, status.WorkflowTransitionFinished, status.WorkflowOutcomeSucceeded},
+		{status.CutOver, status.WorkflowTransitionStarted, 0},
+		{status.CutOver, status.WorkflowTransitionFinished, status.WorkflowOutcomeSucceeded},
+	}, transitions)
+	require.Len(t, totals, 1)
+	require.Equal(t, uint64(3), totals[0].CompletedRows)
+	require.Positive(t, totals[0].CompletedChunks)
+	require.NotEqual(t, -1, mutationIndex)
+	require.Greater(t, cutoverFinishIndex, mutationIndex)
+	require.Len(t, contexts, len(events))
+	for _, observedCtx := range contexts {
+		require.Equal(t, "move", observedCtx.Value(contextKey{}))
+	}
+}
+
+func TestMoveWorkflowCompletedWorkCapabilityIsConditional(t *testing.T) {
+	r := &Runner{copier: &workflowMoveCopier{panicOnCompletedWork: true}}
+	require.NotPanics(t, func() {
+		require.NoError(t, r.runCopy(t.Context()))
+	})
+
+	copyErr := errors.New("copy failed")
+	observer := &recordingMoveWorkflowObserver{}
+	r = &Runner{copier: &workflowMoveCopier{runErr: copyErr, rows: 8, chunks: 2}}
+	r.SetWorkflowObserver(observer)
+	require.ErrorIs(t, r.runCopy(t.Context()), copyErr)
+	events, _ := observer.snapshot()
+	require.Equal(t, status.WorkflowOutcomeFailed, events[1].Outcome)
+	require.Equal(t, status.WorkflowEvent{
+		State:           status.CopyRows,
+		Totals:          status.WorkflowTotals{CompletedRows: 8, CompletedChunks: 2},
+		TotalsAvailable: true,
+	}, events[2])
+}
+
+func TestMoveWorkflowAmbiguousExternalCutover(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(t.Context(), contextKey{}, "ambiguous")
+	observer := &recordingMoveWorkflowObserver{}
+	r := newWorkflowMoveRunner(t, "workflow_ambiguous", false)
+	r.SetWorkflowObserver(observer)
+	callbackErr := errors.New("cutover failed after mutation")
+	r.SetCutoverWithResult(func(context.Context) (CutoverResult, error) {
+		return CutoverResult{DurableMutation: true}, callbackErr
+	})
+
+	require.ErrorIs(t, r.Run(ctx), callbackErr)
+	events, contexts := observer.snapshot()
+	require.Equal(t, []status.WorkflowEvent{
+		{State: status.CutOver, Transition: status.WorkflowTransitionStarted},
+		{DurableMutation: true},
+		{State: status.CutOver, Transition: status.WorkflowTransitionFinished, Outcome: status.WorkflowOutcomeFailed},
+		{TerminalOwnership: status.WorkflowTerminalOwnershipAmbiguous},
+	}, events)
+	for _, observedCtx := range contexts {
+		require.Equal(t, "ambiguous", observedCtx.Value(contextKey{}))
+	}
+}
+
+func TestMoveWorkflowTerminalOwnershipPrecedence(t *testing.T) {
+	r := &Runner{reverseFinalized: true, ownershipAmbiguous: true}
+	require.Equal(t, status.WorkflowTerminalOwnershipReverseFinalized, r.terminalOwnership())
+	r.reverseFinalized = false
+	require.Equal(t, status.WorkflowTerminalOwnershipAmbiguous, r.terminalOwnership())
+	r.ownershipAmbiguous = false
+	require.Zero(t, r.terminalOwnership())
+}

--- a/pkg/sentinel/sentinel.go
+++ b/pkg/sentinel/sentinel.go
@@ -86,6 +86,11 @@ type WaitConfig struct {
 	InvalidateWatermark func(ctx context.Context) error
 
 	Logger *slog.Logger
+
+	// RunWait optionally wraps the blocking wait after the sentinel has been
+	// observed. It is not called when the sentinel is absent. A wrapper must
+	// invoke wait exactly once and return its result.
+	RunWait func(wait func() error) error
 }
 
 // Wait blocks until the sentinel table is dropped (proceed with cutover),
@@ -104,7 +109,7 @@ type WaitConfig struct {
 //
 // Exists, RunChecksum and InvalidateWatermark are required (Wait returns an
 // error if any is nil); a nil Logger defaults to slog.Default().
-func Wait(ctx context.Context, cfg WaitConfig) (retErr error) {
+func Wait(ctx context.Context, cfg WaitConfig) error {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
@@ -118,6 +123,16 @@ func Wait(ctx context.Context, cfg WaitConfig) (retErr error) {
 		return nil
 	}
 
+	run := func() error {
+		return waitWhilePresent(ctx, cfg)
+	}
+	if cfg.RunWait != nil {
+		return cfg.RunWait(run)
+	}
+	return run()
+}
+
+func waitWhilePresent(ctx context.Context, cfg WaitConfig) (retErr error) {
 	cfg.Logger.Warn("cutover deferred while sentinel table exists; will wait",
 		"sentinel-table", TableName,
 		"wait-limit", WaitLimit.String(),

--- a/pkg/sentinel/sentinel_test.go
+++ b/pkg/sentinel/sentinel_test.go
@@ -77,23 +77,29 @@ func blockingChecksum(started *atomic.Bool) func(context.Context) error {
 }
 
 func TestWaitSentinelAbsentUpFront(t *testing.T) {
-	var checksumStarted, invalidateCalled atomic.Bool
+	var checksumStarted, invalidateCalled, waitWrapped atomic.Bool
 	err := sentinel.Wait(t.Context(), sentinel.WaitConfig{
 		Exists:              func(context.Context) (bool, error) { return false, nil },
 		RunChecksum:         blockingChecksum(&checksumStarted),
 		InvalidateWatermark: func(context.Context) error { invalidateCalled.Store(true); return nil },
 		Logger:              discardLogger(),
+		RunWait: func(wait func() error) error {
+			waitWrapped.Store(true)
+			return wait()
+		},
 	})
 	require.NoError(t, err)
 	// An absent sentinel means "proceed immediately": no checksum is spawned
 	// and no watermark cleanup runs.
 	assert.False(t, checksumStarted.Load(), "checksum must not start when sentinel is already absent")
 	assert.False(t, invalidateCalled.Load(), "watermark must not be touched when sentinel is already absent")
+	assert.False(t, waitWrapped.Load(), "wait wrapper must not run when sentinel is already absent")
 }
 
 func TestWaitSentinelDropped(t *testing.T) {
 	setTiming(t, time.Hour, time.Millisecond)
 	var calls atomic.Int32
+	var wrapperCalls atomic.Int32
 	var checksumStarted, invalidateCalled atomic.Bool
 	err := sentinel.Wait(t.Context(), sentinel.WaitConfig{
 		// true up front and on the first tick, then dropped.
@@ -101,10 +107,15 @@ func TestWaitSentinelDropped(t *testing.T) {
 		RunChecksum:         blockingChecksum(&checksumStarted),
 		InvalidateWatermark: func(context.Context) error { invalidateCalled.Store(true); return nil },
 		Logger:              discardLogger(),
+		RunWait: func(wait func() error) error {
+			wrapperCalls.Add(1)
+			return wait()
+		},
 	})
 	require.NoError(t, err)
 	assert.True(t, checksumStarted.Load(), "checksum must run while waiting")
 	assert.True(t, invalidateCalled.Load(), "watermark cleanup must run on the way out")
+	assert.Equal(t, int32(1), wrapperCalls.Load(), "confirmed wait must be wrapped exactly once")
 }
 
 func TestWaitTimeout(t *testing.T) {

--- a/pkg/status/README.md
+++ b/pkg/status/README.md
@@ -16,10 +16,10 @@ This ordering is deliberate — the code uses ordinal comparisons (e.g., `state 
 
 ## Tracker
 
-`Tracker` wraps a `State` with per-state wall-clock timing, and is what the runners hold in place of a bare `State` field. Phases with a clear extent run under `Do(state, fn)`, which transitions to `state`, runs `fn`, and attributes `fn`'s elapsed time (panic inclusive) to that state:
+`Tracker` wraps a `State` with per-state wall-clock timing, and is what the runners hold in place of a bare `State` field. Phases with a clear extent run under `Do(ctx, state, fn)`, which transitions to `state`, synchronously emits typed started/finished observations, runs `fn`, and attributes `fn`'s elapsed time (panic and `runtime.Goexit` inclusive) to that state:
 
 ```go
-err := r.status.Do(status.CopyRows, func() error {
+err := r.status.Do(ctx, status.CopyRows, func() error {
     return r.copier.Run(ctx)
 })
 ```
@@ -29,6 +29,8 @@ err := r.status.Do(status.CopyRows, func() error {
 Because the tracker owns the timing, the runners no longer carry ad-hoc fields like `copyDuration` or `sentinelWaitStartTime`: the status block header renders `Elapsed()` (time in the current state) and final summaries render `Duration(state)` (total time attributed to a state, accumulating across repeat visits). The two can disagree after a bracket completes: `Duration(state)` freezes when the bracket closes, while `Elapsed()` keeps growing until the next transition.
 
 The tracker assumes spirit's linear execution model — one goroutine advances through the phases in order, and the only concurrent transition is a fatal `Set(ErrCleanup)` racing an open bracket (time accrues to the bracketed state up to the fatal transition; the bracket's own exit becomes a no-op). It is not designed for concurrent or overlapping phases. `Begin()` marks the start of a run and resets all timing; runners call it once at the top of `Run`.
+
+An optional `WorkflowObserver` receives the bracketed state transitions and separate authoritative evidence reported by a runner: aggregate completed copy work, durable mutation, and terminal ownership. Observer panics are isolated from runner behavior. `Do` does not recover application panics; its deferred finish reports an abnormal unwind as failed and lets the original panic or `runtime.Goexit` continue unchanged. Evidence is synchronous and independent of a phase's returned error, so a successful mutation followed by fallible cleanup remains observable.
 
 ## Task Interface
 

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -1,7 +1,10 @@
 package status
 
 import (
+	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -31,6 +34,10 @@ type Tracker struct {
 	enteredAt time.Time               // when the current state was entered
 	open      bool                    // the current state has a running interval
 	durations map[State]time.Duration // closed time attributed per state
+
+	observer                atomic.Pointer[workflowObserverSlot]
+	durableMutationObserved atomic.Bool
+	terminalObserved        atomic.Bool
 }
 
 // Begin marks the start of a run: it resets all timing (start time, per-state
@@ -39,6 +46,8 @@ type Tracker struct {
 // at the top of Run, where they previously recorded a startTime field. Calling
 // Begin again starts a fresh run rather than extending the previous one.
 func (t *Tracker) Begin() {
+	t.durableMutationObserved.Store(false)
+	t.terminalObserved.Store(false)
 	now := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -62,14 +71,78 @@ func (t *Tracker) Set(state State) {
 	t.enter(state)
 }
 
-// Do runs fn as the given state: it transitions to state, runs fn, and
-// attributes fn's wall-clock time (panic inclusive) to state. The state
-// remains current after Do returns — as with Set, the next state begins only
-// when it is entered.
-func (t *Tracker) Do(state State, fn func() error) error {
+// Do runs fn as the given state: it transitions to state, synchronously emits
+// started and finished observations, and attributes fn's wall-clock time
+// (panic and runtime.Goexit inclusive) to state. The state remains current
+// after Do returns — as with Set, the next state begins only when it is entered.
+//
+// A single deferred finish distinguishes normal return from abnormal unwind
+// without recovering. This preserves the application's original panic value,
+// including legacy panic(nil), and runtime.Goexit behavior.
+func (t *Tracker) Do(ctx context.Context, state State, fn func() error) (err error) {
 	t.enter(state)
-	defer t.exit(state)
-	return fn()
+	completedNormally := false
+	defer func() {
+		t.exit(state)
+		outcome := WorkflowOutcomeFailed
+		if completedNormally {
+			outcome = workflowOutcome(ctx, err)
+		}
+		t.emit(ctx, WorkflowEvent{
+			State:      state,
+			Transition: WorkflowTransitionFinished,
+			Outcome:    outcome,
+		})
+	}()
+
+	t.emit(ctx, WorkflowEvent{
+		State:      state,
+		Transition: WorkflowTransitionStarted,
+	})
+	err = fn()
+	completedNormally = true
+	return err
+}
+
+// SetObserver replaces the workflow observer. A nil observer disables delivery.
+func (t *Tracker) SetObserver(observer WorkflowObserver) {
+	if observer == nil {
+		t.observer.Store(nil)
+		return
+	}
+	t.observer.Store(&workflowObserverSlot{observer: observer})
+}
+
+// HasObserver reports whether workflow event delivery is enabled.
+func (t *Tracker) HasObserver() bool {
+	return t.observer.Load() != nil
+}
+
+// RecordCompletedWork synchronously reports authoritative aggregate copy work.
+// It is separate from Do's finished event because the copier owns this evidence.
+func (t *Tracker) RecordCompletedWork(ctx context.Context, rows, chunks uint64) {
+	t.emit(ctx, WorkflowEvent{
+		State:           CopyRows,
+		Totals:          WorkflowTotals{CompletedRows: rows, CompletedChunks: chunks},
+		TotalsAvailable: true,
+	})
+}
+
+// DurableMutation reports that an externally visible mutation completed. It is
+// emitted at most once per run and remains independent of any phase outcome.
+func (t *Tracker) DurableMutation(ctx context.Context) {
+	if !t.durableMutationObserved.CompareAndSwap(false, true) {
+		return
+	}
+	t.emit(ctx, WorkflowEvent{DurableMutation: true})
+}
+
+// Terminal reports terminal ownership evidence at most once per run.
+func (t *Tracker) Terminal(ctx context.Context, ownership WorkflowTerminalOwnership) {
+	if !ownership.valid() || !t.terminalObserved.CompareAndSwap(false, true) {
+		return
+	}
+	t.emit(ctx, WorkflowEvent{TerminalOwnership: ownership})
 }
 
 // StartTime returns when the run began: Begin, or the first transition if
@@ -156,4 +229,32 @@ func (t *Tracker) accrueLocked(now time.Time) {
 	}
 	t.durations[t.state.get()] += now.Sub(t.enteredAt)
 	t.open = false
+}
+
+func (t *Tracker) emit(ctx context.Context, event WorkflowEvent) {
+	slot := t.observer.Load()
+	if slot == nil {
+		return
+	}
+	notifyWorkflowObserver(slot.observer, ctx, event)
+}
+
+func notifyWorkflowObserver(observer WorkflowObserver, ctx context.Context, event WorkflowEvent) {
+	defer func() {
+		_ = recover()
+	}()
+	observer.ObserveWorkflow(ctx, event)
+}
+
+func workflowOutcome(ctx context.Context, err error) WorkflowOutcome {
+	if err == nil {
+		return WorkflowOutcomeSucceeded
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return WorkflowOutcomeCancelled
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return WorkflowOutcomeCancelled
+	}
+	return WorkflowOutcomeFailed
 }

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -36,6 +36,7 @@ type Tracker struct {
 	durations map[State]time.Duration // closed time attributed per state
 
 	observer                atomic.Pointer[workflowObserverSlot]
+	completedWorkObserved   atomic.Bool
 	durableMutationObserved atomic.Bool
 	terminalObserved        atomic.Bool
 }
@@ -47,6 +48,7 @@ type Tracker struct {
 // Begin again starts a fresh run rather than extending the previous one.
 func (t *Tracker) Begin() {
 	t.durableMutationObserved.Store(false)
+	t.completedWorkObserved.Store(false)
 	t.terminalObserved.Store(false)
 	now := time.Now()
 	t.mu.Lock()
@@ -118,9 +120,13 @@ func (t *Tracker) HasObserver() bool {
 	return t.observer.Load() != nil
 }
 
-// RecordCompletedWork synchronously reports authoritative aggregate copy work.
-// It is separate from Do's finished event because the copier owns this evidence.
+// RecordCompletedWork synchronously reports the authoritative terminal copy
+// aggregate at most once per run. It is separate from Do's finished event
+// because the copier owns this evidence.
 func (t *Tracker) RecordCompletedWork(ctx context.Context, rows, chunks uint64) {
+	if !t.completedWorkObserved.CompareAndSwap(false, true) {
+		return
+	}
 	t.emit(ctx, WorkflowEvent{
 		State:           CopyRows,
 		Totals:          WorkflowTotals{CompletedRows: rows, CompletedChunks: chunks},

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -247,14 +247,14 @@ func notifyWorkflowObserver(observer WorkflowObserver, ctx context.Context, even
 }
 
 func workflowOutcome(ctx context.Context, err error) WorkflowOutcome {
-	if err == nil {
-		return WorkflowOutcomeSucceeded
-	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return WorkflowOutcomeCancelled
 	}
 	if ctx != nil && ctx.Err() != nil {
 		return WorkflowOutcomeCancelled
+	}
+	if err == nil {
+		return WorkflowOutcomeSucceeded
 	}
 	return WorkflowOutcomeFailed
 }

--- a/pkg/status/tracker_test.go
+++ b/pkg/status/tracker_test.go
@@ -250,6 +250,15 @@ func TestTrackerDoClassifiesOutcomes(t *testing.T) {
 			want:    WorkflowOutcomeSucceeded,
 		},
 		{
+			name: "cancelled runner context with nil error",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			want: WorkflowOutcomeCancelled,
+		},
+		{
 			name:    "failure",
 			context: t.Context,
 			err:     failureErr,

--- a/pkg/status/tracker_test.go
+++ b/pkg/status/tracker_test.go
@@ -382,6 +382,7 @@ func TestTrackerEvidenceIsTypedDeduplicatedAndResetPerRun(t *testing.T) {
 	tr.Begin()
 
 	tr.RecordCompletedWork(t.Context(), 12, 3)
+	tr.RecordCompletedWork(t.Context(), 99, 99)
 	tr.DurableMutation(t.Context())
 	tr.DurableMutation(t.Context())
 	tr.Terminal(t.Context(), 0)
@@ -400,9 +401,16 @@ func TestTrackerEvidenceIsTypedDeduplicatedAndResetPerRun(t *testing.T) {
 	}, events)
 
 	tr.Begin()
+	tr.RecordCompletedWork(t.Context(), 4, 2)
+	tr.RecordCompletedWork(t.Context(), 8, 4)
 	tr.DurableMutation(t.Context())
 	tr.Terminal(t.Context(), WorkflowTerminalOwnershipAmbiguous)
 	events, _ = observer.snapshot()
-	require.Equal(t, WorkflowEvent{DurableMutation: true}, events[3])
-	require.Equal(t, WorkflowEvent{TerminalOwnership: WorkflowTerminalOwnershipAmbiguous}, events[4])
+	require.Equal(t, WorkflowEvent{
+		State:           CopyRows,
+		Totals:          WorkflowTotals{CompletedRows: 4, CompletedChunks: 2},
+		TotalsAvailable: true,
+	}, events[3])
+	require.Equal(t, WorkflowEvent{DurableMutation: true}, events[4])
+	require.Equal(t, WorkflowEvent{TerminalOwnership: WorkflowTerminalOwnershipAmbiguous}, events[5])
 }

--- a/pkg/status/tracker_test.go
+++ b/pkg/status/tracker_test.go
@@ -1,7 +1,12 @@
 package status
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -23,7 +28,7 @@ func TestTrackerDoSetsStateAndReturnsError(t *testing.T) {
 
 	var tr Tracker
 	sentinelErr := errors.New("copy failed")
-	err := tr.Do(CopyRows, func() error {
+	err := tr.Do(t.Context(), CopyRows, func() error {
 		// The state is current while fn runs, so concurrent readers
 		// (status loggers, watchers) observe it.
 		require.Equal(t, CopyRows, tr.Get())
@@ -39,7 +44,7 @@ func TestTrackerDoRecordsDuration(t *testing.T) {
 	t.Parallel()
 
 	var tr Tracker
-	require.NoError(t, tr.Do(Checksum, func() error {
+	require.NoError(t, tr.Do(t.Context(), Checksum, func() error {
 		time.Sleep(20 * time.Millisecond)
 		return nil
 	}))
@@ -58,7 +63,7 @@ func TestTrackerBeginResetsRun(t *testing.T) {
 	var tr Tracker
 	tr.Begin()
 	first := tr.StartTime()
-	require.NoError(t, tr.Do(CopyRows, func() error {
+	require.NoError(t, tr.Do(t.Context(), CopyRows, func() error {
 		time.Sleep(10 * time.Millisecond)
 		return nil
 	}))
@@ -92,7 +97,7 @@ func TestTrackerRepeatedStatesAccumulate(t *testing.T) {
 
 	var tr Tracker
 	for range 2 {
-		require.NoError(t, tr.Do(Checksum, func() error {
+		require.NoError(t, tr.Do(t.Context(), Checksum, func() error {
 			time.Sleep(10 * time.Millisecond)
 			return nil
 		}))
@@ -104,7 +109,7 @@ func TestTrackerDoThenSetDoesNotDoubleCount(t *testing.T) {
 	t.Parallel()
 
 	var tr Tracker
-	require.NoError(t, tr.Do(CopyRows, func() error {
+	require.NoError(t, tr.Do(t.Context(), CopyRows, func() error {
 		time.Sleep(10 * time.Millisecond)
 		return nil
 	}))
@@ -120,7 +125,7 @@ func TestTrackerDoRecordsOnPanic(t *testing.T) {
 
 	var tr Tracker
 	require.Panics(t, func() {
-		_ = tr.Do(CutOver, func() error {
+		_ = tr.Do(t.Context(), CutOver, func() error {
 			time.Sleep(10 * time.Millisecond)
 			panic("cutover exploded")
 		})
@@ -137,9 +142,9 @@ func TestTrackerNestedDoAttributesToInnermost(t *testing.T) {
 
 	var tr Tracker
 	start := time.Now()
-	require.NoError(t, tr.Do(WaitingOnSentinelTable, func() error {
+	require.NoError(t, tr.Do(t.Context(), WaitingOnSentinelTable, func() error {
 		time.Sleep(10 * time.Millisecond)
-		return tr.Do(Checksum, func() error {
+		return tr.Do(t.Context(), Checksum, func() error {
 			time.Sleep(10 * time.Millisecond)
 			return nil
 		})
@@ -175,10 +180,220 @@ func TestTrackerConcurrentReaders(t *testing.T) {
 		})
 	}
 	for range 100 {
-		require.NoError(t, tr.Do(CopyRows, func() error { return nil }))
+		require.NoError(t, tr.Do(t.Context(), CopyRows, func() error { return nil }))
 		tr.Set(Checksum)
 	}
 	close(done)
 	wg.Wait()
 	require.Positive(t, tr.Duration(CopyRows))
+}
+
+type recordingWorkflowObserver struct {
+	mu       sync.Mutex
+	events   []WorkflowEvent
+	contexts []context.Context
+}
+
+func (o *recordingWorkflowObserver) ObserveWorkflow(ctx context.Context, event WorkflowEvent) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.contexts = append(o.contexts, ctx)
+	o.events = append(o.events, event)
+}
+
+func (o *recordingWorkflowObserver) snapshot() ([]WorkflowEvent, []context.Context) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]WorkflowEvent(nil), o.events...), append([]context.Context(nil), o.contexts...)
+}
+
+type workflowObserverFunc func(context.Context, WorkflowEvent)
+
+func (f workflowObserverFunc) ObserveWorkflow(ctx context.Context, event WorkflowEvent) {
+	f(ctx, event)
+}
+
+func TestTrackerDoEmitsOrderedAttempts(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(t.Context(), contextKey{}, "workflow")
+	observer := &recordingWorkflowObserver{}
+	var tr Tracker
+	tr.SetObserver(observer)
+
+	require.NoError(t, tr.Do(ctx, CopyRows, func() error { return nil }))
+	require.NoError(t, tr.Do(ctx, CopyRows, func() error { return nil }))
+
+	events, contexts := observer.snapshot()
+	require.Equal(t, []WorkflowEvent{
+		{State: CopyRows, Transition: WorkflowTransitionStarted},
+		{State: CopyRows, Transition: WorkflowTransitionFinished, Outcome: WorkflowOutcomeSucceeded},
+		{State: CopyRows, Transition: WorkflowTransitionStarted},
+		{State: CopyRows, Transition: WorkflowTransitionFinished, Outcome: WorkflowOutcomeSucceeded},
+	}, events)
+	require.Len(t, contexts, len(events))
+	for _, observedCtx := range contexts {
+		require.Equal(t, "workflow", observedCtx.Value(contextKey{}))
+	}
+}
+
+func TestTrackerDoClassifiesOutcomes(t *testing.T) {
+	failureErr := errors.New("failed")
+	for _, tt := range []struct {
+		name    string
+		context func() context.Context
+		err     error
+		want    WorkflowOutcome
+	}{
+		{
+			name:    "success",
+			context: t.Context,
+			want:    WorkflowOutcomeSucceeded,
+		},
+		{
+			name:    "failure",
+			context: t.Context,
+			err:     failureErr,
+			want:    WorkflowOutcomeFailed,
+		},
+		{
+			name:    "returned cancellation",
+			context: t.Context,
+			err:     fmt.Errorf("copy stopped: %w", context.Canceled),
+			want:    WorkflowOutcomeCancelled,
+		},
+		{
+			name: "cancelled runner context",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			err:  failureErr,
+			want: WorkflowOutcomeCancelled,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			observer := &recordingWorkflowObserver{}
+			var tr Tracker
+			tr.SetObserver(observer)
+			require.ErrorIs(t, tr.Do(tt.context(), Checksum, func() error {
+				return tt.err
+			}), tt.err)
+
+			events, _ := observer.snapshot()
+			require.Len(t, events, 2)
+			require.Equal(t, tt.want, events[1].Outcome)
+		})
+	}
+}
+
+func TestTrackerDoReportsPanicWithoutRecoveringIt(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	var tr Tracker
+	tr.SetObserver(observer)
+	panicValue := &struct{ message string }{message: "cutover exploded"}
+
+	require.PanicsWithValue(t, panicValue, func() {
+		_ = tr.Do(t.Context(), CutOver, func() error {
+			panic(panicValue)
+		})
+	})
+
+	events, _ := observer.snapshot()
+	require.Equal(t, []WorkflowEvent{
+		{State: CutOver, Transition: WorkflowTransitionStarted},
+		{State: CutOver, Transition: WorkflowTransitionFinished, Outcome: WorkflowOutcomeFailed},
+	}, events)
+}
+
+func TestTrackerDoReportsRuntimeGoexit(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	var tr Tracker
+	tr.SetObserver(observer)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		_ = tr.Do(t.Context(), ReverseWindow, func() error {
+			runtime.Goexit()
+			return nil
+		})
+	}()
+	<-done
+
+	events, _ := observer.snapshot()
+	require.Equal(t, []WorkflowEvent{
+		{State: ReverseWindow, Transition: WorkflowTransitionStarted},
+		{State: ReverseWindow, Transition: WorkflowTransitionFinished, Outcome: WorkflowOutcomeFailed},
+	}, events)
+}
+
+func TestTrackerDoPreservesLegacyNilPanic(t *testing.T) {
+	const childEnv = "SPIRIT_TEST_TRACKER_PANIC_NIL"
+	if os.Getenv(childEnv) == "1" {
+		var tr Tracker
+		tr.SetObserver(workflowObserverFunc(func(_ context.Context, event WorkflowEvent) {
+			if event.Transition == WorkflowTransitionFinished && event.Outcome == WorkflowOutcomeFailed {
+				fmt.Println("tracker-failed")
+			}
+		}))
+		_ = tr.Do(context.Background(), CutOver, func() error {
+			panic(nil)
+		})
+		fmt.Println("panic-was-swallowed")
+		return
+	}
+
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestTrackerDoPreservesLegacyNilPanic$")
+	cmd.Env = append(os.Environ(), "GODEBUG=panicnil=1", childEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "an unhandled legacy panic(nil) must still terminate the child")
+	require.Contains(t, string(output), "tracker-failed")
+	require.NotContains(t, string(output), "panic-was-swallowed")
+}
+
+func TestTrackerObserverPanicCannotChangeRunnerBehavior(t *testing.T) {
+	var tr Tracker
+	tr.SetObserver(workflowObserverFunc(func(context.Context, WorkflowEvent) {
+		panic("observer panic")
+	}))
+
+	require.NotPanics(t, func() {
+		require.NoError(t, tr.Do(t.Context(), CopyRows, func() error { return nil }))
+		tr.RecordCompletedWork(t.Context(), 3, 1)
+		tr.DurableMutation(t.Context())
+		tr.Terminal(t.Context(), WorkflowTerminalOwnershipAmbiguous)
+	})
+}
+
+func TestTrackerEvidenceIsTypedDeduplicatedAndResetPerRun(t *testing.T) {
+	observer := &recordingWorkflowObserver{}
+	var tr Tracker
+	tr.SetObserver(observer)
+	tr.Begin()
+
+	tr.RecordCompletedWork(t.Context(), 12, 3)
+	tr.DurableMutation(t.Context())
+	tr.DurableMutation(t.Context())
+	tr.Terminal(t.Context(), 0)
+	tr.Terminal(t.Context(), WorkflowTerminalOwnershipReverseFinalized)
+	tr.Terminal(t.Context(), WorkflowTerminalOwnershipAmbiguous)
+
+	events, _ := observer.snapshot()
+	require.Equal(t, []WorkflowEvent{
+		{
+			State:           CopyRows,
+			Totals:          WorkflowTotals{CompletedRows: 12, CompletedChunks: 3},
+			TotalsAvailable: true,
+		},
+		{DurableMutation: true},
+		{TerminalOwnership: WorkflowTerminalOwnershipReverseFinalized},
+	}, events)
+
+	tr.Begin()
+	tr.DurableMutation(t.Context())
+	tr.Terminal(t.Context(), WorkflowTerminalOwnershipAmbiguous)
+	events, _ = observer.snapshot()
+	require.Equal(t, WorkflowEvent{DurableMutation: true}, events[3])
+	require.Equal(t, WorkflowEvent{TerminalOwnership: WorkflowTerminalOwnershipAmbiguous}, events[4])
 }

--- a/pkg/status/workflow.go
+++ b/pkg/status/workflow.go
@@ -1,0 +1,102 @@
+package status
+
+import "context"
+
+// WorkflowTransition identifies whether a workflow state is beginning or ending.
+type WorkflowTransition uint8
+
+const (
+	WorkflowTransitionStarted WorkflowTransition = iota + 1
+	WorkflowTransitionFinished
+)
+
+func (t WorkflowTransition) String() string {
+	switch t {
+	case WorkflowTransitionStarted:
+		return "started"
+	case WorkflowTransitionFinished:
+		return "finished"
+	default:
+		return ""
+	}
+}
+
+// WorkflowOutcome is present only on a finished workflow state event.
+type WorkflowOutcome uint8
+
+const (
+	WorkflowOutcomeSucceeded WorkflowOutcome = iota + 1
+	WorkflowOutcomeFailed
+	WorkflowOutcomeCancelled
+)
+
+func (o WorkflowOutcome) String() string {
+	switch o {
+	case WorkflowOutcomeSucceeded:
+		return "succeeded"
+	case WorkflowOutcomeFailed:
+		return "failed"
+	case WorkflowOutcomeCancelled:
+		return "cancelled"
+	default:
+		return ""
+	}
+}
+
+// WorkflowTerminalOwnership identifies terminal ownership evidence that cannot
+// be inferred safely from an error alone.
+type WorkflowTerminalOwnership uint8
+
+const (
+	WorkflowTerminalOwnershipReverseFinalized WorkflowTerminalOwnership = iota + 1
+	WorkflowTerminalOwnershipAmbiguous
+)
+
+func (o WorkflowTerminalOwnership) String() string {
+	switch o {
+	case WorkflowTerminalOwnershipReverseFinalized:
+		return "reverse_finalized"
+	case WorkflowTerminalOwnershipAmbiguous:
+		return "ownership_ambiguous"
+	default:
+		return ""
+	}
+}
+
+func (o WorkflowTerminalOwnership) valid() bool {
+	return o == WorkflowTerminalOwnershipReverseFinalized || o == WorkflowTerminalOwnershipAmbiguous
+}
+
+// WorkflowTotals contains authoritative aggregate work completed by CopyRows.
+// Totals are terminal aggregates, never per-row or per-chunk notifications.
+type WorkflowTotals struct {
+	CompletedRows   uint64
+	CompletedChunks uint64
+}
+
+// WorkflowEvent is one typed workflow observation.
+//
+// State events set State and Transition. Finished state events also set Outcome.
+// Completed-work events set State to CopyRows, TotalsAvailable, and Totals while
+// leaving Transition unset. Evidence events set exactly one of DurableMutation
+// or TerminalOwnership and leave the state fields at their zero values.
+type WorkflowEvent struct {
+	State             State
+	Transition        WorkflowTransition
+	Outcome           WorkflowOutcome
+	TerminalOwnership WorkflowTerminalOwnership
+	DurableMutation   bool
+	Totals            WorkflowTotals
+	TotalsAvailable   bool
+}
+
+// WorkflowObserver receives synchronous workflow events in authoritative order.
+// Implementations must return promptly. Tracker isolates observer panics from
+// the runner; observers must provide their own synchronization if needed.
+type WorkflowObserver interface {
+	ObserveWorkflow(context.Context, WorkflowEvent)
+}
+
+type workflowObserverSlot struct {
+	observer WorkflowObserver
+}

--- a/pkg/status/workflow_test.go
+++ b/pkg/status/workflow_test.go
@@ -1,0 +1,24 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowVocabulary(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "started", WorkflowTransitionStarted.String())
+	require.Equal(t, "finished", WorkflowTransitionFinished.String())
+	require.Empty(t, WorkflowTransition(0).String())
+
+	require.Equal(t, "succeeded", WorkflowOutcomeSucceeded.String())
+	require.Equal(t, "failed", WorkflowOutcomeFailed.String())
+	require.Equal(t, "cancelled", WorkflowOutcomeCancelled.String())
+	require.Empty(t, WorkflowOutcome(0).String())
+
+	require.Equal(t, "reverse_finalized", WorkflowTerminalOwnershipReverseFinalized.String())
+	require.Equal(t, "ownership_ambiguous", WorkflowTerminalOwnershipAmbiguous.String())
+	require.Empty(t, WorkflowTerminalOwnership(0).String())
+}


### PR DESCRIPTION
## Summary

Replace runner-specific timing and inferred progress with one lifecycle contract owned by `status.Tracker`.

- `Tracker.Do(ctx, state, fn)` brackets every real migration, move, and datasync attempt and emits synchronous started/finished events.
- Observers receive explicit durable-mutation and terminal-ownership evidence independently from phase completion.
- Copy completion reports settled rows and chunks once from authoritative copier counters.
- Result-bearing forward-cutover callbacks preserve mutation truth even when a later error is returned.
- Ambiguous direct DDL, cutover callbacks, source renames, and reverse renames stop retrying and require manual ownership recovery.
- Reverse-window ownership is persisted so resumed runs retain authoritative terminal and durable-mutation semantics.

Observers are optional. With no observer attached, runners retain their existing behavior and do not query completed-work totals. The tracker remains zero-value ready; observer delivery is synchronous and panic-isolated, and callback state is copied before invocation so observers can safely replace or remove themselves.

## Design

This deliberately does not add a second workflow engine beside Spirit's status machine. `status.Tracker` remains the sole source of current state and timing; observation is a thin view of transitions and durable facts. Terminal evidence has its own event because reverse-finalized or ownership-ambiguous outcomes can be established after the final phase bracket closes.

Mutation and ownership ambiguity remain distinct facts. A result can require manual recovery without claiming that a durable write was confirmed.

## Rebased on main (2026-08-16)

This branch has been rebased onto `main`; two slices are no longer part of it because they landed independently:

- The retry row-accounting fix (`fix(dbconn): return committed retry row count`) merged as #1145 — commit dropped.
- The unbuffered copier was removed in #1140, so `feat(copier): expose completed work totals` now only touches the buffered copier. Its counters are also recorded from `CopyChunk`, the incremental copy entry point added since this branch was written, so the totals stay authoritative on both paths.

`copier.CompletedWorkReporter` is still an optional capability rather than a method on `Copier`. With one built-in implementation left it could be folded into the interface — happy to do that if you prefer it.

## Verification

- `go build ./... && go vet ./...`
- `go test -race -count=1 ./pkg/status ./pkg/copier ./pkg/sentinel`
- `MYSQL_DSN=... go test -race -count=1 ./pkg/migration ./pkg/move ./pkg/datasync` — green except `TestBufferedMigrationFailsGracefullyWithMinimalRBR` / `TestMoveFailsGracefullyWithMinimalRBR`, which fail identically on unmodified `main` locally (the sandbox user lacks `SESSION_VARIABLES_ADMIN`).
- `golangci-lint run` on the touched packages: 0 issues.

Supersedes the observer/lifecycle approach in #1111 and the runner-local timing design merged in #1118. It also consolidates the correctness slices previously proposed in #1112 through #1116.
