### PR TITLE
change: stop deferring not-yet-dispatched keys at flush time

### DIFF
--- a/pkg/change/README.md
+++ b/pkg/change/README.md
@@ -217,7 +217,7 @@ source state at least as new as the change and overwrites it. Only the band
 between them, where a chunk read is genuinely in flight, has to wait.
 
 Deferring the not-yet-dispatched region too (the behaviour before
-[#1169](https://github.com/block/spirit/pull/1169)) pinned the checkpoint's
+[#1167](https://github.com/block/spirit/pull/1167)) pinned the checkpoint's
 binlog position for entire copies: `KeyAboveHighWatermark` returns `false`
 until the first chunk is dispatched, so every change in the window between
 `SetWatermarkOptimization(true)` and the first `chunker.Next()` — a window the

--- a/pkg/change/README.md
+++ b/pkg/change/README.md
@@ -198,14 +198,33 @@ The copier maintains a "watermark" representing its progress. The replication cl
 - **Low watermark**: Skip changes for rows that are currently being copied (avoid races with the copier, which may cause deadlocks/lock waits)
 
 ```go
+// Ingest time (HasChanged): drop what the copier is guaranteed to pick up.
 if chunker.KeyAboveHighWatermark(key[0]) {
     return  // Skip, copier will handle this
 }
 
-if !chunker.KeyBelowLowWatermark(key[0]) {
+// Flush time (bufferedMap.mustDeferKey): defer only the in-flight band.
+if !chunker.KeyBelowLowWatermark(key[0]) && !chunker.KeyNotYetDispatched(key[0]) {
     continue  // Skip, copier is actively working on this range
 }
 ```
+
+Note the flush-time filter has two halves. A buffered change is safe to apply
+both when the copier has already committed its key (`KeyBelowLowWatermark`)
+**and** when the copier has not yet dispatched a chunk covering it
+(`KeyNotYetDispatched`) — in the latter case the copier's later read observes a
+source state at least as new as the change and overwrites it. Only the band
+between them, where a chunk read is genuinely in flight, has to wait.
+
+Deferring the not-yet-dispatched region too (the behaviour before
+[#1169](https://github.com/block/spirit/pull/1169)) pinned the checkpoint's
+binlog position for entire copies: `KeyAboveHighWatermark` returns `false`
+until the first chunk is dispatched, so every change in the window between
+`SetWatermarkOptimization(true)` and the first `chunker.Next()` — a window the
+throttler can stretch arbitrarily — was buffered, including changes to rows at
+the top of the key space. Those entries stay above the low watermark until the
+copier physically reaches their key, and a single one is enough to make every
+flush report `allChangesFlushed=false`.
 
 **Important:** The watermark optimization is disabled before the final cutover to ensure all changes are applied regardless of the copier's position.
 

--- a/pkg/change/checkpoint_stall_test.go
+++ b/pkg/change/checkpoint_stall_test.go
@@ -1,0 +1,206 @@
+package change
+
+import (
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckpointStallPreFirstChunk covers the reported issue: the binlog
+// position in the checkpoint never advances for the whole copy phase.
+//
+//  1. watermark optimization is enabled BEFORE the copier dispatches its
+//     first chunk (this is what migration.setup does).
+//  2. a row at the TOP of the key space is modified in that window.
+//     KeyAboveHighWatermark returns false (chunkPtr is nil, #746), so it is
+//     buffered rather than discarded.
+//  3. the copier then works through the table from the bottom. The buffered
+//     high key is never below the low watermark, so before the fix every
+//     flush deferred it, every flush reported allChangesFlushed=false, and
+//     flushedPos was pinned at its pre-copy value for the whole copy.
+func TestCheckpointStallPreFirstChunk(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS stallt1, stallt2")
+	testutils.RunSQL(t, "CREATE TABLE stallt1 (a INT NOT NULL auto_increment, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE stallt2 (a INT NOT NULL auto_increment, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "INSERT INTO stallt1 (a,b) SELECT NULL, 1 FROM dual")
+	for range 14 {
+		testutils.RunSQL(t, "INSERT INTO stallt1 (a,b) SELECT NULL, 1 FROM stallt1")
+	}
+	testutils.RunSQL(t, "ANALYZE TABLE stallt1")
+
+	t1 := table.NewTableInfo(db, "test", "stallt1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "stallt2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd,
+		applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*binlogClient)
+
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: time.Second})
+	require.NoError(t, err)
+	require.NoError(t, chunker.Open())
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+
+	// The runner enables the optimization at the end of setup, before the
+	// copier has dispatched anything.
+	require.NoError(t, client.SetWatermarkOptimization(t.Context(), true))
+
+	// A write lands in that window. It is buffered, not discarded.
+	testutils.RunSQL(t, "UPDATE stallt1 SET b = 99 WHERE a = 16384")
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen(), "high key should be buffered, not discarded")
+	startPos := client.Position()
+
+	// The copier starts and works through the low end of the table. The
+	// buffered key sits far above the low watermark the whole time — but it
+	// is also far above the highest dispatched chunk, so nothing the copier
+	// has in flight can race with it and it must not block the checkpoint.
+	for range 3 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		chunker.Feedback(chunk, time.Millisecond, chunk.ChunkSize)
+	}
+	require.NoError(t, client.flush(t.Context(), false, nil))
+
+	require.Equal(t, 0, client.GetDeltaLen(), "the buffered high key should have flushed")
+	require.NotEqual(t, startPos, client.Position(),
+		"the flushed binlog position must advance once nothing is left deferred")
+
+	var b int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT b FROM stallt2 WHERE a = 16384").Scan(&b))
+	require.Equal(t, 99, b)
+}
+
+// TestInFlightBandStillDeferred is the guard rail for the fix above: a change
+// whose key falls inside a chunk the copier has dispatched but not yet fed
+// back must still be deferred, or the copier's in-flight read can land a stale
+// image on top of it.
+func TestInFlightBandStillDeferred(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS bandt1, bandt2")
+	testutils.RunSQL(t, "CREATE TABLE bandt1 (a INT NOT NULL auto_increment, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE bandt2 (a INT NOT NULL auto_increment, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "INSERT INTO bandt1 (a,b) SELECT NULL, 1 FROM dual")
+	for range 14 {
+		testutils.RunSQL(t, "INSERT INTO bandt1 (a,b) SELECT NULL, 1 FROM bandt1")
+	}
+	testutils.RunSQL(t, "ANALYZE TABLE bandt1")
+
+	t1 := table.NewTableInfo(db, "test", "bandt1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "bandt2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd,
+		applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*binlogClient)
+
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: time.Second})
+	require.NoError(t, err)
+	require.NoError(t, chunker.Open())
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+	require.NoError(t, client.SetWatermarkOptimization(t.Context(), true))
+
+	// Dispatch chunks [.., 1), [1, 1001), [1001, 2001) but only feed back the
+	// first two, so [1001, 2001) is the in-flight band.
+	var inFlight *table.Chunk
+	for i := range 3 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		if i == 2 {
+			inFlight = chunk
+			continue
+		}
+		chunker.Feedback(chunk, time.Millisecond, chunk.ChunkSize)
+	}
+
+	testutils.RunSQL(t, "UPDATE bandt1 SET b = 77 WHERE a = 1500")
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen())
+	pinned := client.Position()
+
+	require.NoError(t, client.flush(t.Context(), false, nil))
+	require.Equal(t, 1, client.GetDeltaLen(), "in-flight key must stay deferred")
+	require.Equal(t, pinned, client.Position(), "position must not advance past a deferred change")
+
+	// Once the covering chunk is committed the key flushes normally.
+	chunker.Feedback(inFlight, time.Millisecond, inFlight.ChunkSize)
+	require.NoError(t, client.flush(t.Context(), false, nil))
+	require.Equal(t, 0, client.GetDeltaLen())
+	require.NotEqual(t, pinned, client.Position())
+}
+
+// TestCheckpointStallPreFirstChunkGTID is TestCheckpointStallPreFirstChunk on
+// the GTID source. The deferral lives in the shared bufferedMap, and both
+// clients gate their position advance on the same allChangesFlushed result, so
+// the stall — and the fix — are source-agnostic.
+func TestCheckpointStallPreFirstChunkGTID(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS gstallt1, gstallt2")
+	testutils.RunSQL(t, "CREATE TABLE gstallt1 (a INT NOT NULL auto_increment, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "CREATE TABLE gstallt2 (a INT NOT NULL auto_increment, b INT, PRIMARY KEY (a))")
+	testutils.RunSQL(t, "INSERT INTO gstallt1 (a,b) SELECT NULL, 1 FROM dual")
+	for range 14 {
+		testutils.RunSQL(t, "INSERT INTO gstallt1 (a,b) SELECT NULL, 1 FROM gstallt1")
+	}
+	testutils.RunSQL(t, "ANALYZE TABLE gstallt1")
+
+	t1 := table.NewTableInfo(db, "test", "gstallt1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "gstallt2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := NewGTIDClient(db, cfg.Addr, cfg.User, cfg.Passwd,
+		applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*gtidClient)
+
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2, TargetChunkTime: time.Second})
+	require.NoError(t, err)
+	require.NoError(t, chunker.Open())
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	defer client.Close()
+	require.NoError(t, client.SetWatermarkOptimization(t.Context(), true))
+
+	testutils.RunSQL(t, "UPDATE gstallt1 SET b = 99 WHERE a = 16384")
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.Equal(t, 1, client.GetDeltaLen(), "high key should be buffered, not discarded")
+	startPos := client.Position()
+
+	for range 3 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		chunker.Feedback(chunk, time.Millisecond, chunk.ChunkSize)
+	}
+	require.NoError(t, client.flush(t.Context(), false, nil))
+
+	require.Equal(t, 0, client.GetDeltaLen(), "the buffered high key should have flushed")
+	require.NotEqual(t, startPos, client.Position(),
+		"the flushed GTID set must advance once nothing is left deferred")
+	t.Logf("gtid before=%s after=%s", startPos, client.Position())
+}

--- a/pkg/change/checkpoint_stall_test.go
+++ b/pkg/change/checkpoint_stall_test.go
@@ -156,6 +156,7 @@ func TestInFlightBandStillDeferred(t *testing.T) {
 // clients gate their position advance on the same allChangesFlushed result, so
 // the stall — and the fix — are source-agnostic.
 func TestCheckpointStallPreFirstChunkGTID(t *testing.T) {
+	skipUnlessGTIDEnabled(t)
 	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
 	require.NoError(t, err)
 	defer utils.CloseAndLog(db)

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -747,12 +747,12 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 	}
 
 	for key, change := range snapshot {
-		// The low-watermark check defers flushing keys that are still
-		// being copied (KeyBelowLowWatermark returns false). The chunker
-		// is internally synchronized, so no Mutex is needed here.
-		if applyWatermarkFilter && !s.chunker.KeyBelowLowWatermark(change.originalKey[0]) {
+		// Keys the copier may have a read in flight for are deferred to a
+		// later flush; see mustDeferKey. The chunker is internally
+		// synchronized, so no Mutex is needed here.
+		if applyWatermarkFilter && s.mustDeferKey(change.originalKey[0]) {
 			s.keysSkippedBelow.Add(1)
-			s.logger.Debug("key not below watermark", "key", change.originalKey[0])
+			s.logger.Debug("key deferred: copier read in flight", "key", change.originalKey[0])
 			allChangesFlushed = false
 			continue
 		}
@@ -947,13 +947,13 @@ func (s *bufferedMap) flushMapLocked(ctx context.Context, underLock bool, locks 
 	applyWatermarkFilter := !underLock && !bypassWatermark && s.watermarkOptimizationEnabled()
 
 	for key, change := range s.changes {
-		// In bufferedMap, the low-watermark check defers flushing keys that
-		// are still being copied (KeyBelowLowWatermark returns false). It is
-		// only safe to skip when we are not under cutover lock and the caller
-		// has not asked us to drain everything (bypassWatermark).
-		if applyWatermarkFilter && !s.chunker.KeyBelowLowWatermark(change.originalKey[0]) {
+		// In bufferedMap, keys the copier may have a read in flight for are
+		// deferred to a later flush (see mustDeferKey). It is only safe to
+		// skip when we are not under cutover lock and the caller has not
+		// asked us to drain everything (bypassWatermark).
+		if applyWatermarkFilter && s.mustDeferKey(change.originalKey[0]) {
 			s.keysSkippedBelow.Add(1)
-			s.logger.Debug("key not below watermark", "key", change.originalKey[0])
+			s.logger.Debug("key deferred: copier read in flight", "key", change.originalKey[0])
 			allChangesFlushed = false
 			continue
 		}
@@ -1114,6 +1114,28 @@ func (s *bufferedMap) flushQueueLocked(ctx context.Context, underLock bool, lock
 		s.cond.Broadcast()
 	}
 	return nil
+}
+
+// mustDeferKey reports whether a buffered change for key0 has to sit out this
+// flush because the copier may have a read in flight for it.
+//
+// Only the *in-flight band* has to wait:
+//
+//	[ copied & committed ) [ dispatched, not yet committed ) [ not dispatched )
+//	        flush now                    defer                    flush now
+//
+// The right-hand region is what KeyNotYetDispatched adds. Deferring it too
+// (the pre-fix behaviour) is what pinned the checkpoint's binlog position for
+// a whole copy: every change buffered before the copier dispatched its first
+// chunk — the window between SetWatermarkOptimization(true) and the first
+// chunker.Next(), which the throttler can stretch arbitrarily — sits above the
+// low watermark until the copier physically reaches its key, and one such
+// entry is enough to make every flush report allChangesFlushed=false.
+func (s *bufferedMap) mustDeferKey(key0 any) bool {
+	if s.chunker.KeyBelowLowWatermark(key0) {
+		return false // already copied and committed
+	}
+	return !s.chunker.KeyNotYetDispatched(key0)
 }
 
 // watermarkOptimizationEnabled returns true if the watermark optimization

--- a/pkg/table/chunker.go
+++ b/pkg/table/chunker.go
@@ -99,6 +99,20 @@ type MappedChunker interface {
 	ColumnMapping() *ColumnMapping
 	KeyAboveHighWatermark(key0 any) bool
 	KeyBelowLowWatermark(key0 any) bool
+	// KeyNotYetDispatched reports whether the chunker has definitely not yet
+	// handed out a chunk covering key0. When true, no copier read for that key
+	// is in flight, so a buffered change for it can be flushed immediately:
+	// the copier's later read of the covering chunk observes a source state at
+	// least as new as the change, and overwrites it. It is the flush-time
+	// counterpart of KeyBelowLowWatermark ("already copied and committed") —
+	// between them sits the in-flight band, which is the only region a flush
+	// must defer.
+	//
+	// TRUE means the caller will flush, so any ambiguity must return FALSE.
+	// Unlike KeyAboveHighWatermark this is NOT a discard decision, so it
+	// deliberately ignores checkpointHighPtr: a key copied by a *previous*
+	// run has no read in flight in this one.
+	KeyNotYetDispatched(key0 any) bool
 }
 
 // ChunkerConfig holds optional configuration for creating a Chunker.

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -596,6 +596,31 @@ func (t *chunkerComposite) KeyBelowLowWatermark(key0 any) bool {
 	return below
 }
 
+// KeyNotYetDispatched satisfies MappedChunker. See the interface docs.
+func (t *chunkerComposite) KeyNotYetDispatched(key0 any) bool {
+	t.Lock()
+	defer t.Unlock()
+	if t.finalChunkSent {
+		return false
+	}
+	if len(t.chunkPtrs) == 0 {
+		return true
+	}
+	keyDatum, err := NewDatum(key0, t.chunkPtrs[0].Tp)
+	if err != nil {
+		t.logger.Error("failed to create keyDatum in KeyNotYetDispatched", "key", key0, "error", err)
+		return false
+	}
+	// Only a strictly greater key[0] guarantees the whole tuple sorts above
+	// every dispatched chunk — same reasoning as KeyAboveHighWatermark.
+	above, err := keyDatum.GreaterThan(t.chunkPtrs[0])
+	if err != nil {
+		t.logger.Error("comparing chunkPtrs[0] in KeyNotYetDispatched", "error", err)
+		return false
+	}
+	return above
+}
+
 // SetKey allows you to chunk on a secondary index, and not the primary key.
 // This is useful outside of the context of spirit, when the table package
 // is used directly. It is only supported by the composite chunker,

--- a/pkg/table/chunker_mock.go
+++ b/pkg/table/chunker_mock.go
@@ -305,8 +305,22 @@ func (m *MockChunker) KeyBelowLowWatermark(key any) bool {
 }
 
 // KeyNotYetDispatched reports whether the mock chunker has yet to hand out a
-// chunk covering key. Mirrors KeyAboveHighWatermark's comparison; ambiguous
-// keys return false so the caller keeps deferring.
+// chunk covering key. Non-numeric keys return false so the caller keeps
+// deferring.
+//
+// The strict `>` is deliberate, and differs from chunkerOptimistic's `>=`.
+// The real chunkers track the dispatched-but-uncommitted band with two
+// independent cursors (watermark.UpperBound and chunkPtr); this mock has only
+// currentPosition, which it uses for both. Pairing `>` here with
+// KeyBelowLowWatermark's `keyPos < currentPosition` leaves exactly one key —
+// currentPosition itself — in the in-flight band, which is what lets
+// mock-driven tests exercise the deferral branch of bufferedMap.mustDeferKey
+// at all. With `>=` the two predicates would partition the key space with no
+// gap and no MockChunker test could ever reach that branch.
+//
+// Tests that need the key to stop being deferred advance the chunker
+// (SimulateProgress / SetPosition); the live-MySQL tests in pkg/change cover
+// the real boundary semantics against real chunkers.
 func (m *MockChunker) KeyNotYetDispatched(key any) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/table/chunker_mock.go
+++ b/pkg/table/chunker_mock.go
@@ -304,6 +304,27 @@ func (m *MockChunker) KeyBelowLowWatermark(key any) bool {
 	return keyPos < m.currentPosition
 }
 
+// KeyNotYetDispatched reports whether the mock chunker has yet to hand out a
+// chunk covering key. Mirrors KeyAboveHighWatermark's comparison; ambiguous
+// keys return false so the caller keeps deferring.
+func (m *MockChunker) KeyNotYetDispatched(key any) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var keyPos uint64
+	switch v := key.(type) {
+	case int:
+		keyPos = uint64(v)
+	case uint64:
+		keyPos = v
+	case int64:
+		keyPos = uint64(v)
+	default:
+		return false
+	}
+	return keyPos > m.currentPosition
+}
+
 func (m *MockChunker) RowsCopied() uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -626,6 +626,32 @@ func (t *chunkerOptimistic) KeyBelowLowWatermark(key0 any) bool {
 	return below
 }
 
+// KeyNotYetDispatched satisfies MappedChunker. See the interface docs.
+func (t *chunkerOptimistic) KeyNotYetDispatched(key0 any) bool {
+	t.Lock()
+	defer t.Unlock()
+	if t.finalChunkSent {
+		// The final chunk is open-bounded, so every remaining key is covered
+		// by a dispatched chunk.
+		return false
+	}
+	if t.chunkPtr.IsNil() {
+		// Nothing dispatched at all: no copier read can be in flight.
+		return true
+	}
+	keyDatum, err := NewDatum(key0, t.chunkPtr.Tp)
+	if err != nil {
+		t.logger.Error("failed to create keyDatum in KeyNotYetDispatched", "key", key0, "error", err)
+		return false
+	}
+	above, err := keyDatum.GreaterThanOrEqual(t.chunkPtr)
+	if err != nil {
+		t.logger.Error("comparing chunkPtr in KeyNotYetDispatched", "error", err)
+		return false
+	}
+	return above
+}
+
 func (t *chunkerOptimistic) Tables() []*TableInfo {
 	if t.NewTi != nil {
 		return []*TableInfo{t.Ti, t.NewTi}


### PR DESCRIPTION
## The bug

Reported by an internal customer: the binary log position in the checkpoint never advances for an entire copy phase, with a small non-zero `deltas=` in the status block. The low watermark advances normally the whole time, so it is not a stalled watermark.

The key space really has three regions, not two:

| region | copier state | safe to flush? |
| --- | --- | --- |
| below the low watermark | copied & committed | yes — flushed today |
| low → high watermark | chunk dispatched, not yet fed back | **no** — the in-flight read can land a stale image on top |
| above the high watermark | not dispatched yet | yes — but deferred today |

The flush filter only asked `!KeyBelowLowWatermark(...)`, lumping the third region in with the second.

That matters because of the interaction with the #746 fix. `KeyAboveHighWatermark` returns `false` for *every* key until the chunker has dispatched something, deliberately, so no event is dropped in the pre-first-chunk window. But `migration.setup()` enables the optimization before `runCopy`, and `readWorker` calls `throttler.BlockWait()` **before** its first `chunker.Next()` — so there is a window, arbitrarily long if the throttler engages at copy start, where every change is buffered, **including changes to rows at the top of the key space**.

Those entries then sit above the low watermark until the copier physically reaches their key. One of them is enough to make every flush report `allChangesFlushed=false` and pin `flushedPos` / `flushedGTID` at its pre-copy value for the whole copy.

Resume amplifies it: `checkpointHighPtr` suppresses the discard for every key the previous run already copied, so the entire re-copy region is buffered and deferred.

The real exposure is resume. A frozen position means a resume needs binlogs from that point; on a host with short binlog retention, a long copy plus a frozen checkpoint can make the migration unresumable.

## The fix

Add `MappedChunker.KeyNotYetDispatched(key0)` and defer only the true in-flight band:

```go
func (s *bufferedMap) mustDeferKey(key0 any) bool {
	if s.chunker.KeyBelowLowWatermark(key0) {
		return false // already copied and committed
	}
	return !s.chunker.KeyNotYetDispatched(key0)
}
```

Applying a not-yet-dispatched key is safe for the same reason discarding it is: the copier's later read of the covering chunk observes a source state at least as new as the change and overwrites it. It is in fact *strictly safer* than the existing discard, which depends on read-after-delivery visibility (see the "Above-watermark discard vs. binlog visibility" section of `pkg/change/README.md`) — applying does not.

`KeyNotYetDispatched` deliberately ignores `checkpointHighPtr`. That guard exists to suppress a *discard*; a key copied by a previous run has no read in flight in this one.

## Source coverage

The stall is source-agnostic — the deferral lives in the shared `bufferedMap`, and `binlogClient.flush` and `gtidClient.flush` gate their position advance on the same `allChangesFlushed`. Tests cover both.

## Tests

`pkg/change/checkpoint_stall_test.go`:

- `TestCheckpointStallPreFirstChunk` — binlog file+offset source. Fails without the fix.
- `TestCheckpointStallPreFirstChunkGTID` — GTID source. Fails without the fix.
- `TestInFlightBandStillDeferred` — guard rail: a key inside a dispatched-but-not-fed-back chunk must still be deferred and must still pin the position, then flushes once the chunk is fed back. Passes with and without the fix, so the fix is not simply disabling the deferral.

Reproduction before the fix, with the copier walking the low end of the table:

```
chunk 0  `a` < 1                       -> lowWatermark=<not ready>   pos=...072829:373 deltas=1
chunk 1  `a` >= 1     AND `a` < 1001   -> lowWatermark=[1,1001)      pos=...072829:373 deltas=1
...
chunk 11 `a` >= 10001 AND `a` < 11501  -> lowWatermark=[10001,11501) pos=...072829:373 deltas=1
```

Full `go test ./...` green; `golangci-lint run` clean on the touched packages.

## Not fixed here

Changes that land in the *true* in-flight band still pin the position — the pre-existing TODO in `binlog.go` / `gtid.go` `flush`. That band is `inflightChunks × chunkSize` (chunk size reaches `MaxDynamicRowSize` = 100k rows), so on a large table with a uniformly-distributed PK and a busy writer it is hit often rather than pathologically.

The TODO's own suggestion is the right shape and cheaper than it sounds: bump a generation counter per flush, snapshot `bufferedPos` / `bufferedGTID.Clone()` once per generation, tag each buffered entry with its generation, and publish the snapshot of the oldest generation still holding a deferred entry. One clone per flush rather than one per entry, and it works unchanged for GTID, where sets are only partially ordered and a `min` is not available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)