### PR TITLE
statement: converge expression DEFAULTs that MySQL rewrites

### DIFF
--- a/pkg/statement/README.md
+++ b/pkg/statement/README.md
@@ -344,6 +344,7 @@ Two layers of canonicalization apply:
    | `indexNormalizer` | inline `c INT UNIQUE` → table-level `UNIQUE KEY`; assigns MySQL's default names to unnamed indexes |
    | `columnCheckNormalizer` | hoists a column-level `CHECK` into a table-level constraint |
    | `expressionParenNormalizer` | rewrites `CHECK` and generated-column expressions into a canonical parenthesization, keeping only the parentheses the expression's own precedence does not already imply: MySQL stores them fully parenthesized and the parser preserves input parens verbatim, so `CHECK ((a=1) OR ((b=2) AND (c=3)))` and `CHECK (a=1 OR b=2 AND c=3)` both canonicalize to the latter |
+   | `functionAliasNormalizer` | rewrites a function name to the one MySQL stores, in expression `DEFAULT`s, generated columns, `CHECK`s, functional indexes and partition expressions: `STRING_TO_VECTOR` → `to_vector`, `LCASE` → `lower`, `SUBSTRING`/`MID` → `substr`, `DAY` → `dayofmonth`, and the timestamp family inside an expression default → `now()` |
    | `binaryAttributeNormalizer` | resolves the legacy `BINARY` column attribute to the column charset's `_bin` collation |
    | `integerDisplayWidthNormalizer` | strips deprecated integer display widths (`int(11)` → `int`), keeping `tinyint(1)` and `ZEROFILL` |
    | `vectorDimensionNormalizer` | fills in the default dimension of a `VECTOR` column declared without one (`vector` → `vector(2048)`, MySQL 9.7+) |
@@ -368,7 +369,7 @@ Because canonicalization happens at parse time, **`Diff` assumes normalized inpu
 
 ### Relationship to `spirit fmt`
 
-Normalization is an **offline, best-effort** approximation of what MySQL does: it needs no database and covers the common cases. [`spirit fmt`](../../docs/fmt.md) is the **ground-truth** canonicalizer — it round-trips a `CREATE TABLE` through a live MySQL server and reads back `SHOW CREATE TABLE`, so it captures *every* transformation, including ones normalization does not implement (e.g. `DEFAULT FALSE` → `DEFAULT '0'`). Use `spirit fmt` to canonicalize schema files on disk; normalization keeps in-memory parsing and diffing accurate without a server.
+Normalization is an **offline, best-effort** approximation of what MySQL does: it needs no database and covers the common cases. [`spirit fmt`](../../docs/fmt.md) is the **ground-truth** canonicalizer — it round-trips a `CREATE TABLE` through a live MySQL server and reads back `SHOW CREATE TABLE`, so it captures *every* transformation, including ones normalization does not implement (e.g. `DEFAULT FALSE` → `DEFAULT '0'`, and the expression rewrites that restructure rather than rename — `MOD(a,b)` → `(a % b)`, `INSTR(a,b)` → `locate(b,a)`, `WEEKOFYEAR(d)` → `week(d,3)`). Use `spirit fmt` to canonicalize schema files on disk; normalization keeps in-memory parsing and diffing accurate without a server.
 
 ## Helper Functions
 

--- a/pkg/statement/create_table.go
+++ b/pkg/statement/create_table.go
@@ -517,8 +517,12 @@ func (ct *CreateTable) parseColumn(col *ast.ColumnDef) Column {
 					column.DefaultIsString = true
 				} else {
 					// Non-string defaults (numeric, functions, expressions):
-					// keep the Restored text representation.
-					defaultRaw := fmt.Sprintf("%v", ct.parseExpression(defaultExpr))
+					// keep the Restored text representation. Only a
+					// literal-style default takes MySQL's bare-keyword
+					// spelling of CURRENT_TIMESTAMP; inside the parentheses of
+					// an expression default the call form is canonical (MySQL
+					// stores DEFAULT (CURRENT_TIMESTAMP) as DEFAULT (now())).
+					defaultRaw := fmt.Sprintf("%v", restoreValueExprText(defaultExpr, !column.DefaultIsExpr))
 					column.Default = &defaultRaw
 				}
 			}
@@ -1105,57 +1109,9 @@ func (ct *CreateTable) parseSubPartitionDefinition(sub *ast.SubPartitionDefiniti
 	return subDef
 }
 
-// parseExpression converts an expression to a string representation
+// parseExpression converts an expression to a string representation, in the
+// form MySQL reports for a literal-style DEFAULT / ON UPDATE / partition
+// expression. See restoreValueExprText for the bare-keyword caveat.
 func (ct *CreateTable) parseExpression(expr ast.ExprNode) any {
-	if expr == nil {
-		return nil
-	}
-
-	// Handle different expression types
-	switch e := expr.(type) {
-	case *ast.FuncCallExpr:
-		// Handle function calls like CURRENT_TIMESTAMP, CURRENT_TIMESTAMP(3), UUID(), etc.
-		// We use Restore to preserve function arguments (e.g. precision in CURRENT_TIMESTAMP(3)).
-		// RestoreKeyWordLowercase renders the function name and any keywords
-		// inside its arguments in lowercase — matching MySQL's canonical
-		// SHOW CREATE TABLE form (e.g. DEFAULT (concat(...))) so that
-		// function-name case never causes a spurious diff — while leaving
-		// string-literal arguments byte-exact. The previous strings.ToLower
-		// over the whole Restored text corrupted literal case:
-		// DEFAULT (concat('A')) round-tripped to concat('a'), emitting a
-		// different default value and making defaults that differ only in
-		// literal case compare equal.
-		var sb strings.Builder
-		rCtx := format.NewRestoreCtx(format.RestoreStringSingleQuotes|format.RestoreKeyWordLowercase|
-			format.RestoreNameBackQuotes|format.RestoreStringWithoutCharset, &sb)
-		if err := e.Restore(rCtx); err != nil {
-			return e.FnName.L // fallback to function name on error
-		}
-		restored := sb.String()
-		// Normalize: MySQL's canonical SHOW CREATE TABLE uses "CURRENT_TIMESTAMP" (no parens)
-		// when there is no fractional seconds precision, but the parser's Restore always adds "()".
-		// We only strip parens for timestamp-family functions; other functions like json_object()
-		// need to keep their parens as they represent actual function calls.
-		name := strings.ToUpper(e.FnName.L)
-		isTimestampFunc := name == "CURRENT_TIMESTAMP" || name == "NOW" ||
-			name == "LOCALTIME" || name == "LOCALTIMESTAMP" || name == "UTC_TIMESTAMP"
-		if isTimestampFunc && len(e.Args) == 0 && strings.HasSuffix(restored, "()") {
-			restored = strings.TrimSuffix(restored, "()")
-		}
-		return restored
-	default:
-		// For other types, fall back to text representation
-		var sb strings.Builder
-		sb.Reset()
-		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreStringWithoutCharset, &sb)
-		if err := expr.Restore(rCtx); err != nil {
-			return "<error>"
-		}
-		str := sb.String()
-		// if the string is quoted, remove quotes
-		if strings.HasPrefix(str, "'") && strings.HasSuffix(str, "'") {
-			str = str[1 : len(str)-1]
-		}
-		return str
-	}
+	return restoreValueExprText(expr, true)
 }

--- a/pkg/statement/normalize_expression_parens.go
+++ b/pkg/statement/normalize_expression_parens.go
@@ -71,13 +71,21 @@ func (expressionParenNormalizer) Normalize(ct *CreateTable) *CreateTable {
 			continue
 		}
 		canonicalizeExprParens(p, c.Expression)
-		definition := fmt.Sprintf("CHECK (%s)", *c.Expression)
-		if c.NotEnforced {
-			definition += " NOT ENFORCED"
-		}
+		definition := checkConstraintDefinition(c)
 		c.Definition = &definition
 	}
 	return ct
+}
+
+// checkConstraintDefinition renders the CHECK constraint definition text that
+// diffConstraints emits. Any rule that rewrites a CHECK expression has to
+// rebuild the definition from it, or the two drift apart.
+func checkConstraintDefinition(c *Constraint) string {
+	definition := fmt.Sprintf("CHECK (%s)", *c.Expression)
+	if c.NotEnforced {
+		definition += " NOT ENFORCED"
+	}
+	return definition
 }
 
 // parenCanonicalizer is the ast.Visitor behind pass 1 of canonicalizeExprParens:
@@ -113,25 +121,17 @@ func (parenCanonicalizer) Leave(n ast.Node) (ast.Node, bool) {
 }
 
 // canonicalizeExprParens re-parses the expression text and rewrites it in
-// canonical parenthesization, in place. A nil or empty text is left alone.
-//
-// The text was produced by restoring a successfully parsed expression, so a
-// re-parse failure is not expected; if one occurs the text is left unchanged
-// — the worst outcome is a spurious diff on that expression, never a
-// corrupted definition.
+// canonical parenthesization, in place. A nil or empty text is left alone; so
+// is one that does not re-parse (see parseExpressionText).
 func canonicalizeExprParens(p *parser.Parser, text *string) {
 	if text == nil || *text == "" {
 		return
 	}
-	stmt, err := p.ParseOneStmt("SELECT "+*text, "", "")
-	if err != nil {
+	parsed, ok := parseExpressionText(p, *text)
+	if !ok {
 		return
 	}
-	sel, ok := stmt.(*ast.SelectStmt)
-	if !ok || sel.Fields == nil || len(sel.Fields.Fields) != 1 || sel.Fields.Fields[0].Expr == nil {
-		return
-	}
-	node, ok := sel.Fields.Fields[0].Expr.Accept(parenCanonicalizer{})
+	node, ok := parsed.Accept(parenCanonicalizer{})
 	if !ok {
 		return
 	}

--- a/pkg/statement/normalize_function_aliases.go
+++ b/pkg/statement/normalize_function_aliases.go
@@ -154,7 +154,15 @@ func canonicalizeFuncAliases(p *parser.Parser, text *string, render func(ast.Exp
 	if !ok || !rewriter.renamed {
 		return false
 	}
-	rendered, ok := render(node.(ast.ExprNode))
+	// The rewriter only ever renames a call in place, so the node it hands
+	// back is the expression it was given. Check rather than assert anyway:
+	// normalization runs on every parse, and leaving the text alone beats
+	// panicking if a future visitor change breaks that.
+	rewritten, ok := node.(ast.ExprNode)
+	if !ok {
+		return false
+	}
+	rendered, ok := render(rewritten)
 	if !ok {
 		return false
 	}

--- a/pkg/statement/normalize_function_aliases.go
+++ b/pkg/statement/normalize_function_aliases.go
@@ -1,0 +1,176 @@
+package statement
+
+import (
+	"github.com/block/spirit/pkg/parser"
+	"github.com/block/spirit/pkg/parser/ast"
+)
+
+func init() { registerNormalizer(functionAliasNormalizer{}) }
+
+// mysqlFunctionAliases maps a function name MySQL accepts on input to the name
+// it stores. MySQL resolves an alias when it parses the expression and keeps
+// only the resolved item, so SHOW CREATE TABLE reports the stored name — a
+// column written as DEFAULT (STRING_TO_VECTOR('[1,2,3]')) reads back as
+// DEFAULT (to_vector(_latin1'[1,2,3]')).
+//
+// Every entry here was verified against MySQL 9.7 by creating the column and
+// reading SHOW CREATE TABLE back. No key is also a value, so the mapping is
+// idempotent: a live definition never contains a name that needs rewriting
+// (asserted by TestFunctionAliasesAreIdempotent).
+//
+// MySQL also rewrites some functions *structurally*, which a rename cannot
+// express and which this rule deliberately leaves alone: MOD(a,b) and
+// ADDDATE(d, INTERVAL ...) become operators, INSTR(a,b) becomes
+// locate(b,a) with its arguments swapped, WEEKOFYEAR(d) becomes week(d,3),
+// BIN(n) becomes conv(n,10,2). Those defaults still re-emit on every diff.
+// The timestamp family (current_timestamp, localtime, localtimestamp → now) is
+// only reachable here from inside an expression default: the literal-style
+// DEFAULT LOCALTIME / ON UPDATE NOW() forms are folded to CURRENT_TIMESTAMP by
+// the parser, which is the spelling MySQL reports for them.
+var mysqlFunctionAliases = map[string]string{
+	"ceil":              "ceiling",
+	"character_length":  "char_length",
+	"current_date":      "curdate",
+	"current_time":      "curtime",
+	"current_timestamp": "now",
+	"day":               "dayofmonth",
+	"lcase":             "lower",
+	"localtime":         "now",
+	"localtimestamp":    "now",
+	"mid":               "substr",
+	"octet_length":      "length",
+	"position":          "locate",
+	"power":             "pow",
+	"session_user":      "user",
+	"string_to_vector":  "to_vector",
+	"substring":         "substr",
+	"system_user":       "user",
+	"ucase":             "upper",
+	"vector_to_string":  "from_vector",
+}
+
+// functionAliasNormalizer rewrites every function name in a stored expression
+// to the name MySQL reports for it. Without this, an expression that spells a
+// function by one of its aliases never converges: the authored text and the
+// SHOW CREATE TABLE text differ forever, so a declarative diff emits the same
+// no-op statement on every run — and for a column DEFAULT that no-op is a
+// MODIFY COLUMN, i.e. a full table copy each time (issue #1152).
+//
+// It covers every expression MySQL stores and reports back: column expression
+// DEFAULTs, generated columns, CHECK constraints (column-level and table-level),
+// functional index key parts, and partition expressions.
+//
+// The rule renames only; it does not touch the shape of the expression. The
+// other half of the rewriting MySQL does to a stored expression — charset
+// introducers, so that 'x' reads back as _latin1'x' — needs no rule, because
+// the introducer is dropped when the expression is restored to text
+// (format.RestoreStringWithoutCharset) on both sides of the diff.
+type functionAliasNormalizer struct{}
+
+func (functionAliasNormalizer) Name() string { return "function-aliases" }
+
+func (functionAliasNormalizer) Normalize(ct *CreateTable) *CreateTable {
+	p := parser.New()
+	for i := range ct.Columns {
+		col := &ct.Columns[i]
+		// A string-literal default holds a value, not an expression, even in
+		// the parenthesized DEFAULT ('{}') form.
+		if col.DefaultIsExpr && !col.DefaultIsString {
+			canonicalizeFuncAliases(p, col.Default, restoreExprDefaultText)
+		}
+		canonicalizeFuncAliases(p, col.GeneratedExpr, restoreExpressionText)
+		canonicalizeFuncAliases(p, col.Check, restoreExpressionText)
+	}
+	for i := range ct.Constraints {
+		c := &ct.Constraints[i]
+		if c.Type != "CHECK" || c.Expression == nil {
+			continue
+		}
+		if canonicalizeFuncAliases(p, c.Expression, restoreExpressionText) {
+			// The rendered definition is what diffConstraints emits, so it has
+			// to track the expression it was built from.
+			definition := checkConstraintDefinition(c)
+			c.Definition = &definition
+		}
+	}
+	for i := range ct.Indexes {
+		for j := range ct.Indexes[i].ColumnList {
+			canonicalizeFuncAliases(p, ct.Indexes[i].ColumnList[j].Expression, restoreExpressionText)
+		}
+	}
+	if ct.Partition != nil {
+		canonicalizeFuncAliases(p, ct.Partition.Expression, restoreExpressionText)
+		if ct.Partition.SubPartition != nil {
+			// A subpartition expression is parsed through parseExpression, not
+			// the generic expression restore the partition expression uses.
+			canonicalizeFuncAliases(p, ct.Partition.SubPartition.Expression, restoreLiteralStyleText)
+		}
+	}
+	return ct
+}
+
+// functionAliasRewriter is the ast.Visitor behind canonicalizeFuncAliases: it
+// renames each aliased function call on the way back up the tree.
+type functionAliasRewriter struct{ renamed bool }
+
+func (r *functionAliasRewriter) Enter(n ast.Node) (ast.Node, bool) { return n, false }
+
+func (r *functionAliasRewriter) Leave(n ast.Node) (ast.Node, bool) {
+	call, ok := n.(*ast.FuncCallExpr)
+	// A schema-qualified call is a stored function, not a builtin: db.day(x)
+	// is whatever the user defined, and renaming it would call something else.
+	if !ok || call.Schema.L != "" {
+		return n, true
+	}
+	canonical, ok := mysqlFunctionAliases[call.FnName.L]
+	if !ok {
+		return n, true
+	}
+	call.FnName = ast.NewCIStr(canonical)
+	r.renamed = true
+	return n, true
+}
+
+// canonicalizeFuncAliases rewrites the aliased function names in an expression
+// text, in place, and reports whether anything changed. A nil or empty text is
+// left alone.
+//
+// render must be the same restore the text was originally produced with, so
+// that an expression holding an alias and one already spelling the stored name
+// render identically — that identity is the whole point of the rule. An
+// expression with no alias in it is left byte-for-byte untouched rather than
+// re-rendered, so this rule cannot perturb a form another rule established
+// (which is what keeps it order-independent).
+func canonicalizeFuncAliases(p *parser.Parser, text *string, render func(ast.ExprNode) (string, bool)) bool {
+	if text == nil || *text == "" {
+		return false
+	}
+	expr, ok := parseExpressionText(p, *text)
+	if !ok {
+		return false
+	}
+	rewriter := &functionAliasRewriter{}
+	node, ok := expr.Accept(rewriter)
+	if !ok || !rewriter.renamed {
+		return false
+	}
+	rendered, ok := render(node.(ast.ExprNode))
+	if !ok {
+		return false
+	}
+	*text = rendered
+	return true
+}
+
+// restoreExprDefaultText and restoreLiteralStyleText are restoreValueExprText's
+// two modes, in the shape canonicalizeFuncAliases takes: each renders an
+// expression exactly as the parse that produced the text rendered it.
+func restoreExprDefaultText(expr ast.ExprNode) (string, bool) {
+	text, ok := restoreValueExprText(expr, false).(string)
+	return text, ok
+}
+
+func restoreLiteralStyleText(expr ast.ExprNode) (string, bool) {
+	text, ok := restoreValueExprText(expr, true).(string)
+	return text, ok
+}

--- a/pkg/statement/normalize_function_aliases_test.go
+++ b/pkg/statement/normalize_function_aliases_test.go
@@ -1,0 +1,445 @@
+package statement
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFunctionAliasNormalization covers each alias in the map, in the
+// expression contexts MySQL rewrites: expression DEFAULTs, generated columns,
+// CHECK constraints, functional indexes and partition expressions.
+func TestFunctionAliasNormalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		wantExpr string // the canonical text the rule must produce
+		get      func(*CreateTable) *string
+	}{
+		{
+			name:     "vector default (issue #1152)",
+			sql:      "CREATE TABLE t (v vector(3) DEFAULT (STRING_TO_VECTOR('[1,2,3]')))",
+			wantExpr: "to_vector('[1,2,3]')",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "vector_to_string",
+			sql:      "CREATE TABLE t (v varchar(64) DEFAULT (VECTOR_TO_STRING(STRING_TO_VECTOR('[1]'))))",
+			wantExpr: "from_vector(to_vector('[1]'))",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "lcase",
+			sql:      "CREATE TABLE t (c varchar(10) DEFAULT (LCASE('AB')))",
+			wantExpr: "lower('AB')",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "ucase",
+			sql:      "CREATE TABLE t (c varchar(10) DEFAULT (UCASE('ab')))",
+			wantExpr: "upper('ab')",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "mid",
+			sql:      "CREATE TABLE t (c varchar(10) DEFAULT (MID('abcdef',1,2)))",
+			wantExpr: "substr('abcdef', 1, 2)",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "substring",
+			sql:      "CREATE TABLE t (c varchar(10) DEFAULT (SUBSTRING('abcdef',1,2)))",
+			wantExpr: "substr('abcdef', 1, 2)",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "power",
+			sql:      "CREATE TABLE t (c int DEFAULT (POWER(2,3)))",
+			wantExpr: "pow(2, 3)",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "ceil",
+			sql:      "CREATE TABLE t (c int DEFAULT (CEIL(1.2)))",
+			wantExpr: "ceiling(1.2)",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "character_length",
+			sql:      "CREATE TABLE t (c int DEFAULT (CHARACTER_LENGTH('abc')))",
+			wantExpr: "char_length('abc')",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "octet_length",
+			sql:      "CREATE TABLE t (c int DEFAULT (OCTET_LENGTH('abc')))",
+			wantExpr: "length('abc')",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "day",
+			sql:      "CREATE TABLE t (c int DEFAULT (DAY('2020-01-01')))",
+			wantExpr: "dayofmonth('2020-01-01')",
+			get:      firstColumnDefault,
+		},
+		{
+			// POSITION(x IN y) is restored as an infix form, locate(x, y) as a
+			// plain call — the rename has to survive the change of shape.
+			name:     "position",
+			sql:      "CREATE TABLE t (c int DEFAULT (POSITION('a' IN 'abc')))",
+			wantExpr: "locate('a', 'abc')",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "session_user",
+			sql:      "CREATE TABLE t (c varchar(64) DEFAULT (SESSION_USER()))",
+			wantExpr: "user()",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "system_user",
+			sql:      "CREATE TABLE t (c varchar(64) DEFAULT (SYSTEM_USER()))",
+			wantExpr: "user()",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "current_date",
+			sql:      "CREATE TABLE t (c int DEFAULT (YEAR(CURRENT_DATE)))",
+			wantExpr: "year(curdate())",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "current_time",
+			sql:      "CREATE TABLE t (c int DEFAULT (HOUR(CURRENT_TIME)))",
+			wantExpr: "hour(curtime())",
+			get:      firstColumnDefault,
+		},
+		{
+			// An expression default keeps the call form, so the whole
+			// timestamp family collapses onto now() the way MySQL stores it.
+			name:     "current_timestamp inside an expression default",
+			sql:      "CREATE TABLE t (c datetime DEFAULT (CURRENT_TIMESTAMP))",
+			wantExpr: "now()",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "localtimestamp inside an expression default",
+			sql:      "CREATE TABLE t (c datetime DEFAULT (LOCALTIMESTAMP()))",
+			wantExpr: "now()",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "nested aliases",
+			sql:      "CREATE TABLE t (c varchar(10) DEFAULT (LOWER(MID(UCASE('abc'),1,2))))",
+			wantExpr: "lower(substr(upper('abc'), 1, 2))",
+			get:      firstColumnDefault,
+		},
+		{
+			name:     "generated column",
+			sql:      "CREATE TABLE t (a varchar(10), c varchar(10) GENERATED ALWAYS AS (LCASE(a)) VIRTUAL)",
+			wantExpr: "LOWER(`a`)",
+			get:      func(ct *CreateTable) *string { return ct.Columns[1].GeneratedExpr },
+		},
+		{
+			name:     "table-level CHECK",
+			sql:      "CREATE TABLE t (c varchar(10), CHECK (OCTET_LENGTH(c) > 0))",
+			wantExpr: "LENGTH(`c`)>0",
+			get:      func(ct *CreateTable) *string { return ct.Constraints[0].Expression },
+		},
+		{
+			// Hoisted to a table-level constraint by columnCheckNormalizer.
+			name:     "column-level CHECK",
+			sql:      "CREATE TABLE t (c varchar(10) CHECK (LCASE(c) = c))",
+			wantExpr: "LOWER(`c`)=`c`",
+			get:      func(ct *CreateTable) *string { return ct.Constraints[0].Expression },
+		},
+		{
+			name:     "functional index",
+			sql:      "CREATE TABLE t (c varchar(10), KEY idx ((UCASE(c))))",
+			wantExpr: "UPPER(`c`)",
+			get:      func(ct *CreateTable) *string { return ct.Indexes[0].ColumnList[0].Expression },
+		},
+		{
+			name:     "partition expression",
+			sql:      "CREATE TABLE t (dt date NOT NULL, PRIMARY KEY (dt)) PARTITION BY HASH (DAY(dt)) PARTITIONS 2",
+			wantExpr: "DAYOFMONTH(`dt`)",
+			get:      func(ct *CreateTable) *string { return ct.Partition.Expression },
+		},
+		{
+			name: "subpartition expression",
+			sql: "CREATE TABLE t (id int NOT NULL, dt date NOT NULL, PRIMARY KEY (id, dt)) " +
+				"PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (DAY(dt)) SUBPARTITIONS 2 " +
+				"(PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)",
+			wantExpr: "dayofmonth(`dt`)",
+			get:      func(ct *CreateTable) *string { return ct.Partition.SubPartition.Expression },
+		},
+		{
+			// A stored function is not a builtin: renaming db.day() would call
+			// something else entirely.
+			name:     "schema-qualified call is left alone",
+			sql:      "CREATE TABLE t (c int DEFAULT (mydb.day('2020-01-01')))",
+			wantExpr: "`mydb`.`day`('2020-01-01')",
+			get:      firstColumnDefault,
+		},
+		{
+			// The value of a string default is data, not an expression: a
+			// column defaulting to the text "lcase(x)" keeps it verbatim.
+			name:     "string literal default is left alone",
+			sql:      "CREATE TABLE t (c text DEFAULT ('lcase(x)'))",
+			wantExpr: "lcase(x)",
+			get:      firstColumnDefault,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ct, err := ParseCreateTable(tc.sql)
+			require.NoError(t, err)
+			got := tc.get(ct)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantExpr, *got)
+		})
+	}
+}
+
+func firstColumnDefault(ct *CreateTable) *string { return ct.Columns[0].Default }
+
+// TestFunctionAliasConverges is the payoff: the authored spelling and the
+// SHOW CREATE TABLE spelling of the same column must produce no diff. Without
+// the rule the diff emits a MODIFY COLUMN that MySQL immediately rewrites back
+// — a full table copy on every run, forever (issue #1152).
+func TestFunctionAliasConverges(t *testing.T) {
+	tests := []struct {
+		name     string
+		authored string
+		live     string
+	}{
+		{
+			name:     "vector default",
+			authored: "CREATE TABLE t (id int NOT NULL PRIMARY KEY, v vector(3) DEFAULT (STRING_TO_VECTOR('[1,2,3]')))",
+			live:     "CREATE TABLE t (id int NOT NULL PRIMARY KEY, v vector(3) DEFAULT (to_vector(_latin1'[1,2,3]')))",
+		},
+		{
+			name:     "expression default with a charset introducer",
+			authored: "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c varchar(10) DEFAULT (LCASE('AB')))",
+			live:     "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c varchar(10) DEFAULT (lower(_latin1'AB')))",
+		},
+		{
+			name:     "timestamp expression default",
+			authored: "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c datetime DEFAULT (CURRENT_TIMESTAMP))",
+			live:     "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c datetime DEFAULT (now()))",
+		},
+		{
+			name:     "generated column",
+			authored: "CREATE TABLE t (id int NOT NULL PRIMARY KEY, a varchar(10), c varchar(10) GENERATED ALWAYS AS (MID(a,1,2)) STORED)",
+			live:     "CREATE TABLE t (id int NOT NULL PRIMARY KEY, a varchar(10), c varchar(10) GENERATED ALWAYS AS (substr(`a`,1,2)) STORED)",
+		},
+		{
+			name:     "check constraint",
+			authored: "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c varchar(10), CONSTRAINT t_chk_1 CHECK (CHARACTER_LENGTH(c) > 0))",
+			live:     "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c varchar(10), CONSTRAINT t_chk_1 CHECK ((char_length(`c`) > 0)))",
+		},
+		{
+			name:     "functional index",
+			authored: "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c varchar(10), KEY idx ((SUBSTRING(c,1,2))))",
+			live:     "CREATE TABLE t (id int NOT NULL PRIMARY KEY, c varchar(10), KEY idx ((substr(`c`,1,2))))",
+		},
+		{
+			name:     "partition expression",
+			authored: "CREATE TABLE t (dt date NOT NULL, PRIMARY KEY (dt)) PARTITION BY HASH (DAY(dt)) PARTITIONS 2",
+			live:     "CREATE TABLE t (dt date NOT NULL, PRIMARY KEY (dt)) PARTITION BY HASH (dayofmonth(`dt`)) PARTITIONS 2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authored, err := ParseCreateTable(tc.authored)
+			require.NoError(t, err)
+			live, err := ParseCreateTable(tc.live)
+			require.NoError(t, err)
+
+			stmts, err := live.Diff(authored, nil)
+			require.NoError(t, err)
+			assert.Nil(t, stmts, "authored and live spellings must converge")
+		})
+	}
+}
+
+// TestRoundTrip_FunctionAliases is the same convergence check against a real
+// server: MySQL, not a hand-written fixture, decides what a stored expression
+// reads back as. Every alias in mysqlFunctionAliases is exercised here, so a
+// mapping that a future MySQL stops applying (or applies differently) shows up
+// as a failure rather than as a diff that never converges in production.
+func TestRoundTrip_FunctionAliases(t *testing.T) {
+	db := openScratch(t)
+
+	tests := []struct {
+		name     string
+		columns  string // column list of the authored CREATE TABLE
+		suffix   string // clauses after the column list, e.g. PARTITION BY
+		needsVec bool
+	}{
+		{name: "lcase", columns: "c varchar(10) DEFAULT (LCASE('AB'))"},
+		{name: "ucase", columns: "c varchar(10) DEFAULT (UCASE('ab'))"},
+		{name: "mid", columns: "c varchar(10) DEFAULT (MID('abcdef',1,2))"},
+		{name: "substring", columns: "c varchar(10) DEFAULT (SUBSTRING('abcdef',1,2))"},
+		{name: "substring_from_for", columns: "c varchar(10) DEFAULT (SUBSTRING('abcdef' FROM 2 FOR 3))"},
+		{name: "power", columns: "c int DEFAULT (POWER(2,3))"},
+		{name: "ceil", columns: "c int DEFAULT (CEIL(1.2))"},
+		{name: "character_length", columns: "c int DEFAULT (CHARACTER_LENGTH('abc'))"},
+		{name: "octet_length", columns: "c int DEFAULT (OCTET_LENGTH('abc'))"},
+		{name: "day", columns: "c int DEFAULT (DAY('2020-01-01'))"},
+		{name: "position", columns: "c int DEFAULT (POSITION('a' IN 'abc'))"},
+		{name: "session_user", columns: "c varchar(64) DEFAULT (SESSION_USER())"},
+		{name: "system_user", columns: "c varchar(64) DEFAULT (SYSTEM_USER())"},
+		{name: "current_date", columns: "c int DEFAULT (YEAR(CURRENT_DATE))"},
+		{name: "current_time", columns: "c int DEFAULT (HOUR(CURRENT_TIME))"},
+		{name: "current_timestamp", columns: "c datetime DEFAULT (CURRENT_TIMESTAMP)"},
+		{name: "localtime", columns: "c datetime DEFAULT (LOCALTIME)"},
+		{name: "localtimestamp", columns: "c datetime DEFAULT (LOCALTIMESTAMP())"},
+		{name: "nested", columns: "c varchar(10) DEFAULT (LOWER(MID(UCASE('abc'),1,2)))"},
+		{name: "generated_column", columns: "a varchar(10), c varchar(10) GENERATED ALWAYS AS (LCASE(a)) VIRTUAL"},
+		{name: "check_constraint", columns: "c varchar(10), CHECK (CHARACTER_LENGTH(c) > 0)"},
+		{name: "functional_index", columns: "c varchar(10), KEY idx ((UCASE(c)))"},
+		{
+			name:    "partition_expression",
+			columns: "dt date NOT NULL, PRIMARY KEY (dt)",
+			suffix:  "PARTITION BY HASH (DAY(dt)) PARTITIONS 2",
+		},
+		// A subpartitioned table has no live case here: diffPartitions does not
+		// compare subpartitioning at all, so such a table re-emits a
+		// REMOVE PARTITIONING + PARTITION BY pair (which also drops the
+		// SUBPARTITION clause) whatever the expressions say. The rule's effect
+		// on SubPartition.Expression is covered by the unit test above.
+		{
+			name:     "string_to_vector",
+			columns:  "v vector(3) DEFAULT (STRING_TO_VECTOR('[1,2,3]'))",
+			needsVec: true,
+		},
+		{
+			name:     "vector_to_string",
+			columns:  "c varchar(64) DEFAULT (VECTOR_TO_STRING(STRING_TO_VECTOR('[1]')))",
+			needsVec: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.needsVec {
+				testutils.SkipUnlessVectorSupported(t)
+			}
+			table := "fa_" + tc.name
+			// A partitioned case declares its own key (every partitioning
+			// column has to be in it), so it opts out of the shared id column.
+			idColumn := "id int NOT NULL PRIMARY KEY, "
+			if tc.suffix != "" {
+				idColumn = ""
+			}
+			authored := strings.TrimSpace(fmt.Sprintf("CREATE TABLE %s (%s%s) %s",
+				sqlescape.EscapeIdentifier(table), idColumn, tc.columns, tc.suffix))
+
+			_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))
+			require.NoError(t, err)
+			_, err = db.ExecContext(t.Context(), authored)
+			require.NoError(t, err, "MySQL rejected the authored table")
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))
+			})
+
+			live, err := ParseCreateTable(showCreate(t, db, table))
+			require.NoError(t, err)
+			target, err := ParseCreateTable(authored)
+			require.NoError(t, err)
+
+			stmts, err := live.Diff(target, nil)
+			require.NoError(t, err)
+			assert.Nil(t, stmts, "authored schema must not diff against the table MySQL stored")
+		})
+	}
+}
+
+// TestRoundTrip_ExpressionDefaultApplies checks the emission side of the
+// expression-default handling: an ALTER that Spirit generates for a
+// timestamp-family expression default has to be SQL MySQL accepts. The
+// bare-keyword spelling of the literal default — DEFAULT (now) — is not.
+func TestRoundTrip_ExpressionDefaultApplies(t *testing.T) {
+	db := openScratch(t)
+
+	const table = "fa_expr_default"
+	createSQL := "CREATE TABLE " + table + " (id int NOT NULL PRIMARY KEY, c datetime)"
+	targetSQL := "CREATE TABLE " + table + " (id int NOT NULL PRIMARY KEY, c datetime DEFAULT (CURRENT_TIMESTAMP))"
+
+	afterCreate := applyAndConverge(t, db, table, createSQL, targetSQL)
+	assert.Contains(t, afterCreate, "DEFAULT (now())")
+}
+
+// TestFunctionAliasesAreIdempotent guards the property the rule relies on: a
+// canonical name is never itself an alias, so normalizing an already-normalized
+// definition is a no-op. Were a name both key and value, the rule would map a
+// live definition onto something MySQL does not store and the diff would flip
+// between two forms instead of converging.
+func TestFunctionAliasesAreIdempotent(t *testing.T) {
+	for alias, canonical := range mysqlFunctionAliases {
+		_, isAlias := mysqlFunctionAliases[canonical]
+		assert.False(t, isAlias, "%s maps to %s, which is itself an alias", alias, canonical)
+		assert.Equal(t, canonical, strings.ToLower(canonical), "canonical names must be lowercase")
+		assert.Equal(t, alias, strings.ToLower(alias), "alias keys are matched against FnName.L, so must be lowercase")
+	}
+}
+
+// TestFunctionAliasNormalizationIsStable checks the rule is a fixed point:
+// feeding a normalized expression back through the parser must not shift it
+// again, which is what lets a diff converge in one round rather than oscillate
+// between two forms.
+func TestFunctionAliasNormalizationIsStable(t *testing.T) {
+	tests := []struct {
+		template string // one %s, holding the expression
+		expr     string
+		get      func(*CreateTable) *string
+	}{
+		{
+			template: "CREATE TABLE t (v vector(3) DEFAULT (%s))",
+			expr:     "STRING_TO_VECTOR('[1,2,3]')",
+			get:      firstColumnDefault,
+		},
+		{
+			template: "CREATE TABLE t (c datetime DEFAULT (%s))",
+			expr:     "CURRENT_TIMESTAMP",
+			get:      firstColumnDefault,
+		},
+		{
+			template: "CREATE TABLE t (a varchar(10), c varchar(10) GENERATED ALWAYS AS (%s) VIRTUAL)",
+			expr:     "LCASE(a)",
+			get:      func(ct *CreateTable) *string { return ct.Columns[1].GeneratedExpr },
+		},
+		{
+			template: "CREATE TABLE t (c varchar(10), CHECK (%s))",
+			expr:     "OCTET_LENGTH(c) > 0",
+			get:      func(ct *CreateTable) *string { return ct.Constraints[0].Expression },
+		},
+		{
+			template: "CREATE TABLE t (c varchar(10), KEY idx ((%s)))",
+			expr:     "UCASE(c)",
+			get:      func(ct *CreateTable) *string { return ct.Indexes[0].ColumnList[0].Expression },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			once, err := ParseCreateTable(fmt.Sprintf(tc.template, tc.expr))
+			require.NoError(t, err)
+			first := tc.get(once)
+			require.NotNil(t, first)
+
+			twice, err := ParseCreateTable(fmt.Sprintf(tc.template, *first))
+			require.NoError(t, err)
+			second := tc.get(twice)
+			require.NotNil(t, second)
+			assert.Equal(t, *first, *second)
+		})
+	}
+}

--- a/pkg/statement/normalize_function_aliases_test.go
+++ b/pkg/statement/normalize_function_aliases_test.go
@@ -1,15 +1,28 @@
 package statement
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/testutils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// erDefaultValNotAllowed is ER_DEFAULT_VAL_GENERATED_NAMED_FUNCTION_IS_NOT_ALLOWED:
+// the server refusing to store a particular function inside a default value
+// expression. Which functions are on that list is version-dependent, so a case
+// that trips it is skipped rather than failed.
+const erDefaultValNotAllowed = 3770
+
+func isDisallowedInDefaultErr(err error) bool {
+	var myErr *mysql.MySQLError
+	return errors.As(err, &myErr) && myErr.Number == erDefaultValNotAllowed
+}
 
 // TestFunctionAliasNormalization covers each alias in the map, in the
 // expression contexts MySQL rewrites: expression DEFAULTs, generated columns,
@@ -283,6 +296,10 @@ func TestRoundTrip_FunctionAliases(t *testing.T) {
 		columns  string // column list of the authored CREATE TABLE
 		suffix   string // clauses after the column list, e.g. PARTITION BY
 		needsVec bool
+		// mayBeDisallowed marks a case whose function MySQL refuses to store in
+		// a default expression on some versions; such a case skips rather than
+		// fails when the server rejects it. See erDefaultValNotAllowed.
+		mayBeDisallowed bool
 	}{
 		{name: "lcase", columns: "c varchar(10) DEFAULT (LCASE('AB'))"},
 		{name: "ucase", columns: "c varchar(10) DEFAULT (UCASE('ab'))"},
@@ -295,8 +312,13 @@ func TestRoundTrip_FunctionAliases(t *testing.T) {
 		{name: "octet_length", columns: "c int DEFAULT (OCTET_LENGTH('abc'))"},
 		{name: "day", columns: "c int DEFAULT (DAY('2020-01-01'))"},
 		{name: "position", columns: "c int DEFAULT (POSITION('a' IN 'abc'))"},
-		{name: "session_user", columns: "c varchar(64) DEFAULT (SESSION_USER())"},
-		{name: "system_user", columns: "c varchar(64) DEFAULT (SYSTEM_USER())"},
+		// Which functions a default expression may contain moved over time:
+		// 8.0.28 rejects user() outright (error 3770), while 8.0.46 and 9.7
+		// store it. Both spellings resolve to user() before that check runs, so
+		// on a server that rejects it neither the authored nor the canonical
+		// form is storable and the round trip cannot be observed at all.
+		{name: "session_user", columns: "c varchar(64) DEFAULT (SESSION_USER())", mayBeDisallowed: true},
+		{name: "system_user", columns: "c varchar(64) DEFAULT (SYSTEM_USER())", mayBeDisallowed: true},
 		{name: "current_date", columns: "c int DEFAULT (YEAR(CURRENT_DATE))"},
 		{name: "current_time", columns: "c int DEFAULT (HOUR(CURRENT_TIME))"},
 		{name: "current_timestamp", columns: "c datetime DEFAULT (CURRENT_TIMESTAMP)"},
@@ -346,6 +368,9 @@ func TestRoundTrip_FunctionAliases(t *testing.T) {
 			_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))
 			require.NoError(t, err)
 			_, err = db.ExecContext(t.Context(), authored)
+			if tc.mayBeDisallowed && isDisallowedInDefaultErr(err) {
+				t.Skipf("skipping: this server does not allow the function in a default expression: %v", err)
+			}
 			require.NoError(t, err, "MySQL rejected the authored table")
 			t.Cleanup(func() {
 				_, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS "+sqlescape.EscapeIdentifier(table))

--- a/pkg/statement/parse_helpers.go
+++ b/pkg/statement/parse_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/block/spirit/pkg/parser"
 	"github.com/block/spirit/pkg/parser/ast"
 	"github.com/block/spirit/pkg/parser/format"
 )
@@ -54,11 +55,7 @@ func isExpressionDefault(expr ast.ExprNode) bool {
 	case *ast.FuncCallExpr:
 		// CURRENT_TIMESTAMP (and aliases NOW, LOCALTIME, etc.) are literal-style defaults
 		// that don't need parens. Everything else is an expression default.
-		switch e.FnName.L {
-		case "current_timestamp", "now", "localtime", "localtimestamp", "utc_timestamp":
-			return false
-		}
-		return true
+		return !isTimestampFuncName(e.FnName.L)
 	case *ast.ColumnNameExpr:
 		return true
 	default:
@@ -78,6 +75,101 @@ func unwrapParenExpr(expr ast.ExprNode) ast.ExprNode {
 		}
 		expr = paren.Expr
 	}
+}
+
+// restoreValueExprText converts a DEFAULT / ON UPDATE / partition expression
+// to the string representation Spirit stores for it.
+//
+// bareTimestampKeyword selects between MySQL's two spellings of a zero-argument
+// timestamp function. In the literal-style forms — DEFAULT CURRENT_TIMESTAMP,
+// ON UPDATE CURRENT_TIMESTAMP — MySQL reports the bare keyword, while the
+// parser's Restore always writes the call form, so the trailing "()" is
+// stripped. In an *expression* default the call form is the canonical one:
+// MySQL stores DEFAULT (CURRENT_TIMESTAMP) as DEFAULT (now()), and emitting
+// the bare keyword inside the parentheses — DEFAULT (now) — would not even
+// parse, since a bare `now` there is a column reference.
+func restoreValueExprText(expr ast.ExprNode, bareTimestampKeyword bool) any {
+	if expr == nil {
+		return nil
+	}
+
+	// Handle different expression types
+	switch e := expr.(type) {
+	case *ast.FuncCallExpr:
+		// Handle function calls like CURRENT_TIMESTAMP, CURRENT_TIMESTAMP(3), UUID(), etc.
+		// We use Restore to preserve function arguments (e.g. precision in CURRENT_TIMESTAMP(3)).
+		// RestoreKeyWordLowercase renders the function name and any keywords
+		// inside its arguments in lowercase — matching MySQL's canonical
+		// SHOW CREATE TABLE form (e.g. DEFAULT (concat(...))) so that
+		// function-name case never causes a spurious diff — while leaving
+		// string-literal arguments byte-exact. The previous strings.ToLower
+		// over the whole Restored text corrupted literal case:
+		// DEFAULT (concat('A')) round-tripped to concat('a'), emitting a
+		// different default value and making defaults that differ only in
+		// literal case compare equal.
+		var sb strings.Builder
+		rCtx := format.NewRestoreCtx(format.RestoreStringSingleQuotes|format.RestoreKeyWordLowercase|
+			format.RestoreNameBackQuotes|format.RestoreStringWithoutCharset, &sb)
+		if err := e.Restore(rCtx); err != nil {
+			return e.FnName.L // fallback to function name on error
+		}
+		restored := sb.String()
+		// Normalize: MySQL's canonical SHOW CREATE TABLE uses "CURRENT_TIMESTAMP" (no parens)
+		// when there is no fractional seconds precision, but the parser's Restore always adds "()".
+		// We only strip parens for timestamp-family functions; other functions like json_object()
+		// need to keep their parens as they represent actual function calls.
+		if bareTimestampKeyword && isTimestampFuncName(e.FnName.L) &&
+			len(e.Args) == 0 && strings.HasSuffix(restored, "()") {
+			restored = strings.TrimSuffix(restored, "()")
+		}
+		return restored
+	default:
+		// For other types, fall back to text representation
+		var sb strings.Builder
+		sb.Reset()
+		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreStringWithoutCharset, &sb)
+		if err := expr.Restore(rCtx); err != nil {
+			return "<error>"
+		}
+		str := sb.String()
+		// if the string is quoted, remove quotes
+		if strings.HasPrefix(str, "'") && strings.HasSuffix(str, "'") {
+			str = str[1 : len(str)-1]
+		}
+		return str
+	}
+}
+
+// isTimestampFuncName reports whether name (lowercased) is one of the
+// zero-argument timestamp functions MySQL accepts as a literal-style DEFAULT
+// or ON UPDATE value.
+func isTimestampFuncName(name string) bool {
+	switch name {
+	case "current_timestamp", "now", "localtime", "localtimestamp", "utc_timestamp":
+		return true
+	}
+	return false
+}
+
+// parseExpressionText re-parses an expression that was previously restored to
+// text, returning its AST node. Normalization rules use it to work on the tree
+// rather than on the text: the structured form is where a MySQL canonical form
+// can be reasoned about.
+//
+// The text was produced by restoring a successfully parsed expression, so a
+// re-parse failure is not expected; callers treat a false result as "leave the
+// text alone", whose worst outcome is a spurious diff on that expression,
+// never a corrupted definition.
+func parseExpressionText(p *parser.Parser, text string) (ast.ExprNode, bool) {
+	stmt, err := p.ParseOneStmt("SELECT "+text, "", "")
+	if err != nil {
+		return nil, false
+	}
+	sel, ok := stmt.(*ast.SelectStmt)
+	if !ok || sel.Fields == nil || len(sel.Fields.Fields) != 1 || sel.Fields.Fields[0].Expr == nil {
+		return nil, false
+	}
+	return sel.Fields.Fields[0].Expr, true
 }
 
 // restoreExpressionText restores an expression AST node to its SQL text,


### PR DESCRIPTION
Fixes #1152.

## The problem

MySQL resolves a function alias when it stores an expression, so the authored text and the `SHOW CREATE TABLE` text never match. A column written as

```sql
v vector(3) DEFAULT (STRING_TO_VECTOR('[1,2,3]'))
```

reads back as

```sql
v vector(3) DEFAULT (to_vector(_latin1'[1,2,3]'))
```

and the declarative diff emits the same no-op `MODIFY COLUMN` on every run — each one a full table copy. `VECTOR` is the most exposed type (`STRING_TO_VECTOR` is essentially the only way to write a vector literal), but the problem is general: `LCASE`, `MID`/`SUBSTRING`, `DAY`, `POSITION`, `CEIL`, `POWER`, `OCTET_LENGTH`, `SESSION_USER`, `CURRENT_DATE` and friends all do it, and not only in `DEFAULT`s — generated columns, `CHECK` constraints, functional indexes and partition expressions are rewritten the same way.

## The fix

A new `functionAliasNormalizer` (`pkg/statement/normalize_function_aliases.go`), per AGENTS.md — nothing special-cased in `Diff`. It re-parses the stored expression, renames aliased calls on the AST, and re-renders with the same restore the text was produced with. An expression containing no alias is left byte-identical rather than re-rendered, which is what keeps the rule order-independent against `expressionParenNormalizer`. Schema-qualified calls (`db.day(x)` — a stored function, not a builtin) are skipped.

The 19 mappings were each verified against live MySQL 9.7, and re-checked on 8.0, by creating the column and reading `SHOW CREATE TABLE` back — not taken from the manual. No canonical name is itself an alias, so the mapping is idempotent and a live definition is never rewritten (asserted by a test).

**Charset introducers need no rule.** The issue lists them as the second half of the problem, but `format.RestoreStringWithoutCharset` already drops `_latin1'…'` when the expression is restored to text, on both sides of the diff. Verified rather than assumed.

## A third non-convergence, found while probing

MySQL stores `DEFAULT (CURRENT_TIMESTAMP)` as `DEFAULT (now())` — the bare-keyword spelling belongs only to the literal-style `DEFAULT CURRENT_TIMESTAMP`. Spirit stripped the `()` from any zero-argument timestamp function, so besides never converging, the statement it emitted in the other direction — `DEFAULT (now)` — is not SQL MySQL will parse (a bare `now` inside the parentheses is a column reference). The trim is now conditional on the default being literal-style.

## Verification

The issue's reproducer, end to end against MySQL 9.7 — same table, same schema file:

```
before (main):        ALTER TABLE `t1152` MODIFY COLUMN `v` vector(3) NULL DEFAULT (string_to_vector('[1,2,3]'));
after (this branch):  -- No schema differences found.
```

Tests: one unit case per alias per expression context, a live round-trip test that lets MySQL decide what each expression reads back as (so a mapping a future MySQL stops applying fails here rather than in production), plus idempotency and fixed-point checks. `pkg/statement`, `pkg/lint`, `pkg/migration` and `pkg/dbconn` pass; `golangci-lint` is clean.

## Deliberately out of scope

- Rewrites that **restructure** rather than rename: `MOD(a,b)` → `(a % b)`, `INSTR(a,b)` → `locate(b,a)` (arguments swapped), `WEEKOFYEAR(d)` → `week(d,3)`, `BIN(n)` → `conv(n,10,2)`, `ADDDATE(d, INTERVAL …)` → `d + interval …`. A rename table cannot express these; they stay with `spirit fmt`, and both the rule's doc comment and `pkg/statement/README.md` say so explicitly.
- A separate pre-existing bug this work surfaced: a **subpartitioned table never converges** — `diffPartitions` ignores `SubPartition` entirely, and the repartition `ALTER` it emits silently drops the subpartitioning. It reproduces with no aliases in the expressions, so it is not fixed here; the round-trip test carries a comment saying why there is no live subpartition case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)