### PR TITLE
datasync: verify an existing target table against the source

### DIFF
--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -962,9 +962,10 @@ func (r *Runner) hasResumableCheckpoint(ctx context.Context, db *sql.DB) (bool, 
 }
 
 // createTargetTables creates each source table on the target using the
-// source's SHOW CREATE TABLE. Tables that already exist are skipped: on a
+// source's SHOW CREATE TABLE. Tables that already exist are not recreated: on a
 // fresh sync checkTargetEmpty has confirmed they are empty, and on a resume
-// they were created by a previous run.
+// they were created by a previous run. They are still verified against the
+// source first — see verifyExistingTargetTable.
 //
 // When DeferSecondaryIndexes is set, the regular secondary indexes are
 // stripped from the CREATE so the bulk copy loads an index-free table; they
@@ -1011,29 +1012,39 @@ func (r *Runner) createTargetTables(ctx context.Context) error {
 		if err := row.Scan(&name, &createStmt); err != nil {
 			return fmt.Errorf("failed to read CREATE TABLE for source %s: %w", t.TableName, err)
 		}
+		var exists int
+		err := conn.QueryRowContext(ctx,
+			"SELECT 1 FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?",
+			r.target.Config.DBName, t.TableName).Scan(&exists)
+		if err == nil {
+			// The table is already there. Verify it still matches the source
+			// before we copy into it — an unconditional skip here is what makes
+			// a source DDL between attempts silently lossy (issue #1165).
+			var targetName, targetCreateStmt string
+			targetRow := conn.QueryRowContext(ctx, "SHOW CREATE TABLE "+t.QuotedTableName)
+			if err := targetRow.Scan(&targetName, &targetCreateStmt); err != nil {
+				return fmt.Errorf("failed to read CREATE TABLE for target %s: %w", t.TableName, err)
+			}
+			if err := r.verifyExistingTargetTable(t.TableName, createStmt, targetCreateStmt); err != nil {
+				return err
+			}
+			r.logger.Info("target table already exists and matches the source, skipping creation",
+				"table", t.TableName, "database", r.target.Config.DBName)
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("failed to check if table %s exists on target: %w", t.TableName, err)
+		}
 		// When deferring secondary indexes, create the table without its regular
 		// secondary indexes; they are added back by restoreSecondaryIndexes once
 		// the initial copy has completed. We don't track which indexes were
 		// stripped — restore re-derives them from the source schema. UNIQUE,
 		// FULLTEXT and SPATIAL indexes are preserved on the CREATE.
 		if r.sync.DeferSecondaryIndexes {
-			var err error
 			createStmt, err = statement.RemoveSecondaryIndexes(createStmt)
 			if err != nil {
 				return fmt.Errorf("failed to remove secondary indexes from CREATE TABLE for %s: %w", t.TableName, err)
 			}
-		}
-		var exists int
-		err := conn.QueryRowContext(ctx,
-			"SELECT 1 FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?",
-			r.target.Config.DBName, t.TableName).Scan(&exists)
-		if err == nil {
-			r.logger.Info("target table already exists, skipping creation",
-				"table", t.TableName, "database", r.target.Config.DBName)
-			continue
-		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("failed to check if table %s exists on target: %w", t.TableName, err)
 		}
 		if _, err := conn.ExecContext(ctx, createStmt); err != nil {
 			return fmt.Errorf("failed to create table %s on target: %w", t.TableName, err)
@@ -1042,6 +1053,48 @@ func (r *Runner) createTargetTables(ctx context.Context) error {
 			"deferred_indexes", r.sync.DeferSecondaryIndexes)
 	}
 	return nil
+}
+
+// verifyExistingTargetTable compares a target table that already exists against
+// its source, returning an actionable error when the two have diverged.
+//
+// The copy column list is the *intersection* of the source and target columns
+// (table.ColumnMapping), and the continuous checksum compares that same
+// intersection. So a target left behind by an earlier attempt of this sync,
+// against a source that has since been ALTERed, drops the differing columns
+// from both the copy and the verification: the sync converges "clean" while the
+// target quietly misses data. Because a run that aborts still leaves a resumable
+// checkpoint, that is reachable by any consumer that retries an errored sync
+// (issue #1165). Fail here instead, naming the ALTER that reconciles the two.
+//
+// We fail rather than repair: the rows already copied under the old schema
+// would carry column defaults rather than the source's values, so an ALTER on
+// the target alone would not make the copy correct.
+//
+// Regular secondary indexes are excluded from the comparison on both sides.
+// With DeferSecondaryIndexes the target is deliberately created without them,
+// and an attempt that died mid-copy leaves it that way; restoreSecondaryIndexes
+// re-derives whatever is missing once the copy completes. UNIQUE, FULLTEXT and
+// SPATIAL indexes are kept on the initial CREATE, so those are still compared,
+// as are columns, the primary key, constraints and table options.
+func (r *Runner) verifyExistingTargetTable(tableName, sourceCreate, targetCreate string) error {
+	sourceCmp, err := statement.RemoveSecondaryIndexes(sourceCreate)
+	if err != nil {
+		return fmt.Errorf("failed to parse CREATE TABLE for source %s: %w", tableName, err)
+	}
+	targetCmp, err := statement.RemoveSecondaryIndexes(targetCreate)
+	if err != nil {
+		return fmt.Errorf("failed to parse CREATE TABLE for target %s: %w", tableName, err)
+	}
+	diff, err := statement.DiffCreateTables(tableName, sourceCmp, targetCmp, statement.NewDiffOptions())
+	if err != nil {
+		return fmt.Errorf("failed to compare source and target schema for %s: %w", tableName, err)
+	}
+	if diff == "" {
+		return nil
+	}
+	return fmt.Errorf("table %s already exists on the target (%s) but no longer matches the source; copying into it would silently omit the columns the two do not share. Reconcile the target with: %s — or drop the target database and re-copy from scratch",
+		tableName, r.target.Config.DBName, diff)
 }
 
 // restoreSecondaryIndexes adds any secondary indexes that exist on a source

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -1028,7 +1028,7 @@ func (r *Runner) createTargetTables(ctx context.Context) error {
 			if err := r.verifyExistingTargetTable(t.TableName, createStmt, targetCreateStmt); err != nil {
 				return err
 			}
-			r.logger.Info("target table already exists and matches the source, skipping creation",
+			r.logger.Info("target table already exists and passed schema verification, skipping creation",
 				"table", t.TableName, "database", r.target.Config.DBName)
 			continue
 		}
@@ -1093,7 +1093,7 @@ func (r *Runner) verifyExistingTargetTable(tableName, sourceCreate, targetCreate
 	if diff == "" {
 		return nil
 	}
-	return fmt.Errorf("table %s already exists on the target (%s) but no longer matches the source; copying into it would silently omit the columns the two do not share. Reconcile the target with: %s — or drop the target database and re-copy from scratch",
+	return fmt.Errorf("table %s already exists on the target (%s) but its schema has diverged from the source; copying into it is unsafe — any column the two do not share is silently dropped from both the copy and the checksum. Reconcile the target with: %s — or drop the target database and re-copy from scratch",
 		tableName, r.target.Config.DBName, diff)
 }
 

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -946,3 +946,153 @@ func TestSyncValidate(t *testing.T) {
 		})
 	}
 }
+
+// TestSyncResumeSourceSchemaChanged covers issue #1165: a source DDL that lands
+// between attempts must not be silently copied past. The target table exists
+// from the first run, so createTargetTables does not recreate it; without a
+// schema check the column added on the source falls out of the copy's
+// source/target column intersection — and out of the continuous checksum built
+// from that same intersection — so the sync converges "clean" with the target
+// missing the column. The re-run must fail instead, naming the reconciling
+// ALTER.
+func TestSyncResumeSourceSchemaChanged(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_ddl_drift_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_ddl_drift_dest"
+	sourceDSN := src.FormatDSN()
+	targetDSN := dest.FormatDSN()
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_ddl_drift_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_ddl_drift_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_ddl_drift_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_ddl_drift_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
+	testutils.RunSQL(t, `CREATE TABLE sync_ddl_drift_src.t2 (id INT PRIMARY KEY, val VARCHAR(255))`)
+	testutils.RunSQL(t, `INSERT INTO sync_ddl_drift_src.t2 VALUES (10,'ten'),(20,'twenty')`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_ddl_drift_dest`)
+
+	newSync := func() *Sync {
+		return &Sync{
+			SourceDSN:    sourceDSN,
+			TargetDSN:    targetDSN,
+			Threads:      2,
+			WriteThreads: 2,
+		}
+	}
+
+	// First run: copies both tables and leaves a resumable checkpoint.
+	r1, err := NewRunner(newSync())
+	require.NoError(t, err)
+	require.NoError(t, runUntilCopied(t, r1))
+	require.NoError(t, r1.Close())
+
+	// The source gains a column while the sync is not running — the shape a
+	// retry of an errored sync sees when the DDL is what aborted it.
+	testutils.RunSQL(t, `ALTER TABLE sync_ddl_drift_src.t1 ADD COLUMN added VARCHAR(64) NOT NULL DEFAULT 'x'`)
+
+	r2, err := NewRunner(newSync())
+	require.NoError(t, err)
+	runErr := runUntilCopied(t, r2)
+	require.NoError(t, r2.Close())
+	require.Error(t, runErr, "a resume against a stale target schema must fail, not copy a column short")
+	require.Contains(t, runErr.Error(), "t1")
+	require.Contains(t, runErr.Error(), "ADD COLUMN `added`",
+		"the error should carry the ALTER that reconciles the target")
+
+	// The unchanged table must not be implicated in the failure.
+	require.NotContains(t, runErr.Error(), "t2")
+
+	// Reconciling the target unblocks the resume. (The rows copied under the old
+	// schema carry the column default rather than the source's values, which is
+	// why spirit refuses to perform this repair itself — see
+	// verifyExistingTargetTable.) Resume in copy-only mode: a continuous resume
+	// opens the change feed at the checkpointed position, which predates the
+	// ALTER, so the source's DDL guard would cancel the run before the copy
+	// finishes — that guard is exactly what leaves the resumable checkpoint this
+	// test starts from, and it is not what's under test here.
+	testutils.RunSQL(t, `ALTER TABLE sync_ddl_drift_dest.t1 ADD COLUMN added VARCHAR(64) NOT NULL DEFAULT 'x'`)
+	reconciled := newSync()
+	reconciled.CopyOnly = true
+	r3, err := NewRunner(reconciled)
+	require.NoError(t, err)
+	require.NoError(t, runUntilCopied(t, r3))
+	require.NoError(t, r3.Close())
+}
+
+// TestSyncTargetSchemaVerifyIgnoresDeferredIndexes guards the resume-time schema
+// check against the false positive that would break --defer-secondary-indexes:
+// an attempt that died between the deferred CREATE and restoreSecondaryIndexes
+// leaves the target legitimately missing its regular secondary indexes, and the
+// resume must proceed (and restore them) rather than report a schema mismatch.
+// UNIQUE indexes are kept on the deferred CREATE, so dropping one *is* a
+// mismatch and must still be caught.
+func TestSyncTargetSchemaVerifyIgnoresDeferredIndexes(t *testing.T) {
+	cfg, err := mysql.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	src := cfg.Clone()
+	src.DBName = "sync_deferidx_verify_src"
+	dest := cfg.Clone()
+	dest.DBName = "sync_deferidx_verify_dest"
+
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_deferidx_verify_src`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_deferidx_verify_src`)
+	testutils.RunSQL(t, `CREATE TABLE sync_deferidx_verify_src.t1 (
+		id INT PRIMARY KEY,
+		u VARCHAR(36) NOT NULL,
+		a INT,
+		UNIQUE KEY uq_u (u),
+		KEY idx_a (a)
+	)`)
+	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_deferidx_verify_dest`)
+	testutils.RunSQL(t, `CREATE DATABASE sync_deferidx_verify_dest`)
+
+	s := &Sync{
+		SourceDSN:             src.FormatDSN(),
+		TargetDSN:             dest.FormatDSN(),
+		DeferSecondaryIndexes: true,
+	}
+	runner, err := NewRunner(s)
+	require.NoError(t, err)
+
+	sourceDB, err := sql.Open("mysql", s.SourceDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(sourceDB)
+	runner.source = sourceInfo{db: sourceDB, config: src, dsn: s.SourceDSN}
+	targetDB, err := sql.Open("mysql", s.TargetDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+	runner.target = applier.Target{KeyRange: "0", DB: targetDB, Config: dest}
+
+	ctx := context.Background()
+	tables, err := runner.getTables(ctx)
+	require.NoError(t, err)
+	runner.sourceTables = tables
+
+	// Deferred create: target is index-free apart from PRIMARY + UNIQUE.
+	require.NoError(t, runner.createTargetTables(ctx))
+	require.ElementsMatch(t, []string{"uq_u"},
+		secondaryIndexNames(t, targetDB, dest.DBName, "t1"))
+
+	// A resume in that state must not be read as a schema mismatch.
+	require.NoError(t, runner.createTargetTables(ctx),
+		"a target still missing its deferred secondary indexes must resume")
+	require.NoError(t, runner.restoreSecondaryIndexes(ctx))
+
+	// A fully-restored target is equally acceptable.
+	require.NoError(t, runner.createTargetTables(ctx))
+
+	// A dropped UNIQUE index is not deferrable, so it is real drift.
+	testutils.RunSQL(t, `ALTER TABLE sync_deferidx_verify_dest.t1 DROP INDEX uq_u`)
+	err = runner.createTargetTables(ctx)
+	require.Error(t, err, "a missing UNIQUE index is drift, not deferral")
+	require.Contains(t, err.Error(), "uq_u")
+
+	// So is a dropped column.
+	testutils.RunSQL(t, `ALTER TABLE sync_deferidx_verify_dest.t1 ADD UNIQUE KEY uq_u (u)`)
+	testutils.RunSQL(t, `ALTER TABLE sync_deferidx_verify_dest.t1 DROP COLUMN a`)
+	err = runner.createTargetTables(ctx)
+	require.Error(t, err, "a column the target lacks would be silently dropped from the copy")
+	require.Contains(t, err.Error(), "ADD COLUMN `a`")
+}

--- a/pkg/move/check/schema_compare.go
+++ b/pkg/move/check/schema_compare.go
@@ -3,8 +3,6 @@ package check
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"strings"
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/statement"
@@ -29,73 +27,17 @@ func showCreateTable(ctx context.Context, db *sql.DB, schema, table string) (str
 
 // schemaDiff compares two CREATE TABLE statements and returns a runnable
 // ALTER TABLE statement describing how they differ, or an empty string if they
-// are equivalent.
-//
-// The comparison is performed by parsing both statements with the TiDB parser
-// and diffing the structured form via statement.CreateTable.Diff. This canonical
-// comparison:
-//   - ignores AUTO_INCREMENT counter values (instance-specific noise),
-//   - ignores the column-level AUTO_INCREMENT attribute: an unsharded source
+// are equivalent. See statement.DiffCreateTables for the canonicalization
+// rules; move adds one relaxation of its own:
+//   - the column-level AUTO_INCREMENT attribute is ignored: an unsharded source
 //     legitimately differs from a sharded target that drops AUTO_INCREMENT in
 //     favor of a Vitess sequence; the difference does not affect copy
-//     correctness, so it must not block a move into a pre-created target,
-//   - ignores ENGINE and ROW_FORMAT cosmetic defaults,
-//   - DOES compare column types, nullability, defaults, and per-column /
-//     per-table CHARACTER SET and COLLATE,
-//   - DOES compare indexes (including the primary key) and constraints.
+//     correctness, so it must not block a move into a pre-created target.
 //
 // "want" is treated as the source-of-truth (e.g. sources[0] or the move source);
 // "got" is the schema being validated (another source, or a pre-created target).
-// The returned statement describes the transformation that would be required to
-// turn "got" into "want", which is what makes the message actionable. "table" is
-// the real (logical) table name used to build the runnable "ALTER TABLE <table>"
-// prefix, escaped so identifiers containing backticks remain valid.
 func schemaDiff(table, wantCreate, gotCreate string) (string, error) {
-	want, err := statement.ParseCreateTable(wantCreate)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse reference CREATE TABLE: %w", err)
-	}
-	got, err := statement.ParseCreateTable(gotCreate)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse CREATE TABLE under validation: %w", err)
-	}
-	// Diff requires both tables to have the same name. The two CREATE TABLE
-	// statements come from tables with the same logical name on different
-	// instances, but rewrite both names to a fixed token so the comparison is
-	// purely structural and never trips on the name guard.
-	want.TableName = "t"
-	got.TableName = "t"
-
-	// Diff(got -> want): the returned clauses are the ALTER that would morph the
-	// validated schema ("got") into the reference schema ("want"). If nil, the
-	// two schemas are equivalent under the canonicalization rules above.
-	// IgnoreColumnAutoIncrement: a sharded target legitimately drops the
-	// column-level AUTO_INCREMENT flag (IDs come from a Vitess sequence), and
-	// that difference is not a copy-correctness concern — so it must not block
-	// the move (see the doc comment above).
 	diffOpts := statement.NewDiffOptions()
 	diffOpts.IgnoreColumnAutoIncrement = true
-	stmts, err := got.Diff(want, diffOpts)
-	if err != nil {
-		return "", fmt.Errorf("failed to diff CREATE TABLE statements: %w", err)
-	}
-	if len(stmts) == 0 {
-		return "", nil
-	}
-	clauses := make([]string, 0, len(stmts))
-	for _, s := range stmts {
-		if s.Alter != "" {
-			clauses = append(clauses, s.Alter)
-		}
-	}
-	if len(clauses) == 0 {
-		return "", nil
-	}
-	// Prefix with an escaped "ALTER TABLE <table>" so the "reconcile with:" output
-	// is directly runnable. Multiple clauses are joined into a single ALTER.
-	prefix, err := sqlescape.EscapeSQL("ALTER TABLE %n ", table)
-	if err != nil {
-		return "", err
-	}
-	return prefix + strings.Join(clauses, ", "), nil
+	return statement.DiffCreateTables(table, wantCreate, gotCreate, diffOpts)
 }

--- a/pkg/statement/schema_compare.go
+++ b/pkg/statement/schema_compare.go
@@ -30,6 +30,12 @@ import (
 // tables on different instances, so their names are normalized away before the
 // diff and never compared.
 //
+// CreateTable.Diff deliberately splits some reconciliations across more than
+// one ALTER — a partition-type change, or an option-only index change that
+// MySQL would no-op if its DROP and ADD shared a statement. Those are emitted
+// as separate semicolon-separated ALTERs, in order, rather than merged into one
+// (which would produce SQL that silently does the wrong thing).
+//
 // If opts is nil, NewDiffOptions() defaults are used.
 func DiffCreateTables(table, wantCreate, gotCreate string, opts *DiffOptions) (string, error) {
 	want, err := ParseCreateTable(wantCreate)
@@ -57,20 +63,21 @@ func DiffCreateTables(table, wantCreate, gotCreate string, opts *DiffOptions) (s
 	if len(stmts) == 0 {
 		return "", nil
 	}
-	clauses := make([]string, 0, len(stmts))
-	for _, s := range stmts {
-		if s.Alter != "" {
-			clauses = append(clauses, s.Alter)
-		}
-	}
-	if len(clauses) == 0 {
-		return "", nil
-	}
-	// Prefix with an escaped "ALTER TABLE <table>" so the output is directly
-	// runnable. Multiple clauses are joined into a single ALTER.
+	// Prefix each statement with an escaped "ALTER TABLE <table>" so the output
+	// is directly runnable. Diff already grouped the clauses that may share an
+	// ALTER, so preserve its statement boundaries rather than flattening them.
 	prefix, err := sqlescape.EscapeSQL("ALTER TABLE %n ", table)
 	if err != nil {
 		return "", err
 	}
-	return prefix + strings.Join(clauses, ", "), nil
+	alters := make([]string, 0, len(stmts))
+	for _, s := range stmts {
+		if s.Alter != "" {
+			alters = append(alters, prefix+s.Alter)
+		}
+	}
+	if len(alters) == 0 {
+		return "", nil
+	}
+	return strings.Join(alters, "; "), nil
 }

--- a/pkg/statement/schema_compare.go
+++ b/pkg/statement/schema_compare.go
@@ -1,0 +1,76 @@
+package statement
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/block/spirit/pkg/dbconn/sqlescape"
+)
+
+// DiffCreateTables compares two CREATE TABLE statements and returns a runnable
+// ALTER TABLE statement describing how they differ, or an empty string if they
+// are equivalent under opts.
+//
+// The comparison is performed by parsing both statements and diffing the
+// structured form via CreateTable.Diff, so it is insensitive to the textual
+// noise two servers can put in SHOW CREATE TABLE output. What is and isn't
+// compared is controlled by opts; with NewDiffOptions the comparison:
+//   - ignores AUTO_INCREMENT counter values (instance-specific noise),
+//   - ignores ENGINE and ROW_FORMAT cosmetic defaults,
+//   - DOES compare column types, nullability, defaults, and per-column /
+//     per-table CHARACTER SET and COLLATE,
+//   - DOES compare indexes (including the primary key) and constraints.
+//
+// "want" is the schema treated as the source of truth; "got" is the schema
+// being validated against it. The returned statement describes the
+// transformation that would turn "got" into "want", which is what makes the
+// message actionable. "table" is the real (logical) table name used to build
+// the runnable "ALTER TABLE <table>" prefix, escaped so identifiers containing
+// backticks remain valid — the two CREATE TABLE statements themselves may name
+// tables on different instances, so their names are normalized away before the
+// diff and never compared.
+//
+// If opts is nil, NewDiffOptions() defaults are used.
+func DiffCreateTables(table, wantCreate, gotCreate string, opts *DiffOptions) (string, error) {
+	want, err := ParseCreateTable(wantCreate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse reference CREATE TABLE: %w", err)
+	}
+	got, err := ParseCreateTable(gotCreate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse CREATE TABLE under validation: %w", err)
+	}
+	// Diff requires both tables to have the same name. The two CREATE TABLE
+	// statements come from tables with the same logical name on different
+	// instances, but rewrite both names to a fixed token so the comparison is
+	// purely structural and never trips on the name guard.
+	want.TableName = "t"
+	got.TableName = "t"
+
+	// Diff(got -> want): the returned clauses are the ALTER that would morph the
+	// validated schema ("got") into the reference schema ("want"). If nil, the
+	// two schemas are equivalent under the canonicalization rules above.
+	stmts, err := got.Diff(want, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to diff CREATE TABLE statements: %w", err)
+	}
+	if len(stmts) == 0 {
+		return "", nil
+	}
+	clauses := make([]string, 0, len(stmts))
+	for _, s := range stmts {
+		if s.Alter != "" {
+			clauses = append(clauses, s.Alter)
+		}
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	// Prefix with an escaped "ALTER TABLE <table>" so the output is directly
+	// runnable. Multiple clauses are joined into a single ALTER.
+	prefix, err := sqlescape.EscapeSQL("ALTER TABLE %n ", table)
+	if err != nil {
+		return "", err
+	}
+	return prefix + strings.Join(clauses, ", "), nil
+}

--- a/pkg/statement/schema_compare_test.go
+++ b/pkg/statement/schema_compare_test.go
@@ -80,6 +80,23 @@ func TestDiffCreateTables(t *testing.T) {
 	}
 }
 
+// TestDiffCreateTablesKeepsStatementBoundaries covers a reconciliation that
+// Diff deliberately splits across more than one ALTER. Here it is an
+// option-only index change: MySQL no-ops a DROP and ADD of the same index in a
+// single statement, so merging the two into one comma-joined ALTER would emit
+// SQL that silently fails to reconcile the schemas.
+func TestDiffCreateTablesKeepsStatementBoundaries(t *testing.T) {
+	want := "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, b VARCHAR(255), KEY idx_b (b) KEY_BLOCK_SIZE=8)"
+	got := "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, b VARCHAR(255), KEY idx_b (b) KEY_BLOCK_SIZE=4)"
+
+	diff, err := DiffCreateTables("t1", want, got, nil)
+	require.NoError(t, err)
+	require.Equal(t,
+		"ALTER TABLE `t1` DROP INDEX `idx_b`; ALTER TABLE `t1` ADD INDEX `idx_b` (`b`) KEY_BLOCK_SIZE=8",
+		diff,
+		"statements Diff kept separate must not be merged into one ALTER")
+}
+
 func TestDiffCreateTablesParseErrors(t *testing.T) {
 	_, err := DiffCreateTables("t1", "NOT A CREATE TABLE", "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)", nil)
 	require.ErrorContains(t, err, "failed to parse reference CREATE TABLE")

--- a/pkg/statement/schema_compare_test.go
+++ b/pkg/statement/schema_compare_test.go
@@ -1,0 +1,89 @@
+package statement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffCreateTables(t *testing.T) {
+	tests := []struct {
+		name     string
+		table    string // defaults to "t1"
+		want     string
+		got      string
+		opts     *DiffOptions
+		wantDiff string
+	}{
+		{
+			name: "identical",
+			want: "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, b VARCHAR(255))",
+			got:  "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, b VARCHAR(255))",
+		},
+		{
+			// The two CREATEs come from different instances, so the table names
+			// are normalized away and never compared — only the "table"
+			// argument reaches the output.
+			name: "different table names are not a difference",
+			want: "CREATE TABLE src (id INT NOT NULL PRIMARY KEY)",
+			got:  "CREATE TABLE dest (id INT NOT NULL PRIMARY KEY)",
+		},
+		{
+			name:     "column missing from got",
+			want:     "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, added VARCHAR(64))",
+			got:      "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)",
+			wantDiff: "ALTER TABLE `t1` ADD COLUMN `added` varchar(64) NULL",
+		},
+		{
+			name:     "column type differs",
+			want:     "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, b VARCHAR(255))",
+			got:      "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, b VARCHAR(64))",
+			wantDiff: "ALTER TABLE `t1` MODIFY COLUMN `b` varchar(255) NULL",
+		},
+		{
+			// nil opts means NewDiffOptions(), which ignores the AUTO_INCREMENT
+			// counter.
+			name: "nil opts ignores the auto_increment counter",
+			want: "CREATE TABLE t1 (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY) AUTO_INCREMENT=500",
+			got:  "CREATE TABLE t1 (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY) AUTO_INCREMENT=1",
+		},
+		{
+			name: "opts can relax the column auto_increment attribute",
+			want: "CREATE TABLE t1 (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+			got:  "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)",
+			opts: func() *DiffOptions {
+				o := NewDiffOptions()
+				o.IgnoreColumnAutoIncrement = true
+				return o
+			}(),
+		},
+		{
+			// The name used to build the runnable prefix is escaped, so a table
+			// name containing a backtick stays valid SQL.
+			name:     "table name is escaped in the prefix",
+			table:    "we`ird",
+			want:     "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, added INT)",
+			got:      "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)",
+			wantDiff: "ALTER TABLE `we``ird` ADD COLUMN `added` int NULL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := tt.table
+			if name == "" {
+				name = "t1"
+			}
+			diff, err := DiffCreateTables(name, tt.want, tt.got, tt.opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDiff, diff)
+		})
+	}
+}
+
+func TestDiffCreateTablesParseErrors(t *testing.T) {
+	_, err := DiffCreateTables("t1", "NOT A CREATE TABLE", "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)", nil)
+	require.ErrorContains(t, err, "failed to parse reference CREATE TABLE")
+
+	_, err = DiffCreateTables("t1", "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY)", "NOT A CREATE TABLE", nil)
+	require.ErrorContains(t, err, "failed to parse CREATE TABLE under validation")
+}


### PR DESCRIPTION
Fixes #1165.

`createTargetTables` skipped any target table that already existed without looking at its
definition. Since the copy column list is the *intersection* of the source and target columns
(`table.ColumnMapping`) — and the continuous checksum compares that same intersection — a source
DDL landing between attempts was silently dropped from both: the sync converged "clean" with the
target missing data. A run that aborts leaves a resumable checkpoint even when the DDL is what
aborted it, so this was reachable by any consumer that retries an errored sync.

## What changed

- **Verify before copying into an existing target table.** `createTargetTables` now reads the
  target's `SHOW CREATE TABLE` for any table it is about to skip, compares it to the source, and
  fails with the `ALTER` that reconciles the two.
- **Fail rather than repair.** Rows already copied under the old schema carry column defaults
  rather than the source's values, so an ALTER on the target alone would not make the copy correct.
- **Deferred secondary indexes are not a false positive.** Regular secondary indexes are stripped
  from *both* sides before the comparison: with `--defer-secondary-indexes` the target is created
  without them on purpose, and an attempt that died mid-copy leaves it that way;
  `restoreSecondaryIndexes` re-derives whatever is missing after the copy. UNIQUE / FULLTEXT /
  SPATIAL are kept on the initial CREATE, so those are still compared, as are columns, the primary
  key, constraints and table options.
- **Shared canonicalization.** `move`'s `schemaDiff` is promoted to `statement.DiffCreateTables` so
  both callers use one implementation; `move` keeps its own `IgnoreColumnAutoIncrement` relaxation
  for sharded targets.

This gives `datasync` the guarantee `move` already has in its `resume_state` check. It applies on
the fresh path too: a pre-created empty target with the wrong shape would drop columns from the
copy just the same.

## Note on the continuous resume path

Writing the test surfaced something worth recording: after a source DDL, reconciling the target is
not by itself enough to resume a *continuous* sync. The change feed reopens at the checkpointed
position, replays the ALTER, and the source's DDL guard cancels the run
(`table definition changed, cancelling operation`) — the same loop described in the issue's "How it
was found". The practical remedy is a copy-only resume or a fresh copy. `TestSyncResumeSourceSchemaChanged`
reflects that and says so.

## Testing

- `TestSyncResumeSourceSchemaChanged` — the issue's repro: copy, `ADD COLUMN` on the source, re-run.
  Asserts the run fails, that the error names the reconciling `ADD COLUMN`, that the unchanged table
  is not implicated, and that a reconciled target resumes.
- `TestSyncTargetSchemaVerifyIgnoresDeferredIndexes` — a target still missing its deferred regular
  indexes resumes; a dropped UNIQUE index or a dropped column does not.
- `TestDiffCreateTables` / `TestDiffCreateTablesParseErrors` for the promoted helper.
- Both new datasync tests were confirmed to fail with the check neutered.
- `pkg/datasync` (including `-race`), `pkg/statement`, `pkg/move/...`, `pkg/lint` green;
  `golangci-lint` reports `0 issues.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
