### PR TITLE
feat(status): report workflow phases through the metrics sink

### DIFF
--- a/pkg/checksum/continuous_test.go
+++ b/pkg/checksum/continuous_test.go
@@ -83,6 +83,8 @@ func (c *testChunker) Feedback(chunk *table.Chunk, duration time.Duration, actua
 	defer c.mu.Unlock()
 	c.feedback = append(c.feedback, table.FeedbackCall{Chunk: chunk, Duration: duration, ActualRows: actualRows, Timestamp: time.Now()})
 }
+func (c *testChunker) RowsCopied() uint64 { return 0 }
+
 func (c *testChunker) Progress() (uint64, uint64, uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -86,8 +86,12 @@ type Runner struct {
 	// status block (#329).
 	lastCheckpoint status.LastCheckpoint
 
-	logger     *slog.Logger
-	cancelFunc context.CancelFunc
+	logger *slog.Logger
+	// metricsSink receives the copier's per-chunk metrics and the tracker's
+	// phase transitions. It defaults to a NoopSink, so a caller that installs
+	// nothing pays only for the discarded values.
+	metricsSink metrics.Sink
+	cancelFunc  context.CancelFunc
 	// sourceDBConfig connects to the read-only source: ForceKill and
 	// RejectReadOnly are disabled (see Run). targetDBConfig connects to the
 	// writable target and keeps the standard safe defaults — most importantly
@@ -165,6 +169,7 @@ func NewRunner(s *Sync) (*Runner, error) {
 	r := &Runner{
 		sync:              s,
 		logger:            slog.Default(),
+		metricsSink:       &metrics.NoopSink{},
 		continuousReadyCh: make(chan struct{}),
 		firstCleanPassCh:  make(chan struct{}),
 	}
@@ -173,8 +178,32 @@ func NewRunner(s *Sync) (*Runner, error) {
 
 // SetLogger overrides the logger (used by programmatic callers to capture
 // progress output).
+// recordCopyCompleted reports the settled copy aggregate to the metrics sink.
+// The counts come from the chunker rather than a second tally in the copier:
+// the chunker is what accumulates copied rows from applier feedback (see
+// table.Chunker.Feedback), and on a resumed run it already carries the rows
+// copied before the restart.
+func (r *Runner) recordCopyCompleted() {
+	chunker := r.copier.GetChunker()
+	if chunker == nil {
+		return
+	}
+	_, chunks, _ := chunker.Progress()
+	r.status.RecordCopyCompleted(chunker.RowsCopied(), chunks)
+}
+
 func (r *Runner) SetLogger(logger *slog.Logger) {
 	r.logger = logger
+}
+
+// SetMetricsSink installs the destination for this run's metrics, including
+// the workflow phase transitions reported by status.Tracker. It must be called
+// before Run; a nil sink is ignored.
+func (r *Runner) SetMetricsSink(sink metrics.Sink) {
+	if sink == nil {
+		return
+	}
+	r.metricsSink = sink
 }
 
 // Run performs the initial copy and then streams changes continuously
@@ -186,6 +215,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.progMu.Lock()
 	r.cancelFunc = cancel
 	r.progMu.Unlock()
+	r.status.SetMetricsSink(r.metricsSink, r.logger)
 	r.status.Begin()
 	r.logger.Info("Starting sync", "source_dsn", dbconn.RedactDSN(r.sync.SourceDSN))
 
@@ -311,6 +341,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		if err := r.copier.Run(ctx); err != nil {
 			return fmt.Errorf("copy failed: %w", err)
 		}
+		r.recordCopyCompleted()
 		if !r.sync.CopyOnly {
 			if !r.resuming.Load() {
 				if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
@@ -1111,7 +1142,7 @@ func (r *Runner) buildCopyPipeline() error {
 		Concurrency: r.sync.Threads,
 		Logger:      r.logger,
 		Throttler:   &throttler.Noop{},
-		MetricsSink: &metrics.NoopSink{},
+		MetricsSink: r.metricsSink,
 		DBConfig:    r.sourceDBConfig,
 		Applier:     r.applier,
 	})

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -176,13 +176,15 @@ func NewRunner(s *Sync) (*Runner, error) {
 	return r, nil
 }
 
-// SetLogger overrides the logger (used by programmatic callers to capture
-// progress output).
 // recordCopyCompleted reports the settled copy aggregate to the metrics sink.
 // The counts come from the chunker rather than a second tally in the copier:
 // the chunker is what accumulates copied rows from applier feedback (see
-// table.Chunker.Feedback), and on a resumed run it already carries the rows
-// copied before the restart.
+// table.Chunker.Feedback).
+//
+// On a resumed run this reports what the chunker itself has counted, which
+// includes the rows copied before the restart only when the watermark carried
+// that count forward (see table.Chunker.RowsCopied: the composite chunker's
+// does, the optimistic chunker's does not).
 func (r *Runner) recordCopyCompleted() {
 	chunker := r.copier.GetChunker()
 	if chunker == nil {
@@ -192,6 +194,8 @@ func (r *Runner) recordCopyCompleted() {
 	r.status.RecordCopyCompleted(chunker.RowsCopied(), chunks)
 }
 
+// SetLogger overrides the logger (used by programmatic callers to capture
+// progress output).
 func (r *Runner) SetLogger(logger *slog.Logger) {
 	r.logger = logger
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,6 +31,30 @@ const (
 	ChecksumThreadsMetricName      = "checksum_threads"
 	ThrottlerUtilizationMetricName = "throttler_utilization"
 
+	// Workflow phase metrics, emitted by status.Tracker on every state
+	// transition. There are no label/attribute fields on MetricValue, so the
+	// phase is carried as the numeric status.State and correlated inside a
+	// single Send batch, the same way the chunk metrics above describe one
+	// chunk together:
+	//
+	//   entry: [workflow_phase]
+	//   exit:  [workflow_phase_completed, workflow_phase_seconds]
+	//
+	// A sink that wants "time spent in copyRows" reads the exit batch; a sink
+	// that wants "what is this migration doing right now" reads the entry
+	// gauge. status.State.String() names the values.
+	WorkflowPhaseMetricName          = "workflow_phase"
+	WorkflowPhaseCompletedMetricName = "workflow_phase_completed"
+	WorkflowPhaseSecondsMetricName   = "workflow_phase_seconds"
+
+	// Copy completion totals, emitted once when the copy phase ends. They are
+	// the settled per-run aggregate read from the chunker, which is the
+	// component that counts copied rows from applier feedback and carries a
+	// resumed run's rows forward from its checkpoint. The per-chunk counters
+	// above still give the incremental view.
+	CopyRowsCompletedMetricName   = "copy_rows_completed"
+	CopyChunksCompletedMetricName = "copy_chunks_completed"
+
 	// Applier pipeline gauges (see pkg/applier Stats). Together they
 	// distinguish a read-limited copy pipeline (queue near empty, workers
 	// idle) from a write-limited one (queue pegged at capacity with

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,9 +49,15 @@ const (
 
 	// Copy completion totals, emitted once when the copy phase ends. They are
 	// the settled per-run aggregate read from the chunker, which is the
-	// component that counts copied rows from applier feedback and carries a
-	// resumed run's rows forward from its checkpoint. The per-chunk counters
-	// above still give the incremental view.
+	// component that counts copied rows from applier feedback. The per-chunk
+	// counters above still give the incremental view.
+	//
+	// These are the rows *this run* copied, not the rows the migration has
+	// copied across all of its attempts. Whether a resumed run carries its
+	// earlier count forward is chunker-dependent — the composite chunker's
+	// watermark stores the count, the optimistic chunker's stores key
+	// positions only (see table.Chunker.RowsCopied) — so a sink that wants a
+	// lifetime total cannot get one by reading a single sample.
 	CopyRowsCompletedMetricName   = "copy_rows_completed"
 	CopyChunksCompletedMetricName = "copy_chunks_completed"
 

--- a/pkg/migration/phase_metrics_test.go
+++ b/pkg/migration/phase_metrics_test.go
@@ -1,0 +1,73 @@
+package migration
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/block/spirit/pkg/metrics"
+	"github.com/block/spirit/pkg/status"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+type phaseSink struct {
+	mu     sync.Mutex
+	values map[string][]float64
+}
+
+func newPhaseSink() *phaseSink {
+	return &phaseSink{values: map[string][]float64{}}
+}
+
+func (s *phaseSink) Send(_ context.Context, m *metrics.Metrics) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, v := range m.Values {
+		s.values[v.Name] = append(s.values[v.Name], v.Value)
+	}
+	return nil
+}
+
+func (s *phaseSink) get(name string) []float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]float64(nil), s.values[name]...)
+}
+
+// TestMigrationReportsPhasesAndCopyTotals runs a real migration with a sink
+// attached and asserts the phases an operator would chart, plus the settled
+// copy totals read from the chunker.
+func TestMigrationReportsPhasesAndCopyTotals(t *testing.T) {
+	testutils.NewTestTable(t, "phasemetrics", `CREATE TABLE phasemetrics (
+		id int NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	testutils.RunSQL(t, `INSERT INTO phasemetrics (name) VALUES ('a'), ('b'), ('c'), ('d')`)
+
+	sink := newPhaseSink()
+	runner := NewTestRunner(t, "phasemetrics", "ENGINE=InnoDB")
+	defer utils.CloseAndLog(runner)
+	runner.SetMetricsSink(sink)
+
+	require.NoError(t, runner.Run(t.Context()))
+
+	phases := sink.get(metrics.WorkflowPhaseMetricName)
+	require.Contains(t, phases, float64(status.Initial))
+	require.Contains(t, phases, float64(status.CopyRows))
+	require.Contains(t, phases, float64(status.CutOver))
+
+	completed := sink.get(metrics.WorkflowPhaseCompletedMetricName)
+	require.Contains(t, completed, float64(status.CopyRows))
+	require.Len(t, sink.get(metrics.WorkflowPhaseSecondsMetricName), len(completed),
+		"every completed phase carries a duration in the same batch")
+
+	// The copy totals are the chunker's, so they must match the rows actually
+	// copied rather than an independent tally.
+	require.Equal(t, []float64{4}, sink.get(metrics.CopyRowsCompletedMetricName))
+	chunks := sink.get(metrics.CopyChunksCompletedMetricName)
+	require.Len(t, chunks, 1)
+	require.Positive(t, chunks[0])
+}

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -236,9 +236,24 @@ func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
 	return r.changes[0].attemptMySQLDDL(ctx)
 }
 
+// recordCopyCompleted reports the settled copy aggregate to the metrics sink.
+// The counts come from the chunker rather than a second tally in the copier:
+// the chunker is what accumulates copied rows from applier feedback (see
+// table.Chunker.Feedback), and on a resumed run it already carries the rows
+// copied before the restart.
+func (r *Runner) recordCopyCompleted() {
+	chunker := r.copier.GetChunker()
+	if chunker == nil {
+		return
+	}
+	_, chunks, _ := chunker.Progress()
+	r.status.RecordCopyCompleted(chunker.RowsCopied(), chunks)
+}
+
 func (r *Runner) Run(ctx context.Context) error {
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
+	r.status.SetMetricsSink(r.metricsSink, r.logger)
 	r.status.Begin()
 	bi := buildinfo.Get()
 	r.logger.Info("Starting spirit migration",
@@ -402,6 +417,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}); err != nil {
 		return err
 	}
+	r.recordCopyCompleted()
 	r.logger.Info("copy rows complete")
 
 	// Disable both watermark optimizations so that all changes can be flushed.

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -239,8 +239,12 @@ func (r *Runner) attemptMySQLDDL(ctx context.Context) error {
 // recordCopyCompleted reports the settled copy aggregate to the metrics sink.
 // The counts come from the chunker rather than a second tally in the copier:
 // the chunker is what accumulates copied rows from applier feedback (see
-// table.Chunker.Feedback), and on a resumed run it already carries the rows
-// copied before the restart.
+// table.Chunker.Feedback).
+//
+// On a resumed run this reports what the chunker itself has counted, which
+// includes the rows copied before the restart only when the watermark carried
+// that count forward (see table.Chunker.RowsCopied: the composite chunker's
+// does, the optimistic chunker's does not).
 func (r *Runner) recordCopyCompleted() {
 	chunker := r.copier.GetChunker()
 	if chunker == nil {

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -150,9 +150,13 @@ type Runner struct {
 	reversePositions map[string]string
 	cutoverAt        time.Time
 
-	logger     *slog.Logger
-	cancelFunc context.CancelFunc
-	dbConfig   *dbconn.DBConfig
+	logger *slog.Logger
+	// metricsSink receives the copier's per-chunk metrics and the tracker's
+	// phase transitions. It defaults to a NoopSink, so a caller that installs
+	// nothing pays only for the discarded values.
+	metricsSink metrics.Sink
+	cancelFunc  context.CancelFunc
+	dbConfig    *dbconn.DBConfig
 
 	// fatalOnce makes fatalError idempotent. Move wires N repl clients
 	// (one per source) to the same fatalError callback, so a concurrent
@@ -204,10 +208,25 @@ func NewRunner(m *Move) (*Runner, error) {
 		m.WriteThreads = defaultWriteThreads
 	}
 	r := &Runner{
-		move:   m,
-		logger: slog.Default(),
+		move:        m,
+		logger:      slog.Default(),
+		metricsSink: &metrics.NoopSink{},
 	}
 	return r, nil
+}
+
+// recordCopyCompleted reports the settled copy aggregate to the metrics sink.
+// The counts come from the chunker rather than a second tally in the copier:
+// the chunker is what accumulates copied rows from applier feedback (see
+// table.Chunker.Feedback), and on a resumed run it already carries the rows
+// copied before the restart.
+func (r *Runner) recordCopyCompleted() {
+	chunker := r.copier.GetChunker()
+	if chunker == nil {
+		return
+	}
+	_, chunks, _ := chunker.Progress()
+	r.status.RecordCopyCompleted(chunker.RowsCopied(), chunks)
 }
 
 func (r *Runner) Close() error {
@@ -493,7 +512,7 @@ func (r *Runner) resumeFromCheckpoint(ctx context.Context) error {
 		Concurrency: r.move.Threads,
 		Logger:      r.logger,
 		Throttler:   &throttler.Noop{},
-		MetricsSink: &metrics.NoopSink{},
+		MetricsSink: r.metricsSink,
 		DBConfig:    r.dbConfig,
 		Applier:     r.applier, // Use the shared applier
 	})
@@ -963,7 +982,7 @@ func (r *Runner) newCopy(ctx context.Context) error {
 		Concurrency: r.move.Threads,
 		Logger:      r.logger,
 		Throttler:   &throttler.Noop{},
-		MetricsSink: &metrics.NoopSink{},
+		MetricsSink: r.metricsSink,
 		DBConfig:    r.dbConfig,
 		Applier:     r.applier, // Use the shared applier
 	})
@@ -1011,6 +1030,7 @@ func (r *Runner) createCheckpointTable(ctx context.Context) error {
 func (r *Runner) Run(ctx context.Context) error {
 	ctx, r.cancelFunc = context.WithCancel(ctx)
 	defer r.cancelFunc()
+	r.status.SetMetricsSink(r.metricsSink, r.logger)
 	r.status.Begin()
 	bi := buildinfo.Get()
 	r.logger.Info("Starting table move",
@@ -1208,6 +1228,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}); err != nil {
 		return err
 	}
+	r.recordCopyCompleted()
 
 	// Disable both watermark optimizations so that all changes can be flushed.
 	// For non-memory-comparable PKs this also drains the buffered map and
@@ -1512,6 +1533,16 @@ func (r *Runner) Status() string {
 
 func (r *Runner) SetLogger(logger *slog.Logger) {
 	r.logger = logger
+}
+
+// SetMetricsSink installs the destination for this run's metrics, including
+// the workflow phase transitions reported by status.Tracker. It must be called
+// before Run; a nil sink is ignored.
+func (r *Runner) SetMetricsSink(sink metrics.Sink) {
+	if sink == nil {
+		return
+	}
+	r.metricsSink = sink
 }
 
 // runChecks wraps around check.RunChecks and adds the context of this move operation

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -218,8 +218,12 @@ func NewRunner(m *Move) (*Runner, error) {
 // recordCopyCompleted reports the settled copy aggregate to the metrics sink.
 // The counts come from the chunker rather than a second tally in the copier:
 // the chunker is what accumulates copied rows from applier feedback (see
-// table.Chunker.Feedback), and on a resumed run it already carries the rows
-// copied before the restart.
+// table.Chunker.Feedback).
+//
+// On a resumed run this reports what the chunker itself has counted, which
+// includes the rows copied before the restart only when the watermark carried
+// that count forward (see table.Chunker.RowsCopied: the composite chunker's
+// does, the optimistic chunker's does not).
 func (r *Runner) recordCopyCompleted() {
 	chunker := r.copier.GetChunker()
 	if chunker == nil {

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -1,8 +1,12 @@
 package status
 
 import (
+	"context"
+	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/block/spirit/pkg/metrics"
 )
 
 // Tracker owns the current State plus per-state wall-clock timing. Runners
@@ -31,6 +35,56 @@ type Tracker struct {
 	enteredAt time.Time               // when the current state was entered
 	open      bool                    // the current state has a running interval
 	durations map[State]time.Duration // closed time attributed per state
+
+	// sink receives a phase metric on every transition. It is optional: with
+	// no sink installed the tracker does no work beyond the timing above,
+	// which is what makes phase reporting free for callers that don't want it.
+	sinkMu sync.Mutex
+	sink   metrics.Sink
+	logger *slog.Logger
+}
+
+// SetMetricsSink installs the sink that phase transitions are reported to,
+// and the logger used when a send fails. A nil sink (the default) disables
+// reporting; a metrics.NoopSink is accepted and simply discards the values.
+//
+// Reporting is synchronous, so a slow sink slows transitions — bounded by
+// metrics.SinkTimeout per send, and there are only a dozen transitions in a
+// run. It is deliberately the same trade-off the copier already makes for its
+// per-chunk metrics, which send far more often.
+func (t *Tracker) SetMetricsSink(sink metrics.Sink, logger *slog.Logger) {
+	t.sinkMu.Lock()
+	defer t.sinkMu.Unlock()
+	t.sink = sink
+	t.logger = logger
+}
+
+// send delivers one batch. It uses a background context on purpose: a phase
+// that ends because the run was cancelled is exactly the phase an operator
+// most wants reported, so the final transitions must still be sent after the
+// run's context is done.
+func (t *Tracker) send(values ...metrics.MetricValue) {
+	t.sinkMu.Lock()
+	sink, logger := t.sink, t.logger
+	t.sinkMu.Unlock()
+	if sink == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), metrics.SinkTimeout)
+	defer cancel()
+	if err := sink.Send(ctx, &metrics.Metrics{Values: values}); err != nil && logger != nil {
+		logger.Warn("could not send workflow phase metrics", "error", err)
+	}
+}
+
+// RecordCopyCompleted reports the settled copy aggregate once the copy phase
+// has ended. Runners read it from the chunker, which counts rows from applier
+// feedback and already carries a resumed run's earlier rows.
+func (t *Tracker) RecordCopyCompleted(rows, chunks uint64) {
+	t.send(
+		metrics.MetricValue{Name: metrics.CopyRowsCompletedMetricName, Type: metrics.GAUGE, Value: float64(rows)},
+		metrics.MetricValue{Name: metrics.CopyChunksCompletedMetricName, Type: metrics.GAUGE, Value: float64(chunks)},
+	)
 }
 
 // Begin marks the start of a run: it resets all timing (start time, per-state
@@ -41,12 +95,21 @@ type Tracker struct {
 func (t *Tracker) Begin() {
 	now := time.Now()
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.startedAt = now
 	t.enteredAt = now
 	t.open = true
 	t.durations = nil
 	t.state.set(Initial)
+	t.mu.Unlock()
+	// Begin is the run's first transition, so it reports Initial the same way
+	// every later transition reports its state. Nothing is completed here: a
+	// re-Begin abandons the previous run's open interval rather than closing
+	// it, which is what "starts a fresh run" means.
+	t.send(metrics.MetricValue{
+		Name:  metrics.WorkflowPhaseMetricName,
+		Type:  metrics.GAUGE,
+		Value: float64(Initial),
+	})
 }
 
 // Get returns the current state.
@@ -122,17 +185,41 @@ func (t *Tracker) Duration(state State) time.Duration {
 
 func (t *Tracker) enter(state State) {
 	now := time.Now()
+	// Closing the previous state is a phase completion in its own right: a
+	// Set-based transition (Close, ErrCleanup) never runs through exit, so
+	// this is the only place its predecessor's duration is reported.
+	var completed State
+	var completedFor time.Duration
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	if t.startedAt.IsZero() {
 		t.startedAt = now
 	}
 	if t.open {
+		completed, completedFor = t.state.get(), now.Sub(t.enteredAt)
 		t.accrueLocked(now)
 	}
 	t.state.set(state)
 	t.enteredAt = now
 	t.open = true
+	t.mu.Unlock()
+
+	// Sending happens outside t.mu: a sink must never be able to block a
+	// state read (Get, Elapsed, the status block's goroutine).
+	if completedFor > 0 {
+		t.sendPhaseCompleted(completed, completedFor)
+	}
+	t.send(metrics.MetricValue{
+		Name:  metrics.WorkflowPhaseMetricName,
+		Type:  metrics.GAUGE,
+		Value: float64(state),
+	})
+}
+
+func (t *Tracker) sendPhaseCompleted(state State, d time.Duration) {
+	t.send(
+		metrics.MetricValue{Name: metrics.WorkflowPhaseCompletedMetricName, Type: metrics.GAUGE, Value: float64(state)},
+		metrics.MetricValue{Name: metrics.WorkflowPhaseSecondsMetricName, Type: metrics.GAUGE, Value: d.Seconds()},
+	)
 }
 
 // exit closes the bracket opened by Do for state. If a nested Do or a Set has
@@ -142,9 +229,14 @@ func (t *Tracker) enter(state State) {
 func (t *Tracker) exit(state State) {
 	now := time.Now()
 	t.mu.Lock()
-	defer t.mu.Unlock()
+	var d time.Duration
 	if t.open && t.state.get() == state {
+		d = now.Sub(t.enteredAt)
 		t.accrueLocked(now)
+	}
+	t.mu.Unlock()
+	if d > 0 {
+		t.sendPhaseCompleted(state, d)
 	}
 }
 

--- a/pkg/status/tracker.go
+++ b/pkg/status/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/block/spirit/pkg/metrics"
@@ -36,27 +37,52 @@ type Tracker struct {
 	open      bool                    // the current state has a running interval
 	durations map[State]time.Duration // closed time attributed per state
 
-	// sink receives a phase metric on every transition. It is optional: with
-	// no sink installed the tracker does no work beyond the timing above,
-	// which is what makes phase reporting free for callers that don't want it.
-	sinkMu sync.Mutex
+	// sink receives a phase metric on every transition. It is optional, and
+	// held as one atomically-swapped pointer so that the common case — nobody
+	// listening — costs a single load and nothing else: no lock, no context,
+	// no batch. That is what makes phase reporting free for callers that
+	// don't want it.
+	sink atomic.Pointer[trackerSink]
+}
+
+// trackerSink pairs the installed sink with the logger to complain to, so
+// that both are swapped together by a single atomic store.
+type trackerSink struct {
 	sink   metrics.Sink
 	logger *slog.Logger
 }
 
 // SetMetricsSink installs the sink that phase transitions are reported to,
-// and the logger used when a send fails. A nil sink (the default) disables
-// reporting; a metrics.NoopSink is accepted and simply discards the values.
+// and the logger used when a send fails. Reporting is off until it is called
+// with a sink that can actually receive.
 //
-// Reporting is synchronous, so a slow sink slows transitions — bounded by
+// A nil sink, or a *metrics.NoopSink, leaves reporting off rather than
+// installing a discard. That distinction matters because every runner
+// defaults its metricsSink to a NoopSink and passes it here unconditionally:
+// if a NoopSink counted as installed, a run that asked for no metrics would
+// still build a batch and a timeout context on every transition.
+//
+// Reporting is synchronous, so a slow sink delays transitions — bounded by
 // metrics.SinkTimeout per send, and there are only a dozen transitions in a
 // run. It is deliberately the same trade-off the copier already makes for its
-// per-chunk metrics, which send far more often.
+// per-chunk metrics, which send far more often. Delivery time is excluded
+// from the phase durations themselves (see enter).
 func (t *Tracker) SetMetricsSink(sink metrics.Sink, logger *slog.Logger) {
-	t.sinkMu.Lock()
-	defer t.sinkMu.Unlock()
-	t.sink = sink
-	t.logger = logger
+	if sink == nil {
+		t.sink.Store(nil)
+		return
+	}
+	if _, noop := sink.(*metrics.NoopSink); noop {
+		t.sink.Store(nil)
+		return
+	}
+	t.sink.Store(&trackerSink{sink: sink, logger: logger})
+}
+
+// reporting reports whether anything is listening. Callers check it before
+// assembling values, since the batch itself is the allocation worth avoiding.
+func (t *Tracker) reporting() bool {
+	return t.sink.Load() != nil
 }
 
 // send delivers one batch. It uses a background context on purpose: a phase
@@ -64,23 +90,30 @@ func (t *Tracker) SetMetricsSink(sink metrics.Sink, logger *slog.Logger) {
 // most wants reported, so the final transitions must still be sent after the
 // run's context is done.
 func (t *Tracker) send(values ...metrics.MetricValue) {
-	t.sinkMu.Lock()
-	sink, logger := t.sink, t.logger
-	t.sinkMu.Unlock()
-	if sink == nil {
+	s := t.sink.Load()
+	if s == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), metrics.SinkTimeout)
 	defer cancel()
-	if err := sink.Send(ctx, &metrics.Metrics{Values: values}); err != nil && logger != nil {
-		logger.Warn("could not send workflow phase metrics", "error", err)
+	if err := s.sink.Send(ctx, &metrics.Metrics{Values: values}); err != nil && s.logger != nil {
+		s.logger.Warn("could not send workflow phase metrics", "error", err)
 	}
 }
 
 // RecordCopyCompleted reports the settled copy aggregate once the copy phase
 // has ended. Runners read it from the chunker, which counts rows from applier
-// feedback and already carries a resumed run's earlier rows.
+// feedback.
+//
+// What a resumed run reports here is chunker-dependent: the composite
+// chunker restores its count from the watermark, the optimistic chunker
+// starts from zero because its watermark stores key positions only (see
+// table.Chunker.RowsCopied). Read these as the rows this run copied, not as a
+// migration lifetime total.
 func (t *Tracker) RecordCopyCompleted(rows, chunks uint64) {
+	if !t.reporting() {
+		return
+	}
 	t.send(
 		metrics.MetricValue{Name: metrics.CopyRowsCompletedMetricName, Type: metrics.GAUGE, Value: float64(rows)},
 		metrics.MetricValue{Name: metrics.CopyChunksCompletedMetricName, Type: metrics.GAUGE, Value: float64(chunks)},
@@ -101,15 +134,20 @@ func (t *Tracker) Begin() {
 	t.durations = nil
 	t.state.set(Initial)
 	t.mu.Unlock()
+	if !t.reporting() {
+		return
+	}
 	// Begin is the run's first transition, so it reports Initial the same way
 	// every later transition reports its state. Nothing is completed here: a
 	// re-Begin abandons the previous run's open interval rather than closing
 	// it, which is what "starts a fresh run" means.
+	deliveryStart := time.Now()
 	t.send(metrics.MetricValue{
 		Name:  metrics.WorkflowPhaseMetricName,
 		Type:  metrics.GAUGE,
 		Value: float64(Initial),
 	})
+	t.excludeDelivery(Initial, deliveryStart)
 }
 
 // Get returns the current state.
@@ -203,8 +241,13 @@ func (t *Tracker) enter(state State) {
 	t.open = true
 	t.mu.Unlock()
 
+	if !t.reporting() {
+		return
+	}
 	// Sending happens outside t.mu: a sink must never be able to block a
-	// state read (Get, Elapsed, the status block's goroutine).
+	// state read (Get, Elapsed, the status block's goroutine). The new state
+	// is published before delivery, so a reader never sees a stale phase.
+	deliveryStart := time.Now()
 	if completedFor > 0 {
 		t.sendPhaseCompleted(completed, completedFor)
 	}
@@ -213,9 +256,31 @@ func (t *Tracker) enter(state State) {
 		Type:  metrics.GAUGE,
 		Value: float64(state),
 	})
+	t.excludeDelivery(state, deliveryStart)
+}
+
+// excludeDelivery rolls the current phase's start forward by however long
+// delivery took, so that the phase clock begins once the transition has been
+// announced rather than when it was decided. Without it a sink blocking for
+// up to metrics.SinkTimeout would land inside the very duration it is about
+// to be told about, and Do would no longer time exactly the function it
+// brackets.
+//
+// It is a no-op once the tracker has moved on — a fatal Set (ErrCleanup)
+// racing an in-flight delivery must not have its own clock rewritten.
+func (t *Tracker) excludeDelivery(state State, deliveryStart time.Time) {
+	d := time.Since(deliveryStart)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.open && t.state.get() == state {
+		t.enteredAt = t.enteredAt.Add(d)
+	}
 }
 
 func (t *Tracker) sendPhaseCompleted(state State, d time.Duration) {
+	if !t.reporting() {
+		return
+	}
 	t.send(
 		metrics.MetricValue{Name: metrics.WorkflowPhaseCompletedMetricName, Type: metrics.GAUGE, Value: float64(state)},
 		metrics.MetricValue{Name: metrics.WorkflowPhaseSecondsMetricName, Type: metrics.GAUGE, Value: d.Seconds()},

--- a/pkg/status/tracker_metrics_test.go
+++ b/pkg/status/tracker_metrics_test.go
@@ -1,0 +1,175 @@
+package status
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/metrics"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingSink captures each Send as one batch, because the batch is the
+// unit that carries meaning: MetricValue has no labels, so a phase and its
+// duration are only correlated by arriving together.
+type recordingSink struct {
+	mu       sync.Mutex
+	batches  [][]metrics.MetricValue
+	err      error
+	blockFor time.Duration
+}
+
+func (s *recordingSink) Send(ctx context.Context, m *metrics.Metrics) error {
+	if s.blockFor > 0 {
+		select {
+		case <-time.After(s.blockFor):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.batches = append(s.batches, m.Values)
+	return s.err
+}
+
+func (s *recordingSink) snapshot() [][]metrics.MetricValue {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]metrics.MetricValue(nil), s.batches...)
+}
+
+func (s *recordingSink) values(name string) []float64 {
+	var out []float64
+	for _, batch := range s.snapshot() {
+		for _, v := range batch {
+			if v.Name == name {
+				out = append(out, v.Value)
+			}
+		}
+	}
+	return out
+}
+
+func TestTrackerReportsPhaseEntry(t *testing.T) {
+	sink := &recordingSink{}
+	var tracker Tracker
+	tracker.SetMetricsSink(sink, nil)
+
+	tracker.Begin()
+	require.NoError(t, tracker.Do(CopyRows, func() error { return nil }))
+	tracker.Set(Close)
+
+	require.Equal(t,
+		[]float64{float64(Initial), float64(CopyRows), float64(Close)},
+		sink.values(metrics.WorkflowPhaseMetricName),
+		"every transition reports the phase being entered, in order")
+}
+
+func TestTrackerReportsPhaseCompletionOnce(t *testing.T) {
+	sink := &recordingSink{}
+	var tracker Tracker
+	tracker.SetMetricsSink(sink, nil)
+
+	tracker.Begin()
+	require.NoError(t, tracker.Do(CopyRows, func() error {
+		time.Sleep(2 * time.Millisecond)
+		return nil
+	}))
+	tracker.Set(Close)
+
+	// Initial closes when CopyRows is entered; CopyRows closes at the end of
+	// its bracket and must NOT be reported a second time when Close is
+	// entered, or a dashboard would double-count the copy.
+	require.Equal(t,
+		[]float64{float64(Initial), float64(CopyRows)},
+		sink.values(metrics.WorkflowPhaseCompletedMetricName))
+
+	seconds := sink.values(metrics.WorkflowPhaseSecondsMetricName)
+	require.Len(t, seconds, 2)
+	require.Positive(t, seconds[1])
+	require.InDelta(t, tracker.Duration(CopyRows).Seconds(), seconds[1], 0.001)
+}
+
+// TestTrackerPhaseBatchCorrelatesPhaseAndDuration pins the batch contract the
+// sink relies on: a completion batch carries the phase and its duration
+// together, since there is nowhere else to put the phase.
+func TestTrackerPhaseBatchCorrelatesPhaseAndDuration(t *testing.T) {
+	sink := &recordingSink{}
+	var tracker Tracker
+	tracker.SetMetricsSink(sink, nil)
+
+	tracker.Begin()
+	require.NoError(t, tracker.Do(Checksum, func() error { return nil }))
+
+	var found bool
+	for _, batch := range sink.snapshot() {
+		if len(batch) != 2 || batch[0].Name != metrics.WorkflowPhaseCompletedMetricName {
+			continue
+		}
+		if batch[0].Value != float64(Initial) {
+			continue
+		}
+		require.Equal(t, metrics.WorkflowPhaseSecondsMetricName, batch[1].Name)
+		found = true
+	}
+	require.True(t, found, "phase completion must be a single 2-value batch")
+}
+
+func TestTrackerRecordCopyCompleted(t *testing.T) {
+	sink := &recordingSink{}
+	var tracker Tracker
+	tracker.SetMetricsSink(sink, nil)
+
+	tracker.RecordCopyCompleted(1234, 7)
+
+	require.Equal(t, [][]metrics.MetricValue{{
+		{Name: metrics.CopyRowsCompletedMetricName, Type: metrics.GAUGE, Value: 1234},
+		{Name: metrics.CopyChunksCompletedMetricName, Type: metrics.GAUGE, Value: 7},
+	}}, sink.snapshot())
+}
+
+// TestTrackerWithoutSinkIsUnchanged is the "costs nothing when unused" claim:
+// the zero-value tracker must still time phases and must not panic.
+func TestTrackerWithoutSinkIsUnchanged(t *testing.T) {
+	var tracker Tracker
+	tracker.Begin()
+	require.NoError(t, tracker.Do(CopyRows, func() error {
+		time.Sleep(time.Millisecond)
+		return nil
+	}))
+	tracker.RecordCopyCompleted(1, 1)
+	require.Positive(t, tracker.Duration(CopyRows))
+	require.Equal(t, CopyRows, tracker.Get())
+}
+
+// TestTrackerSinkErrorDoesNotFailTransition: metrics are best effort. A sink
+// that always errors must not change the tracker's behavior.
+func TestTrackerSinkErrorDoesNotFailTransition(t *testing.T) {
+	sink := &recordingSink{err: context.DeadlineExceeded}
+	var tracker Tracker
+	tracker.SetMetricsSink(sink, nil)
+
+	tracker.Begin()
+	require.NoError(t, tracker.Do(CopyRows, func() error { return nil }))
+	require.Equal(t, CopyRows, tracker.Get())
+}
+
+// TestTrackerReportsAfterContextCancellation documents why send uses a
+// background context: the last phase of a cancelled run is the one an
+// operator most wants to see.
+func TestTrackerReportsAfterContextCancellation(t *testing.T) {
+	sink := &recordingSink{}
+	var tracker Tracker
+	tracker.SetMetricsSink(sink, nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	tracker.Begin()
+	require.ErrorIs(t, tracker.Do(CopyRows, func() error { return ctx.Err() }), context.Canceled)
+	tracker.Set(ErrCleanup)
+
+	require.Contains(t, sink.values(metrics.WorkflowPhaseMetricName), float64(ErrCleanup))
+	require.Contains(t, sink.values(metrics.WorkflowPhaseCompletedMetricName), float64(CopyRows))
+}

--- a/pkg/status/tracker_metrics_test.go
+++ b/pkg/status/tracker_metrics_test.go
@@ -144,6 +144,52 @@ func TestTrackerWithoutSinkIsUnchanged(t *testing.T) {
 	require.Equal(t, CopyRows, tracker.Get())
 }
 
+// TestTrackerNoopSinkIsNotInstalled: every runner defaults its metricsSink to
+// a NoopSink and hands it over unconditionally, so "no sink" and "the default
+// sink" are the same request. Installing the NoopSink would mean a run that
+// wants no metrics still builds a batch and a timeout context per transition.
+func TestTrackerNoopSinkIsNotInstalled(t *testing.T) {
+	var tracker Tracker
+	tracker.SetMetricsSink(&metrics.NoopSink{}, nil)
+	require.False(t, tracker.reporting(), "a NoopSink leaves reporting off")
+
+	tracker.SetMetricsSink(nil, nil)
+	require.False(t, tracker.reporting(), "a nil sink leaves reporting off")
+
+	tracker.SetMetricsSink(&recordingSink{}, nil)
+	require.True(t, tracker.reporting(), "a real sink turns reporting on")
+
+	// ...and it can be turned back off, since the pair is swapped atomically.
+	tracker.SetMetricsSink(&metrics.NoopSink{}, nil)
+	require.False(t, tracker.reporting())
+}
+
+// TestTrackerSlowSinkDoesNotInflatePhase pins the property that makes
+// synchronous delivery acceptable: Tracker.Do is documented as timing exactly
+// the function it brackets, so the time spent announcing a phase must not be
+// charged to that phase. Without excludeDelivery, entering CopyRows behind a
+// sink that blocks would add the block to CopyRows' duration.
+func TestTrackerSlowSinkDoesNotInflatePhase(t *testing.T) {
+	const blockFor = 40 * time.Millisecond
+	sink := &recordingSink{blockFor: blockFor}
+	var tracker Tracker
+	tracker.SetMetricsSink(sink, nil)
+
+	tracker.Begin()
+	require.NoError(t, tracker.Do(CopyRows, func() error { return nil }))
+
+	// Entering CopyRows delivers two batches (Initial completed, CopyRows
+	// entered), so a naive clock would report >= 2*blockFor for a phase whose
+	// function did nothing at all.
+	require.Less(t, tracker.Duration(CopyRows), blockFor,
+		"phase duration must exclude the time spent delivering the transition")
+
+	seconds := sink.values(metrics.WorkflowPhaseSecondsMetricName)
+	require.NotEmpty(t, seconds)
+	require.Less(t, seconds[len(seconds)-1], blockFor.Seconds(),
+		"the reported duration must exclude delivery too")
+}
+
 // TestTrackerSinkErrorDoesNotFailTransition: metrics are best effort. A sink
 // that always errors must not change the tracker's behavior.
 func TestTrackerSinkErrorDoesNotFailTransition(t *testing.T) {

--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -53,6 +53,18 @@ type Chunker interface {
 	Next() (*Chunk, error)
 	Feedback(chunk *Chunk, duration time.Duration, actualRows uint64)
 	Progress() (rowsRead uint64, chunksCopied uint64, totalRowsExpected uint64)
+	// RowsCopied returns the number of rows the applier has actually settled,
+	// summed from the actualRows reported to Feedback. It is deliberately not
+	// Progress's first return: the optimistic chunker measures progress as
+	// distance travelled through the auto-increment key space (so that it can
+	// be compared against the auto-increment max), which on a sparse table is
+	// nothing like a row count. Use Progress to render a percentage, and this
+	// to report how much data was copied.
+	//
+	// A resumed run reports only what the chunker itself has seen unless the
+	// watermark carried an earlier count forward (the composite chunker's
+	// does; the optimistic chunker's watermark stores key positions only).
+	RowsCopied() uint64
 	OpenAtWatermark(watermark string) error
 	GetLowWatermark() (watermark string, err error)
 	// Reset resets the chunker to start from the beginning, as if Open() was just called.

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -431,6 +431,13 @@ func (t *chunkerComposite) IsRead() bool {
 // wants to do that. For the composite chunker we use
 // the actualRows copied (from feedback) over the estimated
 // rows (from table statistics)
+// RowsCopied returns the rows settled by the applier. For the composite
+// chunker this is the same counter Progress reports, because it already
+// accumulates the actualRows from Feedback.
+func (t *chunkerComposite) RowsCopied() uint64 {
+	return atomic.LoadUint64(&t.rowsCopied)
+}
+
 func (t *chunkerComposite) Progress() (uint64, uint64, uint64) {
 	return atomic.LoadUint64(&t.rowsCopied), t.chunksCopied.Load(), atomic.LoadUint64(&t.Ti.EstimatedRows)
 }

--- a/pkg/table/chunker_mock.go
+++ b/pkg/table/chunker_mock.go
@@ -301,6 +301,12 @@ func (m *MockChunker) KeyBelowLowWatermark(key any) bool {
 	return keyPos < m.currentPosition
 }
 
+func (m *MockChunker) RowsCopied() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.currentPosition
+}
+
 func (m *MockChunker) Progress() (uint64, uint64, uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/table/chunker_multi.go
+++ b/pkg/table/chunker_multi.go
@@ -184,6 +184,16 @@ func (m *multiChunker) Feedback(chunk *Chunk, duration time.Duration, actualRows
 }
 
 // Progress returns aggregate progress across all chunkers
+func (m *multiChunker) RowsCopied() uint64 {
+	m.Lock()
+	defer m.Unlock()
+	var total uint64
+	for _, chunker := range m.chunkers {
+		total += chunker.RowsCopied()
+	}
+	return total
+}
+
 func (m *multiChunker) Progress() (uint64, uint64, uint64) {
 	m.Lock()
 	defer m.Unlock()

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -34,8 +34,13 @@ type chunkerOptimistic struct {
 	// Progress tracking: the implementation here is up to the chunker,
 	// and for the optimistic chunker it is based on the progress
 	// through the auto_increment counter.
-	rowsCopied   uint64 // The sum of chunkSize
-	chunksCopied atomic.Uint64
+	rowsCopied uint64 // The sum of chunkSize: distance travelled, not a row count
+	// actualRowsCopied is the sum of the actualRows reported to Feedback, i.e.
+	// the rows the applier really settled. rowsCopied above cannot serve this
+	// purpose: it advances by the chunk's key-space width so that it can be
+	// compared against the auto-increment max.
+	actualRowsCopied atomic.Uint64
+	chunksCopied     atomic.Uint64
 
 	logger *slog.Logger
 }
@@ -344,6 +349,7 @@ func (t *chunkerOptimistic) Reset() error {
 
 	// Reset progress tracking
 	atomic.StoreUint64(&t.rowsCopied, 0)
+	t.actualRowsCopied.Store(0)
 	t.chunksCopied.Store(0)
 
 	// Make sure min/max value are always specified
@@ -356,11 +362,12 @@ func (t *chunkerOptimistic) Reset() error {
 // Feedback is a way for consumers of chunks to give feedback on how long
 // processing the chunk took. It is incorporated into the calculation of future
 // chunk sizes.
-func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, _ uint64) {
+func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, actualRows uint64) {
 	t.Lock()
 	defer t.Unlock()
 	t.chunkFedBack()
 	t.bumpWatermark(chunk, t.logger)
+	t.actualRowsCopied.Add(actualRows)
 
 	// It is up to the chunker implementation to decide how to track "rows copied"
 	// In the optimistic chunker, since it is really designed around auto_increment
@@ -473,6 +480,7 @@ func (t *chunkerOptimistic) open() (err error) {
 
 	// Initialize progress tracking
 	atomic.StoreUint64(&t.rowsCopied, 0)
+	t.actualRowsCopied.Store(0)
 
 	// Make sure min/max value are always specified
 	// To simplify the code in NextChunk funcs.
@@ -489,6 +497,12 @@ func (t *chunkerOptimistic) IsRead() bool {
 // Progress returns the current progress of the chunker as (rowsCopied, totalRows)
 // It is up to the chunker implementation to select the formula. The optimistic
 // chunker is based on the progress of the auto_increment column.
+// RowsCopied returns the rows settled by the applier, which for this chunker
+// is a separate counter from the key-space distance Progress reports.
+func (t *chunkerOptimistic) RowsCopied() uint64 {
+	return t.actualRowsCopied.Load()
+}
+
 func (t *chunkerOptimistic) Progress() (uint64, uint64, uint64) {
 	maxValue, err := strconv.ParseUint(t.Ti.MaxValue().String(), 10, 64) // autoInc max
 	if err != nil {

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -371,10 +371,15 @@ func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, actualRows u
 
 	// It is up to the chunker implementation to decide how to track "rows copied"
 	// In the optimistic chunker, since it is really designed around auto_increment
-	// tables, we add the ChunkSize to the rowsCopied counter, and ignore
-	// the actualRows. This differs from the composite chunker, which doesn't have an
-	// auto_inc max so it takes the table estimate and compares it to the actual
-	// rows copied.
+	// tables, we add the ChunkSize to the rowsCopied counter that Progress
+	// reports, and ignore the actualRows *there*. This differs from the composite
+	// chunker, which doesn't have an auto_inc max so it takes the table estimate
+	// and compares it to the actual rows copied.
+	//
+	// actualRows is not discarded outright: it is summed into actualRowsCopied
+	// above, which is what RowsCopied reports. The two counters answer
+	// different questions — how far through the key space we are, versus how
+	// many rows were actually written.
 	atomic.AddUint64(&t.rowsCopied, chunk.ChunkSize)
 	t.chunksCopied.Add(1)
 

--- a/pkg/table/rowscopied_test.go
+++ b/pkg/table/rowscopied_test.go
@@ -1,0 +1,87 @@
+package table
+
+import (
+	"database/sql"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRowsCopiedIsNotProgressForOptimisticChunker pins the reason RowsCopied
+// exists as its own accessor. The optimistic chunker measures progress as
+// distance travelled through the auto-increment key space, so on a sparse
+// table Progress's first return is far larger than the rows actually copied,
+// and cannot stand in for a row count.
+func TestRowsCopiedIsNotProgressForOptimisticChunker(t *testing.T) {
+	t1 := newTableInfo4Test("test", "t1")
+	t1.minValue = Datum{Val: int64(1), Tp: signedType}
+	t1.maxValue = Datum{Val: int64(1000000), Tp: signedType}
+	t1.EstimatedRows = 1000000
+	t1.KeyColumns = []string{"id"}
+	t1.keyColumnsMySQLTp = []string{"bigint"}
+	t1.keyDatums = []datumTp{signedType}
+	t1.KeyIsAutoInc = true
+	t1.Columns = []string{"id", "name"}
+	require.NoError(t, t1.PrimaryKeyIsMemoryComparable())
+
+	chunker := &chunkerOptimistic{
+		Ti:                t1,
+		dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: ChunkerDefaultTarget},
+		watermarkTracker:  watermarkTracker{lowerBoundWatermarkMap: make(map[string]*Chunk)},
+		logger:            slog.Default(),
+	}
+	chunker.SetDynamicChunking(false)
+	require.NoError(t, chunker.Open())
+
+	// Walk a few chunks whose key ranges are mostly empty.
+	const copiedPerChunk = 3
+	for range 3 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		chunker.Feedback(chunk, time.Millisecond, copiedPerChunk)
+	}
+
+	rowsRead, chunksCopied, _ := chunker.Progress()
+	require.Equal(t, uint64(3), chunksCopied)
+	require.Equal(t, uint64(3*copiedPerChunk), chunker.RowsCopied(),
+		"settled rows are summed from the applier's feedback")
+	require.Greater(t, rowsRead, chunker.RowsCopied(),
+		"Progress reports key-space distance travelled, not rows")
+}
+
+// TestRowsCopiedCompositeChunker: the composite chunker already counts actual
+// rows, so RowsCopied and Progress's first return agree there. This is what
+// makes RowsCopied a safe single accessor across both chunker types.
+func TestRowsCopiedCompositeChunker(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS rowscopied_composite")
+	testutils.RunSQL(t, `CREATE TABLE rowscopied_composite (
+		a varbinary(40) NOT NULL,
+		b int NOT NULL,
+		PRIMARY KEY (a)
+	)`)
+	testutils.RunSQL(t, `INSERT INTO rowscopied_composite (a, b) SELECT UUID(), 1 FROM dual`)
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	t1 := NewTableInfo(db, "test", "rowscopied_composite")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	chunker, err := NewChunker(t1, ChunkerConfig{})
+	require.NoError(t, err)
+	require.IsType(t, &chunkerComposite{}, chunker)
+	require.NoError(t, chunker.Open())
+
+	chunk, err := chunker.Next()
+	require.NoError(t, err)
+	chunker.Feedback(chunk, time.Millisecond, 42)
+
+	rowsRead, _, _ := chunker.Progress()
+	require.Equal(t, uint64(42), chunker.RowsCopied())
+	require.Equal(t, rowsRead, chunker.RowsCopied())
+}


### PR DESCRIPTION
Spirit already has one always-present, caller-supplied destination for telemetry: metrics.Sink, defaulting to NoopSink. Report phase transitions there instead of introducing a second subscription mechanism.

status.Tracker gains an optional sink. On every transition it emits the phase being entered, and on every phase close the phase that ended plus its duration. MetricValue has no labels, so the phase travels as the numeric status.State correlated inside a single Send batch — the same contract the copier's per-chunk metrics already rely on. Sending happens outside the tracker's mutex so a slow sink can never block a state read, and uses a background context so the final transitions of a cancelled run are still reported. With no sink installed the tracker behaves exactly as before.

move and datasync hardcoded a NoopSink with no way to replace it, so they gain the SetMetricsSink that migration already had; without it, phase reporting would have been migrate-only.

Copy completion reports the settled totals once, read from the chunker rather than a second tally kept by the copier. That required distinguishing two numbers the chunker had conflated: the optimistic chunker's Progress advances by the chunk's key-space width so it can be compared against the auto-increment max, which on a sparse table is nothing like a row count (a 4-row table reports 3000). Chunker.RowsCopied is the sum of the actualRows already passed to Feedback, and the optimistic chunker now keeps it instead of discarding that argument.