### PR TITLE
statement: fix non-converging, destructive diff on partitioned tables

### DIFF
--- a/pkg/statement/README.md
+++ b/pkg/statement/README.md
@@ -329,6 +329,8 @@ type PartitionOptions struct {
 }
 ```
 
+Partitioning is compared as a whole: MySQL cannot alter a partition method in place, so any difference other than a HASH/KEY partition-count change is emitted as `REMOVE PARTITIONING` followed by a complete `PARTITION BY` — including its `SUBPARTITION BY` clause, partition comments, and any explicitly named subpartitions. The per-partition `ENGINE` clause is the one thing deliberately **not** compared: MySQL requires every partition to use the table's engine, so it carries no information, yet `SHOW CREATE TABLE` always prints it while authored SQL does not.
+
 ## Normalization
 
 MySQL rewrites many constructs when it stores a table definition, so the form a human writes rarely matches what `SHOW CREATE TABLE` reports. Left unhandled, this produces **spurious diffs** — a schema file that says `active BOOLEAN` would appear to differ from the live `active tinyint(1)`, and a diff would emit a pointless `MODIFY COLUMN`. To prevent this, `ParseCreateTable` runs a pipeline of **normalization rules** over the parsed `CreateTable` before returning it, canonicalizing both sides so `Diff` compares like with like.
@@ -348,6 +350,7 @@ Two layers of canonicalization apply:
    | `integerDisplayWidthNormalizer` | strips deprecated integer display widths (`int(11)` → `int`), keeping `tinyint(1)` and `ZEROFILL` |
    | `vectorDimensionNormalizer` | fills in the default dimension of a `VECTOR` column declared without one (`vector` → `vector(2048)`, MySQL 9.7+) |
    | `charsetlessTypeNormalizer` | drops charset/collation from the types that cannot carry one (`VECTOR`, spatial) — both the parser's synthetic `binary` charset and one an author wrote by hand, which MySQL accepts and silently discards |
+   | `partitionCommentNormalizer` | pushes a partition-level `COMMENT` down onto explicitly named subpartitions that have none, and clears it from the partition — what MySQL stores for `PARTITION p0 ... COMMENT 'c' (SUBPARTITION s0, SUBPARTITION s1)`. A partition comment on implicit subpartitions (`SUBPARTITIONS n`) stays on the partition |
 
 ### Pipeline
 

--- a/pkg/statement/diff_integration_test.go
+++ b/pkg/statement/diff_integration_test.go
@@ -461,3 +461,127 @@ func TestDiffIntegrationDescIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, stmts)
 }
+
+// TestDiffIntegrationSubpartitionNoSpuriousDiff verifies that a subpartitioned
+// table does not diff against the definition it was created from. The live
+// definition differs cosmetically in two ways Diff has to absorb: the partition
+// expression comes back lowercased and backtick-quoted, and every partition
+// carries an `ENGINE = InnoDB` clause the authored SQL never wrote.
+//
+// This is a regression test. Comparing the per-partition ENGINE made every
+// partitioned table repartition itself on every run — and because the emitted
+// PARTITION BY had no SUBPARTITION BY clause, applying that "no-op" silently
+// dropped the table's subpartitioning.
+func TestDiffIntegrationSubpartitionNoSpuriousDiff(t *testing.T) {
+	const authoredSQL = "CREATE TABLE diff_subpart (dt date NOT NULL, PRIMARY KEY (dt)) " +
+		"PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (dayofmonth(dt)) SUBPARTITIONS 2 " +
+		"(PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)"
+	tt := testutils.NewTestTable(t, "diff_subpart", authoredSQL)
+
+	target, err := ParseCreateTable(authoredSQL)
+	require.NoError(t, err)
+
+	live := showCreateTable(t, tt.DB, tt.Name)
+	require.Contains(t, live, "SUBPARTITION BY HASH", "precondition: the table is subpartitioned")
+	require.Contains(t, live, "ENGINE = InnoDB", "precondition: MySQL prints per-partition ENGINE")
+
+	source, err := ParseCreateTable(live)
+	require.NoError(t, err)
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts, "live definition must not diff against the SQL it was created from")
+
+	requireNoSelfDiff(t, tt.DB, tt.Name)
+}
+
+// TestDiffIntegrationSubpartitionChange verifies that a genuine subpartitioning
+// change is emitted in full and actually applies: the REMOVE PARTITIONING +
+// PARTITION BY pair must carry the SUBPARTITION BY clause, or the table comes
+// back partitioned but no longer subpartitioned. The re-diff then converges.
+func TestDiffIntegrationSubpartitionChange(t *testing.T) {
+	tt := testutils.NewTestTable(t, "diff_subpart_chg",
+		"CREATE TABLE diff_subpart_chg (dt date NOT NULL, PRIMARY KEY (dt)) "+
+			"PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (dayofmonth(dt)) SUBPARTITIONS 2 "+
+			"(PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)")
+
+	const targetSQL = "CREATE TABLE diff_subpart_chg (dt date NOT NULL, PRIMARY KEY (dt)) " +
+		"PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (dayofmonth(dt)) SUBPARTITIONS 4 " +
+		"(PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)"
+	target, err := ParseCreateTable(targetSQL)
+	require.NoError(t, err)
+
+	stmts := diffLiveTable(t, tt.DB, tt.Name, targetSQL)
+	require.Len(t, stmts, 2, "a subpartitioning change needs REMOVE PARTITIONING first")
+	require.Equal(t, "ALTER TABLE `diff_subpart_chg` REMOVE PARTITIONING", stmts[0].Statement)
+	require.Equal(t,
+		"ALTER TABLE `diff_subpart_chg` PARTITION BY RANGE (YEAR(`dt`)) "+
+			"SUBPARTITION BY HASH (dayofmonth(`dt`)) SUBPARTITIONS 4 "+
+			"(PARTITION `p0` VALUES LESS THAN (2020), PARTITION `p1` VALUES LESS THAN MAXVALUE)",
+		stmts[1].Statement)
+
+	// Execute exactly what Diff emitted, as the Runner would.
+	for _, stmt := range stmts {
+		_, err = tt.DB.ExecContext(t.Context(), stmt.Statement)
+		require.NoError(t, err)
+	}
+	postAlter := showCreateTable(t, tt.DB, tt.Name)
+	require.Contains(t, postAlter, "SUBPARTITION BY HASH (dayofmonth(`dt`))", "subpartitioning must survive")
+	require.Contains(t, postAlter, "SUBPARTITIONS 4")
+
+	// Re-diff: the schemas now converge.
+	source, err := ParseCreateTable(postAlter)
+	require.NoError(t, err)
+	stmts, err = source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts)
+}
+
+// TestDiffIntegrationSubpartitionNamesAndComments verifies the high-fidelity
+// shape: explicitly named subpartitions plus partition/subpartition comments.
+// MySQL echoes explicit subpartition names back from SHOW CREATE TABLE, and
+// pushes a partition-level comment down onto the subpartitions that lack one,
+// so both sides have to model that to converge — and a repartition has to
+// re-emit the names and comments rather than silently reset them.
+func TestDiffIntegrationSubpartitionNamesAndComments(t *testing.T) {
+	const authoredSQL = "CREATE TABLE diff_subpart_named (dt date NOT NULL, PRIMARY KEY (dt)) " +
+		"PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY KEY (dt) " +
+		"(PARTITION p0 VALUES LESS THAN (2020) COMMENT 'pc0' (SUBPARTITION s0 COMMENT 'sc0', SUBPARTITION s1), " +
+		"PARTITION p1 VALUES LESS THAN MAXVALUE (SUBPARTITION s2, SUBPARTITION s3))"
+	tt := testutils.NewTestTable(t, "diff_subpart_named", authoredSQL)
+
+	target, err := ParseCreateTable(authoredSQL)
+	require.NoError(t, err)
+	source, err := ParseCreateTable(showCreateTable(t, tt.DB, tt.Name))
+	require.NoError(t, err)
+	stmts, err := source.Diff(target, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts, "named subpartitions and comments must not diff against themselves")
+
+	// Now move p0's boundary. The repartition has to carry every subpartition
+	// name and comment through, or they are silently lost.
+	const movedSQL = "CREATE TABLE diff_subpart_named (dt date NOT NULL, PRIMARY KEY (dt)) " +
+		"PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY KEY (dt) " +
+		"(PARTITION p0 VALUES LESS THAN (2030) COMMENT 'pc0' (SUBPARTITION s0 COMMENT 'sc0', SUBPARTITION s1), " +
+		"PARTITION p1 VALUES LESS THAN MAXVALUE (SUBPARTITION s2, SUBPARTITION s3))"
+	moved, err := ParseCreateTable(movedSQL)
+	require.NoError(t, err)
+
+	stmts = diffLiveTable(t, tt.DB, tt.Name, movedSQL)
+	require.Len(t, stmts, 2)
+	for _, stmt := range stmts {
+		_, err = tt.DB.ExecContext(t.Context(), stmt.Statement)
+		require.NoError(t, err)
+	}
+	postAlter := showCreateTable(t, tt.DB, tt.Name)
+	require.Contains(t, postAlter, "SUBPARTITION BY KEY")
+	require.Contains(t, postAlter, "SUBPARTITION s0 COMMENT = 'sc0'")
+	require.Contains(t, postAlter, "SUBPARTITION s1 COMMENT = 'pc0'")
+	require.Contains(t, postAlter, "VALUES LESS THAN (2030)")
+
+	// Re-diff: the schemas now converge.
+	source, err = ParseCreateTable(postAlter)
+	require.NoError(t, err)
+	stmts, err = source.Diff(moved, nil)
+	require.NoError(t, err)
+	require.Nil(t, stmts)
+}

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -1303,6 +1303,89 @@ func TestDiff(t *testing.T) {
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, B INT NOT NULL, A INT NOT NULL)",
 			expected: "ALTER TABLE `t1` MODIFY COLUMN `B` int NOT NULL AFTER `id`, MODIFY COLUMN `A` int NOT NULL AFTER `B`",
 		},
+		// Partitioning. The sources below are shaped like SHOW CREATE TABLE
+		// output, which always prints a per-partition `ENGINE = InnoDB` that
+		// human-authored SQL omits; that clause must not register as a change
+		// (it cannot differ from the table engine) or every partitioned table
+		// would repartition itself on every run.
+		{
+			name:     "NoChanges_PartitionedEngineClauseOnly",
+			source:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2020) ENGINE = InnoDB, PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)",
+			target:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)",
+			expected: "",
+		},
+		{
+			name:     "NoChanges_Subpartitioned",
+			source:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) SUBPARTITION BY HASH (dayofmonth(`dt`)) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2020) ENGINE = InnoDB, PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)",
+			target:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (dayofmonth(dt)) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)",
+			expected: "",
+		},
+		{
+			// SUBPARTITION BY with neither a count nor explicit names is legal
+			// (MySQL defaults to one subpartition per partition and reports no
+			// SUBPARTITIONS line), so no count must be invented on emission.
+			name:     "NoChanges_SubpartitionedWithoutCount",
+			source:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) SUBPARTITION BY HASH (dayofmonth(`dt`)) (PARTITION p0 VALUES LESS THAN (2020) ENGINE = InnoDB, PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)",
+			target:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (dayofmonth(dt)) (PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)",
+			expected: "",
+		},
+		{
+			name:     "NoChanges_SubpartitionsNamedExplicitly",
+			source:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) SUBPARTITION BY KEY (dt) (PARTITION p0 VALUES LESS THAN (2020) (SUBPARTITION s0 COMMENT = 'sc0' ENGINE = InnoDB, SUBPARTITION s1 ENGINE = InnoDB), PARTITION p1 VALUES LESS THAN MAXVALUE (SUBPARTITION s2 ENGINE = InnoDB, SUBPARTITION s3 ENGINE = InnoDB))",
+			target:   "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY KEY (dt) (PARTITION p0 VALUES LESS THAN (2020) (SUBPARTITION s0 COMMENT 'sc0', SUBPARTITION s1), PARTITION p1 VALUES LESS THAN MAXVALUE (SUBPARTITION s2, SUBPARTITION s3))",
+			expected: "",
+		},
+		// A real subpartitioning change must round-trip the whole clause,
+		// including SUBPARTITION BY: the second statement replaces the
+		// partitioning wholesale, so anything it omits is dropped.
+		{
+			name:   "ChangeSubpartitionCount",
+			source: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) SUBPARTITION BY HASH (dayofmonth(`dt`)) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2020) ENGINE = InnoDB, PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)",
+			target: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (dayofmonth(dt)) SUBPARTITIONS 4 (PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)",
+			expectedStatements: []string{
+				"ALTER TABLE `t1` REMOVE PARTITIONING",
+				"ALTER TABLE `t1` PARTITION BY RANGE (YEAR(`dt`)) SUBPARTITION BY HASH (dayofmonth(`dt`)) SUBPARTITIONS 4 (PARTITION `p0` VALUES LESS THAN (2020), PARTITION `p1` VALUES LESS THAN MAXVALUE)",
+			},
+		},
+		{
+			name:   "AddSubpartitioning",
+			source: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) (PARTITION p0 VALUES LESS THAN (2020) ENGINE = InnoDB, PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)",
+			target: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY LINEAR KEY (dt) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)",
+			expectedStatements: []string{
+				"ALTER TABLE `t1` REMOVE PARTITIONING",
+				"ALTER TABLE `t1` PARTITION BY RANGE (YEAR(`dt`)) SUBPARTITION BY LINEAR KEY (`dt`) SUBPARTITIONS 2 (PARTITION `p0` VALUES LESS THAN (2020), PARTITION `p1` VALUES LESS THAN MAXVALUE)",
+			},
+		},
+		{
+			name:   "RemoveSubpartitioning",
+			source: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) SUBPARTITION BY HASH (dayofmonth(`dt`)) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2020) ENGINE = InnoDB, PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)",
+			target: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2020), PARTITION p1 VALUES LESS THAN MAXVALUE)",
+			expectedStatements: []string{
+				"ALTER TABLE `t1` REMOVE PARTITIONING",
+				"ALTER TABLE `t1` PARTITION BY RANGE (YEAR(`dt`)) (PARTITION `p0` VALUES LESS THAN (2020), PARTITION `p1` VALUES LESS THAN MAXVALUE)",
+			},
+		},
+		{
+			name:   "RepartitionCarriesSubpartitionNamesAndComments",
+			source: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) SUBPARTITION BY KEY (dt) (PARTITION p0 VALUES LESS THAN (2020) (SUBPARTITION s0 COMMENT = 'sc0' ENGINE = InnoDB, SUBPARTITION s1 ENGINE = InnoDB))",
+			target: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY KEY (dt) (PARTITION p0 VALUES LESS THAN (2030) (SUBPARTITION s0 COMMENT 'sc0', SUBPARTITION s1))",
+			expectedStatements: []string{
+				"ALTER TABLE `t1` REMOVE PARTITIONING",
+				"ALTER TABLE `t1` PARTITION BY RANGE (YEAR(`dt`)) SUBPARTITION BY KEY (`dt`) SUBPARTITIONS 2 (PARTITION `p0` VALUES LESS THAN (2030) (SUBPARTITION `s0` COMMENT = 'sc0', SUBPARTITION `s1`))",
+			},
+		},
+		// A partition comment is part of the definition and has to survive a
+		// repartition too — the emitted PARTITION BY is the only definition
+		// MySQL will see.
+		{
+			name:   "RepartitionCarriesPartitionComment",
+			source: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (year(`dt`)) (PARTITION p0 VALUES LESS THAN (2020) COMMENT = 'keep me' ENGINE = InnoDB)",
+			target: "CREATE TABLE t1 (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY HASH (dayofmonth(dt)) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2020) COMMENT 'keep me')",
+			expectedStatements: []string{
+				"ALTER TABLE `t1` REMOVE PARTITIONING",
+				"ALTER TABLE `t1` PARTITION BY RANGE (YEAR(`dt`)) SUBPARTITION BY HASH (dayofmonth(`dt`)) SUBPARTITIONS 2 (PARTITION `p0` VALUES LESS THAN (2020) COMMENT = 'keep me')",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/statement/equality.go
+++ b/pkg/statement/equality.go
@@ -286,6 +286,14 @@ func isPartitionCountOnlyChange(source, target *PartitionOptions) (bool, int) {
 		return false, 0
 	}
 
+	// Subpartitioning cannot be reached by ADD/COALESCE PARTITION. MySQL only
+	// allows subpartitions under RANGE/LIST, so this is unreachable today; the
+	// guard is here so a subpartitioning difference can never be silently
+	// swallowed by a partition-count ALTER.
+	if source.SubPartition != nil || target.SubPartition != nil {
+		return false, 0
+	}
+
 	// Only the partition count differs
 	if source.Partitions == target.Partitions {
 		return false, 0
@@ -363,12 +371,36 @@ func partitionDefinitionEqual(a, b *PartitionDefinition) bool {
 		return false
 	}
 
-	// Compare engine
-	if !ptrEqual(a.Engine, b.Engine) {
+	// The per-partition ENGINE clause is deliberately not compared. MySQL
+	// requires every partition to use the table's storage engine, so the clause
+	// carries no information beyond the table-level ENGINE — but SHOW CREATE
+	// TABLE always prints it (`PARTITION p0 VALUES LESS THAN (2020) ENGINE =
+	// InnoDB`) while human-authored SQL almost never does. Comparing it made
+	// every partitioned table diff against its own live definition, emitting a
+	// REMOVE PARTITIONING + PARTITION BY pair on every run.
+
+	// Compare explicitly named subpartitions. This is symmetric: MySQL echoes
+	// subpartition names back from SHOW CREATE TABLE when, and only when, they
+	// were named explicitly, so a named-on-both-sides table compares names and
+	// an auto-named one compares empty lists.
+	if len(a.SubPartitions) != len(b.SubPartitions) {
 		return false
 	}
 
+	for i := range a.SubPartitions {
+		if !subPartitionDefinitionEqual(&a.SubPartitions[i], &b.SubPartitions[i]) {
+			return false
+		}
+	}
+
 	return true
+}
+
+// subPartitionDefinitionEqual checks if two named subpartitions are equal. Like
+// partitions, a subpartition's ENGINE is not compared (see
+// partitionDefinitionEqual).
+func subPartitionDefinitionEqual(a, b *SubPartitionDefinition) bool {
+	return a.Name == b.Name && ptrEqual(a.Comment, b.Comment)
 }
 
 // partitionValuesEqual checks if two partition values are equal

--- a/pkg/statement/format.go
+++ b/pkg/statement/format.go
@@ -365,6 +365,16 @@ func formatPartitionOptions(partOpts *PartitionOptions) string {
 		parts = append(parts, fmt.Sprintf("PARTITIONS %d", partOpts.Partitions))
 	}
 
+	// Add the subpartitioning clause. MySQL's grammar places SUBPARTITION BY
+	// (and its SUBPARTITIONS count) after the partition method and before the
+	// partition definition list. Emitting it is not optional: the only way Diff
+	// changes a partitioned table's layout is REMOVE PARTITIONING followed by a
+	// fresh PARTITION BY, so a missing clause silently drops the table's
+	// subpartitioning.
+	if partOpts.SubPartition != nil {
+		parts = append(parts, formatSubPartitionOptions(partOpts.SubPartition))
+	}
+
 	// Add partition definitions if present
 	if len(partOpts.Definitions) > 0 {
 		var defParts []string
@@ -372,6 +382,49 @@ func formatPartitionOptions(partOpts *PartitionOptions) string {
 			defParts = append(defParts, formatPartitionDefinition(&def))
 		}
 		parts = append(parts, fmt.Sprintf("(%s)", strings.Join(defParts, ", ")))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// formatSubPartitionOptions formats the SUBPARTITION BY clause of a
+// partitioned table, including its SUBPARTITIONS count. MySQL only supports
+// HASH and KEY subpartitioning, optionally LINEAR.
+//
+// The count is emitted whenever it is known, even when the partition
+// definitions spell their subpartitions out by name: MySQL accepts the
+// redundant SUBPARTITIONS n as long as it agrees with the lists (verified
+// against MySQL 9.7), and the count is the only representation of
+// subpartitioning for the far more common form where SHOW CREATE TABLE reports
+// SUBPARTITIONS n and leaves the auto-generated subpartition names implicit.
+func formatSubPartitionOptions(subOpts *SubPartitionOptions) string {
+	parts := []string{"SUBPARTITION BY"}
+
+	if subOpts.Linear {
+		parts = append(parts, "LINEAR")
+	}
+
+	parts = append(parts, subOpts.Type)
+
+	switch subOpts.Type {
+	case "HASH":
+		if subOpts.Expression != nil {
+			parts = append(parts, fmt.Sprintf("(%s)", *subOpts.Expression))
+		} else if len(subOpts.Columns) > 0 {
+			// HASH can also use column names directly
+			parts = append(parts, fmt.Sprintf("(%s)", quoteIdentList(subOpts.Columns, ", ")))
+		}
+	case "KEY":
+		if len(subOpts.Columns) > 0 {
+			parts = append(parts, fmt.Sprintf("(%s)", quoteIdentList(subOpts.Columns, ", ")))
+		} else {
+			// KEY() with empty columns uses the primary key
+			parts = append(parts, "()")
+		}
+	}
+
+	if subOpts.Count > 0 {
+		parts = append(parts, fmt.Sprintf("SUBPARTITIONS %d", subOpts.Count))
 	}
 
 	return strings.Join(parts, " ")
@@ -402,6 +455,38 @@ func formatPartitionDefinition(def *PartitionDefinition) string {
 		case "MAXVALUE":
 			parts = append(parts, "VALUES LESS THAN MAXVALUE")
 		}
+	}
+
+	// Partition comment. Emitted in the `COMMENT = 'x'` form SHOW CREATE TABLE
+	// prints. Without it a repartition would silently drop the comment.
+	if def.Comment != nil {
+		parts = append(parts, fmt.Sprintf("COMMENT = '%s'", sqlescape.EscapeString(*def.Comment)))
+	}
+
+	// Explicitly named subpartitions, when the definition carries them. MySQL
+	// only reports subpartition names from SHOW CREATE TABLE when they were
+	// named explicitly at CREATE time — otherwise it reports SUBPARTITIONS n
+	// alone and auto-names them — so passing them through keeps the names
+	// stable across a repartition.
+	if len(def.SubPartitions) > 0 {
+		subParts := make([]string, 0, len(def.SubPartitions))
+		for i := range def.SubPartitions {
+			subParts = append(subParts, formatSubPartitionDefinition(&def.SubPartitions[i]))
+		}
+		parts = append(parts, fmt.Sprintf("(%s)", strings.Join(subParts, ", ")))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// formatSubPartitionDefinition formats a single named subpartition. Only the
+// name and comment are emitted; a subpartition's ENGINE always matches the
+// table's (see partitionDefinitionEqual) and is therefore not diffed.
+func formatSubPartitionDefinition(sub *SubPartitionDefinition) string {
+	parts := []string{"SUBPARTITION " + sqlescape.EscapeIdentifier(sub.Name)}
+
+	if sub.Comment != nil {
+		parts = append(parts, fmt.Sprintf("COMMENT = '%s'", sqlescape.EscapeString(*sub.Comment)))
 	}
 
 	return strings.Join(parts, " ")

--- a/pkg/statement/normalize_partition_comment.go
+++ b/pkg/statement/normalize_partition_comment.go
@@ -1,0 +1,46 @@
+package statement
+
+func init() { registerNormalizer(partitionCommentNormalizer{}) }
+
+// partitionCommentNormalizer mirrors what MySQL does with a partition-level
+// COMMENT on a partition whose subpartitions are named explicitly: the comment
+// is pushed down onto every subpartition that does not carry its own, and the
+// partition itself is left with no comment. Given
+//
+//	PARTITION p0 VALUES LESS THAN (2020) COMMENT 'pc0'
+//	  (SUBPARTITION s0 COMMENT 'sc0', SUBPARTITION s1)
+//
+// SHOW CREATE TABLE reports s0 with 'sc0', s1 with 'pc0', and p0 with no
+// comment at all (verified against MySQL 9.7). Without this rule the authored
+// form never converges with the live one: the partition comment differs
+// forever, so Diff re-emits REMOVE PARTITIONING + PARTITION BY on every run.
+//
+// The pushdown only happens when the subpartitions are spelled out. A partition
+// comment on a table that leaves its subpartitions implicit (SUBPARTITIONS n)
+// is stored on the partition, as it is for an unsubpartitioned table, so those
+// are left untouched.
+type partitionCommentNormalizer struct{}
+
+func (partitionCommentNormalizer) Name() string { return "partition-comment-pushdown" }
+
+func (partitionCommentNormalizer) Normalize(ct *CreateTable) *CreateTable {
+	if ct.Partition == nil {
+		return ct
+	}
+
+	for i := range ct.Partition.Definitions {
+		def := &ct.Partition.Definitions[i]
+		if def.Comment == nil || len(def.SubPartitions) == 0 {
+			continue
+		}
+		for j := range def.SubPartitions {
+			if def.SubPartitions[j].Comment == nil {
+				inherited := *def.Comment // copy: don't alias one string across structs
+				def.SubPartitions[j].Comment = &inherited
+			}
+		}
+		def.Comment = nil
+	}
+
+	return ct
+}

--- a/pkg/statement/normalize_partition_comment_test.go
+++ b/pkg/statement/normalize_partition_comment_test.go
@@ -1,0 +1,32 @@
+package statement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPartitionCommentPushdown covers the two halves of MySQL's behavior: a
+// partition comment is pushed onto explicitly named subpartitions that lack
+// their own, and is left on the partition when the subpartitions are implicit.
+func TestPartitionCommentPushdown(t *testing.T) {
+	ct, err := ParseCreateTable("CREATE TABLE t (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY KEY (dt) (PARTITION p0 VALUES LESS THAN (2020) COMMENT 'pc0' (SUBPARTITION s0 COMMENT 'sc0', SUBPARTITION s1))")
+	require.NoError(t, err)
+
+	p0 := ct.Partition.Definitions[0]
+	require.Nil(t, p0.Comment, "partition comment moves onto the subpartitions")
+	require.Len(t, p0.SubPartitions, 2)
+	require.Equal(t, "sc0", *p0.SubPartitions[0].Comment, "own comment wins")
+	require.Equal(t, "pc0", *p0.SubPartitions[1].Comment, "inherits the partition comment")
+
+	// Implicit subpartitions: nothing to push down to, comment stays put.
+	ct, err = ParseCreateTable("CREATE TABLE t (dt DATE NOT NULL, PRIMARY KEY (dt)) PARTITION BY RANGE (YEAR(dt)) SUBPARTITION BY KEY (dt) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2020) COMMENT 'pc0')")
+	require.NoError(t, err)
+	require.Equal(t, "pc0", *ct.Partition.Definitions[0].Comment)
+	require.Empty(t, ct.Partition.Definitions[0].SubPartitions)
+
+	// Unpartitioned tables are untouched (the rule runs on every parse).
+	ct, err = ParseCreateTable("CREATE TABLE t (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+	require.Nil(t, ct.Partition)
+}


### PR DESCRIPTION
`CreateTable.Diff` never converged for a partitioned table, and for a subpartitioned one the statements it emitted silently dropped the subpartitioning. Two independent defects.

### 1. The per-partition `ENGINE` clause was compared

`SHOW CREATE TABLE` always prints it:

```
(PARTITION p0 VALUES LESS THAN (2020) ENGINE = InnoDB,
 PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)
```

Human-authored SQL never does. MySQL requires every partition to use the table's storage engine, so the clause carries no information beyond the table-level `ENGINE` — but `partitionDefinitionEqual` compared it, so **every partitioned table with explicit partition definitions differed from its own live definition**, emitting a `REMOVE PARTITIONING` + `PARTITION BY` pair on every run. This reproduces with no subpartitioning involved.

### 2. `formatPartitionOptions` omitted `SUBPARTITION BY`

The only way `Diff` changes a partition layout is `REMOVE PARTITIONING` followed by a complete `PARTITION BY`, so anything emission omits is dropped. For the table below — where both sides are the same table, one as authored and one as MySQL 9.7 reports it — `Diff` returned this on every run:

```sql
ALTER TABLE `sp1` REMOVE PARTITIONING
ALTER TABLE `sp1` PARTITION BY RANGE (YEAR(`dt`)) (PARTITION `p0` VALUES LESS THAN (2020), PARTITION `p1` VALUES LESS THAN MAXVALUE)
```

A no-op-looking change that actually removes the table's subpartitioning. Partition comments and explicitly named subpartitions were dropped the same way.

## Changes

- **`equality.go`** — stop comparing the per-partition and per-subpartition `ENGINE`. Compare explicitly named subpartitions instead; that comparison is symmetric because MySQL echoes subpartition names back from `SHOW CREATE TABLE` when, and only when, they were named explicitly. Also guards `isPartitionCountOnlyChange` so a subpartitioning difference can never be swallowed by an `ADD`/`COALESCE PARTITION` (unreachable today — MySQL only allows subpartitions under RANGE/LIST — but the guard is free).
- **`format.go`** — emit `SUBPARTITION BY [LINEAR] HASH(expr)|KEY(cols) [SUBPARTITIONS n]` in MySQL's grammar position (after the partition method, before the definition list), plus partition `COMMENT` and named subpartition lists.
- **`normalize_partition_comment.go`** (new) — modelling the named form exposed one more MySQL behavior: a partition-level `COMMENT` on a partition whose subpartitions are named explicitly is stored on the subpartitions that lack their own and cleared from the partition. Left unhandled, that shape also never converges.

## Testing

Verified against MySQL 9.7 (`compose/9.7.yml`). Nine cases in the `TestDiff` table cover the reproducer, add/remove/change subpartitioning, the count-less `SUBPARTITION BY` form, and comment/name round-trips. Three integration tests in `diff_integration_test.go` execute exactly what `Diff` emits — as the Runner would — then assert the subpartitioning, names and comments survive on the server and that a re-diff converges to nil:

```
--- PASS: TestDiffIntegrationSubpartitionNoSpuriousDiff
--- PASS: TestDiffIntegrationSubpartitionChange
--- PASS: TestDiffIntegrationSubpartitionNamesAndComments
--- PASS: TestPartitionCommentPushdown
```

`go test ./pkg/statement/... ./pkg/migration/... ./pkg/move/check/` passes; `golangci-lint run ./pkg/statement/...` reports 0 issues.

Found while investigating #1152 (function-alias normalization); independent of that work — it reproduces with no aliases in the partition expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
