### PR TITLE
statement: compare resolved column charset/collation in Diff

### DIFF
--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -656,9 +656,10 @@ func (ct *CreateTable) diffTableOptions(target *CreateTable, opts *DiffOptions) 
 	return clauses
 }
 
-// columnsEqualWithContext checks if two columns are equal, considering table context for charset/collation
-// If a column's charset is nil, it inherits from the table. If it's explicitly set to the same as the table,
-// it's considered equal to nil (no explicit charset needed).
+// columnsEqualWithContext checks if two columns are equal, considering table
+// context for charset/collation: a column with no explicit charset/collation
+// inherits its owning table's defaults, so those attributes are compared on
+// their resolved values (see charsetCollationEqual).
 func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable, opts *DiffOptions) bool {
 	// Column names are case-insensitive in MySQL, so `id` and `ID` refer
 	// to the same column.
@@ -736,37 +737,7 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 		return false
 	}
 
-	// Charset comparison with table context
-	// If column charset is nil, it inherits from table
-	// If column charset equals table charset, it's redundant (same as nil)
-	sourceCharset := a.Charset
-	targetCharset := b.Charset
-
-	// Normalize: if charset equals table charset, treat as nil
-	if sourceCharset != nil && ct.TableOptions != nil && ct.TableOptions.Charset != nil && *sourceCharset == *ct.TableOptions.Charset {
-		sourceCharset = nil
-	}
-	if targetCharset != nil && target.TableOptions != nil && target.TableOptions.Charset != nil && *targetCharset == *target.TableOptions.Charset {
-		targetCharset = nil
-	}
-
-	if !ptrEqual(sourceCharset, targetCharset) {
-		return false
-	}
-
-	// Collation comparison with table context
-	sourceCollation := a.Collation
-	targetCollation := b.Collation
-
-	// Normalize: if collation equals table collation, treat as nil
-	if sourceCollation != nil && ct.TableOptions != nil && ct.TableOptions.Collation != nil && *sourceCollation == *ct.TableOptions.Collation {
-		sourceCollation = nil
-	}
-	if targetCollation != nil && target.TableOptions != nil && target.TableOptions.Collation != nil && *targetCollation == *target.TableOptions.Collation {
-		targetCollation = nil
-	}
-
-	if !ptrEqual(sourceCollation, targetCollation) {
+	if !charsetCollationEqual(a, b, ct, target, opts) {
 		return false
 	}
 
@@ -777,6 +748,135 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 		return false
 	}
 	return true
+}
+
+// charsetCarryingTypes are the column types that store text and therefore
+// carry a real charset/collation, inheriting the owning table's defaults when
+// the column declares neither. Type names are the parser's canonical
+// spellings. Binary and JSON types are excluded: they carry only a synthetic
+// "binary" charset that is identical on both sides of a same-type compare,
+// and spatial/vector types have theirs stripped by charsetlessTypeNormalizer.
+var charsetCarryingTypes = map[string]bool{
+	"char":       true,
+	"varchar":    true,
+	"tinytext":   true,
+	"text":       true,
+	"mediumtext": true,
+	"longtext":   true,
+	"enum":       true,
+	"set":        true,
+}
+
+// charsetOfCollation returns the character set a collation name belongs to.
+// MySQL collation names are the owning charset name followed by an
+// underscore-separated suffix (utf8mb4_general_ci -> utf8mb4); the sole
+// exception is "binary", which is both a charset and its only collation.
+func charsetOfCollation(collation string) string {
+	if idx := strings.IndexByte(collation, '_'); idx > 0 {
+		return collation[:idx]
+	}
+	return collation
+}
+
+// resolvedCharsetCollation returns the charset and collation a column
+// actually uses, following MySQL's resolution rules: explicit column values
+// win; an explicit column collation implies its charset; a column with
+// neither inherits the owning table's defaults, where a table collation
+// likewise implies the table charset. A value that cannot be determined from
+// the statement alone is returned as "": a column or table with a charset
+// but no collation uses that charset's *default* collation, and a table with
+// neither option uses the server defaults — both depend on server version
+// and configuration.
+func resolvedCharsetCollation(col *Column, table *CreateTable) (charset, collation string) {
+	switch {
+	case col.Collation != nil:
+		collation = strings.ToLower(*col.Collation)
+		if col.Charset != nil {
+			charset = strings.ToLower(*col.Charset)
+		} else {
+			charset = charsetOfCollation(collation)
+		}
+	case col.Charset != nil:
+		// An explicit column charset without a collation selects the
+		// charset's default collation — not the table's collation.
+		charset = strings.ToLower(*col.Charset)
+	default:
+		if tableCollation := table.TableOptions.getCollation(); tableCollation != nil {
+			collation = strings.ToLower(*tableCollation)
+		}
+		if tableCharset := table.TableOptions.getCharset(); tableCharset != nil {
+			charset = strings.ToLower(*tableCharset)
+		} else if collation != "" {
+			charset = charsetOfCollation(collation)
+		}
+	}
+	return charset, collation
+}
+
+// explicitUnlessTableDefault returns a column-level charset/collation value
+// with the redundant spelling of the owning table's default normalized to
+// nil, so an explicit value that merely restates the table default compares
+// equal to an inherited (nil) one.
+func explicitUnlessTableDefault(value, tableDefault *string) *string {
+	if value != nil && tableDefault != nil && *value == *tableDefault {
+		return nil
+	}
+	return value
+}
+
+// charsetCollationEqual reports whether two columns have the same effective
+// charset and collation given their owning tables' defaults. Equality is
+// decided on the RESOLVED values, not the written ones: a column that
+// inherits its table default and a column that matches a *different* default
+// on the other table are genuinely different columns, and since a
+// table-level DEFAULT CHARSET / COLLATE clause only affects columns added
+// later, converging them requires a MODIFY COLUMN in the same ALTER as the
+// table-option change.
+//
+// Each attribute is compared strictly when both sides resolve to a concrete
+// value. When a side is underdetermined (see resolvedCharsetCollation), that
+// attribute falls back to comparing the written values with redundant
+// table-default spellings normalized away — an unexpressed preference is
+// treated as a match rather than guessed at, which keeps the diff from
+// emitting a MODIFY it could never prove converged.
+func charsetCollationEqual(a, b *Column, source, target *CreateTable, opts *DiffOptions) bool {
+	if !charsetCarryingTypes[strings.ToLower(a.Type)] {
+		// Non-character types have no table default to inherit, so compare
+		// the written values directly.
+		return ptrEqual(a.Charset, b.Charset) && ptrEqual(a.Collation, b.Collation)
+	}
+
+	// IgnoreCharsetCollation suppresses the table-option diff, so the table
+	// defaults it ignores must not leak into the column comparison through
+	// resolution either — a column inheriting a difference between the two
+	// (ignored) table defaults is not a column change in this mode. Explicit
+	// column-level differences are still compared by the written-value
+	// comparisons below.
+	sourceCharset, sourceCollation := "", ""
+	targetCharset, targetCollation := "", ""
+	if !opts.IgnoreCharsetCollation {
+		sourceCharset, sourceCollation = resolvedCharsetCollation(a, source)
+		targetCharset, targetCollation = resolvedCharsetCollation(b, target)
+	}
+
+	if sourceCharset != "" && targetCharset != "" {
+		if sourceCharset != targetCharset {
+			return false
+		}
+	} else if !ptrEqual(
+		explicitUnlessTableDefault(a.Charset, source.TableOptions.getCharset()),
+		explicitUnlessTableDefault(b.Charset, target.TableOptions.getCharset()),
+	) {
+		return false
+	}
+
+	if sourceCollation != "" && targetCollation != "" {
+		return sourceCollation == targetCollation
+	}
+	return ptrEqual(
+		explicitUnlessTableDefault(a.Collation, source.TableOptions.getCollation()),
+		explicitUnlessTableDefault(b.Collation, target.TableOptions.getCollation()),
+	)
 }
 
 // getPrimaryKeyIndex returns the PRIMARY KEY index if it exists (table-level PK), nil otherwise

--- a/pkg/statement/diff_integration_test.go
+++ b/pkg/statement/diff_integration_test.go
@@ -585,3 +585,61 @@ func TestDiffIntegrationSubpartitionNamesAndComments(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, stmts)
 }
+
+// TestDiffIntegrationTableCollationChangeConverges verifies that changing a
+// table's default collation converges in a single apply when a column
+// inherits the live table's default. MySQL's table-level DEFAULT COLLATE
+// clause only affects columns added later, so the diff must include a MODIFY
+// COLUMN for the inheriting column alongside the table-option change — a diff
+// that emits only the table option leaves the column on the old collation and
+// the same drift resurfaces on the next plan.
+func TestDiffIntegrationTableCollationChangeConverges(t *testing.T) {
+	tt := testutils.NewTestTable(t, "diff_collation_converge",
+		"CREATE TABLE diff_collation_converge (id varchar(512) NOT NULL, PRIMARY KEY (id)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+
+	const targetSQL = "CREATE TABLE diff_collation_converge (id varchar(512) COLLATE utf8mb4_general_ci NOT NULL, PRIMARY KEY (id)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+
+	stmts := diffLiveTable(t, tt.DB, tt.Name, targetSQL)
+	require.Len(t, stmts, 1)
+	require.Equal(t, "ALTER TABLE `diff_collation_converge` MODIFY COLUMN `id` varchar(512) COLLATE utf8mb4_general_ci NOT NULL, COLLATE=utf8mb4_general_ci", stmts[0].Statement)
+
+	execStatements(t, tt.DB, stmts)
+	var collation string
+	err := tt.DB.QueryRowContext(t.Context(),
+		"SELECT COLLATION_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'id'",
+		tt.Name).Scan(&collation)
+	require.NoError(t, err)
+	require.Equal(t, "utf8mb4_general_ci", collation)
+
+	// Re-diff: converged in one apply — nothing left over.
+	stmts = diffLiveTable(t, tt.DB, tt.Name, targetSQL)
+	require.Nil(t, stmts)
+}
+
+// TestDiffIntegrationInheritedColumnFollowsNewTableCollation verifies the
+// same convergence when the target column also inherits its table default:
+// the emitted MODIFY carries no explicit COLLATE, and MySQL resolves it
+// against the new table default set by the table-option clause in the same
+// ALTER, so the column lands on the target collation in one apply.
+func TestDiffIntegrationInheritedColumnFollowsNewTableCollation(t *testing.T) {
+	tt := testutils.NewTestTable(t, "diff_collation_inherit",
+		"CREATE TABLE diff_collation_inherit (id int NOT NULL, name varchar(100), PRIMARY KEY (id)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+
+	const targetSQL = "CREATE TABLE diff_collation_inherit (id int NOT NULL, name varchar(100), PRIMARY KEY (id)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+
+	stmts := diffLiveTable(t, tt.DB, tt.Name, targetSQL)
+	require.Len(t, stmts, 1)
+	require.Equal(t, "ALTER TABLE `diff_collation_inherit` MODIFY COLUMN `name` varchar(100) NULL, COLLATE=utf8mb4_general_ci", stmts[0].Statement)
+
+	execStatements(t, tt.DB, stmts)
+	var collation string
+	err := tt.DB.QueryRowContext(t.Context(),
+		"SELECT COLLATION_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'name'",
+		tt.Name).Scan(&collation)
+	require.NoError(t, err)
+	require.Equal(t, "utf8mb4_general_ci", collation)
+
+	// Re-diff: converged in one apply — nothing left over.
+	stmts = diffLiveTable(t, tt.DB, tt.Name, targetSQL)
+	require.Nil(t, stmts)
+}

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -720,6 +720,53 @@ func TestDiff(t *testing.T) {
 			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100) COLLATE utf8mb4_bin) CHARSET utf8mb4",
 			expected: "ALTER TABLE `t1` MODIFY COLUMN `name` varchar(100) COLLATE utf8mb4_bin NULL",
 		},
+		// A table-level DEFAULT CHARSET/COLLATE change only affects columns
+		// added later, so when the table defaults differ, a column that
+		// inherits its table default must still be MODIFYed to converge in a
+		// single ALTER — even against a target column that (explicitly or by
+		// inheritance) matches the target table's different default.
+		{
+			name:     "TableCollationChangeModifiesInheritingColumn_ExplicitTarget",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100)) CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100) COLLATE utf8mb4_general_ci) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `name` varchar(100) COLLATE utf8mb4_general_ci NULL, COLLATE=utf8mb4_general_ci",
+		},
+		{
+			name:     "TableCollationChangeModifiesInheritingColumn_InheritedTarget",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100)) CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `name` varchar(100) NULL, COLLATE=utf8mb4_general_ci",
+		},
+		{
+			name:     "TableCharsetChangeModifiesInheritingColumn",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100)) CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100)) CHARSET=latin1 COLLATE=latin1_swedish_ci",
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `name` varchar(100) NULL, DEFAULT CHARSET=latin1, COLLATE=latin1_swedish_ci",
+		},
+		// When both tables share the same defaults, a column that inherits
+		// them and a column that explicitly restates them are the same
+		// column — no MODIFY in either direction.
+		{
+			name:     "SameTableDefaults_InheritedVsExplicitColumn",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+			expected: "",
+		},
+		{
+			name:     "SameTableDefaults_ExplicitVsInheritedColumn",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+			expected: "",
+		},
+		// A column already carrying the target's collation explicitly does
+		// not need a MODIFY when only the table default changes: the
+		// table-option clause alone converges.
+		{
+			name:     "TableCollationChangeSkipsAlreadyMatchingColumn",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100) COLLATE utf8mb4_general_ci) CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, name VARCHAR(100) COLLATE utf8mb4_general_ci) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+			expected: "ALTER TABLE `t1` COLLATE=utf8mb4_general_ci",
+		},
 		// Nil TableOptions tests - verifies no panic when TableOptions is nil
 		// This can happen when CREATE TABLE has no explicit ENGINE/CHARSET clause
 		{


### PR DESCRIPTION
Diff's column equality check normalizes a column's charset/collation to nil when it equals its own table's default. When the source and target tables have *different* defaults, a source column inheriting its default (nil) and a target column matching its different default (normalized to nil) falsely compare equal, so the diff emits only the table-level `DEFAULT CHARSET`/`COLLATE` clause. MySQL applies that clause to columns added later, not to existing ones — the column keeps the old collation, and the same drift comes back on the next diff. Converging takes two applies, with a leftover `MODIFY COLUMN` surfacing only in the second.

```
CREATE TABLE t1 (id varchar(512) NOT NULL, PRIMARY KEY (id))
  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci          -- live
CREATE TABLE t1 (id varchar(512) COLLATE utf8mb4_general_ci NOT NULL, PRIMARY KEY (id))
  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci          -- desired

before: ALTER TABLE `t1` COLLATE=utf8mb4_general_ci
          └─ id keeps utf8mb4_0900_ai_ci; drift resurfaces next diff
after:  ALTER TABLE `t1` MODIFY COLUMN `id` varchar(512) COLLATE utf8mb4_general_ci NOT NULL, COLLATE=utf8mb4_general_ci
          └─ converges in one apply
```

Equality is now decided on the resolved values: nil inherits the owning table's default, an explicit collation implies its charset, and an explicit charset without a collation selects that charset's default collation. When a side cannot be resolved from the statement alone (no table options → server default; explicit charset only → its version-dependent default collation), that attribute falls back to the previous written-value comparison, so an unexpressed preference is still treated as a match rather than guessed at — the differ never emits a MODIFY it could not prove converged. Resolution only applies to types that carry a charset (an INT column must not "inherit" the table collation), and `IgnoreCharsetCollation` keeps the ignored table defaults out of the column comparison entirely.

Two behaviors worth calling out:

- A column that already explicitly matches the target collation no longer gets a spurious MODIFY when only the table default changes — the table-option clause alone converges. Previously the explicit value was normalized to nil on one side only, emitting a MODIFY that rebuilds the table without changing its schema.
- When both columns inherit, the emitted MODIFY carries no explicit COLLATE; the integration test proves on a real server that MySQL resolves it against the *new* table default set by the table-option clause in the same ALTER, so that case also converges in one apply.

*This PR was written by Claude Code (Fable 5).*