### PR TITLE
fix(dbconn): RetryableTransaction must not report rows from rolled-back attempts

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -192,6 +192,7 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 	)
 	for i := range config.MaxRetries {
 		func() {
+			var attemptRowsAffected int64
 			// Start a transaction
 			if trx, err = db.BeginTx(ctx, nil); err != nil {
 				return
@@ -267,13 +268,14 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 				// and that's absolutely fine!
 				count, errC := res.RowsAffected()
 				if errC == nil { // affectedRows is supported
-					rowsAffected += count
+					attemptRowsAffected += count
 				}
 			} // end for each statement
 			// Commit it!
 			if err = trx.Commit(); err != nil {
 				return
 			}
+			rowsAffected = attemptRowsAffected
 		}()
 		if isFatal { // don't retry loop if fatal
 			return rowsAffected, err

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -129,8 +129,16 @@ func TestRetryableTrx(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		rollbackErr <- trx.Rollback()
 	}()
-	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, config, "UPDATE test.dbexec SET colb=123 WHERE id = 1")
+	rowsAffected, err := RetryableTransaction(
+		t.Context(),
+		db,
+		ErrorOnDupKey,
+		config,
+		"UPDATE test.dbexec SET colb=colb+1 WHERE id = 2",
+		"UPDATE test.dbexec SET colb=123 WHERE id = 1",
+	)
 	require.NoError(t, err)
+	require.EqualValues(t, 2, rowsAffected, "rolled-back attempts must not contribute affected rows")
 	require.NoError(t, <-rollbackErr)
 	require.NoError(t, db.Close())
 
@@ -145,8 +153,16 @@ func TestRetryableTrx(t *testing.T) {
 	require.NoError(t, err)
 	_, err = trx.ExecContext(t.Context(), "SELECT * FROM test.dbexec WHERE id = 2 FOR UPDATE")
 	require.NoError(t, err)
-	_, err = RetryableTransaction(t.Context(), db, ErrorOnDupKey, config, "UPDATE test.dbexec SET colb=123 WHERE id = 2") // this will fail, since it times out and exhausts retries.
+	rowsAffected, err = RetryableTransaction(
+		t.Context(),
+		db,
+		ErrorOnDupKey,
+		config,
+		"UPDATE test.dbexec SET colb=colb+1 WHERE id = 1",
+		"UPDATE test.dbexec SET colb=123 WHERE id = 2",
+	) // this will fail, since it times out and exhausts retries.
 	require.Error(t, err)
+	require.Zero(t, rowsAffected, "rolled-back attempts must not report affected rows")
 	err = trx.Rollback() // now we can rollback.
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- `RetryableTransaction` accumulated `rowsAffected` across retry attempts in a shared variable, so a rolled-back attempt's affected-row count leaked into the total returned by a later successful attempt (or a final failed one).
- Track affected rows per attempt in a local variable, and only fold it into the running total after the transaction successfully commits.

Extracted from the `pkg/dbconn` slice of #1137 as a small, independent fix so it can land ahead of that larger PR.

## Test plan
- [x] `go test ./pkg/dbconn/...` (against local MySQL)
- [x] `go build ./...`
- [x] `go vet ./...`