### PR TITLE
migrate: remove --table and --alter in favor of --statement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Spirit is designed for **speed** — it is multi-threaded in both row-copying an
 cd cmd/spirit && go build
 
 # Run a schema change
-./spirit migrate --host=<host> --username=<user> --password=<pass> --database=<db> --table=<table> --alter="<alter statement>"
+./spirit migrate --host=<host> --username=<user> --password=<pass> --database=<db> --statement="<ddl statement>"
 
 # Other subcommands
 ./spirit move --help
@@ -126,13 +126,11 @@ assert.NoError(t, m.Close())
 For tests that need to call `Migration.Run()` directly (e.g., testing error paths, replica DSN, or the `Migration` struct API), use `NewTestMigration`:
 
 ```go
-m := NewTestMigration(t, WithThreads(1))
-m.Table = "mytable"
-m.Alter = "ENGINE=InnoDB"
+m := NewTestMigration(t, WithThreads(1), WithStatement("ALTER TABLE mytable ENGINE=InnoDB"))
 require.NoError(t, m.Run())
 ```
 
-Available options: `WithThreads(n)`, `WithTargetChunkTime(d)`, `WithBuffered(b)`, `WithTable(name)`, `WithAlter(stmt)`, `WithStatement(sql)`, `WithTestThrottler()`, `WithDeferCutOver()`, `WithSkipDropAfterCutover()`, `WithDBName(name)`, `WithRespectSentinel()`, `WithHost(host)`, `WithReplicaDSN(dsn)`, `WithReplicaMaxLag(d)`, `WithConfFile(t, content)`.
+Available options: `WithThreads(n)`, `WithWriteThreads(n)`, `WithAutoscaling()`, `WithStatement(sql)`, `WithTargetChunkTime(d)`, `WithTestThrottler()`, `WithDeferCutOver()`, `WithDBName(name)`, `WithRespectSentinel()`, `WithHost(host)`, `WithReplicaDSN(dsn)`, `WithReplicaMaxLag(d)`, `WithSkipDropAfterCutover()`.
 
 **General test patterns:**
 - Integration tests connect to real MySQL — there are no mocked database tests for core logic

--- a/compose/replication-tls/test-replication-tls-custom.sh
+++ b/compose/replication-tls/test-replication-tls-custom.sh
@@ -205,8 +205,7 @@ main() {
       --password="rootpassword" \
       --database="test" \
       --tls-mode="DISABLED" \
-      --table="users" \
-      --alter="CHANGE COLUMN name name VARCHAR(150) NOT NULL" \
+      --statement="ALTER TABLE users CHANGE COLUMN name name VARCHAR(150) NOT NULL" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3411)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -235,8 +234,7 @@ main() {
       --database="test" \
       --tls-mode="REQUIRED" \
       --tls-ca="mysql-certs/custom-ca.pem" \
-      --table="users" \
-      --alter="MODIFY COLUMN id BIGINT AUTO_INCREMENT" \
+      --statement="ALTER TABLE users MODIFY COLUMN id BIGINT AUTO_INCREMENT" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3411)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -258,8 +256,7 @@ main() {
       --database="test" \
       --tls-mode="VERIFY_CA" \
       --tls-ca="mysql-certs/custom-ca.pem" \
-      --table="users" \
-      --alter="MODIFY COLUMN name VARCHAR(100) CHARACTER SET latin1" \
+      --statement="ALTER TABLE users MODIFY COLUMN name VARCHAR(100) CHARACTER SET latin1" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3411)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -282,8 +279,7 @@ main() {
       --database="test" \
       --tls-mode="VERIFY_IDENTITY" \
       --tls-ca="mysql-certs/custom-ca.pem" \
-      --table="users" \
-      --alter="CHANGE COLUMN updated_at updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" \
+      --statement="ALTER TABLE users CHANGE COLUMN updated_at updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3411)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -312,8 +308,7 @@ main() {
       --database="test" \
       --tls-mode="PREFERRED" \
       --tls-ca="mysql-certs/custom-ca.pem" \
-      --table="users" \
-      --alter="ADD INDEX idx_name_email (name, email)" \
+      --statement="ALTER TABLE users ADD INDEX idx_name_email (name, email)" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3411)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -336,8 +331,7 @@ main() {
       --database="test" \
       --tls-mode="VERIFY_IDENTITY" \
       --tls-ca="mysql-certs/custom-ca.pem" \
-      --table="users" \
-      --alter="MODIFY COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP" \
+      --statement="ALTER TABLE users MODIFY COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3411)/test?tls=false" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -366,8 +360,7 @@ main() {
       --database="test" \
       --tls-mode="VERIFY_IDENTITY" \
       --tls-ca="mysql-certs/custom-ca.pem" \
-      --table="users" \
-      --alter="CHANGE COLUMN created_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP" \
+      --statement="ALTER TABLE users CHANGE COLUMN created_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3411)/test?tls=skip-verify" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s

--- a/compose/replication-tls/test-replication-tls-mixed.sh
+++ b/compose/replication-tls/test-replication-tls-mixed.sh
@@ -189,8 +189,7 @@ main() {
       --password="rootpassword" \
       --database="test" \
       --tls-mode="DISABLED" \
-      --table="users" \
-      --alter="CHANGE COLUMN name name VARCHAR(150) NOT NULL" \
+      --statement="ALTER TABLE users CHANGE COLUMN name name VARCHAR(150) NOT NULL" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3421)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -218,8 +217,7 @@ main() {
       --password="rootpassword" \
       --database="test" \
       --tls-mode="REQUIRED" \
-      --table="users" \
-      --alter="MODIFY COLUMN id BIGINT AUTO_INCREMENT" \
+      --statement="ALTER TABLE users MODIFY COLUMN id BIGINT AUTO_INCREMENT" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3421)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -249,8 +247,7 @@ main() {
       --password="rootpassword" \
       --database="test" \
       --tls-mode="PREFERRED" \
-      --table="users" \
-      --alter="MODIFY COLUMN name VARCHAR(100) CHARACTER SET latin1" \
+      --statement="ALTER TABLE users MODIFY COLUMN name VARCHAR(100) CHARACTER SET latin1" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3421)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -280,8 +277,7 @@ main() {
       --password="rootpassword" \
       --database="test" \
       --tls-mode="REQUIRED" \
-      --table="users" \
-      --alter="CHANGE COLUMN updated_at updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" \
+      --statement="ALTER TABLE users CHANGE COLUMN updated_at updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3421)/test?tls=false" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -310,8 +306,7 @@ main() {
       --password="rootpassword" \
       --database="test" \
       --tls-mode="REQUIRED" \
-      --table="users" \
-      --alter="ADD INDEX idx_name_email (name, email)" \
+      --statement="ALTER TABLE users ADD INDEX idx_name_email (name, email)" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3421)/test?tls=preferred" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -340,8 +335,7 @@ main() {
       --password="rootpassword" \
       --database="test" \
       --tls-mode="REQUIRED" \
-      --table="users" \
-      --alter="CHANGE COLUMN created_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP" \
+      --statement="ALTER TABLE users CHANGE COLUMN created_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3421)/test?tls=skip-verify" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s

--- a/compose/replication-tls/test-replication-tls.sh
+++ b/compose/replication-tls/test-replication-tls.sh
@@ -155,8 +155,7 @@ main() {
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="REQUIRED" \
-      --table="test_table" \
-      --alter="MODIFY COLUMN id BIGINT AUTO_INCREMENT" \
+      --statement="ALTER TABLE test_table MODIFY COLUMN id BIGINT AUTO_INCREMENT" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -179,8 +178,7 @@ main() {
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="DISABLED" \
-      --table="test_table" \
-      --alter="CHANGE COLUMN name name VARCHAR(150) NOT NULL" \
+      --statement="ALTER TABLE test_table CHANGE COLUMN name name VARCHAR(150) NOT NULL" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -207,8 +205,7 @@ main() {
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="SKIP_VERIFY" \
-      --table="test_table" \
-      --alter="MODIFY COLUMN name VARCHAR(100) CHARACTER SET latin1" \
+      --statement="ALTER TABLE test_table MODIFY COLUMN name VARCHAR(100) CHARACTER SET latin1" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -231,8 +228,7 @@ main() {
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_CA" \
       --tls-ca="mysql-certs/combined-ca.pem" \
-      --table="test_table" \
-      --alter="CHANGE COLUMN created_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" \
+      --statement="ALTER TABLE test_table CHANGE COLUMN created_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -263,8 +259,7 @@ main() {
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_IDENTITY" \
-      --table="test_table" \
-      --alter="ADD INDEX idx_name_email (name, created_at)" \
+      --statement="ALTER TABLE test_table ADD INDEX idx_name_email (name, created_at)" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -291,8 +286,7 @@ main() {
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="PREFERRED" \
-      --table="test_table" \
-      --alter="ADD INDEX idx_preferred_test (created_at)" \
+      --statement="ALTER TABLE test_table ADD INDEX idx_preferred_test (created_at)" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -314,8 +308,7 @@ main() {
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="REQUIRED" \
-      --table="test_table" \
-      --alter="MODIFY COLUMN name TEXT" \
+      --statement="ALTER TABLE test_table MODIFY COLUMN name TEXT" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test?tls=false" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s
@@ -336,8 +329,7 @@ main() {
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="SKIP_VERIFY" \
-      --table="test_table" \
-      --alter="ADD INDEX idx_created_at (created_at)" \
+      --statement="ALTER TABLE test_table ADD INDEX idx_created_at (created_at)" \
       --replica-dsn="root:rootpassword@tcp(127.0.0.1:3401)/test?tls=skip-verify" \
       --replica-max-lag=10s \
       --lock-wait-timeout=2s

--- a/compose/tls/test-tls-custom-certs.sh
+++ b/compose/tls/test-tls-custom-certs.sh
@@ -34,8 +34,7 @@ echo "----------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="REQUIRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_required VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_required VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: VERIFY_CA (should work with custom CA)"
@@ -47,8 +46,7 @@ echo "----------------------------------------------------------"
   --database="$MYSQL_DATABASE" \
   --tls-mode="VERIFY_CA" \
   --tls-ca="mysql-certs/custom-ca.pem" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_verify_ca VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_ca VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: VERIFY_IDENTITY with IP (should work - custom cert has IP SANs)"
@@ -60,8 +58,7 @@ echo "--------------------------------------------------------------------------
   --database="$MYSQL_DATABASE" \
   --tls-mode="VERIFY_IDENTITY" \
   --tls-ca="mysql-certs/custom-ca.pem" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_verify_identity_ip VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_ip VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: VERIFY_IDENTITY with hostname (should work - custom cert has DNS SANs)"
@@ -73,8 +70,7 @@ echo "--------------------------------------------------------------------------
   --database="$MYSQL_DATABASE" \
   --tls-mode="VERIFY_IDENTITY" \
   --tls-ca="mysql-certs/custom-ca.pem" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_verify_identity_hostname VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_hostname VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: PREFERRED (should use TLS when available)"
@@ -85,8 +81,7 @@ echo "-------------------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="PREFERRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_preferred_tls VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_preferred_tls VARCHAR(50)"
 
 echo ""
 echo "✅ Custom Certificate TLS Testing Complete!"

--- a/compose/tls/test-tls-disabled.sh
+++ b/compose/tls/test-tls-disabled.sh
@@ -28,8 +28,7 @@ echo "------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="DISABLED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_disabled VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_disabled VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: PREFERRED (should fallback to plain)"
@@ -40,8 +39,7 @@ echo "---------------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="PREFERRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_preferred VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_preferred VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: REQUIRED (should fail)"
@@ -53,8 +51,7 @@ set +e  # Allow this to fail
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="REQUIRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_required VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_required VARCHAR(50)"
 set -e
 
 echo ""

--- a/compose/tls/test-tls-enabled-modes.sh
+++ b/compose/tls/test-tls-enabled-modes.sh
@@ -30,8 +30,7 @@ set +e  # Allow this to fail
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="DISABLED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_disabled VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_disabled VARCHAR(50)"
 DISABLED_RESULT=$?
 set -e
 
@@ -50,8 +49,7 @@ echo "------------------------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="REQUIRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_required VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_required VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: VERIFY_CA (should work with server certificates)"
@@ -65,8 +63,7 @@ if [ -f "mysql-certs/ca.pem" ]; then
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_CA" \
       --tls-ca="mysql-certs/ca.pem" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_ca VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_ca VARCHAR(50)"
 else
     echo "⚠️  No MySQL CA certificate found, testing without custom certificate"
     ./spirit migrate \
@@ -75,8 +72,7 @@ else
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_CA" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_ca VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_ca VARCHAR(50)"
 fi
 
 echo ""
@@ -92,8 +88,7 @@ if [ -f "mysql-certs/ca.pem" ]; then
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_IDENTITY" \
       --tls-ca="mysql-certs/ca.pem" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
     IP_RESULT=$?
     set -e
     
@@ -116,8 +111,7 @@ if [ -f "mysql-certs/ca.pem" ]; then
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_IDENTITY" \
       --tls-ca="mysql-certs/ca.pem" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_identity VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity VARCHAR(50)"
     HOSTNAME_RESULT=$?
     set -e
     
@@ -137,8 +131,7 @@ else
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_IDENTITY" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
     IP_RESULT=$?
     set -e
     
@@ -151,8 +144,7 @@ else
           --password="$MYSQL_PASSWORD" \
           --database="$MYSQL_DATABASE" \
           --tls-mode="VERIFY_IDENTITY" \
-          --table="test_table" \
-          --alter="ADD COLUMN test_col_verify_identity_hostname_fail VARCHAR(50)" 2>/dev/null || echo "✅ VERIFY_IDENTITY with hostname also failed (expected - MySQL needs proper certificate configuration)"
+          --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_hostname_fail VARCHAR(50)" 2>/dev/null || echo "✅ VERIFY_IDENTITY with hostname also failed (expected - MySQL needs proper certificate configuration)"
     fi
 fi
 
@@ -165,8 +157,7 @@ echo "-------------------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="PREFERRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_preferred_tls VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_preferred_tls VARCHAR(50)"
 
 echo ""
 echo "✅ TLS-Enabled Mode Testing Complete!"

--- a/compose/tls/test-tls-enabled.sh
+++ b/compose/tls/test-tls-enabled.sh
@@ -30,8 +30,7 @@ set +e  # Allow this to fail
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="DISABLED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_disabled VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_disabled VARCHAR(50)"
 DISABLED_RESULT=$?
 set -e
 
@@ -50,8 +49,7 @@ echo "------------------------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="REQUIRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_required VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_required VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: VERIFY_CA (should work with server certificates)"
@@ -65,8 +63,7 @@ if [ -f "mysql-certs/ca.pem" ]; then
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_CA" \
       --tls-ca="mysql-certs/ca.pem" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_ca VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_ca VARCHAR(50)"
 else
     echo "⚠️  No MySQL CA certificate found, testing without custom certificate"
     ./spirit migrate \
@@ -75,8 +72,7 @@ else
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_CA" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_ca VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_ca VARCHAR(50)"
 fi
 
 echo ""
@@ -92,8 +88,7 @@ if [ -f "mysql-certs/ca.pem" ]; then
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_IDENTITY" \
       --tls-ca="mysql-certs/ca.pem" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
     IP_RESULT=$?
     set -e
     
@@ -116,8 +111,7 @@ if [ -f "mysql-certs/ca.pem" ]; then
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_IDENTITY" \
       --tls-ca="mysql-certs/ca.pem" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_identity VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity VARCHAR(50)"
     HOSTNAME_RESULT=$?
     set -e
     
@@ -137,8 +131,7 @@ else
       --password="$MYSQL_PASSWORD" \
       --database="$MYSQL_DATABASE" \
       --tls-mode="VERIFY_IDENTITY" \
-      --table="test_table" \
-      --alter="ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
+      --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_ip_fail VARCHAR(50)"
     IP_RESULT=$?
     set -e
     
@@ -151,8 +144,7 @@ else
           --password="$MYSQL_PASSWORD" \
           --database="$MYSQL_DATABASE" \
           --tls-mode="VERIFY_IDENTITY" \
-          --table="test_table" \
-          --alter="ADD COLUMN test_col_verify_identity_hostname_fail VARCHAR(50)" 2>/dev/null || echo "✅ VERIFY_IDENTITY with hostname also failed (expected - MySQL needs proper certificate configuration)"
+          --statement="ALTER TABLE test_table ADD COLUMN test_col_verify_identity_hostname_fail VARCHAR(50)" 2>/dev/null || echo "✅ VERIFY_IDENTITY with hostname also failed (expected - MySQL needs proper certificate configuration)"
     fi
 fi
 
@@ -165,8 +157,7 @@ echo "-------------------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="PREFERRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_preferred_tls VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_preferred_tls VARCHAR(50)"
 
 echo ""
 echo "✅ TLS-Enabled Mode Testing Complete!"

--- a/compose/tls/test-tls-modes.sh
+++ b/compose/tls/test-tls-modes.sh
@@ -28,8 +28,7 @@ echo "------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="DISABLED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_disabled VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_disabled VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: PREFERRED (should fallback to plain)"
@@ -40,8 +39,7 @@ echo "---------------------------------------------------------"
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="PREFERRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_preferred VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_preferred VARCHAR(50)"
 
 echo ""
 echo "🔍 Testing TLS Mode: REQUIRED (should fail)"
@@ -53,8 +51,7 @@ set +e  # Allow this to fail
   --password="$MYSQL_PASSWORD" \
   --database="$MYSQL_DATABASE" \
   --tls-mode="REQUIRED" \
-  --table="test_table" \
-  --alter="ADD COLUMN test_col_required VARCHAR(50)"
+  --statement="ALTER TABLE test_table ADD COLUMN test_col_required VARCHAR(50)"
 set -e
 
 echo ""

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -64,6 +64,12 @@ Operationally, this means:
 - If you must change Spirit versions, let the in-flight migration finish first, or accept the lost progress and start fresh with the new version.
 - For long-running migrations that span planned binary upgrades, plan to drain the migration before the upgrade window.
 
+##### Upgrading from a version with `--table`/`--alter`
+
+Resume requires the statement text to match the checkpoint exactly. Versions that still had `--table` and `--alter` stored the statement they composed from that pair (``ALTER TABLE `t` <alter>``, with the table name back-quoted), so a migration started on such a version will **not** resume once you upgrade: the mismatch is treated as definitive and Spirit starts a fresh copy, discarding the checkpoint and the `_new` table.
+
+Drain any in-flight migrations before upgrading past the release that removed those flags.
+
 ### checksum-yield-timeout
 
 - Type: Duration
@@ -256,6 +262,8 @@ When set to `true`, Spirit will keep the old table (renamed to `_<table>_old`) a
 `--statement` is the only way to tell Spirit what change to make. It accepts most DDL statements, including `CREATE TABLE`, `ALTER TABLE`, `CREATE INDEX`, `RENAME TABLE` and `DROP TABLE`. Others such as `DROP INDEX` are _not_ supported and should be rewritten as `ALTER TABLE` statements.
 
 The table name is taken from the statement itself. If it is qualified (`` `schema`.`table` ``) the schema must match `--database`.
+
+`--statement` replaced the earlier `--table` and `--alter` pair, which has been removed. Because resume matches on the exact statement text, migrations started before that removal will not resume — see [Upgrading from a version with `--table`/`--alter`](#upgrading-from-a-version-with---table--alter).
 
 You can also send multiple `ALTER TABLE` statements at once, for example: `--statement="ALTER TABLE t1 CHARSET=utf8mb4; ALTER TABLE t2 CHARSET=utf8mb4;"` All of these statements will cutover atomically, which is useful when you are changing charsets or collations since if you were to perform these alters sequentially it may cause performance issues due to datatype mismatches in joins.
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -8,12 +8,11 @@ Basic usage:
 
 ```bash
 spirit migrate --host mydb:3306 --username root --password secret \
-               --database mydb --table users --alter "ADD COLUMN email VARCHAR(255)"
+               --database mydb --statement "ALTER TABLE users ADD COLUMN email VARCHAR(255)"
 ```
 
 ## Configuration
 
-- [alter](#alter)
 - [checkpoint-max-age](#checkpoint-max-age)
 - [checksum-yield-timeout](#checksum-yield-timeout)
 - [conf](#conf)
@@ -29,7 +28,6 @@ spirit migrate --host mydb:3306 --username root --password secret \
 - [replica-max-lag](#replica-max-lag)
 - [skip-drop-after-cutover](#skip-drop-after-cutover)
 - [statement](#statement)
-- [table](#table)
 - [target-chunk-time](#target-chunk-time)
 - [target-chunk-size](#target-chunk-size)
 - [threads](#threads)
@@ -41,16 +39,6 @@ spirit migrate --host mydb:3306 --username root --password secret \
   - [VERIFY\_CA](#verify_ca)
   - [VERIFY\_IDENTITY](#verify_identity)
 - [username](#username)
-
-### alter
-
-- Type: String
-- Default value: ``
-- Examples: `add column foo int`, `add index foo (bar)`
-
-The alter table command to perform. The default value is a _null alter table_, which can be useful for testing.
-
-See also: `--statement`.
 
 ### checkpoint-max-age
 
@@ -99,8 +87,8 @@ For most migrations the default of `24h` is appropriate. You may want to lower t
 ```bash
 # Yield every 4 hours to limit HLL growth
 spirit migrate --checksum-yield-timeout=4h \
-       --host mydb:3306 --database mydb --table large_table \
-       --alter "ADD INDEX idx_foo (foo)"
+       --host mydb:3306 --database mydb \
+       --statement "ALTER TABLE large_table ADD INDEX idx_foo (foo)"
 ```
 
 ### conf
@@ -263,9 +251,11 @@ When set to `true`, Spirit will keep the old table (renamed to `_<table>_old`) a
 ### statement
 
 - Type: String
-- Default value: ``
+- Required
 
-Spirit accepts either a pair of `--table` and `--alter` arguments or a `--statement` argument. When using `--statement` you can send most DDL statements to Spirit, including `CREATE TABLE`, `ALTER TABLE`, `CREATE INDEX`, `RENAME TABLE` and `DROP TABLE`. Others such as `DROP INDEX` are _not_ supported and should be rewritten as `ALTER TABLE` statements.
+`--statement` is the only way to tell Spirit what change to make. It accepts most DDL statements, including `CREATE TABLE`, `ALTER TABLE`, `CREATE INDEX`, `RENAME TABLE` and `DROP TABLE`. Others such as `DROP INDEX` are _not_ supported and should be rewritten as `ALTER TABLE` statements.
+
+The table name is taken from the statement itself. If it is qualified (`` `schema`.`table` ``) the schema must match `--database`.
 
 You can also send multiple `ALTER TABLE` statements at once, for example: `--statement="ALTER TABLE t1 CHARSET=utf8mb4; ALTER TABLE t2 CHARSET=utf8mb4;"` All of these statements will cutover atomically, which is useful when you are changing charsets or collations since if you were to perform these alters sequentially it may cause performance issues due to datatype mismatches in joins.
 
@@ -274,13 +264,6 @@ There are some restrictions to `--statement`:
 - When sending multiple statements, all statements must be `ALTER TABLE` statements.
 - When sending multiple statements, the `INSTANT` and `INPLACE` optimizations will be skipped. This means that metadata-only changes that would execute instantly if submitted alone will require a full table copy.
 - When sending multiple statements, all statements must operate on tables in the same underlying database (aka schema).
-
-### table
-
-- Type: String
-- Default value: ``
-
-The table that the schema change will be performed on.
 
 ### target-chunk-time
 
@@ -484,8 +467,7 @@ spirit migrate --tls-mode PREFERRED \
        --username admin \
        --password mypassword \
        --database production \
-       --table users \
-       --alter "ADD COLUMN last_login_ip VARCHAR(45) AFTER last_login" \
+       --statement "ALTER TABLE users ADD COLUMN last_login_ip VARCHAR(45) AFTER last_login" \
        --threads 8
 ```
 **Result**: Automatically uses TLS for RDS hosts with embedded certificates, optional for others.
@@ -499,8 +481,7 @@ spirit migrate --tls-mode REQUIRED \
        --username staging_user \
        --password staging_pass \
        --database inventory \
-       --table products \
-       --alter "ADD COLUMN supplier_notes JSON AFTER supplier_id" \
+       --statement "ALTER TABLE products ADD COLUMN supplier_notes JSON AFTER supplier_id" \
        --threads 6
 ```
 **Result**: TLS encryption required, but accepts self-signed or invalid certificates.
@@ -515,8 +496,7 @@ spirit migrate --tls-mode VERIFY_CA \
        --username app_user \
        --password app_password \
        --database analytics \
-       --table events \
-       --alter "ADD COLUMN event_metadata JSON AFTER event_type" \
+       --statement "ALTER TABLE events ADD COLUMN event_metadata JSON AFTER event_type" \
        --threads 4
 ```
 **Result**: Verifies certificate against custom CA bundle but allows IP addresses/hostname mismatches.
@@ -528,8 +508,7 @@ spirit migrate --tls-mode VERIFY_CA \
        --username internal_user \
        --password internal_pass \
        --database hr_system \
-       --table employees \
-       --alter "ADD COLUMN emergency_contact VARCHAR(255) AFTER phone_number" \
+       --statement "ALTER TABLE employees ADD COLUMN emergency_contact VARCHAR(255) AFTER phone_number" \
        --threads 2
 ```
 **Result**: Uses embedded RDS certificate bundle as fallback for certificate verification.
@@ -544,8 +523,7 @@ spirit migrate --tls-mode VERIFY_IDENTITY \
        --username secure_user \
        --password very_secure_password \
        --database financial \
-       --table transactions \
-       --alter "ADD COLUMN fraud_score DECIMAL(5,4) AFTER amount" \
+       --statement "ALTER TABLE transactions ADD COLUMN fraud_score DECIMAL(5,4) AFTER amount" \
        --threads 8
 ```
 **Result**: Full TLS verification including hostname matching - maximum security. Custom certificate takes precedence over RDS auto-detection.
@@ -557,8 +535,7 @@ spirit migrate --tls-mode VERIFY_IDENTITY \
        --username rds_admin \
        --password rds_password \
        --database customer_data \
-       --table profiles \
-       --alter "ADD COLUMN gdpr_consent_date DATETIME AFTER created_at" \
+       --statement "ALTER TABLE profiles ADD COLUMN gdpr_consent_date DATETIME AFTER created_at" \
        --threads 10
 ```
 **Result**: Uses embedded RDS certificate with full verification for RDS hostname.

--- a/pkg/dbconn/sqlescape/utils.go
+++ b/pkg/dbconn/sqlescape/utils.go
@@ -99,7 +99,7 @@ func EscapeIdentifier(identifier string) string {
 
 // RawSQL marks a string as trusted raw SQL for the %r verb. Converting a
 // value to RawSQL is an explicit assertion that it is safe to execute
-// verbatim (e.g. the operator's own --alter / --statement text): %r performs
+// verbatim (e.g. the operator's own --statement text): %r performs
 // no quoting and no format interpretation. The conversion is deliberately
 // required — a plain string is rejected — so that `grep -rn 'RawSQL('` is a
 // complete audit list of every raw splice in the tree.

--- a/pkg/migration/ddl_test.go
+++ b/pkg/migration/ddl_test.go
@@ -81,7 +81,7 @@ func TestUnsupportedClauseRejectedBeforeDDL(t *testing.T) {
 		return count > 0
 	}
 
-	// --alter path: a trailing ALGORITHM= clause must fail fast.
+	// Composed ALTER TABLE: a trailing ALGORITHM= clause must fail fast.
 	m := NewTestRunner(t, "rejectalgorithm", "ADD COLUMN c INT, ALGORITHM=INPLACE", WithThreads(1))
 	err := m.Run(t.Context())
 	require.Error(t, err)
@@ -91,7 +91,7 @@ func TestUnsupportedClauseRejectedBeforeDDL(t *testing.T) {
 	require.NoError(t, m.Close())
 	require.False(t, columnExists("c")) // no DDL may have been executed
 
-	// --statement path: ALGORITHM= and LOCK= must also fail fast.
+	// Raw statement: ALGORITHM= and LOCK= must also fail fast.
 	m = NewTestRunnerFromStatement(t, "ALTER TABLE rejectalgorithm ADD COLUMN d INT, ALGORITHM=COPY, LOCK=SHARED", WithThreads(1))
 	err = m.Run(t.Context())
 	require.Error(t, err)

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/checksum"
-	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/migration/check"
-	"github.com/block/spirit/pkg/parser"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
@@ -39,8 +37,6 @@ type Migration struct {
 	Password     *string `name:"password" help:"Password" optional:""`
 	Database     string  `name:"database" help:"Database" optional:""`
 	ConfFile     string  `name:"conf" help:"MySQL conf file" optional:"" type:"existingfile"`
-	Table        string  `name:"table" help:"Table" optional:""`
-	Alter        string  `name:"alter" help:"The alter statement to run on the table" optional:""`
 	Threads      int     `name:"threads" help:"Number of concurrent threads for copy and checksum tasks. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
 	WriteThreads int     `name:"write-threads" help:"Number of concurrent apply (write) threads. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
 
@@ -70,7 +66,7 @@ type Migration struct {
 	LockWaitTimeout      time.Duration `name:"lock-wait-timeout" help:"The DDL lock_wait_timeout required for checksum and cutover" optional:"" default:"30s"`
 	SkipDropAfterCutover bool          `name:"skip-drop-after-cutover" help:"Keep old table after completing cutover" optional:"" default:"false"`
 	DeferCutOver         bool          `name:"defer-cutover" help:"Defer cutover (and checksum) until sentinel table is dropped" optional:"" default:"false"`
-	Statement            string        `name:"statement" help:"The SQL statement to run (replaces --table and --alter)" optional:"" default:""`
+	Statement            string        `name:"statement" help:"The SQL statement to run" required:""`
 
 	// TLS Configuration
 	TLSMode            string `name:"tls-mode" help:"TLS connection mode (case insensitive): DISABLED, PREFERRED (default), REQUIRED, VERIFY_CA, VERIFY_IDENTITY" optional:""`
@@ -136,10 +132,8 @@ func (m *Migration) Run() error {
 }
 
 // normalizeOptions does some validation and sets defaults.
-// for example, it validates that only --statement or --table and --alter are specified,
-// and when --statement is not specified, it generates it
-// so the rest of the code can use --statement as the canonical
-// source of truth for what's happening.
+// --statement is the only way to describe the change, and it is the canonical
+// source of truth for the rest of the code.
 func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, err error) {
 	if m.TargetChunkTime == 0 {
 		m.TargetChunkTime = table.ChunkerDefaultTarget
@@ -177,49 +171,23 @@ func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, er
 		return nil, err
 	}
 
-	if m.Statement != "" { // statement is specified
-		if m.Table != "" || m.Alter != "" {
-			return nil, errors.New("only --statement or --table and --alter can be specified")
+	if m.Statement == "" {
+		return nil, errors.New("--statement is required")
+	}
+	// extract the table and alter from the statement.
+	// if it is a CREATE INDEX statement, we rewrite it to an alter statement.
+	// This also returns the StmtNode.
+	stmts, err = statement.New(m.Statement)
+	if err != nil {
+		// The error could be a parser error, or it might be something
+		// specific like mixed ALTER + non alter statements.
+		return nil, err
+	}
+	for _, stmt := range stmts {
+		if stmt.Schema != "" && stmt.Schema != m.Database {
+			return nil, errors.New("schema name in statement (`schema`.`table`) does not match --database")
 		}
-		// extract the table and alter from the statement.
-		// if it is a CREATE INDEX statement, we rewrite it to an alter statement.
-		// This also returns the StmtNode.
-		stmts, err = statement.New(m.Statement)
-		if err != nil {
-			// The error could be a parser error, or it might be something
-			// specific like mixed ALTER + non alter statements.
-			return nil, err
-		}
-		for _, stmt := range stmts {
-			if stmt.Schema != "" && stmt.Schema != m.Database {
-				return nil, errors.New("schema name in statement (`schema`.`table`) does not match --database")
-			}
-			stmt.Schema = m.Database
-		}
-	} else { // --alter and --table are specified
-		if m.Table == "" {
-			return nil, errors.New("table name is required")
-		}
-		if m.Alter == "" {
-			return nil, errors.New("alter statement is required")
-		}
-		// Trim whitespace and remove trailing semicolon. Without this, the attemptInstantDDL and attemptInplaceDDL functions will fail.
-		m.Alter = strings.TrimSpace(m.Alter)
-		m.Alter = strings.TrimSuffix(m.Alter, ";")
-		fullStatement := fmt.Sprintf("ALTER TABLE %s %s", sqlescape.EscapeIdentifier(m.Table), m.Alter)
-		m.Statement = fullStatement // used in resume from checkpoint
-		p := parser.New()
-		stmtNodes, _, err := p.Parse(fullStatement, "", "")
-		if err != nil {
-			return nil, errors.New("could not parse SQL statement: " + fullStatement)
-		}
-		stmts = append(stmts, &statement.AbstractStatement{
-			Schema:    m.Database,
-			Table:     m.Table,
-			Alter:     m.Alter,
-			Statement: fullStatement,
-			StmtNode:  &stmtNodes[0],
-		})
+		stmt.Schema = m.Database
 	}
 	return stmts, err
 }

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -85,6 +85,13 @@ func TestMissingStatement(t *testing.T) {
 	err = m.Run()
 	require.Error(t, err)
 	require.ErrorContains(t, err, "not a supported statement type")
+
+	// An ALTER TABLE that does not say what to alter. MySQL rejects this as a
+	// syntax error; our parser accepts it, so it is rejected downstream.
+	m = NewTestMigration(t, WithStatement("ALTER TABLE t1missing"))
+	err = m.Run()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "does not specify any changes")
 }
 
 func TestBadDatabaseCredentials(t *testing.T) {

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -71,20 +71,20 @@ func TestE2EExplicitAutoIncrementInAlter(t *testing.T) {
 	require.Equal(t, int64(5000), insertedID, "User-specified AUTO_INCREMENT=5000 should be preserved")
 }
 
-func TestMissingAlter(t *testing.T) {
+func TestMissingStatement(t *testing.T) {
 	t.Parallel()
-	testutils.NewTestTable(t, "t1missing", `CREATE TABLE t1missing (
-		id int(11) NOT NULL AUTO_INCREMENT,
-		name varchar(255) NOT NULL,
-		PRIMARY KEY (id)
-	)`)
-	// Deliberately exercises the legacy --table/--alter path: an empty alter
-	// must be rejected. Dies with the legacy path.
+	// --statement is the only way to describe the change, so an empty one
+	// must be rejected before we touch the database.
 	m := NewTestMigration(t)
-	m.Table = "t1missing"
 	err := m.Run()
 	require.Error(t, err)
-	require.ErrorContains(t, err, "alter statement is required")
+	require.ErrorContains(t, err, "--statement is required")
+
+	// A statement that is not a schema change at all is rejected too.
+	m = NewTestMigration(t, WithStatement("SELECT 1"))
+	err = m.Run()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not a supported statement type")
 }
 
 func TestBadDatabaseCredentials(t *testing.T) {
@@ -745,22 +745,24 @@ func TestBadOptions(t *testing.T) {
 	t.Parallel()
 	_, err := NewRunner(&Migration{})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "table name is required")
+	require.ErrorContains(t, err, "--statement is required")
 
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	require.NoError(t, err)
 
 	_, err = NewRunner(&Migration{Host: cfg.Addr})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "table name is required")
+	require.ErrorContains(t, err, "--statement is required")
 
-	_, err = NewRunner(&Migration{Host: cfg.Addr, Database: "mytable"})
+	_, err = NewRunner(&Migration{Host: cfg.Addr, Database: "mydatabase"})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "table name is required")
+	require.ErrorContains(t, err, "--statement is required")
 
-	_, err = NewRunner(&Migration{Host: cfg.Addr, Database: "mydatabase", Table: "mytable"})
+	// The schema in the statement must match --database.
+	_, err = NewRunner(&Migration{Host: cfg.Addr, Database: "mydatabase",
+		Statement: "ALTER TABLE otherdb.mytable ENGINE=InnoDB"})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "alter statement is required")
+	require.ErrorContains(t, err, "does not match --database")
 }
 
 // TestBadAlter tests various invalid ALTER statement scenarios.

--- a/pkg/migration/singleversion_test.go
+++ b/pkg/migration/singleversion_test.go
@@ -73,15 +73,6 @@ func TestUnparsableStatements(t *testing.T) {
 	m = NewTestMigration(t, WithStatement("ALTER TABLE t1parse ADD COLUMN c BLOB DEFAULT ('abc')"))
 	require.NoError(t, m.Run())
 
-	// The same thing via the legacy --table/--alter path (this path always
-	// worked: the alter clause is executed verbatim, without a parser round
-	// trip). Adds c2 since the --statement run above already added c.
-	// Dies with the legacy path.
-	m = NewTestMigration(t)
-	m.Table = "t1parse"
-	m.Alter = "ADD COLUMN c2 BLOB DEFAULT ('abc')"
-	require.NoError(t, m.Run())
-
 	// CREATE TRIGGER — not supported. The fork parses it now that it has
 	// stored-program grammar, so it is refused by statement type rather than
 	// rejected as a syntax error.
@@ -90,11 +81,9 @@ func TestUnparsableStatements(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "not a supported statement type")
 
-	// https://github.com/pingcap/tidb/pull/61498
-	// Legacy --table/--alter path for the same reason as above.
-	m = NewTestMigration(t)
-	m.Table = "t1parse"
-	m.Alter = `ADD COLUMN src_col timestamp NULL DEFAULT NULL, add column new_col timestamp NULL DEFAULT(src_col)`
+	// A column default that references another column added in the same
+	// statement. https://github.com/pingcap/tidb/pull/61498
+	m = NewTestMigration(t, WithStatement("ALTER TABLE t1parse ADD COLUMN src_col timestamp NULL DEFAULT NULL, add column new_col timestamp NULL DEFAULT(src_col)"))
 	require.NoError(t, m.Run())
 
 	// Cleanup

--- a/pkg/move/check/source_schema_consistency.go
+++ b/pkg/move/check/source_schema_consistency.go
@@ -30,7 +30,7 @@ func init() {
 // created in newCopy.
 //
 // Two things are validated for each source 1..N-1:
-//  1. Table set: when moving everything (no explicit --table list), the source
+//  1. Table set: when moving everything (no explicit SourceTables list), the source
 //     must expose exactly the same set of tables as sources[0]. An extra or
 //     missing table is drift. When only a named subset is moved, tables outside
 //     that subset are irrelevant and ignored.

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -28,6 +28,7 @@ var (
 	ErrNoStatements            = errors.New("could not find any compatible statements to execute")
 	ErrMixMatchMultiStatements = errors.New("when performing atomic schema changes, all statements must be of type ALTER TABLE")
 	ErrUnsafeForInplace        = errors.New("statement contains operations that are not safe for INPLACE algorithm")
+	ErrAlterNoSpecs            = errors.New("ALTER TABLE does not specify any changes to make")
 	ErrMultipleAlterClauses    = errors.New("ALTER contains multiple clauses. Combinations of INSTANT and INPLACE operations cannot be detected safely. Consider executing these as separate ALTER statements")
 	ErrAlterContainsUnique     = errors.New("ALTER contains adding a unique index")
 )
@@ -70,14 +71,14 @@ func NewWithOptions(statement string, opts Options) ([]*AbstractStatement, error
 				return nil, fmt.Errorf("could not restore alter clause statement: %w", err)
 			}
 			normalizedStmt := sb.String()
-			trimLen := len(alterStmt.Table.Name.String()) + 15 // len ALTER TABLE + quotes
-			if len(alterStmt.Table.Schema.String()) > 0 {
-				trimLen += len(alterStmt.Table.Schema.String()) + 3 // len schema + quotes and dot.
+			alterClause, err := trimAlterTablePrefix(alterStmt, normalizedStmt)
+			if err != nil {
+				return nil, err
 			}
 			stmts = append(stmts, &AbstractStatement{
 				Schema:    alterStmt.Table.Schema.String(),
 				Table:     alterStmt.Table.Name.String(),
-				Alter:     normalizedStmt[trimLen:],
+				Alter:     alterClause,
 				Statement: statement,
 				StmtNode:  &stmtNodes[i],
 			})
@@ -152,6 +153,39 @@ func NewWithOptions(statement string, opts Options) ([]*AbstractStatement, error
 	}
 
 	return stmts, nil
+}
+
+// trimAlterTablePrefix returns just the alter clauses from a restored
+// ALTER TABLE statement, i.e. the "ADD COLUMN ..." in
+// "ALTER TABLE `t` ADD COLUMN ...".
+//
+// AlterTableStmt.Restore writes "ALTER TABLE " + the table reference + " " +
+// the comma-separated specs, so the prefix is found by restoring the table
+// reference the same way. Counting characters off the raw identifier does not
+// work: restore back-quotes identifiers and doubles any embedded back-quote,
+// so a name like `a``b` is longer restored than raw.
+//
+// A statement with no specs at all has no prefix to trim. MySQL rejects
+// "ALTER TABLE t" as a syntax error but our parser accepts it, so reject it
+// here rather than returning an empty alter — downstream an empty Alter means
+// "not a schema change" (see the CREATE TABLE case in NewWithOptions), which
+// would silently do the wrong thing.
+func trimAlterTablePrefix(alterStmt *ast.AlterTableStmt, normalizedStmt string) (string, error) {
+	if len(alterStmt.Specs) == 0 {
+		return "", fmt.Errorf("%w: %s", ErrAlterNoSpecs, normalizedStmt)
+	}
+	var sb strings.Builder
+	rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
+	if err := alterStmt.Table.Restore(rCtx); err != nil {
+		return "", fmt.Errorf("could not restore alter table name: %w", err)
+	}
+	alterClause, ok := strings.CutPrefix(normalizedStmt, "ALTER TABLE "+sb.String()+" ")
+	if !ok {
+		// Unreachable unless AlterTableStmt.Restore changes shape; fail loudly
+		// rather than slicing at a guessed offset.
+		return "", fmt.Errorf("could not find the alter clauses in restored statement: %s", normalizedStmt)
+	}
+	return alterClause, nil
 }
 
 // MustNew is like New but panics if the statement cannot be parsed.

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -163,7 +163,7 @@ func NewWithOptions(statement string, opts Options) ([]*AbstractStatement, error
 // the comma-separated specs, so the prefix is found by restoring the table
 // reference the same way. Counting characters off the raw identifier does not
 // work: restore back-quotes identifiers and doubles any embedded back-quote,
-// so a name like `a``b` is longer restored than raw.
+// so a name containing one restores longer than it is raw.
 //
 // A statement with no specs at all has no prefix to trim. MySQL rejects
 // "ALTER TABLE t" as a syntax error but our parser accepts it, so reject it

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -64,14 +64,7 @@ func NewWithOptions(statement string, opts Options) ([]*AbstractStatement, error
 			// if the schema name is included it could be different from the --database
 			// specified, which causes all sorts of problems. The easiest way to handle this
 			// it just to not permit it.
-			var sb strings.Builder
-			sb.Reset()
-			rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
-			if err = alterStmt.Restore(rCtx); err != nil {
-				return nil, fmt.Errorf("could not restore alter clause statement: %w", err)
-			}
-			normalizedStmt := sb.String()
-			alterClause, err := trimAlterTablePrefix(alterStmt, normalizedStmt)
+			alterClause, err := alterClauses(alterStmt, format.DefaultRestoreFlags)
 			if err != nil {
 				return nil, err
 			}
@@ -155,35 +148,47 @@ func NewWithOptions(statement string, opts Options) ([]*AbstractStatement, error
 	return stmts, nil
 }
 
-// trimAlterTablePrefix returns just the alter clauses from a restored
-// ALTER TABLE statement, i.e. the "ADD COLUMN ..." in
-// "ALTER TABLE `t` ADD COLUMN ...".
+// alterClauses returns just the alter clauses of an ALTER TABLE statement,
+// i.e. the "ADD COLUMN ..." in "ALTER TABLE `t` ADD COLUMN ...".
 //
 // AlterTableStmt.Restore writes "ALTER TABLE " + the table reference + " " +
-// the comma-separated specs, so the prefix is found by restoring the table
-// reference the same way. Counting characters off the raw identifier does not
-// work: restore back-quotes identifiers and doubles any embedded back-quote,
-// so a name containing one restores longer than it is raw.
+// the comma-separated specs (see its implementation in pkg/parser/ast/ddl.go),
+// so the clauses are whatever follows that prefix. Both the statement and the
+// prefix are restored here, from one flags value and through the same writer
+// calls Restore itself uses, so the two cannot render differently: whatever
+// flags do to keyword case or identifier quoting, they do to both sides.
+//
+// Counting characters off the raw identifier is not a workable substitute:
+// restore back-quotes identifiers and doubles any embedded back-quote, so a
+// name containing one restores longer than it is raw.
 //
 // A statement with no specs at all has no prefix to trim. MySQL rejects
 // "ALTER TABLE t" as a syntax error but our parser accepts it, so reject it
 // here rather than returning an empty alter — downstream an empty Alter means
 // "not a schema change" (see the CREATE TABLE case in NewWithOptions), which
 // would silently do the wrong thing.
-func trimAlterTablePrefix(alterStmt *ast.AlterTableStmt, normalizedStmt string) (string, error) {
-	if len(alterStmt.Specs) == 0 {
-		return "", fmt.Errorf("%w: %s", ErrAlterNoSpecs, normalizedStmt)
+func alterClauses(alterStmt *ast.AlterTableStmt, flags format.RestoreFlags) (string, error) {
+	var stmtSB strings.Builder
+	if err := alterStmt.Restore(format.NewRestoreCtx(flags, &stmtSB)); err != nil {
+		return "", fmt.Errorf("could not restore alter clause statement: %w", err)
 	}
-	var sb strings.Builder
-	rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
-	if err := alterStmt.Table.Restore(rCtx); err != nil {
+	if len(alterStmt.Specs) == 0 {
+		return "", fmt.Errorf("%w: %s", ErrAlterNoSpecs, stmtSB.String())
+	}
+	// Mirror the opening of AlterTableStmt.Restore exactly: the keyword, the
+	// table reference, then the single space before the first spec.
+	var prefixSB strings.Builder
+	prefixCtx := format.NewRestoreCtx(flags, &prefixSB)
+	prefixCtx.WriteKeyWord("ALTER TABLE ")
+	if err := alterStmt.Table.Restore(prefixCtx); err != nil {
 		return "", fmt.Errorf("could not restore alter table name: %w", err)
 	}
-	alterClause, ok := strings.CutPrefix(normalizedStmt, "ALTER TABLE "+sb.String()+" ")
+	prefixCtx.WritePlain(" ")
+	alterClause, ok := strings.CutPrefix(stmtSB.String(), prefixSB.String())
 	if !ok {
-		// Unreachable unless AlterTableStmt.Restore changes shape; fail loudly
-		// rather than slicing at a guessed offset.
-		return "", fmt.Errorf("could not find the alter clauses in restored statement: %s", normalizedStmt)
+		// Unreachable unless AlterTableStmt.Restore changes the shape this
+		// mirrors; fail loudly rather than cutting at a guessed offset.
+		return "", fmt.Errorf("could not find the alter clauses in restored statement: %s", stmtSB.String())
 	}
 	return alterClause, nil
 }

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -3,6 +3,7 @@ package statement
 import (
 	"testing"
 
+	"github.com/block/spirit/pkg/parser/format"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -37,6 +38,34 @@ func TestAlterClauseTrimming(t *testing.T) {
 
 	_, err = New("ALTER TABLE test.t1")
 	require.ErrorIs(t, err, ErrAlterNoSpecs)
+}
+
+// TestAlterClausesRestoreFlags pins that alterClauses cuts the prefix using the
+// flags it is given rather than assuming the defaults. Restoring the statement
+// and the prefix through the same flags is what keeps the cut correct, so
+// lowercase keywords and unquoted identifiers must work as well as the default
+// uppercase + back-quoted rendering.
+func TestAlterClausesRestoreFlags(t *testing.T) {
+	stmts, err := New("ALTER TABLE `a``b` ADD COLUMN c INT, DROP COLUMN d")
+	require.NoError(t, err)
+	alterStmt, ok := stmts[0].AsAlterTable()
+	require.True(t, ok)
+
+	clauses, err := alterClauses(alterStmt, format.DefaultRestoreFlags)
+	require.NoError(t, err)
+	require.Equal(t, "ADD COLUMN `c` INT, DROP COLUMN `d`", clauses)
+
+	// Lowercase keywords: the literal "ALTER TABLE " no longer appears, so a
+	// hard-coded prefix would fail to cut here.
+	clauses, err = alterClauses(alterStmt, format.RestoreKeyWordLowercase|format.RestoreNameBackQuotes)
+	require.NoError(t, err)
+	require.Equal(t, "add column `c` int, drop column `d`", clauses)
+
+	// No identifier quoting at all: the prefix shortens along with the table
+	// reference, and the embedded back-quote is no longer doubled.
+	clauses, err = alterClauses(alterStmt, format.RestoreKeyWordUppercase)
+	require.NoError(t, err)
+	require.Equal(t, "ADD COLUMN c INT, DROP COLUMN d", clauses)
 }
 
 func TestExtractFromStatement(t *testing.T) {

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -10,6 +10,34 @@ import (
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
+// TestAlterClauseTrimming covers finding where the alter clauses start in a
+// restored "ALTER TABLE <table> <specs>". This used to be computed by counting
+// characters off the raw table name, which mis-trims quoted identifiers and
+// panicked outright when there were no specs at all.
+func TestAlterClauseTrimming(t *testing.T) {
+	// An embedded back-quote is doubled by restore, so the restored table
+	// reference is longer than the raw name.
+	abstractStmt, err := New("ALTER TABLE `a``b` ADD COLUMN c INT")
+	require.NoError(t, err)
+	require.Equal(t, "a`b", abstractStmt[0].Table)
+	require.Equal(t, "ADD COLUMN `c` INT", abstractStmt[0].Alter)
+
+	// Same, schema-qualified.
+	abstractStmt, err = New("ALTER TABLE `x``y`.`a``b` ADD COLUMN c INT")
+	require.NoError(t, err)
+	require.Equal(t, "x`y", abstractStmt[0].Schema)
+	require.Equal(t, "a`b", abstractStmt[0].Table)
+	require.Equal(t, "ADD COLUMN `c` INT", abstractStmt[0].Alter)
+
+	// An ALTER with no specs is a syntax error in MySQL, but our parser
+	// accepts it. It must be rejected, not returned with an empty alter.
+	_, err = New("ALTER TABLE t1")
+	require.ErrorIs(t, err, ErrAlterNoSpecs)
+
+	_, err = New("ALTER TABLE test.t1")
+	require.ErrorIs(t, err, ErrAlterNoSpecs)
+}
+
 func TestExtractFromStatement(t *testing.T) {
 	abstractStmt, err := New("ALTER TABLE t1 ADD INDEX (something)")
 	require.NoError(t, err)

--- a/pkg/statement/statement_test.go
+++ b/pkg/statement/statement_test.go
@@ -10,6 +10,7 @@ import (
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
+
 // TestAlterClauseTrimming covers finding where the alter clauses start in a
 // restored "ALTER TABLE <table> <specs>". This used to be computed by counting
 // characters off the raw table name, which mis-trims quoted identifiers and

--- a/scripts/buildandrun.sh
+++ b/scripts/buildandrun.sh
@@ -3,7 +3,7 @@ set -e
 
 make build
 
-params=(--host="$HOST" --username="$USERNAME" --password="$PASSWORD" --database="$DATABASE" --table="$TABLE" --alter="engine=innodb")
+params=(--host="$HOST" --username="$USERNAME" --password="$PASSWORD" --database="$DATABASE" --statement="ALTER TABLE \`$TABLE\` ENGINE=InnoDB")
 
 if [ -n "$REPLICA_DSN" ]; then
   params+=(--replica-dsn="$REPLICA_DSN")


### PR DESCRIPTION
Closes #1148.

## Why now

The parser fork round-trips the grammar that used to make `--alter` necessary. Issue #542 — `--statement` dropping the parentheses on expression column defaults (`DEFAULT ('{}')` → MySQL error 1101), with `--table`/`--alter` as the documented workaround — is closed, and this PR demonstrates it: the two verbatim-alter holdouts in `TestUnparsableStatements` (`BLOB DEFAULT ('abc')` and a `DEFAULT(src_col)` self-reference) now run through `--statement` and pass.

With the workaround no longer needed, keeping both flags just meant two code paths into `normalizeOptions`: one that parsed the operator's statement, and one that string-composed ``ALTER TABLE `<t>` <alter>`` and parsed that.

## Commit 1 — remove the flags

**`pkg/migration/migration.go`** — dropped the `Table` and `Alter` fields and the ~25-line else-branch that composed the statement; the `sqlescape` and `parser` imports went with it. `--statement` is now a Kong-`required` flag, so omitting it fails at flag parsing:

```
spirit: error: missing flags: --statement=STRING
```

rather than deep inside `normalizeOptions`. Programmatic callers bypass Kong, so the check there remains (`--statement is required`).

**Tests** — the three legacy holdouts left behind by #1138 are converted: `TestMissingAlter` → `TestMissingStatement`, `TestBadOptions` re-pointed at the new error (plus a schema-mismatch case), and `TestUnparsableStatements` fully on `--statement`.

**Docs and scripts** — `docs/migrate.md` (removed the `### alter` and `### table` sections and their TOC entries, rewrote the basic-usage, yield-timeout and six TLS examples, rewrote `### statement` as required), `AGENTS.md` (also corrected the stale `With*` helper list — `WithTable`/`WithAlter`/`WithBuffered`/`WithConfFile` no longer exist), `scripts/buildandrun.sh`, and 50 call sites across the 8 `compose/tls` + `compose/replication-tls` scripts. Two stale comments in `pkg/dbconn/sqlescape` and `pkg/move/check` that referenced the flags were updated too.

## Commit 2 — fix a panic that removing the flags exposes

Extracting the alter clauses from a restored `ALTER TABLE <table> <specs>` counted characters off the raw table name:

```go
trimLen := len(alterStmt.Table.Name.String()) + 15
... Alter: normalizedStmt[trimLen:]
```

That is wrong in two ways:

- Restore back-quotes identifiers and **doubles any embedded back-quote**, so the restored table reference can be longer than the raw name. ``ALTER TABLE `a``b` ADD COLUMN c INT`` restores a 19-character prefix but the arithmetic says 18, yielding an alter of ``` ` ADD COLUMN `c` INT ```.
- An ALTER with **no specs** has no prefix to trim at all. `ALTER TABLE t1missing` restores to 23 characters against a computed offset of 24, and the slice **panics** with `slice bounds out of range [24:23]`. MySQL rejects that as a syntax error, but our parser accepts it — so this was reachable straight from the CLI, and more exposed once `--statement` is the only entry point.

The fix finds the boundary by restoring the table reference with the same flags and cutting that prefix, and rejects a spec-less ALTER with a new `ErrAlterNoSpecs` rather than returning an empty alter — downstream an empty `Alter` means "not a schema change" (the CREATE TABLE case), which would silently do the wrong thing.

## Compatibility

**No backward compatibility is kept, by design.** Checkpoints written by a `--table`/`--alter` run store the composed ``ALTER TABLE `t` <alter>`` text, and resume requires an exact statement match — a mismatch is treated as definitive and starts fresh. **In-flight migrations should be drained before upgrading**; this is worth a release note.

## Verification

- `go build`, `go vet`, and `go vet -tags singleversion` clean; golangci-lint clean (uncapped).
- Green against a dedicated MySQL container: `./pkg/migration/...` on both tag sets, plus every package that imports `pkg/statement` (`./pkg/statement/...`, `./pkg/datasync/...`, `./pkg/fmt/...`, `./pkg/lint/...`, `./pkg/move/...`) and `./pkg/dbconn/...`.
- `bash -n` on every rewritten shell script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)