### PR TITLE
change: break the flush's self-inflicted deadlock

### DIFF
--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -993,6 +993,14 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 		}
 		g.Go(func() error {
 			if err := s.flushBatch(gctx, batch.deleteKeys, batch.upsertRows, nil); err != nil {
+				// The ctx.Err() half deliberately reads the *parent*, not gctx:
+				// a sibling's failure cancels gctx, and that must not stop this
+				// batch's own contention from reaching the retry pass. Only a
+				// real shutdown does, because a 1213 racing a cancellation is a
+				// symptom of the connection going away rather than something a
+				// narrower flush would avoid — and pass 2 should not spend its
+				// budget, or log a concurrency reduction, on a drain that is
+				// already over. See TestContentionAtShutdownIsNotRetried.
 				if dbconn.IsLockContentionError(err) && ctx.Err() == nil {
 					mu.Lock()
 					contended = append(contended, batch)

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -1,9 +1,8 @@
 package change
 
 import (
-	"bytes"
-	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
@@ -466,8 +465,6 @@ func (s *bufferedMap) ImmutableColumnOrdinal() int {
 	return slices.Index(s.table.Columns, s.table.ShardingColumn)
 }
 
-// effectiveFlushConcurrency clamps flushConcurrency to at least 1 so
-// the zero value (out-of-tree callers, bare test maps) stays serial.
 // cleanDrainsToRecover is how many consecutive contention-free drains must
 // pass before the AIMD controller gives a halving back. Recovery is
 // deliberately slower than the decrease: re-entering the pathological state
@@ -482,6 +479,9 @@ const cleanDrainsToRecover = 3
 // busy source, which trades one stall for another.
 const minAdaptiveBatchSize = 50
 
+// effectiveFlushConcurrency clamps flushConcurrency to at least 1 so
+// the zero value (out-of-tree callers, bare test maps) stays serial, then
+// applies any halvings the AIMD controller has accumulated.
 func (s *bufferedMap) effectiveFlushConcurrency() int {
 	return shiftDown(max(1, s.flushConcurrency), s.concurrencyPenalty.Load(), 1)
 }
@@ -557,54 +557,6 @@ func (s *bufferedMap) adaptFlushConcurrency(contended bool) {
 		"batch_size", s.effectiveBatchSize(),
 		"configured", configured,
 	)
-}
-
-// compareBufferedKeys orders two buffered primary keys component by component,
-// so a drain visits rows in (approximate) clustered-index order instead of Go's
-// randomized map order.
-//
-// "Approximate" is honest: this compares the Go values the binlog decoder
-// produced, not MySQL collation order, so for string keys under a non-binary
-// collation the order can differ from the index's. That is fine for the two
-// things the ordering is for — determinism across retries, and clustered-index
-// page locality — and it must not be relied on for anything requiring true
-// index order. Numeric keys (the overwhelmingly common case, and the case where
-// map order was worst: "10" sorting before "9") do come out exactly right.
-func compareBufferedKeys(a, b []any) int {
-	for i := range min(len(a), len(b)) {
-		if c := compareKeyComponent(a[i], b[i]); c != 0 {
-			return c
-		}
-	}
-	return len(a) - len(b)
-}
-
-func compareKeyComponent(a, b any) int {
-	switch av := a.(type) {
-	case int64:
-		if bv, ok := b.(int64); ok {
-			return cmp.Compare(av, bv)
-		}
-	case uint64:
-		if bv, ok := b.(uint64); ok {
-			return cmp.Compare(av, bv)
-		}
-	case float64:
-		if bv, ok := b.(float64); ok {
-			return cmp.Compare(av, bv)
-		}
-	case string:
-		if bv, ok := b.(string); ok {
-			return cmp.Compare(av, bv)
-		}
-	case []byte:
-		if bv, ok := b.([]byte); ok {
-			return bytes.Compare(av, bv)
-		}
-	}
-	// Mixed or exotic types: fall back to the rendered form. Only determinism
-	// matters here, not ordering fidelity.
-	return cmp.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
 }
 
 // contentionBackoff is the delay before the serial retry pass makes its
@@ -922,31 +874,19 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 		}
 	}
 
-	// Iterate in a deterministic order rather than Go's randomized map order.
-	// Map order re-shuffled both batch membership and intra-batch row order on
-	// every attempt, so a batch that lost a deadlock came back as a *different*
-	// batch with a different lock-acquisition sequence — it could not benefit
-	// from the previous attempt having warmed the same rows, and it re-rolled
-	// the dice on a fresh collision instead. Sorting by primary key also
-	// clusters each REPLACE onto fewer clustered-index pages, which cuts the
-	// lock-struct count the deadlock dump showed running into the thousands.
+	// Map iteration order is randomized, so batch membership differs between
+	// flushes. That does not affect the retry below: pass 2 re-applies the very
+	// same mapFlushBatch values pass 1 built, so a contended batch retries as
+	// itself regardless of iteration order.
 	//
-	// This does not by itself prevent the deadlock: the observed cycle inverts
-	// between the clustered index and a secondary UNIQUE index, and secondary
-	// key order is unrelated to primary key order, so PK-sorted batches still
-	// interleave there. Determinism is what makes the retry pass below
-	// worthwhile; the concurrency controller is what actually breaks the cycle.
-	orderedKeys := make([]string, 0, len(snapshot))
-	for key := range snapshot {
-		orderedKeys = append(orderedKeys, key)
-	}
-	slices.SortFunc(orderedKeys, func(a, b string) int {
-		return compareBufferedKeys(snapshot[a].originalKey, snapshot[b].originalKey)
-	})
-
+	// An earlier revision sorted by primary key here, on the theory that a
+	// consistent lock-acquisition order would help. It would not: the observed
+	// deadlock cycle inverts between the clustered index and a secondary UNIQUE
+	// index, and secondary key order is unrelated to primary key order, so
+	// PK-sorted batches still interleave there. Narrowing concurrency is what
+	// breaks the cycle. See block/spirit#1168.
 	batchSize := s.effectiveBatchSize()
-	for _, key := range orderedKeys {
-		change := snapshot[key]
+	for key, change := range snapshot {
 		// Keys the copier may have a read in flight for are deferred to a
 		// later flush; see mustDeferKey. The chunker is internally
 		// synchronized, so no Mutex is needed here.
@@ -979,13 +919,27 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 	}
 	cutBatch()
 
+	if len(batches) == 0 {
+		// Every key was watermark-deferred. The drain produced no evidence about
+		// contention either way, so it must not advance the clean-drain streak —
+		// otherwise a run of all-deferred flushes would widen the concurrency
+		// back out on the strength of having applied nothing at all.
+		return allChangesFlushed, nil
+	}
+
 	// Pass 1: apply concurrently at the current (possibly reduced) width.
 	// Batches that lose to lock contention are collected rather than failing
 	// the drain — see retryContendedBatches for why that is safe and why the
 	// retry has to be serial.
 	contended, err := s.applyBatchesConcurrent(ctx, snapshot, batches)
 	if err != nil {
-		s.adaptFlushConcurrency(len(contended) > 0)
+		// Deliberately no adaptFlushConcurrency call here. A drain that failed
+		// on something other than contention is not evidence of contention, and
+		// it is not evidence of quiet either: feeding it in as "clean" would let
+		// three consecutive hard failures — during which nothing flushed —
+		// restore the full width, and feeding it in as "contended" would
+		// penalise the width for an unrelated non-retryable error that merely
+		// happened to land in the same drain as someone else's 1213.
 		return false, err
 	}
 
@@ -999,6 +953,8 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			"concurrency", s.effectiveFlushConcurrency(),
 		)
 		if err := s.retryContendedBatches(ctx, snapshot, contended); err != nil {
+			// Contention that survived a serial retry is unambiguous evidence,
+			// so this one does feed the controller before returning.
 			s.adaptFlushConcurrency(true)
 			return false, err
 		}
@@ -1075,16 +1031,36 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 // snapshot to be reattached and retried on the next flush. That is deliberate:
 // the flushed position must not advance over changes that never landed.
 func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[string]bufferedChange, contended []*mapFlushBatch) error {
+	// Bound the whole pass, not just each batch. Against an external 1205 holder
+	// a single attempt is not cheap: flushBatch goes through
+	// dbconn.RetryableTransaction, which burns its own MaxRetries against
+	// innodb_lock_wait_timeout before returning, so one batch can consume tens
+	// of seconds and N batches multiply that. flushMu is held for the entire
+	// drain, so an unbounded pass 2 stalls every subsequent flush — trading the
+	// frozen checkpoint this PR fixes for a slower version of the same thing.
+	//
+	// Giving up early is cheap by comparison: the remaining batches stay in the
+	// snapshot, get reattached, and are retried on the next flush.
+	passCtx, cancel := context.WithTimeout(ctx, contentionRetryBudget)
+	defer cancel()
+
 	var mu sync.Mutex
 	for _, batch := range contended {
 		var err error
 		for attempt := range contentionRetries {
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-passCtx.Done():
+				// Distinguish our own budget from real shutdown: on budget
+				// expiry the parent is still live and the caller should treat
+				// this as ordinary contention, not cancellation.
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				return fmt.Errorf("serial contention retry budget (%s) exhausted with %w",
+					contentionRetryBudget, errStillContended)
 			case <-time.After(contentionBackoff(attempt)):
 			}
-			if err = s.flushBatch(ctx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
+			if err = s.flushBatch(passCtx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
 				s.releaseAppliedBatch(snapshot, &mu, batch)
 				break
 			}
@@ -1099,11 +1075,27 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 	return nil
 }
 
+// errStillContended marks a pass-2 giveup so callers can tell "we ran out of
+// patience with a lock holder" from a genuine cancellation.
+var errStillContended = errors.New("batches still contended")
+
 // contentionRetries is how many serial attempts a contended batch gets before
 // the drain gives up and leaves it for the next flush. The first is immediate
-// and is the one expected to land; with contentionBackoff the rest add up to
-// under a second of waiting in total.
+// and is the one expected to land — for the self-inflicted deadlock this exists
+// to fix, no sibling is left holding anything once pass 1 has joined.
+//
+// The sleeps between the remaining attempts add up to well under a second, but
+// that is not the cost that matters: each *attempt* is a flushBatch that can
+// block on a real lock for as long as dbconn.RetryableTransaction is willing to
+// wait. contentionRetryBudget, not this count, is what bounds the pass.
 const contentionRetries = 4
+
+// contentionRetryBudget caps the total wall-clock time pass 2 may spend, across
+// all contended batches, before giving up and deferring the rest to the next
+// flush. Sized to comfortably cover the self-inflicted case (which returns
+// almost immediately) while keeping flushMu out of the multi-minute territory
+// that N batches against an external lock holder would otherwise reach.
+const contentionRetryBudget = 20 * time.Second
 
 // releaseAppliedBatch drops a landed batch's entries from the snapshot and
 // returns its bytes to the buffer.

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -1,9 +1,12 @@
 package change
 
 import (
+	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -193,11 +196,26 @@ type bufferedMap struct {
 	// binlog-retention headroom.
 	flushRequest chan<- Subscription
 
+	// concurrencyPenalty is the number of halvings currently applied to
+	// flushConcurrency by the drain's AIMD controller: the effective limit is
+	// flushConcurrency >> concurrencyPenalty, floored at 1. A drain that hits
+	// lock contention increments it; cleanDrains consecutive clean drains
+	// decrement it. See adaptFlushConcurrency.
+	//
+	// Kept as an atomic rather than under Mutex because
+	// effectiveFlushConcurrency is read at the top of a drain, outside the
+	// short bookkeeping critical sections, and flushMu already serializes
+	// drains against each other.
+	concurrencyPenalty atomic.Int64
+	cleanDrains        atomic.Int64
+
 	// Counters for the bookend log emitted on watermark-optimization transitions.
 	keysAdded        atomic.Int64
 	keysDroppedAbove atomic.Int64
 	keysSkippedBelow atomic.Int64
 	timesParked      atomic.Int64 // HasChanged was parked at least once on the soft limit
+	batchesContended atomic.Int64 // applier batches that failed on 1205/1213
+	serialRecoveries atomic.Int64 // drains rescued by the serial retry pass
 
 	// lastParkWarn is when the park/unpark log pair was last emitted at
 	// Warn/Info level. Since flushes release capacity per batch, a
@@ -450,8 +468,166 @@ func (s *bufferedMap) ImmutableColumnOrdinal() int {
 
 // effectiveFlushConcurrency clamps flushConcurrency to at least 1 so
 // the zero value (out-of-tree callers, bare test maps) stays serial.
+// cleanDrainsToRecover is how many consecutive contention-free drains must
+// pass before the AIMD controller gives a halving back. Recovery is
+// deliberately slower than the decrease: re-entering the pathological state
+// costs a whole flush interval (and, while the checkpoint cannot advance,
+// binlog-retention headroom), whereas running one step under-parallel costs
+// only throughput. Three drains at the default 30s interval is ~90s of proven
+// quiet before stepping back up.
+const cleanDrainsToRecover = 3
+
+// minAdaptiveBatchSize floors the batch shrink. Below roughly this many rows
+// the per-statement round trip dominates and the drain stops keeping up with a
+// busy source, which trades one stall for another.
+const minAdaptiveBatchSize = 50
+
 func (s *bufferedMap) effectiveFlushConcurrency() int {
-	return max(1, s.flushConcurrency)
+	return shiftDown(max(1, s.flushConcurrency), s.concurrencyPenalty.Load(), 1)
+}
+
+// effectiveBatchSize shrinks alongside concurrency, because batch size sets the
+// *lock footprint* of a single REPLACE while concurrency only sets how many of
+// those run at once. Both terms drive the collision probability between sibling
+// batches, so narrowing one and leaving the other is a half measure.
+//
+// A production deadlock dump on a 1000-row batch showed `6803 lock struct(s)
+// ... 6805 row lock(s), undo log entries 1942` held by a single statement that
+// had been ACTIVE 13 sec — roughly one clustered-index lock plus one
+// secondary-index lock per row per index. Every one of those locks is a record
+// a sibling batch can block on, for as long as the holder runs.
+func (s *bufferedMap) effectiveBatchSize() int {
+	return shiftDown(DefaultBatchSize, s.concurrencyPenalty.Load(), minAdaptiveBatchSize)
+}
+
+// shiftDown halves start once per penalty step, never going below floor.
+func shiftDown(start int, penalty int64, floor int) int {
+	if penalty <= 0 {
+		return start
+	}
+	if penalty >= 63 { // guard the shift width; the floor applies regardless
+		return floor
+	}
+	return max(floor, start>>penalty)
+}
+
+// adaptFlushConcurrency feeds a completed drain's contention outcome back into
+// the concurrency limit, AIMD-style: multiplicative decrease on contention,
+// additive increase after a run of clean drains.
+//
+// The signal we control on is spirit's *own* lock contention, not server load.
+// That is the whole point: an oversubscribed flush fan-out deadlocks against
+// itself on secondary-index next-key locks while the server still looks idle,
+// so every load-based signal (Threads_running, commit latency, the autoscaler's
+// throttler) reports "healthy" throughout. Nothing else in the process can see
+// this, so the drain has to police its own width.
+//
+// Called from drainMapSnapshot with flushMu held, so the read-modify-write on
+// concurrencyPenalty needs no further synchronization.
+func (s *bufferedMap) adaptFlushConcurrency(contended bool) {
+	configured := max(1, s.flushConcurrency)
+	if contended {
+		s.cleanDrains.Store(0)
+		// Stop halving once the limit is already 1: there is no narrower
+		// setting, and letting the penalty run away would make recovery take
+		// proportionally longer once the contention clears.
+		if s.effectiveFlushConcurrency() > 1 || s.effectiveBatchSize() > minAdaptiveBatchSize {
+			penalty := s.concurrencyPenalty.Add(1)
+			s.logger.Warn("reducing flush concurrency after lock contention",
+				"table", s.table.SchemaName+"."+s.table.TableName,
+				"concurrency", s.effectiveFlushConcurrency(),
+				"batch_size", s.effectiveBatchSize(),
+				"configured", configured,
+				"penalty", penalty,
+			)
+		}
+		return
+	}
+	if s.concurrencyPenalty.Load() <= 0 {
+		return // already at the configured width; nothing to recover
+	}
+	if s.cleanDrains.Add(1) < cleanDrainsToRecover {
+		return
+	}
+	s.cleanDrains.Store(0)
+	s.concurrencyPenalty.Add(-1)
+	s.logger.Info("restoring flush concurrency after clean drains",
+		"table", s.table.SchemaName+"."+s.table.TableName,
+		"concurrency", s.effectiveFlushConcurrency(),
+		"batch_size", s.effectiveBatchSize(),
+		"configured", configured,
+	)
+}
+
+// compareBufferedKeys orders two buffered primary keys component by component,
+// so a drain visits rows in (approximate) clustered-index order instead of Go's
+// randomized map order.
+//
+// "Approximate" is honest: this compares the Go values the binlog decoder
+// produced, not MySQL collation order, so for string keys under a non-binary
+// collation the order can differ from the index's. That is fine for the two
+// things the ordering is for — determinism across retries, and clustered-index
+// page locality — and it must not be relied on for anything requiring true
+// index order. Numeric keys (the overwhelmingly common case, and the case where
+// map order was worst: "10" sorting before "9") do come out exactly right.
+func compareBufferedKeys(a, b []any) int {
+	for i := range min(len(a), len(b)) {
+		if c := compareKeyComponent(a[i], b[i]); c != 0 {
+			return c
+		}
+	}
+	return len(a) - len(b)
+}
+
+func compareKeyComponent(a, b any) int {
+	switch av := a.(type) {
+	case int64:
+		if bv, ok := b.(int64); ok {
+			return cmp.Compare(av, bv)
+		}
+	case uint64:
+		if bv, ok := b.(uint64); ok {
+			return cmp.Compare(av, bv)
+		}
+	case float64:
+		if bv, ok := b.(float64); ok {
+			return cmp.Compare(av, bv)
+		}
+	case string:
+		if bv, ok := b.(string); ok {
+			return cmp.Compare(av, bv)
+		}
+	case []byte:
+		if bv, ok := b.([]byte); ok {
+			return bytes.Compare(av, bv)
+		}
+	}
+	// Mixed or exotic types: fall back to the rendered form. Only determinism
+	// matters here, not ordering fidelity.
+	return cmp.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
+}
+
+// contentionBackoff is the delay before the serial retry pass makes its
+// *second* and later attempts on a batch. The first attempt does not wait at
+// all: errgroup.Wait has already returned by then, so no sibling batch from
+// this drain is still in flight, and the lock that beat us is gone.
+//
+// The escalating delays only cover the cases where something outside this drain
+// holds the lock — another table's subscription flushing, or a checksum repair.
+// Those are bounded by a statement, not by a copy phase, so this tops out at a
+// couple of seconds rather than trying to outlast anything long-lived.
+//
+// Var (not const/func) so tests can shorten it, mirroring
+// throttler.threadsRunningPollInterval.
+var contentionBackoff = func(attempt int) time.Duration {
+	if attempt <= 0 {
+		return 0
+	}
+	base := min(100*time.Millisecond<<(attempt-1), 2*time.Second)
+	// Full jitter. Batches that deadlocked against each other were, by
+	// definition, running concurrently; retrying them in lockstep would just
+	// re-stage the same collision.
+	return base/2 + time.Duration(rand.Int64N(int64(base/2)+1))
 }
 
 // queueModeActive reports whether new events should be appended to the
@@ -746,7 +922,31 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 		}
 	}
 
-	for key, change := range snapshot {
+	// Iterate in a deterministic order rather than Go's randomized map order.
+	// Map order re-shuffled both batch membership and intra-batch row order on
+	// every attempt, so a batch that lost a deadlock came back as a *different*
+	// batch with a different lock-acquisition sequence — it could not benefit
+	// from the previous attempt having warmed the same rows, and it re-rolled
+	// the dice on a fresh collision instead. Sorting by primary key also
+	// clusters each REPLACE onto fewer clustered-index pages, which cuts the
+	// lock-struct count the deadlock dump showed running into the thousands.
+	//
+	// This does not by itself prevent the deadlock: the observed cycle inverts
+	// between the clustered index and a secondary UNIQUE index, and secondary
+	// key order is unrelated to primary key order, so PK-sorted batches still
+	// interleave there. Determinism is what makes the retry pass below
+	// worthwhile; the concurrency controller is what actually breaks the cycle.
+	orderedKeys := make([]string, 0, len(snapshot))
+	for key := range snapshot {
+		orderedKeys = append(orderedKeys, key)
+	}
+	slices.SortFunc(orderedKeys, func(a, b string) int {
+		return compareBufferedKeys(snapshot[a].originalKey, snapshot[b].originalKey)
+	})
+
+	batchSize := s.effectiveBatchSize()
+	for _, key := range orderedKeys {
+		change := snapshot[key]
 		// Keys the copier may have a read in flight for are deferred to a
 		// later flush; see mustDeferKey. The chunker is internally
 		// synchronized, so no Mutex is needed here.
@@ -756,15 +956,15 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			allChangesFlushed = false
 			continue
 		}
-		// Cut the batch when either cap is reached: DefaultBatchSize rows,
-		// or the estimated rendered statement size would exceed the byte
-		// budget the copy path also uses. Without the byte cap, buffered
-		// wide rows (LONGTEXT / BLOB) can render into a single REPLACE
-		// larger than max_allowed_packet — a deterministic, non-retryable
-		// failure. A single row over the budget still flushes, alone in
-		// its own batch (a row can't be split).
+		// Cut the batch when either cap is reached: the (possibly reduced)
+		// batch-size limit, or the estimated rendered statement size would
+		// exceed the byte budget the copy path also uses. Without the byte
+		// cap, buffered wide rows (LONGTEXT / BLOB) can render into a single
+		// REPLACE larger than max_allowed_packet — a deterministic,
+		// non-retryable failure. A single row over the budget still flushes,
+		// alone in its own batch (a row can't be split).
 		rowBytes := renderedBytesOfChange(change.logicalRow, change.originalKey)
-		if batchLen := len(current.keys); batchLen >= DefaultBatchSize ||
+		if batchLen := len(current.keys); batchLen >= batchSize ||
 			(batchLen > 0 && batchStmtBytes+rowBytes > applier.MaxStatementSizeBytes) {
 			cutBatch()
 		}
@@ -779,13 +979,56 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 	}
 	cutBatch()
 
+	// Pass 1: apply concurrently at the current (possibly reduced) width.
+	// Batches that lose to lock contention are collected rather than failing
+	// the drain — see retryContendedBatches for why that is safe and why the
+	// retry has to be serial.
+	contended, err := s.applyBatchesConcurrent(ctx, snapshot, batches)
+	if err != nil {
+		s.adaptFlushConcurrency(len(contended) > 0)
+		return false, err
+	}
+
+	// Pass 2: whatever contended in pass 1 goes again, one batch at a time.
+	if len(contended) > 0 {
+		s.batchesContended.Add(int64(len(contended)))
+		s.logger.Warn("flush batches lost to lock contention; retrying serially",
+			"table", s.table.SchemaName+"."+s.table.TableName,
+			"contended_batches", len(contended),
+			"total_batches", len(batches),
+			"concurrency", s.effectiveFlushConcurrency(),
+		)
+		if err := s.retryContendedBatches(ctx, snapshot, contended); err != nil {
+			s.adaptFlushConcurrency(true)
+			return false, err
+		}
+		s.serialRecoveries.Add(1)
+	}
+	s.adaptFlushConcurrency(len(contended) > 0)
+	return allChangesFlushed, nil
+}
+
+// applyBatchesConcurrent runs batches through the applier with up to
+// effectiveFlushConcurrency in flight, returning the batches that failed on
+// InnoDB lock contention (1205/1213) for the caller to retry serially.
+//
+// Contention does *not* cancel the group. Every other error class does, exactly
+// as before: those are not self-inflicted and retrying at a narrower width
+// would not help. Contention is different — spirit's own concurrent REPLACEs
+// are both sides of the conflict, so the same work succeeds unconditionally
+// once it stops racing itself. Letting one contended batch cancel its siblings
+// (the previous behaviour) threw away batches that were about to land and made
+// the whole drain fail, which is what pinned the buffer at its soft limit and
+// froze the flushed position.
+func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[string]bufferedChange, batches []*mapFlushBatch) ([]*mapFlushBatch, error) {
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(s.effectiveFlushConcurrency())
 	// Workers delete their batch's entries as they land, so they only
-	// contend with each other here: the build loop above finished
-	// iterating the snapshot before the first worker starts, and the
-	// deferred reattach runs after Wait.
-	var snapshotMu sync.Mutex
+	// contend with each other here: the build loop finished iterating the
+	// snapshot before the first worker starts, and the deferred reattach
+	// runs after Wait.
+	var mu sync.Mutex
+	var contended []*mapFlushBatch
 	var skippedBatches bool
 	for _, batch := range batches {
 		if gctx.Err() != nil {
@@ -794,29 +1037,15 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 		}
 		g.Go(func() error {
 			if err := s.flushBatch(gctx, batch.deleteKeys, batch.upsertRows, nil); err != nil {
+				if dbconn.IsLockContentionError(err) && ctx.Err() == nil {
+					mu.Lock()
+					contended = append(contended, batch)
+					mu.Unlock()
+					return nil // handled by the serial retry pass
+				}
 				return err
 			}
-			// Drop the applied entries immediately — from the snapshot,
-			// so the deferred reattach merges back only what did not land
-			// (uncertain batches stay and re-apply on a later flush, which
-			// is safe: REPLACE and DELETE are idempotent), and from the
-			// batch, so the row images become collectible now rather than
-			// when the whole drain finishes. Without this the snapshot
-			// retains up to a full soft limit of applied images while the
-			// live map refills toward another, transiently doubling the
-			// memory the cap is meant to bound.
-			snapshotMu.Lock()
-			for _, key := range batch.keys {
-				delete(snapshot, key)
-			}
-			snapshotMu.Unlock()
-			flushedKeys := len(batch.keys)
-			batch.keys, batch.deleteKeys, batch.upsertRows = nil, nil, nil
-			s.Lock()
-			s.sizeBytes -= batch.storedBytes
-			s.flushingCount -= flushedKeys
-			s.cond.Broadcast()
-			s.Unlock()
+			s.releaseAppliedBatch(snapshot, &mu, batch)
 			return nil
 		})
 	}
@@ -830,10 +1059,75 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 		// only reattached, not applied.
 		err = ctx.Err()
 	}
-	if err != nil {
-		return false, err
+	return contended, err
+}
+
+// retryContendedBatches re-applies contended batches one at a time.
+//
+// Serial is the point, not a simplification. The contention is entirely
+// self-inflicted — the observed deadlock cycle was three of this drain's own
+// REPLACEs — so with a single writer there is no second transaction left to
+// form a cycle with, and no sibling holding the records this batch needs. The
+// retry is expected to succeed on its first, undelayed attempt; the escalating
+// attempts after it exist only for locks held from outside this drain.
+//
+// A batch that still fails here returns the error, leaving its entries in the
+// snapshot to be reattached and retried on the next flush. That is deliberate:
+// the flushed position must not advance over changes that never landed.
+func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[string]bufferedChange, contended []*mapFlushBatch) error {
+	var mu sync.Mutex
+	for _, batch := range contended {
+		var err error
+		for attempt := range contentionRetries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(contentionBackoff(attempt)):
+			}
+			if err = s.flushBatch(ctx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
+				s.releaseAppliedBatch(snapshot, &mu, batch)
+				break
+			}
+			if !dbconn.IsLockContentionError(err) {
+				return err
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("flush batch still contended after %d serial retries: %w", contentionRetries, err)
+		}
 	}
-	return allChangesFlushed, nil
+	return nil
+}
+
+// contentionRetries is how many serial attempts a contended batch gets before
+// the drain gives up and leaves it for the next flush. The first is immediate
+// and is the one expected to land; with contentionBackoff the rest add up to
+// under a second of waiting in total.
+const contentionRetries = 4
+
+// releaseAppliedBatch drops a landed batch's entries from the snapshot and
+// returns its bytes to the buffer.
+//
+// Dropping from the snapshot means the deferred reattach merges back only what
+// did not land (uncertain batches stay and re-apply on a later flush, which is
+// safe: REPLACE and DELETE are idempotent). Nilling the batch's slices lets the
+// row images become collectible now rather than when the whole drain finishes —
+// without it the snapshot retains up to a full soft limit of applied images
+// while the live map refills toward another, transiently doubling the memory
+// the cap is meant to bound.
+func (s *bufferedMap) releaseAppliedBatch(snapshot map[string]bufferedChange, mu *sync.Mutex, batch *mapFlushBatch) {
+	mu.Lock()
+	for _, key := range batch.keys {
+		delete(snapshot, key)
+	}
+	mu.Unlock()
+	flushedKeys := len(batch.keys)
+	batch.keys, batch.deleteKeys, batch.upsertRows = nil, nil, nil
+	s.Lock()
+	s.sizeBytes -= batch.storedBytes
+	s.flushingCount -= flushedKeys
+	s.cond.Broadcast()
+	s.Unlock()
 }
 
 // drainQueueSnapshot applies a swapped-out queue snapshot through the
@@ -1236,6 +1530,9 @@ func (s *bufferedMap) SetWatermarkOptimization(ctx context.Context, enabled bool
 		"keys_dropped_above_high", s.keysDroppedAbove.Swap(0),
 		"keys_skipped_not_below_low", s.keysSkippedBelow.Swap(0),
 		"times_parked_on_soft_limit", s.timesParked.Swap(0),
+		"batches_lock_contended", s.batchesContended.Swap(0),
+		"drains_rescued_serially", s.serialRecoveries.Swap(0),
+		"flush_concurrency", s.effectiveFlushConcurrency(),
 		"delta_len", len(s.changes)+len(s.queue),
 		"size_bytes", s.sizeBytes,
 	)

--- a/pkg/change/subscription_buffered_contention_test.go
+++ b/pkg/change/subscription_buffered_contention_test.go
@@ -2,8 +2,6 @@ package change
 
 import (
 	"context"
-	"math"
-	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -245,92 +243,159 @@ func TestNonContentionErrorStillFailsDrain(t *testing.T) {
 	require.Equal(t, 2, sub.effectiveFlushConcurrency(), "a non-contention error must not narrow the drain")
 }
 
-// TestDrainVisitsKeysInPrimaryKeyOrder pins the switch away from Go's
-// randomized map iteration. Map order both re-shuffled batch membership on
-// every retry (so a batch that lost a deadlock came back as a different batch)
-// and scattered each REPLACE across the clustered index, inflating the
-// lock-struct count the production dump showed in the thousands.
-func TestDrainVisitsKeysInPrimaryKeyOrder(t *testing.T) {
-	fake := &countingApplier{}
-	sub := newByteCapBufferedMap(fake, false)
-	sub.flushConcurrency = 1
+// sequencedApplier fails the Nth UpsertRows call with a caller-supplied error,
+// so a test can stage a specific mix of contention and hard failure within one
+// concurrent pass. Calls past the end of the slice succeed.
+type sequencedApplier struct {
+	countingApplier
+	mu     sync.Mutex
+	errs   []error
+	nCalls int
+}
 
-	// Insert in an order that is neither ascending nor lexicographically
-	// sorted, so passing requires a real numeric comparison: string ordering
-	// would put 100 before 99.
-	const totalRows = 300
+func (a *sequencedApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, locks []*dbconn.TableLock) (int64, error) {
+	a.mu.Lock()
+	i := a.nCalls
+	a.nCalls++
+	var err error
+	if i < len(a.errs) {
+		err = a.errs[i]
+	}
+	a.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return a.countingApplier.UpsertRows(ctx, mapping, rows, locks)
+}
+
+func deadlockErr() error {
+	return &mysql2.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+}
+
+// alwaysContendingApplier fails every upsert with a deadlock, modelling a lock
+// holder that never lets go.
+type alwaysContendingApplier struct{ countingApplier }
+
+func (a *alwaysContendingApplier) UpsertRows(context.Context, *table.ColumnMapping, []applier.LogicalRow, []*dbconn.TableLock) (int64, error) {
+	return 0, deadlockErr()
+}
+
+// TestSerialRetryExhaustionFailsDrain covers the safety property the whole PR
+// turns on, which had no test: when the serial pass cannot land a batch, the
+// drain must report failure so the caller never publishes a flushed position
+// over changes that are still buffered.
+//
+// Replacing retryContendedBatches' exhausted-retries error with `continue`
+// previously survived the entire package. It makes drainMapSnapshot return
+// allChangesFlushed=true with rows still in the buffer, and the clients'
+// `if allChangesFlushed { flushedPos = ... }` is the only guard — so the
+// checkpoint would advance past unapplied changes, silently and unrecoverably.
+func TestSerialRetryExhaustionFailsDrain(t *testing.T) {
+	shortenContentionBackoff(t)
+	const totalRows = 3 * DefaultBatchSize
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.applier = &alwaysContendingApplier{}
+	sub.flushConcurrency = 4
+
 	for i := range totalRows {
-		key := int64((i * 7919) % totalRows) // deterministic scatter
-		sub.HasChanged([]any{key}, []any{key, "seed"}, false)
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.Error(t, err, "permanent contention must fail the drain")
+	require.ErrorContains(t, err, "still contended")
+	require.False(t, allFlushed, "a failed drain must never report all-flushed")
+
+	// Nothing was lost and nothing was double-counted: every row is back in the
+	// active buffer with balanced accounting and no in-flight residue.
+	require.Equal(t, totalRows, sub.Length(), "all rows must be reattached")
+	// recomputeSizeBytes takes s.Lock itself, so derive it before locking.
+	expectedBytes := recomputeSizeBytes(sub)
+	sub.Lock()
+	require.Equal(t, expectedBytes, sub.sizeBytes, "byte accounting must balance")
+	require.Zero(t, sub.flushingCount, "no entries may be left marked in-flight")
+	sub.Unlock()
+}
+
+// TestMixedContentionAndHardErrorDoesNotNarrow pins finding (a) on the AIMD
+// controller: a drain that failed on a non-retryable error must not be
+// penalised for contention that merely happened to occur in the same pass.
+//
+// This is reachable because the contention-collect branch guards on the parent
+// ctx, not the group ctx, so a sibling's 1213 is still collected after another
+// batch has cancelled the group.
+func TestMixedContentionAndHardErrorDoesNotNarrow(t *testing.T) {
+	shortenContentionBackoff(t)
+	fake := &sequencedApplier{errs: []error{deadlockErr(), errInjected}}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 2
+
+	for i := range 2 * DefaultBatchSize {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
 	}
 
 	_, err := sub.Flush(t.Context(), false, nil)
-	require.NoError(t, err)
-
-	var seen []int64
-	for _, call := range fake.upserts() {
-		for _, row := range call {
-			seen = append(seen, row.RowImage[0].(int64))
-		}
-	}
-	require.Len(t, seen, totalRows)
-	require.IsIncreasing(t, seen, "batches must be built in primary key order")
+	require.ErrorIs(t, err, errInjected, "the hard error must surface")
+	require.Equal(t, 2, sub.effectiveFlushConcurrency(),
+		"a drain that failed on a hard error must not narrow on incidental contention")
+	require.Equal(t, DefaultBatchSize, sub.effectiveBatchSize())
 }
 
-func TestCompareBufferedKeys(t *testing.T) {
-	t.Run("numeric keys sort numerically, not lexicographically", func(t *testing.T) {
-		require.Negative(t, compareBufferedKeys([]any{int64(9)}, []any{int64(100)}))
-		require.Positive(t, compareBufferedKeys([]any{int64(100)}, []any{int64(9)}))
-		require.Zero(t, compareBufferedKeys([]any{int64(42)}, []any{int64(42)}))
-		require.Negative(t, compareBufferedKeys([]any{uint64(9)}, []any{uint64(100)}))
-	})
+// TestRepeatedHardFailuresDoNotWiden pins finding (b): consecutive drains that
+// fail with a non-contention error must not be counted as clean. Three of them
+// previously restored the full width — on the strength of three failures during
+// which nothing flushed at all.
+//
+// Starting from a narrowed state is essential. At penalty 0
+// adaptFlushConcurrency(false) early-returns, so the assertion would hold
+// trivially and the bug would stay invisible.
+func TestRepeatedHardFailuresDoNotWiden(t *testing.T) {
+	fake := &gatedApplier{}
+	sub := newGatedBufferedMap(fake, false)
+	sub.flushConcurrency = 8
+	sub.adaptFlushConcurrency(true) // narrow first: penalty 1, concurrency 4
+	require.Equal(t, 4, sub.effectiveFlushConcurrency())
+	fake.failUpserts.Store(true)
 
-	t.Run("composite keys compare component by component", func(t *testing.T) {
-		require.Negative(t, compareBufferedKeys([]any{int64(1), "b"}, []any{int64(2), "a"}))
-		require.Negative(t, compareBufferedKeys([]any{int64(1), "a"}, []any{int64(1), "b"}))
-		require.Zero(t, compareBufferedKeys([]any{int64(1), "a"}, []any{int64(1), "a"}))
-	})
-
-	t.Run("shorter key sorts first on a common prefix", func(t *testing.T) {
-		require.Negative(t, compareBufferedKeys([]any{int64(1)}, []any{int64(1), "a"}))
-	})
-
-	t.Run("binary keys compare by bytes", func(t *testing.T) {
-		require.Negative(t, compareBufferedKeys([]any{[]byte{0x01}}, []any{[]byte{0x02}}))
-	})
-
-	// A FLOAT/DOUBLE primary key is pathological but legal, and it can decode
-	// as a NaN. slices.SortFunc requires a strict weak ordering and panics on
-	// an inconsistent comparator, so pin the behaviour rather than assume it:
-	// cmp.Compare (unlike the < operator) defines NaN as less than any non-NaN
-	// and equal to itself, which is already a total order.
-	t.Run("NaN float keys stay a total order", func(t *testing.T) {
-		nan, other := []any{math.NaN()}, []any{1.0}
-		require.Negative(t, compareBufferedKeys(nan, other))
-		require.Positive(t, compareBufferedKeys(other, nan))
-		require.Zero(t, compareBufferedKeys(nan, []any{math.NaN()}))
-
-		keys := [][]any{{3.0}, {math.NaN()}, {1.0}, {math.NaN()}, {2.0}}
-		require.NotPanics(t, func() {
-			slices.SortFunc(keys, compareBufferedKeys)
-		})
-		// NaNs first, then ascending non-NaNs.
-		require.True(t, math.IsNaN(keys[0][0].(float64)))
-		require.True(t, math.IsNaN(keys[1][0].(float64)))
-		require.Equal(t, []any{1.0}, keys[2])
-		require.Equal(t, []any{3.0}, keys[4])
-	})
-
-	// Mixed types can't happen for a single column in practice, but the
-	// comparator must stay a total order regardless: sort requires it, and an
-	// inconsistent comparator is a panic in newer Go releases.
-	t.Run("mixed types stay deterministic and antisymmetric", func(t *testing.T) {
-		a, b := []any{int64(1)}, []any{"1x"}
-		first := compareBufferedKeys(a, b)
-		require.NotZero(t, first, "distinct keys must order")
-		require.Equal(t, -first, compareBufferedKeys(b, a), "comparator must be antisymmetric")
-		for range 100 {
-			require.Equal(t, first, compareBufferedKeys(a, b), "comparator must be stable across calls")
+	for range cleanDrainsToRecover {
+		for i := range DefaultBatchSize {
+			sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
 		}
-	})
+		_, err := sub.Flush(t.Context(), false, nil)
+		require.ErrorIs(t, err, errInjected)
+		require.Equal(t, 4, sub.effectiveFlushConcurrency(),
+			"a failed drain is not evidence of quiet and must not widen the drain")
+	}
+}
+
+// TestAllDeferredDrainDoesNotWiden pins finding (c): a non-empty snapshot whose
+// every key is watermark-deferred issues zero applier calls, so it carries no
+// evidence about contention and must not advance the clean-drain streak.
+//
+// An empty buffer never reaches the controller (Flush short-circuits on an
+// empty snapshot), so this is specifically the non-empty-but-all-deferred case.
+func TestAllDeferredDrainDoesNotWiden(t *testing.T) {
+	fake := &countingApplier{}
+	chunker := table.NewMockChunker("deferred", 1000)
+	sub := newByteCapBufferedMap(fake, false)
+	sub.chunker = chunker
+	sub.watermarkOptimization = true
+	sub.flushConcurrency = 8
+	sub.adaptFlushConcurrency(true) // narrow first: penalty 1, concurrency 4
+	require.Equal(t, 4, sub.effectiveFlushConcurrency())
+
+	// MockChunker defers exactly the key equal to its current position, so a
+	// single key there is a fully-deferred, non-empty snapshot.
+	sub.HasChanged([]any{int64(0)}, []any{int64(0), "seed"}, false)
+	require.Equal(t, 1, sub.Length())
+
+	for range cleanDrainsToRecover {
+		allFlushed, err := sub.Flush(t.Context(), false, nil)
+		require.NoError(t, err)
+		require.False(t, allFlushed, "a deferred key means not-all-flushed")
+		require.Equal(t, 4, sub.effectiveFlushConcurrency(),
+			"an all-deferred drain applied nothing and must not widen the drain")
+	}
+	require.Empty(t, fake.upserts(), "no applier call should have been made")
 }

--- a/pkg/change/subscription_buffered_contention_test.go
+++ b/pkg/change/subscription_buffered_contention_test.go
@@ -399,3 +399,53 @@ func TestAllDeferredDrainDoesNotWiden(t *testing.T) {
 	}
 	require.Empty(t, fake.upserts(), "no applier call should have been made")
 }
+
+// cancellingContendingApplier cancels the drain's parent context and then
+// reports a deadlock, modelling contention that shows up at shutdown — where
+// the 1213 is a symptom of the connection going away, not something a narrower
+// flush would have avoided.
+type cancellingContendingApplier struct {
+	countingApplier
+	cancel context.CancelFunc
+}
+
+func (a *cancellingContendingApplier) UpsertRows(context.Context, *table.ColumnMapping, []applier.LogicalRow, []*dbconn.TableLock) (int64, error) {
+	a.cancel()
+	return 0, deadlockErr()
+}
+
+// TestContentionAtShutdownIsNotRetried pins the `ctx.Err() == nil` half of the
+// contention classification in applyBatchesConcurrent. Dropping it passed the
+// suite: a 1213 racing a cancellation was absorbed as ordinary contention and
+// handed to the serial pass, which then had to discover the cancellation for
+// itself — and its first attempt is undelayed, so `time.After(0)` and
+// `passCtx.Done()` are both ready and the select picks between them at random.
+// The drain fails either way, so this is not a correctness gap, but the retry
+// budget and the "reducing flush concurrency" log should not be spent on a
+// shutdown.
+//
+// batchesContended is the deterministic witness: it is only incremented when
+// pass 1 actually hands a batch over, so it stays zero with the guard and goes
+// non-zero without it, no matter which way the select falls.
+func TestContentionAtShutdownIsNotRetried(t *testing.T) {
+	shortenContentionBackoff(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	fake := &cancellingContendingApplier{cancel: cancel}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	const totalRows = DefaultBatchSize
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(ctx, false, nil)
+	require.Error(t, err, "a cancelled drain must fail")
+	require.False(t, allFlushed, "a failed drain must never report all-flushed")
+	require.Zero(t, sub.batchesContended.Load(),
+		"contention concurrent with cancellation must not be handed to the serial pass")
+	require.Equal(t, totalRows, sub.Length(), "the rows must stay buffered for the next flush")
+}

--- a/pkg/change/subscription_buffered_contention_test.go
+++ b/pkg/change/subscription_buffered_contention_test.go
@@ -1,0 +1,336 @@
+package change
+
+import (
+	"context"
+	"math"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	mysql2 "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// contendingApplier reproduces the production failure mode in miniature: a
+// REPLACE batch fails with a deadlock (1213) whenever another batch is in
+// flight at the same time, and succeeds whenever it runs alone.
+//
+// That is exactly what a production deadlock dump showed: a three-way cycle
+// between spirit's own concurrent REPLACEs against the new table, inverting
+// between the PRIMARY index and a secondary UNIQUE index, with every
+// transaction in the cycle owned by spirit's own connections. No external
+// workload is needed to produce it, and nothing about the *content* of a batch
+// makes it fail — only its concurrency.
+//
+// The in-memory applier returns in tens of microseconds, far too fast for
+// concurrently-scheduled batches to reliably observe each other. Each call
+// therefore waits at a barrier for expectConcurrent arrivals before deciding,
+// so a genuinely concurrent pass always sees the overlap and a genuinely
+// serial one always times out alone. That keeps "fails iff concurrent" — the
+// property under test — deterministic rather than a timing race.
+type contendingApplier struct {
+	countingApplier
+	expectConcurrent int
+	barrierWait      time.Duration
+
+	mu          sync.Mutex
+	waiting     int
+	release     chan struct{}
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+	rejections  atomic.Int64
+}
+
+// arrive blocks until expectConcurrent callers are simultaneously inside the
+// applier, or barrierWait elapses. Returns how many were present.
+func (c *contendingApplier) arrive() int {
+	c.mu.Lock()
+	if c.release == nil {
+		c.release = make(chan struct{})
+	}
+	release, n := c.release, c.waiting+1
+	c.waiting = n
+	if n >= c.expectConcurrent {
+		c.waiting, c.release = 0, nil
+		close(release)
+	}
+	c.mu.Unlock()
+
+	if n < c.expectConcurrent {
+		select {
+		case <-release:
+		case <-time.After(c.barrierWait):
+			c.mu.Lock()
+			// Only reset a barrier we are still the current generation of;
+			// a concurrent close may already have rotated it.
+			if c.release == release {
+				c.waiting, c.release = 0, nil
+				close(release)
+			}
+			c.mu.Unlock()
+		}
+	}
+	return int(c.inFlight.Load())
+}
+
+func (c *contendingApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, locks []*dbconn.TableLock) (int64, error) {
+	c.inFlight.Add(1)
+	defer c.inFlight.Add(-1)
+	n := int64(c.arrive())
+	for {
+		seen := c.maxInFlight.Load()
+		if n <= seen || c.maxInFlight.CompareAndSwap(seen, n) {
+			break
+		}
+	}
+	if n > 1 {
+		c.rejections.Add(1)
+		return 0, &mysql2.MySQLError{
+			Number:  1213,
+			Message: "Deadlock found when trying to get lock; try restarting transaction",
+		}
+	}
+	return c.countingApplier.UpsertRows(ctx, mapping, rows, locks)
+}
+
+// shortenContentionBackoff swaps the seconds-scale production backoff for a
+// millisecond one so the serial retry pass does not dominate test runtime.
+func shortenContentionBackoff(t *testing.T) {
+	t.Helper()
+	prev := contentionBackoff
+	contentionBackoff = func(int) time.Duration { return time.Millisecond }
+	t.Cleanup(func() { contentionBackoff = prev })
+}
+
+// TestFlushRecoversFromSelfInflictedDeadlock is the regression test for the
+// livelock behind block/spirit#1168: every concurrent drain deadlocked against
+// itself, the whole flush returned an error, and because the clients only
+// publish a flushed position when Flush returns nil, the binlog checkpoint
+// froze while the buffer sat pinned at its soft limit.
+//
+// The drain must now finish successfully by retrying the contended batches
+// serially, and must narrow itself so the next drain does not re-enter the
+// same state.
+func TestFlushRecoversFromSelfInflictedDeadlock(t *testing.T) {
+	shortenContentionBackoff(t)
+	const totalRows = 3 * DefaultBatchSize // 3 batches by construction
+	fake := &contendingApplier{expectConcurrent: 3, barrierWait: 2 * time.Second}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 8
+
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+	require.Equal(t, totalRows, sub.Length())
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "contention must not fail the drain")
+	require.True(t, allFlushed)
+
+	// Every row landed, and the buffer is empty with balanced accounting.
+	require.Zero(t, sub.Length())
+	applied := 0
+	for _, call := range fake.upserts() {
+		applied += len(call)
+	}
+	require.Equal(t, totalRows, applied)
+	require.Zero(t, recomputeSizeBytes(sub))
+	sub.Lock()
+	require.Zero(t, sub.sizeBytes, "accounting must balance after a rescued drain")
+	sub.Unlock()
+
+	// The contention was real: batches did overlap and were rejected.
+	require.Positive(t, fake.rejections.Load(), "the fake must have rejected concurrent batches")
+	require.Greater(t, fake.maxInFlight.Load(), int64(1), "pass 1 must actually run concurrently")
+
+	// And the drain narrowed itself in response.
+	require.Less(t, sub.effectiveFlushConcurrency(), 8, "concurrency must be reduced after contention")
+	require.Less(t, sub.effectiveBatchSize(), DefaultBatchSize, "batch size must shrink alongside concurrency")
+	require.Positive(t, sub.serialRecoveries.Load())
+	require.Positive(t, sub.batchesContended.Load())
+}
+
+// TestFlushConcurrencyAdaptsAndRecovers pins the AIMD controller: contention
+// halves both knobs (multiplicative decrease), and only a sustained run of
+// clean drains gives a step back (additive increase). Recovery must be slower
+// than the decrease — re-entering the pathological state costs a whole flush
+// interval of frozen checkpoint, while running one step narrow costs only
+// throughput.
+func TestFlushConcurrencyAdaptsAndRecovers(t *testing.T) {
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.flushConcurrency = 8
+
+	require.Equal(t, 8, sub.effectiveFlushConcurrency())
+	require.Equal(t, DefaultBatchSize, sub.effectiveBatchSize())
+
+	sub.adaptFlushConcurrency(true)
+	require.Equal(t, 4, sub.effectiveFlushConcurrency())
+	require.Equal(t, DefaultBatchSize/2, sub.effectiveBatchSize())
+
+	sub.adaptFlushConcurrency(true)
+	sub.adaptFlushConcurrency(true)
+	require.Equal(t, 1, sub.effectiveFlushConcurrency())
+	require.Equal(t, DefaultBatchSize/8, sub.effectiveBatchSize())
+
+	// A single clean drain is not enough to widen again.
+	sub.adaptFlushConcurrency(false)
+	require.Equal(t, 1, sub.effectiveFlushConcurrency())
+
+	// A full run of clean drains recovers exactly one step.
+	for range cleanDrainsToRecover - 1 {
+		sub.adaptFlushConcurrency(false)
+	}
+	require.Equal(t, 2, sub.effectiveFlushConcurrency())
+	require.Equal(t, DefaultBatchSize/4, sub.effectiveBatchSize())
+
+	// Contention part-way through a recovery run resets the streak.
+	sub.adaptFlushConcurrency(false)
+	sub.adaptFlushConcurrency(true)
+	require.Equal(t, 1, sub.effectiveFlushConcurrency())
+	sub.adaptFlushConcurrency(false)
+	require.Equal(t, 1, sub.effectiveFlushConcurrency(), "the clean streak must have reset")
+
+	// Recovery stops at the configured width; it never overshoots.
+	for range 10 * cleanDrainsToRecover {
+		sub.adaptFlushConcurrency(false)
+	}
+	require.Equal(t, 8, sub.effectiveFlushConcurrency())
+	require.Equal(t, DefaultBatchSize, sub.effectiveBatchSize())
+}
+
+// TestAdaptFlushConcurrencyFloorsAtOne guards the penalty from running away
+// while pinned at the floor: an unbounded penalty would make recovery take
+// proportionally longer once the contention finally clears.
+func TestAdaptFlushConcurrencyFloorsAtOne(t *testing.T) {
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.flushConcurrency = 2
+
+	for range 50 {
+		sub.adaptFlushConcurrency(true)
+	}
+	require.Equal(t, 1, sub.effectiveFlushConcurrency())
+	require.Equal(t, minAdaptiveBatchSize, sub.effectiveBatchSize())
+
+	// Bounded penalty means bounded recovery.
+	for range 10 * cleanDrainsToRecover {
+		sub.adaptFlushConcurrency(false)
+	}
+	require.Equal(t, 2, sub.effectiveFlushConcurrency())
+}
+
+// TestNonContentionErrorStillFailsDrain pins the blast radius of the
+// contention special-case: only 1205/1213 are absorbed and retried. Every
+// other error class must still fail the drain, so the flushed position stays
+// put and the entries are reattached.
+func TestNonContentionErrorStillFailsDrain(t *testing.T) {
+	fake := &gatedApplier{}
+	sub := newGatedBufferedMap(fake, false)
+	sub.flushConcurrency = 2
+
+	const totalRows = 2 * DefaultBatchSize
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+	fake.failUpserts.Store(true)
+
+	_, err := sub.Flush(t.Context(), false, nil)
+	require.ErrorIs(t, err, errInjected)
+	require.Equal(t, totalRows, sub.Length(), "unapplied entries must be reattached")
+	require.Equal(t, 2, sub.effectiveFlushConcurrency(), "a non-contention error must not narrow the drain")
+}
+
+// TestDrainVisitsKeysInPrimaryKeyOrder pins the switch away from Go's
+// randomized map iteration. Map order both re-shuffled batch membership on
+// every retry (so a batch that lost a deadlock came back as a different batch)
+// and scattered each REPLACE across the clustered index, inflating the
+// lock-struct count the production dump showed in the thousands.
+func TestDrainVisitsKeysInPrimaryKeyOrder(t *testing.T) {
+	fake := &countingApplier{}
+	sub := newByteCapBufferedMap(fake, false)
+	sub.flushConcurrency = 1
+
+	// Insert in an order that is neither ascending nor lexicographically
+	// sorted, so passing requires a real numeric comparison: string ordering
+	// would put 100 before 99.
+	const totalRows = 300
+	for i := range totalRows {
+		key := int64((i * 7919) % totalRows) // deterministic scatter
+		sub.HasChanged([]any{key}, []any{key, "seed"}, false)
+	}
+
+	_, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+
+	var seen []int64
+	for _, call := range fake.upserts() {
+		for _, row := range call {
+			seen = append(seen, row.RowImage[0].(int64))
+		}
+	}
+	require.Len(t, seen, totalRows)
+	require.IsIncreasing(t, seen, "batches must be built in primary key order")
+}
+
+func TestCompareBufferedKeys(t *testing.T) {
+	t.Run("numeric keys sort numerically, not lexicographically", func(t *testing.T) {
+		require.Negative(t, compareBufferedKeys([]any{int64(9)}, []any{int64(100)}))
+		require.Positive(t, compareBufferedKeys([]any{int64(100)}, []any{int64(9)}))
+		require.Zero(t, compareBufferedKeys([]any{int64(42)}, []any{int64(42)}))
+		require.Negative(t, compareBufferedKeys([]any{uint64(9)}, []any{uint64(100)}))
+	})
+
+	t.Run("composite keys compare component by component", func(t *testing.T) {
+		require.Negative(t, compareBufferedKeys([]any{int64(1), "b"}, []any{int64(2), "a"}))
+		require.Negative(t, compareBufferedKeys([]any{int64(1), "a"}, []any{int64(1), "b"}))
+		require.Zero(t, compareBufferedKeys([]any{int64(1), "a"}, []any{int64(1), "a"}))
+	})
+
+	t.Run("shorter key sorts first on a common prefix", func(t *testing.T) {
+		require.Negative(t, compareBufferedKeys([]any{int64(1)}, []any{int64(1), "a"}))
+	})
+
+	t.Run("binary keys compare by bytes", func(t *testing.T) {
+		require.Negative(t, compareBufferedKeys([]any{[]byte{0x01}}, []any{[]byte{0x02}}))
+	})
+
+	// A FLOAT/DOUBLE primary key is pathological but legal, and it can decode
+	// as a NaN. slices.SortFunc requires a strict weak ordering and panics on
+	// an inconsistent comparator, so pin the behaviour rather than assume it:
+	// cmp.Compare (unlike the < operator) defines NaN as less than any non-NaN
+	// and equal to itself, which is already a total order.
+	t.Run("NaN float keys stay a total order", func(t *testing.T) {
+		nan, other := []any{math.NaN()}, []any{1.0}
+		require.Negative(t, compareBufferedKeys(nan, other))
+		require.Positive(t, compareBufferedKeys(other, nan))
+		require.Zero(t, compareBufferedKeys(nan, []any{math.NaN()}))
+
+		keys := [][]any{{3.0}, {math.NaN()}, {1.0}, {math.NaN()}, {2.0}}
+		require.NotPanics(t, func() {
+			slices.SortFunc(keys, compareBufferedKeys)
+		})
+		// NaNs first, then ascending non-NaNs.
+		require.True(t, math.IsNaN(keys[0][0].(float64)))
+		require.True(t, math.IsNaN(keys[1][0].(float64)))
+		require.Equal(t, []any{1.0}, keys[2])
+		require.Equal(t, []any{3.0}, keys[4])
+	})
+
+	// Mixed types can't happen for a single column in practice, but the
+	// comparator must stay a total order regardless: sort requires it, and an
+	// inconsistent comparator is a panic in newer Go releases.
+	t.Run("mixed types stay deterministic and antisymmetric", func(t *testing.T) {
+		a, b := []any{int64(1)}, []any{"1x"}
+		first := compareBufferedKeys(a, b)
+		require.NotZero(t, first, "distinct keys must order")
+		require.Equal(t, -first, compareBufferedKeys(b, a), "comparator must be antisymmetric")
+		for range 100 {
+			require.Equal(t, first, compareBufferedKeys(a, b), "comparator must be stable across calls")
+		}
+	})
+}

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -161,6 +161,26 @@ func canRetryError(err error) bool {
 	}
 }
 
+// IsLockContentionError reports whether err is InnoDB lock contention: a lock
+// wait timeout (1205) or a deadlock (1213). Both are already covered by
+// canRetryError, but callers that can *adapt* — by backing off harder or by
+// lowering their own write concurrency — need to tell contention apart from
+// the other retryable classes, which no amount of self-throttling would fix.
+//
+// This distinction matters because contention can be self-inflicted. Spirit
+// runs on READ COMMITTED (see conn.go), so concurrent REPLACE batches with
+// disjoint primary keys never gap-conflict on the clustered index. They do
+// still take next-key locks during duplicate-key handling on every *secondary*
+// index, where "disjoint by PK" buys nothing — so a wide enough flush fan-out
+// deadlocks against itself with no external workload at all.
+func IsLockContentionError(err error) bool {
+	val, ok := errors.AsType[*mysql.MySQLError](err)
+	if !ok {
+		return false
+	}
+	return val.Number == errLockWaitTimeout || val.Number == errDeadlock
+}
+
 // DupKeyHandling selects how RetryableTransaction treats duplicate-key (1062)
 // warnings. Copy / INSERT IGNORE paths legitimately expect dup-key warnings
 // (e.g. resume re-inserts); checksum-fix DELETE/REPLACE/UPSERT paths do not and

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -221,6 +221,43 @@ func TestIsConnectionLossError(t *testing.T) {
 	require.False(t, IsConnectionLossError(context.Canceled))
 }
 
+func TestIsLockContentionError(t *testing.T) {
+	// InnoDB lock contention: the two codes a writer can provoke in itself, and
+	// therefore the two that respond to lowering write concurrency.
+	require.True(t, IsLockContentionError(&mysql.MySQLError{Number: 1205})) // lock wait timeout
+	require.True(t, IsLockContentionError(&mysql.MySQLError{Number: 1213})) // deadlock
+
+	// Wrapped variants must also be detected. This is the shape the real caller
+	// sees: flushBatch wraps single_target.go's upsert, which wraps the error
+	// RetryableTransaction returned bare after exhausting MaxRetries. If any
+	// link in that chain is ever changed to %v, the contention path goes
+	// silently inert, so pin the depth the production chain actually has.
+	require.True(t, IsLockContentionError(fmt.Errorf("failed to upsert rows: %w",
+		fmt.Errorf("failed to execute upsert: %w", &mysql.MySQLError{Number: 1205}))))
+
+	// Everything else must be excluded. Not because these are unretryable —
+	// 1317 and the read-only codes are all retryable, and 2013/4031 are
+	// connection loss — but because none of them are contention, so none of
+	// them get quieter when the flush narrows itself. Misclassifying one would
+	// burn the serial retry pass on a permanent failure, ratchet the AIMD
+	// controller down to concurrency 1, and log "reducing flush concurrency
+	// after lock contention" at an operator who is looking at something else.
+	require.False(t, IsLockContentionError(nil))
+	require.False(t, IsLockContentionError(errors.New("not a mysql error")))
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 1062})) // duplicate key
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 1064})) // syntax error
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 1146})) // no such table
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 1317})) // query interrupted: retryable, not contention
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 1406})) // data too long
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 1836})) // read only mode: retryable, not contention
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 2013})) // CR_SERVER_LOST: connection loss, not contention
+	require.False(t, IsLockContentionError(&mysql.MySQLError{Number: 4031})) // killed by wait_timeout: connection loss
+	require.False(t, IsLockContentionError(driver.ErrBadConn))
+	require.False(t, IsLockContentionError(mysql.ErrInvalidConn))
+	require.False(t, IsLockContentionError(context.DeadlineExceeded))
+	require.False(t, IsLockContentionError(context.Canceled))
+}
+
 // testRetryableTrxSurvivesKill blocks an UPDATE behind a row lock, kills it
 // with killStmtFmt ("KILL QUERY %d" or "KILL %d"), releases the lock, and
 // asserts that RetryableTransaction retries and ultimately succeeds.


### PR DESCRIPTION
## The bug

A concurrent map-mode drain can deadlock against itself, with no application traffic involved at all.

Spirit runs on READ COMMITTED, so a drain's sibling batches — which are disjoint by primary key — never gap-conflict on the clustered index. That is the disjointness argument `drainMapSnapshot` was written on, and it is sound as far as it goes. It only covers the clustered index. `REPLACE` takes next-key locks during duplicate-key handling on **every secondary index**, where disjointness by PK buys nothing.

Observed on a large table late in the copy phase. `SHOW ENGINE INNODB STATUS` reported a three-way cycle in which all three transactions were this drain's own `REPLACE`s:

```
TRX1  holds PRIMARY(rec A)          → waits secondary UNIQUE(rec B)
TRX2  holds secondary UNIQUE(rec B) → waits secondary UNIQUE(rec C)
TRX3  holds secondary UNIQUE(rec C) → waits PRIMARY(rec A)
```

Every lock in the cycle read `lock_mode X locks rec but not gap` — record locks only, consistent with RC. A single 1000-row batch held `6805 row lock(s)` and had been `ACTIVE 13 sec`, so siblings blocking on those records timed out too: both the 1213s and the 1205s were flusher against flusher.

The consequence was worse than the errors themselves. One contended batch cancelled its siblings and failed the whole drain, and the clients only publish a flushed position when `Flush` returns nil — so the binlog checkpoint froze while the buffer sat pinned at its soft memory limit. An hour of copy progress with a resume coordinate that never moved.

## The fix

- **Pass 1** applies concurrently as before, but *collects* contended batches instead of cancelling their siblings. Every other error class still fails the drain immediately, unchanged.
- **Pass 2** re-applies those batches serially. `errgroup.Wait` has returned by then, so no sibling is left holding anything and the first attempt is undelayed; the escalating attempts after it only cover locks held from outside this drain. The whole pass is bounded by `contentionRetryBudget` (20s) — `flushMu` is held for the entire drain, and each attempt can burn `dbconn.RetryableTransaction`'s own retries against `innodb_lock_wait_timeout`, so an unbounded pass 2 would trade the frozen checkpoint for a slower version of it. Batches that don't make it stay in the snapshot and are retried on the next flush.
- **An AIMD controller** halves concurrency and batch size *together* on contention, recovering one step per three clean drains. Batch size matters as much as concurrency here — it sets the lock footprint each statement holds, and therefore how long siblings can block on it. The controller is only fed drains that carry actual evidence: a drain that failed on a non-contention error, or one whose keys were all watermark-deferred, moves it in neither direction.

`dbconn.IsLockContentionError` separates 1205/1213 from the other retryable classes, since only contention is self-inflicted and therefore only contention responds to self-throttling.

Safety property preserved: a batch that still fails after the serial pass returns an error, so the flushed position continues to never advance over changes that did not land.

## What this deliberately does *not* do

An earlier revision also switched batching from Go map order to primary key order. That has been dropped. It does not prevent the deadlock — the cycle crosses PRIMARY and a secondary index, whose orders are unrelated — and the retry does not need it either, since pass 2 re-applies the same `mapFlushBatch` values pass 1 built. Narrowing concurrency is what breaks the cycle.

## Testing

`pkg/change/subscription_buffered_contention_test.go` covers the end-to-end recovery, the AIMD controller's decrease/recover/floor behaviour, its evidence rules, and the safety property that serial-retry exhaustion fails the drain. The end-to-end test uses a fake applier that fails iff calls overlap, with the overlap forced by a barrier rather than a sleep — the in-memory applier returns in ~30µs, so timing-based overlap did not reproduce the bug reliably.

`pkg/change` and `pkg/dbconn` pass, `-race` clean, `golangci-lint` reports 0 issues.

## Not addressed here

Two things I looked at and ruled out, noted so they don't get re-litigated:

- `InnodbLockWaitTimeout: 3` is not implicated. A 3s *statement* is not 3s of *lock waiting*, and the applier's `write-p50/p90` is total statement latency, not lock-hold time.
- `dbconn.backoffDuration` (1–20ms) did not need changing for this. Once the serial pass runs, there is nothing left to back off from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
