### PR TITLE
change: bound flush drain size, defer contention, and show the unflushed position

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -580,7 +580,7 @@ migration from scratch.
 
 ## Reading the status output
 
-While a migration runs, Spirit logs one status report every 30 seconds. It is deliberately the only recurring `INFO` output: the checkpoint, the binlog flush and the binlog rotations each used to log on their own schedule, and they are now rows in this report instead ([#329](https://github.com/block/spirit/issues/329)). Their detail is still available by running with debug logging.
+While a migration runs, Spirit logs one status report every 30 seconds. It is deliberately the only recurring `INFO` output: the checkpoint, the binlog flush, the binlog rotations and the reader's own backpressure each used to log on their own schedule, and they are now fields in this report instead ([#329](https://github.com/block/spirit/issues/329)). Their detail is still available by running with debug logging.
 
 The report is a header line plus one indented row per subsystem:
 
@@ -588,7 +588,7 @@ The report is a header line plus one indented row per subsystem:
 2026/08/14 11:47:10 INFO migration status: state=copyRows total-time=2m30s copier-time=2m30s
   copier   46.13%  7550855/16370180  chunk-size=8097  eta=3m29s  throttled=false
   applier queue=128/128  workers=4  wait-p50=1.564s  write-p50=37ms  write-p90=131ms
-  binlog  deltas=0  rotations=56 (0 forced)  flushed 30s ago (took 9µs, 0 rows)
+  binlog  deltas=0  rotations=56 (0 forced)  parks=0 is-parked=false  flushed 30s ago (took 9µs, 0 rows)  read=binlog.000047:104861122
   ckpt    50s ago  binlog.000047:104857600
 ```
 
@@ -625,7 +625,12 @@ Spirit keeps the new table in sync with writes that land during the copy by subs
 | `deltas` | Changes discovered in the binary log that have not been applied to the new table yet. This is usually low at the start of a migration because of the *key above watermark* optimization: a change to a row the copier has not reached yet can simply be dropped, since the copier will read the current version when it gets there. It rises as the copy approaches 100%, and the `applyChangeset` state exists to drain it before cutover. |
 | `rotations` | How many binlog rotations Spirit has followed on the source. High counts usually just indicate a high volume of write activity on the server (from any workload, not only this migration). Worth knowing because binlog retention is what bounds how long a paused or resumable migration can survive. |
 | `(n forced)` | The subset of those rotations Spirit caused itself, by issuing `FLUSH BINARY LOGS` when it was waiting for the feed to catch up and the position had stalled. A number that climbs here (rather than in `rotations`) means Spirit's own catch-up waiting is churning through binlogs. Always `0` when the run uses GTID coordinates (see [GTID auto-detection](#gtid-auto-detection)) — that feed never issues `FLUSH BINARY LOGS`. |
+| `parks` | How many times Spirit has throttled its own binlog reader, cumulatively for the run. The reader parks when a subscription's buffer of pending changes reaches a soft limit — either 256MiB of buffered row images or 50,000 pending changes, whichever binds first — and resumes as the next flush applies them. Capacity comes back one applied batch at a time, so one sustained episode of backpressure produces many parks rather than one long one: read the *rate* between reports, not the absolute number. A count that never moves means the applier is keeping up with the source's write rate. |
+| `is-parked` | Whether the reader is parked *right now*. Together with `parks` this separates a reader being briefly throttled and recovering (`parks` climbing, `is-parked=false`) from one being held off for minutes at a time (`is-parked=true` across consecutive reports). The latter is the reading to act on: while the reader is parked Spirit is not consuming the source's binary log, so a long stall eats into `binlog_expire_logs_seconds` and can make the run unresumable. It usually means the change feed cannot apply as fast as the source writes; check the `flushed` figures on this row for how long a drain is taking. |
 | `flushed X ago (took Y, n rows)` | When the change feed last flushed its buffered changes to the new table, how long that flush took, and how many buffered changes it started with. Flushes are periodic (every 30 seconds by default), so `X` reads somewhere between `0s` and the interval during a healthy copy; a value that keeps climbing well past it means flushes are not completing. `0 rows` is the normal reading for a feed that is keeping up — there was nothing left to write. |
+| `read` | How far the feed has *read* the binary log, in the run's coordinate scheme. This is not the resume point: it is ahead of the `ckpt` position by whatever is still buffered and unflushed. Omitted before the feed has read anything. |
+
+The `read` field is there to tell "the reader is fine, only publication is blocked" apart from "the feed has stalled" — two situations the `ckpt` row cannot distinguish, because it shows the flushed position, which is frozen in both. Spirit only advances the flushed position when a flush lands *every* buffered change, so while any change is held back the checkpoint stops moving by design. If `read` advances between reports the reader is working normally; if it is also standing still, the feed itself has stopped. The gap between `read` and the `ckpt` position is how much re-reading a resume would have to do.
 
 ### `ckpt` row
 

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1195,13 +1195,18 @@ func (c *binlogClient) FlushResidual() (int, int) {
 func (c *binlogClient) FeedStats() FeedStats {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return FeedStats{
+	stats := FeedStats{
 		LastFlushAt:       c.lastFlushAt,
 		LastFlushDuration: c.lastFlushDuration,
 		LastFlushRows:     c.lastFlushRows,
 		Rotations:         c.rotations.Load(),
 		ForcedRotations:   c.flushedBinlogs.Load(),
 	}
+	// Already under c.mu, which is what guards bufferedPos.
+	if c.bufferedPos.Name != "" {
+		stats.BufferedPosition = formatBinlogPosition(c.bufferedPos)
+	}
+	return stats
 }
 
 // Flush empties the changeset in a loop until the amount of changes is considered "trivial".

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -112,6 +112,11 @@ type binlogClient struct {
 	// cap. See DefaultSubscriptionSoftLimitBytes.
 	subscriptionSoftLimitBytes int64
 
+	// subscriptionSoftLimitChanges is the per-subscription change-count
+	// cap, applied alongside the byte cap. Zero disables it. See
+	// DefaultSubscriptionSoftLimitChanges.
+	subscriptionSoftLimitChanges int
+
 	// flushConcurrency is the map-mode flush batch concurrency passed
 	// to each subscription on construction. See DefaultFlushConcurrency.
 	flushConcurrency int
@@ -143,22 +148,29 @@ func NewBinlogClient(db *sql.DB, host string, username, password string, appl ap
 	} else if softLimit < 0 {
 		softLimit = 0 // explicit opt-out
 	}
+	softLimitChanges := config.SubscriptionSoftLimitChanges
+	if softLimitChanges == 0 {
+		softLimitChanges = DefaultSubscriptionSoftLimitChanges
+	} else if softLimitChanges < 0 {
+		softLimitChanges = 0 // explicit opt-out
+	}
 	return &binlogClient{
-		db:                         db,
-		dbConfig:                   config.DBConfig,
-		host:                       host,
-		username:                   username,
-		password:                   password,
-		logger:                     config.Logger,
-		subs:                       newSubscriptionRegistry(),
-		callerCancelFunc:           config.CancelFunc,
-		ddlFilterSchema:            config.DDLFilterSchema,
-		ddlFilterTables:            toSet(config.DDLFilterTables),
-		serverID:                   config.ServerID,
-		applier:                    appl,
-		subscriptionSoftLimitBytes: softLimit,
-		flushConcurrency:           config.resolveFlushConcurrency(),
-		flushRequests:              make(chan Subscription, 1),
+		db:                           db,
+		dbConfig:                     config.DBConfig,
+		host:                         host,
+		username:                     username,
+		password:                     password,
+		logger:                       config.Logger,
+		subs:                         newSubscriptionRegistry(),
+		callerCancelFunc:             config.CancelFunc,
+		ddlFilterSchema:              config.DDLFilterSchema,
+		ddlFilterTables:              toSet(config.DDLFilterTables),
+		serverID:                     config.ServerID,
+		applier:                      appl,
+		subscriptionSoftLimitBytes:   softLimit,
+		subscriptionSoftLimitChanges: softLimitChanges,
+		flushConcurrency:             config.resolveFlushConcurrency(),
+		flushRequests:                make(chan Subscription, 1),
 	}
 }
 
@@ -181,6 +193,7 @@ func (c *binlogClient) AddSubscription(currentTable, newTable *table.TableInfo, 
 		Chunker:          chunker,
 		Logger:           c.logger,
 		SoftLimitBytes:   c.subscriptionSoftLimitBytes,
+		SoftLimitChanges: c.subscriptionSoftLimitChanges,
 		FlushRequest:     c.flushRequests,
 		FlushConcurrency: c.flushConcurrency,
 	})

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1206,15 +1206,18 @@ func (c *binlogClient) FlushResidual() (int, int) {
 // FeedStats satisfies StatsReporter, so the runner can fold the feed's
 // activity into the binlog row of its periodic status block.
 func (c *binlogClient) FeedStats() FeedStats {
+	// Collected before c.mu is taken: mergeParkStats locks each subscription,
+	// and the subscriptions take c.mu on their flush paths.
+	var stats FeedStats
+	mergeParkStats(&stats, c.subs.Snapshot())
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	stats := FeedStats{
-		LastFlushAt:       c.lastFlushAt,
-		LastFlushDuration: c.lastFlushDuration,
-		LastFlushRows:     c.lastFlushRows,
-		Rotations:         c.rotations.Load(),
-		ForcedRotations:   c.flushedBinlogs.Load(),
-	}
+	stats.LastFlushAt = c.lastFlushAt
+	stats.LastFlushDuration = c.lastFlushDuration
+	stats.LastFlushRows = c.lastFlushRows
+	stats.Rotations = c.rotations.Load()
+	stats.ForcedRotations = c.flushedBinlogs.Load()
 	// Already under c.mu, which is what guards bufferedPos.
 	if c.bufferedPos.Name != "" {
 		stats.BufferedPosition = formatBinlogPosition(c.bufferedPos)

--- a/pkg/change/config.go
+++ b/pkg/change/config.go
@@ -72,6 +72,14 @@ type ClientConfig struct {
 	// zero-value default) means use DefaultSubscriptionSoftLimitBytes.
 	SubscriptionSoftLimitBytes int64
 
+	// SubscriptionSoftLimitChanges overrides
+	// DefaultSubscriptionSoftLimitChanges for new subscriptions: the cap on
+	// pending change *count* before HasChanged parks, applied alongside
+	// SubscriptionSoftLimitBytes. Set to a negative value to disable the cap
+	// entirely. Zero (the zero-value default) means use
+	// DefaultSubscriptionSoftLimitChanges.
+	SubscriptionSoftLimitChanges int
+
 	// FlushConcurrency overrides DefaultFlushConcurrency for new
 	// subscriptions: the maximum number of applier batches a map-mode
 	// flush keeps in flight concurrently. Set to a negative value to

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -1179,12 +1179,17 @@ func (c *gtidClient) countRotation(currentLogName, nextLogName string) string {
 func (c *gtidClient) FeedStats() FeedStats {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return FeedStats{
+	stats := FeedStats{
 		LastFlushAt:       c.lastFlushAt,
 		LastFlushDuration: c.lastFlushDuration,
 		LastFlushRows:     c.lastFlushRows,
 		Rotations:         c.rotations.Load(),
 	}
+	// Already under c.mu, which is what guards bufferedGTID.
+	if c.bufferedGTID != nil && !c.bufferedGTID.IsEmpty() {
+		stats.BufferedPosition = c.bufferedGTID.String()
+	}
+	return stats
 }
 
 // Flush satisfies Source. Same shape as binlogClient.Flush.

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -1190,14 +1190,17 @@ func (c *gtidClient) countRotation(currentLogName, nextLogName string) string {
 // client never issues `FLUSH BINARY LOGS` — BlockWait polls
 // @@GLOBAL.gtid_executed instead of chasing a file offset.
 func (c *gtidClient) FeedStats() FeedStats {
+	// Collected before c.mu is taken: mergeParkStats locks each subscription,
+	// and the subscriptions take c.mu on their flush paths.
+	var stats FeedStats
+	mergeParkStats(&stats, c.subs.Snapshot())
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	stats := FeedStats{
-		LastFlushAt:       c.lastFlushAt,
-		LastFlushDuration: c.lastFlushDuration,
-		LastFlushRows:     c.lastFlushRows,
-		Rotations:         c.rotations.Load(),
-	}
+	stats.LastFlushAt = c.lastFlushAt
+	stats.LastFlushDuration = c.lastFlushDuration
+	stats.LastFlushRows = c.lastFlushRows
+	stats.Rotations = c.rotations.Load()
 	// Already under c.mu, which is what guards bufferedGTID.
 	if c.bufferedGTID != nil && !c.bufferedGTID.IsEmpty() {
 		stats.BufferedPosition = c.bufferedGTID.String()

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -105,6 +105,11 @@ type gtidClient struct {
 
 	subscriptionSoftLimitBytes int64
 
+	// subscriptionSoftLimitChanges is the per-subscription change-count
+	// cap, applied alongside the byte cap. Zero disables it. See
+	// DefaultSubscriptionSoftLimitChanges.
+	subscriptionSoftLimitChanges int
+
 	// flushConcurrency is the map-mode flush batch concurrency passed
 	// to each subscription on construction. See DefaultFlushConcurrency.
 	flushConcurrency int
@@ -132,22 +137,29 @@ func NewGTIDClient(db *sql.DB, host string, username, password string, appl appl
 	} else if softLimit < 0 {
 		softLimit = 0
 	}
+	softLimitChanges := config.SubscriptionSoftLimitChanges
+	if softLimitChanges == 0 {
+		softLimitChanges = DefaultSubscriptionSoftLimitChanges
+	} else if softLimitChanges < 0 {
+		softLimitChanges = 0
+	}
 	return &gtidClient{
-		db:                         db,
-		dbConfig:                   config.DBConfig,
-		host:                       host,
-		username:                   username,
-		password:                   password,
-		logger:                     config.Logger,
-		subs:                       newSubscriptionRegistry(),
-		callerCancelFunc:           config.CancelFunc,
-		ddlFilterSchema:            config.DDLFilterSchema,
-		ddlFilterTables:            toSet(config.DDLFilterTables),
-		serverID:                   config.ServerID,
-		applier:                    appl,
-		subscriptionSoftLimitBytes: softLimit,
-		flushConcurrency:           config.resolveFlushConcurrency(),
-		flushRequests:              make(chan Subscription, 1),
+		db:                           db,
+		dbConfig:                     config.DBConfig,
+		host:                         host,
+		username:                     username,
+		password:                     password,
+		logger:                       config.Logger,
+		subs:                         newSubscriptionRegistry(),
+		callerCancelFunc:             config.CancelFunc,
+		ddlFilterSchema:              config.DDLFilterSchema,
+		ddlFilterTables:              toSet(config.DDLFilterTables),
+		serverID:                     config.ServerID,
+		applier:                      appl,
+		subscriptionSoftLimitBytes:   softLimit,
+		subscriptionSoftLimitChanges: softLimitChanges,
+		flushConcurrency:             config.resolveFlushConcurrency(),
+		flushRequests:                make(chan Subscription, 1),
 	}
 }
 
@@ -161,6 +173,7 @@ func (c *gtidClient) AddSubscription(currentTable, newTable *table.TableInfo, ch
 		Chunker:          chunker,
 		Logger:           c.logger,
 		SoftLimitBytes:   c.subscriptionSoftLimitBytes,
+		SoftLimitChanges: c.subscriptionSoftLimitChanges,
 		FlushRequest:     c.flushRequests,
 		FlushConcurrency: c.flushConcurrency,
 	})

--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -74,6 +74,29 @@ const (
 	// (binlog_expire_logs_seconds). Tune this value, or the source's
 	// retention, accordingly.
 	DefaultSubscriptionSoftLimitBytes = 256 << 20
+	// DefaultSubscriptionSoftLimitChanges caps the number of pending
+	// changes per subscription before HasChanged parks, alongside
+	// DefaultSubscriptionSoftLimitBytes. Whichever binds first parks the
+	// reader.
+	//
+	// The byte cap alone is not enough because bytes and count measure
+	// different costs. Bytes bound memory, which is what a handful of wide
+	// LONGTEXT rows threatens. Count bounds how long the drain that empties
+	// the buffer takes: the flush applies rows in batches of at most
+	// DefaultBatchSize per round trip, so drain time scales with count and
+	// is indifferent to row width. A narrow-row table therefore reaches an
+	// unworkable drain long before it reaches 256MiB — in production, a
+	// table averaging ~600 bytes per change filled to over 450k pending
+	// changes while still well inside the byte cap, and the drain that
+	// followed ran for 21m37s holding flushMu for its full duration.
+	//
+	// 50k is chosen to keep that drain in the tens of seconds rather than
+	// the tens of minutes, so it fits inside roughly one DefaultFlushInterval
+	// and the flushed position keeps advancing. It is well above
+	// binlogTrivialThreshold, so it does not interfere with the "flush until
+	// trivial" loops, and it still lets dedup absorb hot-row workloads —
+	// map-mode overwrites of already-buffered keys bypass the cap entirely.
+	DefaultSubscriptionSoftLimitChanges = 50000
 	// DefaultTimeout is how long BlockWait is supposed to wait before returning errors.
 	DefaultTimeout = 30 * time.Second
 	// Maximum number of consecutive errors before recreating the streamer

--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -90,12 +90,24 @@ const (
 	// changes while still well inside the byte cap, and the drain that
 	// followed ran for 21m37s holding flushMu for its full duration.
 	//
-	// 50k is chosen to keep that drain in the tens of seconds rather than
-	// the tens of minutes, so it fits inside roughly one DefaultFlushInterval
-	// and the flushed position keeps advancing. It is well above
-	// binlogTrivialThreshold, so it does not interfere with the "flush until
-	// trivial" loops, and it still lets dedup absorb hot-row workloads —
-	// map-mode overwrites of already-buffered keys bypass the cap entirely.
+	// 50k targets a drain of roughly two minutes rather than twenty. Scaling
+	// that production drain — at most 452,571 rows in 21m37s — down to 50k
+	// gives about 2m23s, and that is a floor rather than an estimate: the
+	// 452,571 figure is the backlog at flush *start*, so if fewer rows actually
+	// landed the per-row cost is higher and the scaled time is longer.
+	//
+	// Two minutes is not "one flush interval", and it is not meant to be. What
+	// matters is that the drain *completes*, because only a complete drain
+	// reports allChangesFlushed=true and only that advances the flushed
+	// position; a cap tight enough to fit one DefaultFlushInterval would
+	// truncate every drain and freeze the position just as before. Overlapping
+	// flushes are not a concern either — flushMu serializes them, so a tick
+	// arriving mid-drain waits rather than piling on.
+	//
+	// It is well above binlogTrivialThreshold, so it does not interfere with
+	// the "flush until trivial" loops, and it still lets dedup absorb hot-row
+	// workloads — map-mode overwrites of already-buffered keys bypass the cap
+	// entirely.
 	DefaultSubscriptionSoftLimitChanges = 50000
 	// DefaultTimeout is how long BlockWait is supposed to wait before returning errors.
 	DefaultTimeout = 30 * time.Second

--- a/pkg/change/stats.go
+++ b/pkg/change/stats.go
@@ -24,6 +24,20 @@ type FeedStats struct {
 	// Source.Flush always ends on (it loops until the backlog is trivial and
 	// then flushes once more).
 	LastFlushRows int
+	// BufferedPosition is how far the feed has *read*, in the same opaque
+	// encoding Source.Position uses. Empty before the feed has read anything.
+	//
+	// This is deliberately not the resume coordinate. Source.Position and the
+	// ckpt row both report the *flushed* position, which only advances when a
+	// flush lands every buffered change — so while any change is held back the
+	// checkpoint is frozen by design, and the status block goes silent about
+	// the reader even though it is working normally. That is indistinguishable
+	// from a genuinely stalled feed, which is the case an operator most needs
+	// to tell apart. Reporting the buffered position alongside restores the
+	// distinction: if it advances between status blocks the reader is fine and
+	// only publication is blocked, and the gap to the ckpt row is how much
+	// re-reading a restart would cost.
+	BufferedPosition string
 	// Rotations counts binlog rotations the feed has followed. Duplicate
 	// rotate events (the server sends a real one and an artificial one
 	// carrying the same position) are counted once.
@@ -61,7 +75,24 @@ func (s FeedStats) String() string {
 			s.LastFlushRows,
 		)
 	}
-	return fmt.Sprintf("rotations=%d (%d forced)  %s", s.Rotations, s.ForcedRotations, flush)
+	out := fmt.Sprintf("rotations=%d (%d forced)  %s", s.Rotations, s.ForcedRotations, flush)
+	if s.BufferedPosition != "" {
+		// Last, and rendered whole. A GTID set gains a UUID per failover and
+		// has no upper bound on length, so putting it anywhere but the end of
+		// the row would push the flush phrase off a narrow terminal — and the
+		// flush phrase is the other half of the answer.
+		//
+		// It is not abbreviated, for two reasons. The ckpt row prints the
+		// flushed position in full, and the point of this field is to be
+		// compared against that one: elide one copy and they stop being
+		// diffable by eye. And the interval that moves between status blocks
+		// belongs to whichever server is currently being written to, which
+		// need not sort last in the set — a middle elision could hide exactly
+		// the digits that are changing and make a healthy reader look frozen,
+		// which is the misreading this field exists to prevent.
+		out += "  read=" + s.BufferedPosition
+	}
+	return out
 }
 
 // StatusRow renders the feed stats of srcs as the binlog row of a runner status
@@ -88,6 +119,14 @@ func StatusRow(srcs ...Source) string {
 			merged.LastFlushAt = s.LastFlushAt
 			merged.LastFlushDuration = s.LastFlushDuration
 			merged.LastFlushRows = s.LastFlushRows
+			// The buffered position comes from the same feed as the flush
+			// figures rather than being merged across feeds. Positions from
+			// different sources are not comparable — a sharded move reads one
+			// feed per source, each with its own coordinate space — so there is
+			// nothing to sum or average. Taking the stalest feed's is the
+			// useful choice: that is the feed holding the position back, and
+			// therefore the one whose reader progress is in question.
+			merged.BufferedPosition = s.BufferedPosition
 		}
 		merged.Rotations += s.Rotations
 		merged.ForcedRotations += s.ForcedRotations

--- a/pkg/change/stats.go
+++ b/pkg/change/stats.go
@@ -48,6 +48,51 @@ type FeedStats struct {
 	// whether cutover-time waiting is churning through binlogs; a rising
 	// count with a flat Rotations count means we are the one doing it.
 	ForcedRotations int64
+	// Parks counts, cumulatively, how many times a subscription has parked
+	// the binlog reader on one of its soft limits. Summed across the feed's
+	// subscriptions.
+	//
+	// Parking is normal under a write rate the applier cannot match, and a
+	// single sustained episode of backpressure produces many parks — flushes
+	// release capacity per applied batch, so the reader is woken and re-parks
+	// repeatedly while one drain runs. The number to read is therefore the
+	// *rate* between status blocks, not the absolute value.
+	Parks int64
+	// IsParked is true when at least one of the feed's subscriptions is
+	// parked at the instant the status block was rendered. Together with
+	// Parks this separates the two cases an operator cares about: a rising
+	// Parks with is-parked=false is a reader being briefly throttled and
+	// recovering, while is-parked=true across consecutive status blocks is a
+	// reader being held off for minutes at a time, which is what puts the
+	// source's binlog retention at risk.
+	IsParked bool
+}
+
+// ParkReporter is implemented by Subscription implementations that apply
+// backpressure to the change reader and can report on it. Optional, for the
+// same reason StatsReporter is: a subscription that never parks contributes
+// nothing rather than having to grow a method.
+type ParkReporter interface {
+	ParkStats() (parks int64, parked bool)
+}
+
+// mergeParkStats folds the park stats of subs into stats. Parks sum because
+// each subscription throttles the shared reader independently; IsParked ORs
+// because one parked subscription is enough to stall it.
+//
+// Callers must not hold the client's own mutex: this reaches into each
+// subscription's lock, and the subscriptions take the client's lock on their
+// flush paths.
+func mergeParkStats(stats *FeedStats, subs []Subscription) {
+	for _, sub := range subs {
+		reporter, ok := sub.(ParkReporter)
+		if !ok {
+			continue
+		}
+		parks, parked := reporter.ParkStats()
+		stats.Parks += parks
+		stats.IsParked = stats.IsParked || parked
+	}
 }
 
 // StatsReporter is implemented by change.Source implementations that can
@@ -75,7 +120,12 @@ func (s FeedStats) String() string {
 			s.LastFlushRows,
 		)
 	}
-	out := fmt.Sprintf("rotations=%d (%d forced)  %s", s.Rotations, s.ForcedRotations, flush)
+	// parks/is-parked are rendered unconditionally, like the rotation counters
+	// and unlike read= below. A field that appears only while something is
+	// wrong cannot be eye-diffed against the previous status block, and the
+	// reading that matters here is the delta between blocks.
+	out := fmt.Sprintf("rotations=%d (%d forced)  parks=%d is-parked=%t  %s",
+		s.Rotations, s.ForcedRotations, s.Parks, s.IsParked, flush)
 	if s.BufferedPosition != "" {
 		// Last, and rendered whole. A GTID set gains a UUID per failover and
 		// has no upper bound on length, so putting it anywhere but the end of
@@ -130,6 +180,8 @@ func StatusRow(srcs ...Source) string {
 		}
 		merged.Rotations += s.Rotations
 		merged.ForcedRotations += s.ForcedRotations
+		merged.Parks += s.Parks
+		merged.IsParked = merged.IsParked || s.IsParked
 		found = true
 	}
 	if !found {

--- a/pkg/change/stats_test.go
+++ b/pkg/change/stats_test.go
@@ -2,6 +2,7 @@ package change
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -238,4 +239,64 @@ func TestFeedStatsFromLiveFeed(t *testing.T) {
 		return client.FeedStats().Rotations > before
 	}, 10*time.Second, 50*time.Millisecond,
 		"rotation was not counted (still %d)", client.FeedStats().Rotations)
+}
+
+// The buffered position is the field that tells "the reader is fine, only
+// publication is blocked" apart from "the feed has stalled". The ckpt row
+// cannot: it shows the flushed position, which is frozen in both cases.
+func TestFeedStatsStringWithBufferedPosition(t *testing.T) {
+	s := FeedStats{
+		LastFlushAt:       time.Now().Add(-10 * time.Second),
+		LastFlushDuration: 2854617 * time.Nanosecond,
+		LastFlushRows:     5583,
+		BufferedPosition:  "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638",
+		Rotations:         4,
+		ForcedRotations:   1,
+	}
+	require.Equal(t,
+		"rotations=4 (1 forced)  flushed 10s ago (took 2.855ms, 5583 rows)  "+
+			"read=f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638",
+		s.String())
+}
+
+// The position goes last and whole. A GTID set has no bounded length, so
+// anywhere else it would push the flush phrase off a narrow terminal, and
+// truncating it would stop it being comparable with the ckpt row.
+func TestFeedStatsStringRendersLongPositionInFullAtTheEnd(t *testing.T) {
+	long := "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638," +
+		"a1b2c3d4-154f-3776-8f0f-ced626dbde36:1-42," +
+		"b7c8d9e0-154f-3776-8f0f-ced626dbde36:1-7"
+	got := FeedStats{BufferedPosition: long}.String()
+	require.Equal(t, "rotations=0 (0 forced)  never flushed  read="+long, got)
+	require.True(t, strings.HasSuffix(got, long), "nothing may follow the position")
+}
+
+// A feed that has not read anything yet omits the field rather than rendering
+// an empty one, which also keeps every pre-existing status line byte-identical.
+func TestFeedStatsStringOmitsEmptyBufferedPosition(t *testing.T) {
+	require.Equal(t, "rotations=0 (0 forced)  never flushed", FeedStats{}.String())
+	require.NotContains(t, FeedStats{Rotations: 3}.String(), "read=")
+}
+
+// The buffered position is taken from the same feed as the flush figures, not
+// merged: positions from different sources are not comparable, and the stalest
+// feed is the one whose reader progress is in question.
+func TestStatusRowBufferedPositionFollowsStalestFeed(t *testing.T) {
+	recent := &statsFeed{stats: FeedStats{
+		LastFlushAt:      time.Now().Add(-time.Second),
+		BufferedPosition: "recent-feed-pos",
+		Rotations:        2,
+	}}
+	stale := &statsFeed{stats: FeedStats{
+		LastFlushAt:      time.Now().Add(-90 * time.Second),
+		BufferedPosition: "stale-feed-pos",
+		Rotations:        3,
+	}}
+	row := StatusRow(recent, stale)
+	require.Contains(t, row, "read=stale-feed-pos")
+	require.NotContains(t, row, "recent-feed-pos")
+	require.Contains(t, row, "rotations=5 (0 forced)", "counters still sum")
+
+	// Order must not matter.
+	require.Equal(t, row, StatusRow(stale, recent))
 }

--- a/pkg/change/stats_test.go
+++ b/pkg/change/stats_test.go
@@ -51,7 +51,7 @@ func (f *statsFeed) Close()                                                     
 
 func TestFeedStatsStringNeverFlushed(t *testing.T) {
 	require.Equal(t,
-		"rotations=0 (0 forced)  never flushed",
+		"rotations=0 (0 forced)  parks=0 is-parked=false  never flushed",
 		FeedStats{}.String())
 }
 
@@ -64,7 +64,7 @@ func TestFeedStatsString(t *testing.T) {
 		ForcedRotations:   1,
 	}
 	require.Equal(t,
-		"rotations=4 (1 forced)  flushed 10s ago (took 2.855ms, 5583 rows)",
+		"rotations=4 (1 forced)  parks=0 is-parked=false  flushed 10s ago (took 2.855ms, 5583 rows)",
 		s.String())
 }
 
@@ -85,7 +85,7 @@ func TestStatusRowSingleSource(t *testing.T) {
 		ForcedRotations:   1,
 	}}
 	require.Equal(t,
-		"rotations=2 (1 forced)  flushed 3s ago (took 5ms, 12 rows)",
+		"rotations=2 (1 forced)  parks=0 is-parked=false  flushed 3s ago (took 5ms, 12 rows)",
 		StatusRow(src))
 }
 
@@ -108,7 +108,7 @@ func TestStatusRowMergesSources(t *testing.T) {
 		ForcedRotations:   0,
 	}}
 	require.Equal(t,
-		"rotations=5 (1 forced)  flushed 1m30s ago (took 7ms, 900 rows)",
+		"rotations=5 (1 forced)  parks=0 is-parked=false  flushed 1m30s ago (took 7ms, 900 rows)",
 		StatusRow(recent, stale))
 	// Order must not matter.
 	require.Equal(t, StatusRow(recent, stale), StatusRow(stale, recent))
@@ -125,7 +125,7 @@ func TestStatusRowNeverFlushedWins(t *testing.T) {
 	}}
 	never := &statsFeed{stats: FeedStats{Rotations: 1}}
 	require.Equal(t,
-		"rotations=2 (0 forced)  never flushed",
+		"rotations=2 (0 forced)  parks=0 is-parked=false  never flushed",
 		StatusRow(flushed, never))
 	require.Equal(t, StatusRow(flushed, never), StatusRow(never, flushed))
 }
@@ -163,7 +163,7 @@ func TestGTIDCountRotation(t *testing.T) {
 // minus forced rotations: it never issues FLUSH BINARY LOGS.
 func TestGTIDFeedStats(t *testing.T) {
 	c := &gtidClient{subs: newSubscriptionRegistry()}
-	require.Equal(t, "rotations=0 (0 forced)  never flushed", StatusRow(c))
+	require.Equal(t, "rotations=0 (0 forced)  parks=0 is-parked=false  never flushed", StatusRow(c))
 
 	c.rotations.Store(2)
 	c.recordFlush(time.Now().Add(-5*time.Millisecond), 42)
@@ -174,7 +174,7 @@ func TestGTIDFeedStats(t *testing.T) {
 	require.Equal(t, 42, stats.LastFlushRows)
 	require.False(t, stats.LastFlushAt.IsZero())
 	require.GreaterOrEqual(t, stats.LastFlushDuration, 5*time.Millisecond)
-	require.Contains(t, StatusRow(c), "rotations=2 (0 forced)  flushed 0s ago")
+	require.Contains(t, StatusRow(c), "rotations=2 (0 forced)  parks=0 is-parked=false  flushed 0s ago")
 }
 
 // The feed records real flushes and real rotations, which is what the runner
@@ -254,7 +254,7 @@ func TestFeedStatsStringWithBufferedPosition(t *testing.T) {
 		ForcedRotations:   1,
 	}
 	require.Equal(t,
-		"rotations=4 (1 forced)  flushed 10s ago (took 2.855ms, 5583 rows)  "+
+		"rotations=4 (1 forced)  parks=0 is-parked=false  flushed 10s ago (took 2.855ms, 5583 rows)  "+
 			"read=f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638",
 		s.String())
 }
@@ -267,14 +267,14 @@ func TestFeedStatsStringRendersLongPositionInFullAtTheEnd(t *testing.T) {
 		"a1b2c3d4-154f-3776-8f0f-ced626dbde36:1-42," +
 		"b7c8d9e0-154f-3776-8f0f-ced626dbde36:1-7"
 	got := FeedStats{BufferedPosition: long}.String()
-	require.Equal(t, "rotations=0 (0 forced)  never flushed  read="+long, got)
+	require.Equal(t, "rotations=0 (0 forced)  parks=0 is-parked=false  never flushed  read="+long, got)
 	require.True(t, strings.HasSuffix(got, long), "nothing may follow the position")
 }
 
 // A feed that has not read anything yet omits the field rather than rendering
 // an empty one, which also keeps every pre-existing status line byte-identical.
 func TestFeedStatsStringOmitsEmptyBufferedPosition(t *testing.T) {
-	require.Equal(t, "rotations=0 (0 forced)  never flushed", FeedStats{}.String())
+	require.Equal(t, "rotations=0 (0 forced)  parks=0 is-parked=false  never flushed", FeedStats{}.String())
 	require.NotContains(t, FeedStats{Rotations: 3}.String(), "read=")
 }
 
@@ -299,4 +299,76 @@ func TestStatusRowBufferedPositionFollowsStalestFeed(t *testing.T) {
 
 	// Order must not matter.
 	require.Equal(t, row, StatusRow(stale, recent))
+}
+
+// stubSubscription is a Subscription that does nothing, so the park-stats
+// tests can vary the one thing they are about.
+type stubSubscription struct{}
+
+func (*stubSubscription) HasChanged([]any, []any, bool) {}
+func (*stubSubscription) Length() int                   { return 0 }
+func (*stubSubscription) Flush(context.Context, bool, []*dbconn.TableLock) (bool, error) {
+	return true, nil
+}
+func (*stubSubscription) Tables() []*table.TableInfo                           { return nil }
+func (*stubSubscription) ImmutableColumnOrdinal() int                          { return -1 }
+func (*stubSubscription) SetWatermarkOptimization(context.Context, bool) error { return nil }
+func (*stubSubscription) Close()                                               {}
+
+// parkingStub additionally reports park stats.
+type parkingStub struct {
+	stubSubscription
+	parks  int64
+	parked bool
+}
+
+func (p *parkingStub) ParkStats() (int64, bool) { return p.parks, p.parked }
+
+// Parking is the reader being held off, which is the one thing the periodic
+// status block could not previously show — the feed logged it on its own
+// schedule instead, at a rate that buried the block it should have complemented.
+func TestFeedStatsStringRendersParks(t *testing.T) {
+	require.Equal(t,
+		"rotations=0 (0 forced)  parks=417 is-parked=true  never flushed",
+		FeedStats{Parks: 417, IsParked: true}.String())
+}
+
+// Parks sum because each subscription throttles the shared reader
+// independently; IsParked ORs because one parked subscription is enough to
+// stall that reader, and a sibling that is running does not make the stall any
+// less real.
+func TestMergeParkStatsAcrossSubscriptions(t *testing.T) {
+	var stats FeedStats
+	mergeParkStats(&stats, []Subscription{
+		&parkingStub{parks: 3, parked: false},
+		&parkingStub{parks: 4, parked: true},
+		&parkingStub{parks: 5, parked: false},
+	})
+	require.Equal(t, int64(12), stats.Parks)
+	require.True(t, stats.IsParked)
+
+	// A subscription that does not report parks contributes nothing rather
+	// than being counted as unparked-and-therefore-fine.
+	var noneReport FeedStats
+	mergeParkStats(&noneReport, []Subscription{&stubSubscription{}})
+	require.Zero(t, noneReport.Parks)
+	require.False(t, noneReport.IsParked)
+}
+
+// Same merge rules across feeds: a sharded move reads one feed per source, and
+// a stall on any of them is a stall.
+func TestStatusRowMergesParkStats(t *testing.T) {
+	busy := &statsFeed{stats: FeedStats{
+		LastFlushAt: time.Now().Add(-time.Second),
+		Parks:       9,
+		IsParked:    true,
+	}}
+	idle := &statsFeed{stats: FeedStats{
+		LastFlushAt: time.Now().Add(-2 * time.Second),
+		Parks:       1,
+		IsParked:    false,
+	}}
+	row := StatusRow(busy, idle)
+	require.Contains(t, row, "parks=10 is-parked=true")
+	require.Equal(t, row, StatusRow(idle, busy), "order must not matter")
 }

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -2,7 +2,6 @@ package change
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
@@ -214,6 +213,7 @@ type bufferedMap struct {
 	keysSkippedBelow atomic.Int64
 	timesParked      atomic.Int64 // HasChanged was parked at least once on the soft limit
 	batchesContended atomic.Int64 // applier batches that failed on 1205/1213
+	batchesDeferred  atomic.Int64 // contended batches left for the next flush
 	serialRecoveries atomic.Int64 // drains rescued by the serial retry pass
 
 	// lastParkWarn is when the park/unpark log pair was last emitted at
@@ -952,11 +952,42 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			"total_batches", len(batches),
 			"concurrency", s.effectiveFlushConcurrency(),
 		)
-		if err := s.retryContendedBatches(ctx, snapshot, contended); err != nil {
-			// Contention that survived a serial retry is unambiguous evidence,
-			// so this one does feed the controller before returning.
-			s.adaptFlushConcurrency(true)
+		leftover, err := s.retryContendedBatches(ctx, snapshot, contended)
+		if err != nil {
+			// A hard error or a real cancellation, not contention: same
+			// reasoning as the pass-1 error path above, so the controller is
+			// left alone.
 			return false, err
+		}
+		if len(leftover) > 0 {
+			// Contention that outlived the serial pass is deferred, not failed.
+			//
+			// Reporting it as an error would throw away the whole drain, and a
+			// drain is not a cheap thing to throw away: when the copier has the
+			// applier queue saturated, one pass over a full buffer runs for
+			// minutes, so a single batch contending at the end would discard
+			// hundreds of batches' worth of *recorded* progress. The rows they
+			// wrote stay written either way, but on the error path flushedGTID
+			// never advances and the flush is never recorded, which is the
+			// frozen-checkpoint symptom this whole path exists to prevent —
+			// re-entered from the other side.
+			//
+			// allChangesFlushed=false protects the checkpoint exactly as well
+			// as an error does: clients gate position advancement on it, so a
+			// deferred batch holds the position back just as a failed drain
+			// would. It is the same mechanism watermark-deferred keys already
+			// use. The difference is only that the batches which *did* land
+			// count, and the leftovers are retried on the next flush rather
+			// than after a whole failed drain's worth of lost ground.
+			s.batchesDeferred.Add(int64(len(leftover)))
+			s.logger.Warn("flush batches still contended; deferring to the next flush",
+				"table", s.table.SchemaName+"."+s.table.TableName,
+				"deferred_batches", len(leftover),
+				"contended_batches", len(contended),
+				"total_batches", len(batches),
+			)
+			s.adaptFlushConcurrency(true)
+			return false, nil
 		}
 		s.serialRecoveries.Add(1)
 	}
@@ -1035,10 +1066,11 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 // retry is expected to succeed on its first, undelayed attempt; the escalating
 // attempts after it exist only for locks held from outside this drain.
 //
-// A batch that still fails here returns the error, leaving its entries in the
-// snapshot to be reattached and retried on the next flush. That is deliberate:
-// the flushed position must not advance over changes that never landed.
-func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[string]bufferedChange, contended []*mapFlushBatch) error {
+// Returns the batches that still could not land, which the caller defers to the
+// next flush; their entries are left in the snapshot to be reattached. A
+// non-nil error means something other than contention went wrong — a hard
+// error, or a genuine cancellation of the parent context.
+func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[string]bufferedChange, contended []*mapFlushBatch) ([]*mapFlushBatch, error) {
 	// Bound the whole pass, not just each batch. Against an external 1205 holder
 	// a single attempt is not cheap: flushBatch goes through
 	// dbconn.RetryableTransaction, which burns its own MaxRetries against
@@ -1053,39 +1085,51 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 	defer cancel()
 
 	var mu sync.Mutex
-	for _, batch := range contended {
+	var leftover []*mapFlushBatch
+	for i, batch := range contended {
 		var err error
 		for attempt := range contentionRetries {
 			select {
 			case <-passCtx.Done():
-				// Distinguish our own budget from real shutdown: on budget
-				// expiry the parent is still live and the caller should treat
-				// this as ordinary contention, not cancellation.
+				// Distinguish our own budget from real shutdown. Only the
+				// latter is an error; the budget expiring just means the
+				// batches we have not reached yet go back in the buffer.
 				if ctx.Err() != nil {
-					return ctx.Err()
+					return nil, ctx.Err()
 				}
-				return fmt.Errorf("serial contention retry budget (%s) exhausted with %w",
-					contentionRetryBudget, errStillContended)
+				return append(leftover, contended[i:]...), nil
 			case <-time.After(contentionBackoff(attempt)):
 			}
 			if err = s.flushBatch(passCtx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
 				s.releaseAppliedBatch(snapshot, &mu, batch)
 				break
 			}
+			// The budget can expire *during* an attempt, not just between
+			// them, in which case flushBatch reports the cancellation rather
+			// than 1205/1213 — production showed this as a bare "failed to
+			// execute upsert: context deadline exceeded", which reads like a
+			// statement timeout and is nothing of the sort. Check passCtx
+			// before classifying, so our own impatience is never mistaken for
+			// a hard error.
+			if passCtx.Err() != nil {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				return append(leftover, contended[i:]...), nil
+			}
 			if !dbconn.IsLockContentionError(err) {
-				return err
+				return nil, err
 			}
 		}
 		if err != nil {
-			return fmt.Errorf("flush batch still contended after %d serial retries: %w", contentionRetries, err)
+			// Still contended after every attempt. Defer this one but keep
+			// going: the batches are disjoint, so one stubborn lock holder
+			// says nothing about whether the next batch can land.
+			leftover = append(leftover, batch)
 		}
 	}
-	return nil
+	return leftover, nil
 }
-
-// errStillContended marks a pass-2 giveup so callers can tell "we ran out of
-// patience with a lock holder" from a genuine cancellation.
-var errStillContended = errors.New("batches still contended")
 
 // contentionRetries is how many serial attempts a contended batch gets before
 // the drain gives up and leaves it for the next flush. The first is immediate
@@ -1103,7 +1147,16 @@ const contentionRetries = 4
 // flush. Sized to comfortably cover the self-inflicted case (which returns
 // almost immediately) while keeping flushMu out of the multi-minute territory
 // that N batches against an external lock holder would otherwise reach.
-const contentionRetryBudget = 20 * time.Second
+//
+// It is deliberately not scaled up for a saturated applier queue, where an
+// attempt spends seconds waiting for a worker before it even reaches MySQL and
+// this budget buys only a handful of attempts. Expiring is cheap now — the
+// leftovers are deferred, not failed — so the right response to a queue we are
+// starving behind is to hand the batches back and let the next flush try, not
+// to hold flushMu longer while the copier keeps winning the queue.
+//
+// A var so tests can shorten it, as with contentionBackoff.
+var contentionRetryBudget = 20 * time.Second
 
 // releaseAppliedBatch drops a landed batch's entries from the snapshot and
 // returns its bytes to the buffer.
@@ -1531,6 +1584,7 @@ func (s *bufferedMap) SetWatermarkOptimization(ctx context.Context, enabled bool
 		"keys_skipped_not_below_low", s.keysSkippedBelow.Swap(0),
 		"times_parked_on_soft_limit", s.timesParked.Swap(0),
 		"batches_lock_contended", s.batchesContended.Swap(0),
+		"batches_contention_deferred", s.batchesDeferred.Swap(0),
 		"drains_rescued_serially", s.serialRecoveries.Swap(0),
 		"flush_concurrency", s.effectiveFlushConcurrency(),
 		"delta_len", len(s.changes)+len(s.queue),

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -1187,41 +1187,53 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 	//
 	// Giving up early is cheap by comparison: the remaining batches stay in the
 	// snapshot, get reattached, and are retried on the next flush.
-	passCtx, cancel := context.WithTimeout(ctx, contentionRetryBudget)
-	defer cancel()
+	//
+	// The budget is a plain deadline rather than a context, and this is the
+	// important part. An earlier revision derived a context.WithTimeout from ctx
+	// and handed *that* to flushBatch, which meant the budget did not merely
+	// stop the pass — it killed whatever REPLACE was running when it expired.
+	// Production showed the result as
+	//
+	//	failed to upsert rows: failed to execute upsert: context deadline exceeded
+	//
+	// which reads like a statement timeout and is nothing of the sort. On a
+	// table whose batches take longer than the budget, that fires on a
+	// perfectly healthy statement, every time. Checking the error's provenance
+	// before classifying it stopped the misdiagnosis but not the abort.
+	//
+	// So the budget now gates only the decision to *start* another attempt.
+	// Attempts run on ctx and are allowed to finish, which is safe because an
+	// attempt is already bounded from below the flush: RetryableTransaction
+	// makes at most MaxRetries tries, each capped by innodb_lock_wait_timeout.
+	// Overrun past the budget is therefore one attempt's worth, and no deadline
+	// of our own can ever surface as an apply failure. Same shape as
+	// drainDispatchBudget, which likewise stops scheduling rather than
+	// cancelling.
+	deadline := time.Now().Add(contentionRetryBudget)
 
 	var mu sync.Mutex
 	deferred := 0
 	for i, batch := range contended {
 		var err error
 		for attempt := range contentionRetries {
-			select {
-			case <-passCtx.Done():
-				// Distinguish our own budget from real shutdown. Only the
-				// latter is an error; the budget expiring just means the
-				// batches we have not reached yet go back in the buffer.
-				if ctx.Err() != nil {
-					return 0, ctx.Err()
-				}
+			if time.Now().After(deadline) {
+				// Our own impatience, not a failure: the batches not reached
+				// yet — this one included — go back in the buffer.
 				return deferred + len(contended) - i, nil
+			}
+			select {
+			case <-ctx.Done():
+				// A real shutdown. That *is* an error, and the caller must not
+				// treat the drain as having merely deferred work.
+				return 0, ctx.Err()
 			case <-time.After(contentionBackoff(attempt)):
 			}
-			if err = s.flushBatch(passCtx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
+			if err = s.flushBatch(ctx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
 				s.releaseAppliedBatch(snapshot, &mu, batch)
 				break
 			}
-			// The budget can expire *during* an attempt, not just between
-			// them, in which case flushBatch reports the cancellation rather
-			// than 1205/1213 — production showed this as a bare "failed to
-			// execute upsert: context deadline exceeded", which reads like a
-			// statement timeout and is nothing of the sort. Check passCtx
-			// before classifying, so our own impatience is never mistaken for
-			// a hard error.
-			if passCtx.Err() != nil {
-				if ctx.Err() != nil {
-					return 0, ctx.Err()
-				}
-				return deferred + len(contended) - i, nil
+			if ctx.Err() != nil {
+				return 0, ctx.Err()
 			}
 			if !dbconn.IsLockContentionError(err) {
 				return 0, err
@@ -1250,18 +1262,27 @@ const contentionRetries = 4
 
 // contentionRetryBudget caps the total wall-clock time pass 2 may spend, across
 // all contended batches, before giving up and deferring the rest to the next
-// flush. Sized to comfortably cover the self-inflicted case (which returns
-// almost immediately) while keeping flushMu out of the multi-minute territory
-// that N batches against an external lock holder would otherwise reach.
+// flush. It bounds when a new attempt may *start*; see retryContendedBatches
+// for why it is not a context, and why that distinction matters more than the
+// number.
 //
-// It is deliberately not scaled up for the case where the copier is taking the
-// target's write capacity and each attempt is slow enough that this budget buys
-// only a handful of them. Expiring is cheap now — the leftovers are deferred,
-// not failed — so the right response to losing ground is to hand the batches
-// back and let the next flush try, not to hold flushMu longer.
+// The number still has to be in scale with one attempt, or the budget expires
+// before the first batch has had a fair try and pass 2 becomes decorative. It
+// was 20s, which was too small on the table this was tuned against: a drain
+// there worked through at most 452,571 rows in 21m37s, so with batches of
+// DefaultBatchSize and the reduced concurrency in force at the time, average
+// per-batch latency was *at least* ~11s — and a single flushBatch can spend
+// several times that inside RetryableTransaction, which retries up to
+// MaxRetries with innodb_lock_wait_timeout on each.
+//
+// Two minutes gives a handful of batches a genuine serial retry while staying
+// well inside drainDispatchBudget, so the drain's own bound is still the outer
+// one. Expiring remains cheap — the leftovers are deferred, not failed — so
+// this is a "how much is worth trying before handing back" figure, not a
+// deadline anything depends on.
 //
 // A var so tests can shorten it, as with contentionBackoff.
-var contentionRetryBudget = 20 * time.Second
+var contentionRetryBudget = 2 * time.Minute
 
 // releaseAppliedBatch drops a landed batch's entries from the snapshot and
 // returns its bytes to the buffer.

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -952,14 +952,14 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			"total_batches", len(batches),
 			"concurrency", s.effectiveFlushConcurrency(),
 		)
-		leftover, err := s.retryContendedBatches(ctx, snapshot, contended)
+		deferred, err := s.retryContendedBatches(ctx, snapshot, contended)
 		if err != nil {
 			// A hard error or a real cancellation, not contention: same
 			// reasoning as the pass-1 error path above, so the controller is
 			// left alone.
 			return false, err
 		}
-		if len(leftover) > 0 {
+		if deferred > 0 {
 			// Contention that outlived the serial pass is deferred, not failed.
 			//
 			// Reporting it as an error would throw away the whole drain, and a
@@ -980,10 +980,10 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			// use. The difference is only that the batches which *did* land
 			// count, and the leftovers are retried on the next flush rather
 			// than after a whole failed drain's worth of lost ground.
-			s.batchesDeferred.Add(int64(len(leftover)))
+			s.batchesDeferred.Add(int64(deferred))
 			s.logger.Warn("flush batches still contended; deferring to the next flush",
 				"table", s.table.SchemaName+"."+s.table.TableName,
-				"deferred_batches", len(leftover),
+				"deferred_batches", deferred,
 				"contended_batches", len(contended),
 				"total_batches", len(batches),
 			)
@@ -1067,11 +1067,15 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 // retry is expected to succeed on its first, undelayed attempt; the escalating
 // attempts after it exist only for locks held from outside this drain.
 //
-// Returns the batches that still could not land, which the caller defers to the
-// next flush; their entries are left in the snapshot to be reattached. A
-// non-nil error means something other than contention went wrong — a hard
+// Returns how many batches still could not land. Deferring them is not
+// something this function does to them, it is something it declines to do: only
+// releaseAppliedBatch takes a batch's keys out of the snapshot, so a batch that
+// never lands is still there when drainMapSnapshot's deferred reattach runs.
+// The count is for the caller's accounting and logging.
+//
+// A non-nil error means something other than contention went wrong — a hard
 // error, or a genuine cancellation of the parent context.
-func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[string]bufferedChange, contended []*mapFlushBatch) ([]*mapFlushBatch, error) {
+func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[string]bufferedChange, contended []*mapFlushBatch) (int, error) {
 	// Bound the whole pass, not just each batch. Against an external 1205 holder
 	// a single attempt is not cheap: flushBatch goes through
 	// dbconn.RetryableTransaction, which burns its own MaxRetries against
@@ -1086,7 +1090,7 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 	defer cancel()
 
 	var mu sync.Mutex
-	var leftover []*mapFlushBatch
+	deferred := 0
 	for i, batch := range contended {
 		var err error
 		for attempt := range contentionRetries {
@@ -1096,9 +1100,9 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 				// latter is an error; the budget expiring just means the
 				// batches we have not reached yet go back in the buffer.
 				if ctx.Err() != nil {
-					return nil, ctx.Err()
+					return 0, ctx.Err()
 				}
-				return append(leftover, contended[i:]...), nil
+				return deferred + len(contended) - i, nil
 			case <-time.After(contentionBackoff(attempt)):
 			}
 			if err = s.flushBatch(passCtx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
@@ -1114,22 +1118,22 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 			// a hard error.
 			if passCtx.Err() != nil {
 				if ctx.Err() != nil {
-					return nil, ctx.Err()
+					return 0, ctx.Err()
 				}
-				return append(leftover, contended[i:]...), nil
+				return deferred + len(contended) - i, nil
 			}
 			if !dbconn.IsLockContentionError(err) {
-				return nil, err
+				return 0, err
 			}
 		}
 		if err != nil {
 			// Still contended after every attempt. Defer this one but keep
 			// going: the batches are disjoint, so one stubborn lock holder
 			// says nothing about whether the next batch can land.
-			leftover = append(leftover, batch)
+			deferred++
 		}
 	}
-	return leftover, nil
+	return deferred, nil
 }
 
 // contentionRetries is how many serial attempts a contended batch gets before

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -896,6 +896,13 @@ func (s *bufferedMap) Flush(ctx context.Context, underLock bool, locks []*dbconn
 		if err != nil {
 			return false, err
 		}
+		if len(remainder) > 0 {
+			// A remainder with no error means the drain gave up its dispatch
+			// budget. Reporting success here would publish a position covering
+			// entries that were only reattached, so it has to hold the position
+			// back — the same contract the map drain's truncation uses.
+			allChangesFlushed = false
+		}
 	}
 	return allChangesFlushed, nil
 }
@@ -1102,29 +1109,40 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 	var mu sync.Mutex
 	var contended []*mapFlushBatch
 	var skippedBatches bool
-	// Stop *scheduling* once the budget is spent; batches already in flight
-	// are waited out below. g.Go blocks once effectiveFlushConcurrency are
-	// running, so the loop paces itself and this check runs roughly once per
-	// completed batch — the finest granularity available without abandoning
-	// work that is already partly done. Overrun is therefore bounded by one
-	// batch's own latency.
+	// Stop starting new batches once the budget is spent; batches already in
+	// flight are waited out below. Unlike the cancellation above this is not an
+	// error — the unstarted batches stay in the snapshot, are reattached, and go
+	// again on the next flush — and the caller reports the drain as incomplete
+	// so no position advances past them.
+	//
+	// Checked in two places, because the loop's own check goes stale. g.Go
+	// blocks once effectiveFlushConcurrency batches are running, so a check that
+	// passes can be followed by an arbitrarily long wait for a slot: at
+	// concurrency 1 with hour-long batches, the loop tests the deadline at t≈0,
+	// blocks in g.Go for an hour, and then launches a batch the budget no longer
+	// covers. The re-check inside the worker is what actually enforces "no new
+	// batch *starts* after the deadline"; the loop check is just a cheap early
+	// exit. Overrun is therefore one in-flight batch's latency, which is the
+	// least that can be promised without abandoning work already under way.
 	deadline := time.Now().Add(drainDispatchBudget)
-	budgetSpent := false
+	var budgetSpent atomic.Bool
 	for _, batch := range batches {
 		if gctx.Err() != nil {
 			skippedBatches = true
 			break // a batch failed or ctx was canceled; don't queue the rest
 		}
-		if time.Now().After(deadline) {
-			// Unlike the cancellation above this is not an error: the
-			// unscheduled batches stay in the snapshot, are reattached, and go
-			// again on the next flush. The caller reports the drain as
-			// incomplete so the position does not advance past them.
-			budgetSpent = true
-			s.drainsTimedOut.Add(1)
+		if budgetSpent.Load() || time.Now().After(deadline) {
+			budgetSpent.Store(true)
 			break
 		}
 		g.Go(func() error {
+			if time.Now().After(deadline) {
+				// The slot opened after the budget expired. Leave this batch's
+				// entries in the snapshot for the next flush rather than
+				// starting work the budget does not cover.
+				budgetSpent.Store(true)
+				return nil
+			}
 			if err := s.flushBatch(gctx, batch.deleteKeys, batch.upsertRows, nil); err != nil {
 				// The ctx.Err() half deliberately reads the *parent*, not gctx:
 				// a sibling's failure cancels gctx, and that must not stop this
@@ -1156,7 +1174,10 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 		// only reattached, not applied.
 		err = ctx.Err()
 	}
-	return contended, !budgetSpent, err
+	if budgetSpent.Load() {
+		s.drainsTimedOut.Add(1)
+	}
+	return contended, !budgetSpent.Load(), err
 }
 
 // retryContendedBatches re-applies contended batches one at a time.
@@ -1346,6 +1367,19 @@ func (s *bufferedMap) drainQueueSnapshot(ctx context.Context, snapshot []queuedC
 		return nil
 	}
 
+	// Same dispatch backstop the map drain applies, for the same reason: this
+	// runs with flushMu held, so an unbounded queue drain blocks every
+	// subsequent flush and the post-copy phase behind it. Queue mode is where
+	// non-memory-comparable PKs spend the post-copy phase, so leaving it
+	// unbounded would exempt exactly those tables.
+	//
+	// A segment boundary is the only place it is safe to stop. The queue is
+	// ordered and drained FIFO, so an applied prefix is a valid amount of work
+	// and reattachLocked prepends the remainder ahead of anything that arrived
+	// during the drain, preserving binlog order. Stopping mid-segment would
+	// split a batch that has already been partly built.
+	deadline := time.Now().Add(drainDispatchBudget)
+
 	prevIsDelete := snapshot[0].logicalRow.IsDeleted
 	for i, change := range snapshot {
 		rowBytes := renderedBytesOfChange(change.logicalRow, change.originalKey)
@@ -1355,6 +1389,13 @@ func (s *bufferedMap) drainQueueSnapshot(ctx context.Context, snapshot []queuedC
 		if typeFlip || batchFull || overBudget {
 			if err := flushSegment(i); err != nil {
 				return snapshot[applied:], err
+			}
+			if time.Now().After(deadline) {
+				// Not an error: the remainder is handed back for the next
+				// flush, and Flush reports the drain as incomplete so no
+				// position advances past it.
+				s.drainsTimedOut.Add(1)
+				return snapshot[applied:], nil
 			}
 		}
 		if change.logicalRow.IsDeleted {

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -173,6 +173,12 @@ type bufferedMap struct {
 	// can briefly exceed the limit by up to one oversized row.
 	softLimitBytes int64
 
+	// softLimitChanges is the second soft cap, on pending change *count*
+	// (Length(), so in-flight drain entries included). Zero disables it.
+	// Same admit-then-park semantics as softLimitBytes. See
+	// overSoftLimitLocked for why both caps exist.
+	softLimitChanges int
+
 	watermarkOptimization bool
 	chunker               table.MappedChunker
 
@@ -215,6 +221,7 @@ type bufferedMap struct {
 	batchesContended atomic.Int64 // applier batches that failed on 1205/1213
 	batchesDeferred  atomic.Int64 // contended batches left for the next flush
 	serialRecoveries atomic.Int64 // drains rescued by the serial retry pass
+	drainsTimedOut   atomic.Int64 // drains cut short by drainDispatchBudget
 
 	// lastParkWarn is when the park/unpark log pair was last emitted at
 	// Warn/Info level. Since flushes release capacity per batch, a
@@ -281,6 +288,12 @@ type BufferedSubscriptionConfig struct {
 	// cap. See bufferedMap.softLimitBytes for the semantics.
 	SoftLimitBytes int64
 
+	// SoftLimitChanges is the per-subscription cap on pending change
+	// *count* before HasChanged parks, applied alongside SoftLimitBytes;
+	// whichever binds first parks the reader. Zero disables it. See
+	// bufferedMap.overSoftLimitLocked for why both exist.
+	SoftLimitChanges int
+
 	// FlushRequest, when non-nil, receives the parked subscription (a
 	// non-blocking send) each time HasChanged parks on the soft limit.
 	// Owners that flush on a periodic ticker should select on it and
@@ -343,6 +356,7 @@ func NewBufferedSubscription(cfg BufferedSubscriptionConfig) (Subscription, erro
 		applier:              cfg.Applier,
 		pkIsMemoryComparable: cfg.CurrentTable.PrimaryKeyIsMemoryComparable() == nil,
 		softLimitBytes:       cfg.SoftLimitBytes,
+		softLimitChanges:     cfg.SoftLimitChanges,
 		flushRequest:         cfg.FlushRequest,
 		flushConcurrency:     cfg.FlushConcurrency,
 	}
@@ -428,12 +442,32 @@ var _ Subscription = (*bufferedMap)(nil)
 func (s *bufferedMap) Length() int {
 	s.Lock()
 	defer s.Unlock()
+	return s.lengthLocked()
+}
 
-	// flushingCount covers entries an in-flight Flush has swapped out
-	// but not yet applied — they are still pending changes, and callers
-	// like AllChangesFlushed must not see the buffer as empty while a
-	// drain is mid-air.
+// lengthLocked is Length without the Mutex, for callers that already hold it.
+//
+// flushingCount covers entries an in-flight Flush has swapped out but not yet
+// applied — they are still pending changes, and callers like AllChangesFlushed
+// must not see the buffer as empty while a drain is mid-air.
+func (s *bufferedMap) lengthLocked() int {
 	return len(s.changes) + len(s.queue) + s.flushingCount
+}
+
+// overSoftLimitLocked reports whether the buffer has reached either soft cap.
+//
+// Two caps because bytes and count measure different costs. Bytes bound the
+// migrator's memory, which is what a few wide LONGTEXT rows threaten. Count
+// bounds how long the resulting drain takes, which is set by applier round
+// trips and is indifferent to row width — and a narrow-row table hits the
+// second wall long before the first. On a production table averaging ~600
+// bytes per buffered change, 256MiB of bytes is over 450k changes, and a drain
+// of that size ran for 21m37s holding flushMu throughout.
+func (s *bufferedMap) overSoftLimitLocked() bool {
+	if s.softLimitBytes > 0 && s.sizeBytes >= s.softLimitBytes {
+		return true
+	}
+	return s.softLimitChanges > 0 && s.lengthLocked() >= s.softLimitChanges
 }
 
 func (s *bufferedMap) Tables() []*table.TableInfo {
@@ -473,6 +507,42 @@ func (s *bufferedMap) ImmutableColumnOrdinal() int {
 // only throughput. Three drains at the default 30s interval is ~90s of proven
 // quiet before stepping back up.
 const cleanDrainsToRecover = 3
+
+// drainDispatchBudget is a backstop on how long one drain spends dispatching
+// batches. Batches not yet scheduled when it expires stay in the snapshot, are
+// reattached, and go again on the next flush.
+//
+// The primary control on drain length is not here: it is
+// DefaultSubscriptionSoftLimitChanges, which bounds how large the buffer — and
+// therefore the snapshot a drain works through — is allowed to get in the first
+// place. That is the right lever, because a drain that finishes is worth far
+// more than a drain that is merely short. Only a complete drain reports
+// allChangesFlushed=true, and only that advances the flushed position; a
+// truncated one protects the checkpoint but does not move it. Capping *time*
+// too aggressively would therefore reproduce the frozen checkpoint it is meant
+// to prevent, just with a livelier status line. So this budget is set well
+// above the time a full buffer is expected to take (~50k changes drained in
+// roughly two minutes on the production table this was tuned against) and is
+// expected never to fire in normal operation.
+//
+// It exists for the case the count cap cannot cover: per-row cost is not
+// bounded. Wide rows, many secondary indexes, or a struggling target can make
+// 50k changes take an hour, and flushMu is held for the whole drain, so
+// everything else in the flush path queues behind it —
+// SetWatermarkOptimization takes flushMu as its first act, and the runner calls
+// it the moment the copy finishes. In production a 21m37s drain over ~452k
+// changes left the post-copy phase blocked on that mutex for over half an hour
+// after the copy had already completed. It also starves the AIMD controller,
+// which is fed once per drain and needs cleanDrainsToRecover of them to give a
+// halving back: at one sample per 20 minutes, "~90s of proven quiet" becomes an
+// hour, so a width reduced by a single transient 1213 stays reduced for the
+// rest of the migration.
+//
+// The budget does not apply to flushMapLocked, the serial path used under the
+// cutover lock and by SetWatermarkOptimization. Those must drain completely.
+//
+// A var so tests can shorten it.
+var drainDispatchBudget = 10 * DefaultFlushInterval
 
 // minAdaptiveBatchSize floors the batch shrink. Below roughly this many rows
 // the per-statement round trip dominates and the drain stops keeping up with a
@@ -649,7 +719,7 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 	// — the exit duration is the operator's main signal for binlog-
 	// retention risk, and without these lines a stalled migrator looks
 	// indistinguishable from one that's just slow.
-	if s.softLimitBytes > 0 && !dedupOverwrite && s.sizeBytes >= s.softLimitBytes && !s.closed {
+	if !dedupOverwrite && !s.closed && s.overSoftLimitLocked() {
 		s.timesParked.Add(1)
 		s.requestFlush()
 		parkEntryLog, parkExitLog := s.logger.Debug, s.logger.Debug
@@ -657,19 +727,22 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 			s.lastParkWarn = time.Now()
 			parkEntryLog, parkExitLog = s.logger.Warn, s.logger.Info
 		}
-		parkEntryLog("subscription parked on soft memory limit",
+		parkEntryLog("subscription parked on soft limit",
 			"table", s.table.SchemaName+"."+s.table.TableName,
 			"size_bytes", s.sizeBytes,
 			"soft_limit_bytes", s.softLimitBytes,
+			"changes", s.lengthLocked(),
+			"soft_limit_changes", s.softLimitChanges,
 		)
 		parkStart := time.Now()
-		for s.sizeBytes >= s.softLimitBytes && !s.closed {
+		for !s.closed && s.overSoftLimitLocked() {
 			s.cond.Wait()
 		}
-		parkExitLog("subscription unparked from soft memory limit",
+		parkExitLog("subscription unparked from soft limit",
 			"table", s.table.SchemaName+"."+s.table.TableName,
 			"parked_duration", time.Since(parkStart).String(),
 			"size_bytes", s.sizeBytes,
+			"changes", s.lengthLocked(),
 			"closed", s.closed,
 		)
 	}
@@ -931,7 +1004,18 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 	// Batches that lose to lock contention are collected rather than failing
 	// the drain — see retryContendedBatches for why that is safe and why the
 	// retry has to be serial.
-	contended, err := s.applyBatchesConcurrent(ctx, snapshot, batches)
+	contended, complete, err := s.applyBatchesConcurrent(ctx, snapshot, batches)
+	if !complete {
+		// The dispatch budget expired. Everything unscheduled is still in the
+		// snapshot and will be reattached; report the drain as incomplete so no
+		// client publishes a position that covers it.
+		allChangesFlushed = false
+		s.logger.Warn("flush drain exceeded its dispatch budget; deferring the remainder",
+			"table", s.table.SchemaName+"."+s.table.TableName,
+			"budget", drainDispatchBudget.String(),
+			"total_batches", len(batches),
+		)
+	}
 	if err != nil {
 		// Deliberately no adaptFlushConcurrency call here. A drain that failed
 		// on something other than contention is not evidence of contention, and
@@ -1008,7 +1092,7 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 // (the previous behaviour) threw away batches that were about to land and made
 // the whole drain fail, which is what pinned the buffer at its soft limit and
 // froze the flushed position.
-func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[string]bufferedChange, batches []*mapFlushBatch) ([]*mapFlushBatch, error) {
+func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[string]bufferedChange, batches []*mapFlushBatch) ([]*mapFlushBatch, bool, error) {
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(s.effectiveFlushConcurrency())
 	// Workers delete their batch's entries as they land, so they only
@@ -1018,10 +1102,27 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 	var mu sync.Mutex
 	var contended []*mapFlushBatch
 	var skippedBatches bool
+	// Stop *scheduling* once the budget is spent; batches already in flight
+	// are waited out below. g.Go blocks once effectiveFlushConcurrency are
+	// running, so the loop paces itself and this check runs roughly once per
+	// completed batch — the finest granularity available without abandoning
+	// work that is already partly done. Overrun is therefore bounded by one
+	// batch's own latency.
+	deadline := time.Now().Add(drainDispatchBudget)
+	budgetSpent := false
 	for _, batch := range batches {
 		if gctx.Err() != nil {
 			skippedBatches = true
 			break // a batch failed or ctx was canceled; don't queue the rest
+		}
+		if time.Now().After(deadline) {
+			// Unlike the cancellation above this is not an error: the
+			// unscheduled batches stay in the snapshot, are reattached, and go
+			// again on the next flush. The caller reports the drain as
+			// incomplete so the position does not advance past them.
+			budgetSpent = true
+			s.drainsTimedOut.Add(1)
+			break
 		}
 		g.Go(func() error {
 			if err := s.flushBatch(gctx, batch.deleteKeys, batch.upsertRows, nil); err != nil {
@@ -1055,7 +1156,7 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 		// only reattached, not applied.
 		err = ctx.Err()
 	}
-	return contended, err
+	return contended, !budgetSpent, err
 }
 
 // retryContendedBatches re-applies contended batches one at a time.
@@ -1590,6 +1691,7 @@ func (s *bufferedMap) SetWatermarkOptimization(ctx context.Context, enabled bool
 		"batches_lock_contended", s.batchesContended.Swap(0),
 		"batches_contention_deferred", s.batchesDeferred.Swap(0),
 		"drains_rescued_serially", s.serialRecoveries.Swap(0),
+		"drains_truncated_by_time_budget", s.drainsTimedOut.Swap(0),
 		"flush_concurrency", s.effectiveFlushConcurrency(),
 		"delta_len", len(s.changes)+len(s.queue),
 		"size_bytes", s.sizeBytes,

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -1060,6 +1060,13 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			// A hard error or a real cancellation, not contention: same
 			// reasoning as the pass-1 error path above, so the controller is
 			// left alone.
+			//
+			// The count still lands in the counter. Batches the pass had already
+			// given up on before the error arrived are reattached and retried
+			// like any other deferral, so leaving them out understated the
+			// counter for no benefit. It is only an accounting figure — the
+			// error is what decides the drain.
+			s.batchesDeferred.Add(int64(deferred))
 			return false, err
 		}
 		if deferred > 0 {
@@ -1246,13 +1253,21 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 
 	var mu sync.Mutex
 	deferred := 0
+	// giveUpAt reports the total deferral count when the budget expires while
+	// batch i is the one in hand: the batches already counted, plus batch i and
+	// every batch after it, none of which has landed. Named and shared rather
+	// than written out at each check — the two checks below are the same
+	// decision made at different moments, and an accumulator dropped from one of
+	// them would understate how much of the drain is stuck without breaking
+	// anything a test would notice.
+	giveUpAt := func(i int) int { return deferred + len(contended) - i }
 	for i, batch := range contended {
 		var err error
 		for attempt := range contentionRetries {
 			if time.Now().After(deadline) {
 				// Our own impatience, not a failure: the batches not reached
 				// yet — this one included — go back in the buffer.
-				return deferred + len(contended) - i, nil
+				return giveUpAt(i), nil
 			}
 			select {
 			case <-ctx.Done():
@@ -1260,6 +1275,16 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 				// treat the drain as having merely deferred work.
 				return 0, ctx.Err()
 			case <-time.After(contentionBackoff(attempt)):
+			}
+			// Re-checked after the wait, and this is the check that enforces the
+			// contract. The backoff escalates to a couple of seconds, so the
+			// check above can pass with a millisecond left and the attempt would
+			// then start well past the deadline. The pre-wait check is only a
+			// cheap early exit that avoids sleeping for a budget already gone.
+			// Same division of labour as drainDispatchBudget's loop check versus
+			// its worker check.
+			if time.Now().After(deadline) {
+				return giveUpAt(i), nil
 			}
 			if err = s.flushBatch(ctx, batch.deleteKeys, batch.upsertRows, nil); err == nil {
 				s.releaseAppliedBatch(snapshot, &mu, batch)
@@ -1269,7 +1294,12 @@ func (s *bufferedMap) retryContendedBatches(ctx context.Context, snapshot map[st
 				return 0, ctx.Err()
 			}
 			if !dbconn.IsLockContentionError(err) {
-				return 0, err
+				// A hard error fails the drain, but the batches this pass had
+				// already given up on are still deferred — they are back in the
+				// buffer either way. Reporting them keeps the deferral counter
+				// honest; the caller decides what to do with a count that
+				// arrives alongside an error.
+				return deferred, err
 			}
 		}
 		if err != nil {

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -963,10 +963,11 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			// Contention that outlived the serial pass is deferred, not failed.
 			//
 			// Reporting it as an error would throw away the whole drain, and a
-			// drain is not a cheap thing to throw away: when the copier has the
-			// applier queue saturated, one pass over a full buffer runs for
-			// minutes, so a single batch contending at the end would discard
-			// hundreds of batches' worth of *recorded* progress. The rows they
+			// drain is not a cheap thing to throw away: with the copier taking
+			// the target's write capacity, one pass over a full buffer has been
+			// observed to run for minutes, so a single batch contending at the
+			// end would discard hundreds of batches' worth of *recorded*
+			// progress. The rows they
 			// wrote stay written either way, but on the error path flushedGTID
 			// never advances and the flush is never recorded, which is the
 			// frozen-checkpoint symptom this whole path exists to prevent —
@@ -1148,12 +1149,11 @@ const contentionRetries = 4
 // almost immediately) while keeping flushMu out of the multi-minute territory
 // that N batches against an external lock holder would otherwise reach.
 //
-// It is deliberately not scaled up for a saturated applier queue, where an
-// attempt spends seconds waiting for a worker before it even reaches MySQL and
-// this budget buys only a handful of attempts. Expiring is cheap now — the
-// leftovers are deferred, not failed — so the right response to a queue we are
-// starving behind is to hand the batches back and let the next flush try, not
-// to hold flushMu longer while the copier keeps winning the queue.
+// It is deliberately not scaled up for the case where the copier is taking the
+// target's write capacity and each attempt is slow enough that this budget buys
+// only a handful of them. Expiring is cheap now — the leftovers are deferred,
+// not failed — so the right response to losing ground is to hand the batches
+// back and let the next flush try, not to hold flushMu longer.
 //
 // A var so tests can shorten it, as with contentionBackoff.
 var contentionRetryBudget = 20 * time.Second

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -217,18 +217,22 @@ type bufferedMap struct {
 	keysAdded        atomic.Int64
 	keysDroppedAbove atomic.Int64
 	keysSkippedBelow atomic.Int64
-	timesParked      atomic.Int64 // HasChanged was parked at least once on the soft limit
+	// timesParked counts every park on a soft limit, cumulatively for the
+	// life of the subscription. Unlike its neighbours it is not reset by the
+	// watermark-toggle bookend log, because the status block reports it
+	// periodically and a counter that silently restarts mid-migration reads
+	// as the parking having stopped.
+	timesParked      atomic.Int64
 	batchesContended atomic.Int64 // applier batches that failed on 1205/1213
 	batchesDeferred  atomic.Int64 // contended batches left for the next flush
 	serialRecoveries atomic.Int64 // drains rescued by the serial retry pass
 	drainsTimedOut   atomic.Int64 // drains cut short by drainDispatchBudget
 
-	// lastParkWarn is when the park/unpark log pair was last emitted at
-	// Warn/Info level. Since flushes release capacity per batch, a
-	// saturated applier produces frequent short parks rather than one
-	// long one; without throttling, the pair would log every couple of
-	// seconds for the lifetime of a long drain. Guarded by Mutex.
-	lastParkWarn time.Time
+	// parked is true while a HasChanged caller is sitting on the soft
+	// limit. Guarded by Mutex, which the parked goroutine releases inside
+	// cond.Wait(), so a status reader can observe it while the park is in
+	// progress — that is the whole point of reporting it.
+	parked bool
 
 	pkIsMemoryComparable bool
 }
@@ -240,13 +244,6 @@ type bufferedMap struct {
 // against — these constants are noise next to the BLOB / large-string
 // payload sizes. Both are approximate; the cap is "soft" anyway.
 const (
-	// parkWarnInterval throttles the park/unpark log pair. Parks under
-	// sustained backpressure are frequent and short (capacity returns
-	// per applied batch), so the pair is emitted at Warn/Info level at
-	// most once per interval per subscription and at Debug otherwise.
-	// The timesParked counter still counts every park.
-	parkWarnInterval = 30 * time.Second
-
 	// bufferedChangeOverhead is the fixed per-entry cost for an item
 	// in s.changes beyond what estimateRowSize captures: the hashed-
 	// key string header (~16 B), the bufferedChange struct laid out
@@ -443,6 +440,19 @@ func (s *bufferedMap) Length() int {
 	s.Lock()
 	defer s.Unlock()
 	return s.lengthLocked()
+}
+
+// ParkStats satisfies ParkReporter, so the runner's status block can report
+// backpressure instead of the subscription logging every park itself.
+//
+// Taking the Mutex is what makes `parked` readable: the parked goroutine is
+// inside cond.Wait(), which releases the Mutex for the duration of the park.
+// A drain holds the Mutex only for short bookkeeping sections, so this does
+// not queue behind one.
+func (s *bufferedMap) ParkStats() (int64, bool) {
+	s.Lock()
+	defer s.Unlock()
+	return s.timesParked.Load(), s.parked
 }
 
 // lengthLocked is Length without the Mutex, for callers that already hold it.
@@ -713,21 +723,21 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 		_, dedupOverwrite = s.changes[hashedKey]
 	}
 
-	// Soft backpressure: park while the buffer is at or above the byte
-	// threshold. See softLimitBytes on bufferedMap for the semantics.
-	// We log on entry and exit because parking stalls the binlog reader
-	// — the exit duration is the operator's main signal for binlog-
-	// retention risk, and without these lines a stalled migrator looks
-	// indistinguishable from one that's just slow.
+	// Soft backpressure: park while the buffer is at or above either soft
+	// limit. See overSoftLimitLocked for the semantics.
+	//
+	// Both log lines are Debug. Parking stalls the binlog reader, so it does
+	// need to be visible — but flushes release capacity per applied batch, so
+	// sustained backpressure produces a park/unpark pair every few seconds for
+	// the lifetime of a long drain, and at Warn/Info that buried the periodic
+	// status block it was meant to complement. The status block now carries
+	// `parks=` and `is-parked=` on its binlog row instead, which answers the
+	// same question — is the reader being held back, and how often — at the
+	// cadence an operator actually reads.
 	if !dedupOverwrite && !s.closed && s.overSoftLimitLocked() {
 		s.timesParked.Add(1)
 		s.requestFlush()
-		parkEntryLog, parkExitLog := s.logger.Debug, s.logger.Debug
-		if time.Since(s.lastParkWarn) >= parkWarnInterval {
-			s.lastParkWarn = time.Now()
-			parkEntryLog, parkExitLog = s.logger.Warn, s.logger.Info
-		}
-		parkEntryLog("subscription parked on soft limit",
+		s.logger.Debug("subscription parked on soft limit",
 			"table", s.table.SchemaName+"."+s.table.TableName,
 			"size_bytes", s.sizeBytes,
 			"soft_limit_bytes", s.softLimitBytes,
@@ -735,10 +745,12 @@ func (s *bufferedMap) HasChanged(key, row []any, deleted bool) {
 			"soft_limit_changes", s.softLimitChanges,
 		)
 		parkStart := time.Now()
+		s.parked = true
 		for !s.closed && s.overSoftLimitLocked() {
 			s.cond.Wait()
 		}
-		parkExitLog("subscription unparked from soft limit",
+		s.parked = false
+		s.logger.Debug("subscription unparked from soft limit",
 			"table", s.table.SchemaName+"."+s.table.TableName,
 			"parked_duration", time.Since(parkStart).String(),
 			"size_bytes", s.sizeBytes,
@@ -1749,7 +1761,7 @@ func (s *bufferedMap) SetWatermarkOptimization(ctx context.Context, enabled bool
 		"keys_added", s.keysAdded.Swap(0),
 		"keys_dropped_above_high", s.keysDroppedAbove.Swap(0),
 		"keys_skipped_not_below_low", s.keysSkippedBelow.Swap(0),
-		"times_parked_on_soft_limit", s.timesParked.Swap(0),
+		"times_parked_on_soft_limit_total", s.timesParked.Load(),
 		"batches_lock_contended", s.batchesContended.Swap(0),
 		"batches_contention_deferred", s.batchesDeferred.Swap(0),
 		"drains_rescued_serially", s.serialRecoveries.Swap(0),

--- a/pkg/change/subscription_buffered_contention_test.go
+++ b/pkg/change/subscription_buffered_contention_test.go
@@ -112,6 +112,21 @@ func shortenContentionBudget(t *testing.T, d time.Duration) {
 	t.Cleanup(func() { contentionRetryBudget = prev })
 }
 
+// fixContentionBackoff pins the backoff to production's shape — first attempt
+// immediate, every later one a fixed delay — so a test can arrange for the
+// budget to expire *inside* the sleep rather than before it.
+func fixContentionBackoff(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := contentionBackoff
+	contentionBackoff = func(attempt int) time.Duration {
+		if attempt <= 0 {
+			return 0
+		}
+		return d
+	}
+	t.Cleanup(func() { contentionBackoff = prev })
+}
+
 // TestFlushRecoversFromSelfInflictedDeadlock is the regression test for the
 // livelock behind block/spirit#1168: every concurrent drain deadlocked against
 // itself, the whole flush returned an error, and because the clients only
@@ -317,6 +332,13 @@ func TestSerialRetryExhaustionDefersWithoutFailing(t *testing.T) {
 	require.False(t, allFlushed,
 		"changes that never landed must hold the flushed position back")
 	require.Equal(t, int64(3), sub.batchesDeferred.Load(), "every batch must be deferred")
+	// A deferred drain is evidence of contention and must narrow the width. The
+	// deferral branch returns before the tail adaptFlushConcurrency call, so it
+	// makes its own — and without it, sustained contention is a steady state
+	// that defers at unchanged width forever, re-contending every drain and
+	// reaching the frozen checkpoint by a third route.
+	require.Less(t, sub.effectiveFlushConcurrency(), 4,
+		"a deferred drain must narrow the flush width")
 
 	// Nothing was lost and nothing was double-counted: every row is back in the
 	// active buffer with balanced accounting and no in-flight residue.
@@ -664,4 +686,174 @@ func TestHardErrorDuringSerialRetryStillFailsDrain(t *testing.T) {
 	require.False(t, allFlushed)
 	require.Zero(t, sub.batchesDeferred.Load(), "a hard error is not a deferral")
 	require.Equal(t, totalRows, sub.Length(), "the rows must stay buffered")
+}
+
+// TestRetryBudgetIsNotDefeatedByTheBackoffSleep pins the other half of "the
+// budget gates attempt starts".
+//
+// Checking the deadline before the inter-attempt backoff is not enough: the
+// backoff escalates to a couple of seconds, so a check can pass with a
+// millisecond left, sleep through the expiry, and then start a full flushBatch
+// anyway — holding flushMu for an attempt the budget had already declined. The
+// check that matters is the one after the wait.
+func TestRetryBudgetIsNotDefeatedByTheBackoffSleep(t *testing.T) {
+	// The budget expires during the second attempt's backoff: the first attempt
+	// is immediate, so it starts and fails well inside the budget, and the
+	// sleep that follows outlasts it ten times over.
+	shortenContentionBudget(t, 50*time.Millisecond)
+	fixContentionBackoff(t, 500*time.Millisecond)
+
+	// Contends on every call, so nothing can land and the only thing bounding
+	// the pass is the budget.
+	fake := &budgetBurningApplier{contendingCalls: 1 << 30}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	const totalRows = DefaultBatchSize // one batch by construction
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "an expired budget defers, it does not fail")
+	require.False(t, allFlushed)
+	require.Equal(t, totalRows, sub.Length(), "the batch stays buffered")
+
+	// One call in pass 1 and one in pass 2. A third means an attempt started
+	// after the deadline had already passed, which is the defect.
+	require.Equal(t, int64(2), fake.calls.Load(),
+		"no attempt may start once the budget has expired mid-backoff")
+	require.False(t, fake.sawCanceledCtx.Load(),
+		"the budget must still never reach the applier as a cancellation")
+}
+
+// stallOnCallApplier contends on every call and, on one specific call, sleeps
+// long enough to outlast the retry budget. That lets a test place the expiry
+// *after* a batch has already exhausted its retries, which is the ordering in
+// which the deferral count can silently lose the batches it had already
+// counted.
+type stallOnCallApplier struct {
+	countingApplier
+	stallOnCall int64
+	stall       time.Duration
+
+	calls          atomic.Int64
+	sawCanceledCtx atomic.Bool
+}
+
+func (a *stallOnCallApplier) UpsertRows(ctx context.Context, _ *table.ColumnMapping, _ []applier.LogicalRow, _ []*dbconn.TableLock) (int64, error) {
+	if ctx.Err() != nil {
+		a.sawCanceledCtx.Store(true)
+	}
+	if a.calls.Add(1) == a.stallOnCall {
+		time.Sleep(a.stall)
+	}
+	return 0, deadlockErr()
+}
+
+// TestStubbornBatchDoesNotStrandItsSiblings pins the behaviour the serial pass
+// was rewritten to introduce.
+//
+// The pass used to give up at the first batch that exhausted its retries,
+// deferring everything behind it unexamined. The batches are disjoint by key,
+// so one stubborn lock holder says nothing about whether the next batch can
+// land — and abandoning the rest turns one unlucky batch into a drain that
+// applied a fraction of what it could have, on a path where a drain costs
+// minutes.
+func TestStubbornBatchDoesNotStrandItsSiblings(t *testing.T) {
+	shortenContentionBackoff(t)
+
+	// Serial pass 1 so the call order is fixed: two batches contend (calls 1-2),
+	// the first exhausts all four serial attempts (calls 3-6), and the second
+	// lands on its first attempt (call 7).
+	errs := []error{deadlockErr(), deadlockErr(), deadlockErr(), deadlockErr(), deadlockErr(), deadlockErr()}
+	fake := &sequencedApplier{errs: errs}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	const batches = 2
+	for i := range batches * DefaultBatchSize {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "one stubborn batch is a deferral, not a failure")
+	require.False(t, allFlushed)
+	require.Equal(t, int64(1), sub.batchesDeferred.Load(),
+		"only the stubborn batch is deferred; the sibling behind it must be tried")
+	require.Equal(t, DefaultBatchSize, sub.Length(),
+		"the sibling's rows must have landed, not been stranded")
+}
+
+// TestBudgetExpiryCountsAlreadyDeferredBatches pins the deferral arithmetic at
+// the budget checks.
+//
+// Both checks report "the batches already counted, plus this one and everything
+// after it". Dropping the accumulator is invisible to safety — the count is
+// still non-zero, so the drain still reports itself incomplete — but the number
+// is the only view an operator gets of this path, and "1 deferred" when six are
+// stuck sends someone looking in the wrong place.
+func TestBudgetExpiryCountsAlreadyDeferredBatches(t *testing.T) {
+	shortenContentionBackoff(t)
+	shortenContentionBudget(t, 100*time.Millisecond)
+
+	const batches = 3
+	// Calls 1-3 are pass 1. Calls 4-7 are the first batch's four serial
+	// attempts, all contending, so it is counted as deferred — and call 7 then
+	// outlasts the budget, so the pass gives up before reaching batch 2.
+	fake := &stallOnCallApplier{stallOnCall: 7, stall: 300 * time.Millisecond}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	for i := range batches * DefaultBatchSize {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "an expired budget defers, it does not fail")
+	require.False(t, allFlushed)
+	require.Equal(t, int64(7), fake.calls.Load(),
+		"no attempt may start after the budget expired")
+	require.False(t, fake.sawCanceledCtx.Load())
+	// One batch exhausted its retries, two were never reached. All three are
+	// buffered, so all three must be counted.
+	require.Equal(t, int64(batches), sub.batchesDeferred.Load(),
+		"the batch already deferred must be counted alongside the unreached ones")
+	require.Equal(t, batches*DefaultBatchSize, sub.Length())
+}
+
+// TestHardErrorAfterADeferralStillCountsIt is the accounting half of
+// TestHardErrorDuringSerialRetryStillFailsDrain: the error decides the drain,
+// but batches the pass had already given up on are reattached and retried like
+// any other deferral, so leaving them out of the counter reports less stuck
+// work than there is.
+func TestHardErrorAfterADeferralStillCountsIt(t *testing.T) {
+	shortenContentionBackoff(t)
+
+	// Calls 1-2 pass 1, calls 3-6 the first batch's exhausted retries, call 7
+	// the second batch hitting something non-retryable.
+	errs := []error{
+		deadlockErr(), deadlockErr(),
+		deadlockErr(), deadlockErr(), deadlockErr(), deadlockErr(),
+		errInjected,
+	}
+	fake := &sequencedApplier{errs: errs}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	const batches = 2
+	for i := range batches * DefaultBatchSize {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.ErrorIs(t, err, errInjected, "a hard error still fails the drain")
+	require.False(t, allFlushed)
+	require.Equal(t, int64(1), sub.batchesDeferred.Load(),
+		"the batch that exhausted its retries before the error is still deferred")
+	require.Equal(t, batches*DefaultBatchSize, sub.Length(), "nothing landed")
 }

--- a/pkg/change/subscription_buffered_contention_test.go
+++ b/pkg/change/subscription_buffered_contention_test.go
@@ -105,6 +105,13 @@ func shortenContentionBackoff(t *testing.T) {
 	t.Cleanup(func() { contentionBackoff = prev })
 }
 
+func shortenContentionBudget(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := contentionRetryBudget
+	contentionRetryBudget = d
+	t.Cleanup(func() { contentionRetryBudget = prev })
+}
+
 // TestFlushRecoversFromSelfInflictedDeadlock is the regression test for the
 // livelock behind block/spirit#1168: every concurrent drain deadlocked against
 // itself, the whole flush returned an error, and because the clients only
@@ -280,17 +287,21 @@ func (a *alwaysContendingApplier) UpsertRows(context.Context, *table.ColumnMappi
 	return 0, deadlockErr()
 }
 
-// TestSerialRetryExhaustionFailsDrain covers the safety property the whole PR
-// turns on, which had no test: when the serial pass cannot land a batch, the
-// drain must report failure so the caller never publishes a flushed position
+// TestSerialRetryExhaustionDefersWithoutFailing covers the safety property the
+// contention path turns on: the caller must never publish a flushed position
 // over changes that are still buffered.
 //
-// Replacing retryContendedBatches' exhausted-retries error with `continue`
-// previously survived the entire package. It makes drainMapSnapshot return
-// allChangesFlushed=true with rows still in the buffer, and the clients'
-// `if allChangesFlushed { flushedPos = ... }` is the only guard — so the
-// checkpoint would advance past unapplied changes, silently and unrecoverably.
-func TestSerialRetryExhaustionFailsDrain(t *testing.T) {
+// allChangesFlushed=false is what enforces that, not the error. Clients gate
+// position advancement on it — it is the same mechanism watermark-deferred keys
+// use — so a deferred batch holds the position back exactly as a failed drain
+// would, while the batches that *did* land still count as progress. Erroring
+// instead discards the whole drain, which in production meant throwing away six
+// minutes of successful work because one batch contended at the end.
+//
+// The mutation this has to catch is `return true` for allChangesFlushed, not a
+// missing error: that is what would let the checkpoint advance past unapplied
+// changes, silently and unrecoverably.
+func TestSerialRetryExhaustionDefersWithoutFailing(t *testing.T) {
 	shortenContentionBackoff(t)
 	const totalRows = 3 * DefaultBatchSize
 	sub := newByteCapBufferedMap(&countingApplier{}, false)
@@ -302,9 +313,10 @@ func TestSerialRetryExhaustionFailsDrain(t *testing.T) {
 	}
 
 	allFlushed, err := sub.Flush(t.Context(), false, nil)
-	require.Error(t, err, "permanent contention must fail the drain")
-	require.ErrorContains(t, err, "still contended")
-	require.False(t, allFlushed, "a failed drain must never report all-flushed")
+	require.NoError(t, err, "unresolved contention is deferred, not an error")
+	require.False(t, allFlushed,
+		"changes that never landed must hold the flushed position back")
+	require.Equal(t, int64(3), sub.batchesDeferred.Load(), "every batch must be deferred")
 
 	// Nothing was lost and nothing was double-counted: every row is back in the
 	// active buffer with balanced accounting and no in-flight residue.
@@ -315,6 +327,74 @@ func TestSerialRetryExhaustionFailsDrain(t *testing.T) {
 	require.Equal(t, expectedBytes, sub.sizeBytes, "byte accounting must balance")
 	require.Zero(t, sub.flushingCount, "no entries may be left marked in-flight")
 	sub.Unlock()
+
+	// The deferral is not a one-way door: once the contention clears, the very
+	// next flush lands the same rows and reports the position as advanceable.
+	sub.applier = &countingApplier{}
+	allFlushed, err = sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed, "the retry must be able to complete the drain")
+	require.Zero(t, sub.Length(), "the deferred rows must land on the next flush")
+}
+
+// TestPartialContentionKeepsLandedBatches is the reason deferral beats
+// erroring. One batch contends permanently while the rest apply cleanly; the
+// clean ones must stay applied and only the contended one comes back.
+//
+// On the error path all of them returned to the buffer as far as the *caller*
+// was concerned — the writes had happened, but the drain reported failure, so
+// flushedGTID never advanced and the flush was never recorded. With a
+// production drain running minutes per pass, that made a late-arriving 1213
+// cost the entire pass.
+func TestPartialContentionKeepsLandedBatches(t *testing.T) {
+	shortenContentionBackoff(t)
+	const batches = 4
+	const totalRows = batches * DefaultBatchSize
+
+	// Fail the first upsert forever, so exactly one batch is unlandable while
+	// its three siblings succeed on their first attempt.
+	fake := &oneStubbornBatchApplier{}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1 // serial pass 1, so "the first call" is deterministic
+
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "a single stubborn batch must not fail the drain")
+	require.False(t, allFlushed, "the unlanded batch must hold the position back")
+	require.Equal(t, int64(1), sub.batchesDeferred.Load(), "only one batch should defer")
+
+	require.Equal(t, DefaultBatchSize, sub.Length(),
+		"only the contended batch may return to the buffer")
+	expectedBytes := recomputeSizeBytes(sub)
+	sub.Lock()
+	require.Equal(t, expectedBytes, sub.sizeBytes, "byte accounting must balance")
+	require.Zero(t, sub.flushingCount, "no entries may be left marked in-flight")
+	sub.Unlock()
+}
+
+// oneStubbornBatchApplier fails every attempt at the batch it saw first, and
+// applies everything else normally.
+type oneStubbornBatchApplier struct {
+	countingApplier
+	mu       sync.Mutex
+	stubborn []applier.LogicalRow
+}
+
+func (a *oneStubbornBatchApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, locks []*dbconn.TableLock) (int64, error) {
+	a.mu.Lock()
+	if a.stubborn == nil {
+		a.stubborn = rows
+	}
+	doomed := len(rows) > 0 && len(a.stubborn) > 0 && &a.stubborn[0] == &rows[0]
+	a.mu.Unlock()
+	if doomed {
+		return 0, deadlockErr()
+	}
+	return a.countingApplier.UpsertRows(ctx, mapping, rows, locks)
 }
 
 // TestMixedContentionAndHardErrorDoesNotNarrow pins finding (a) on the AIMD
@@ -448,4 +528,76 @@ func TestContentionAtShutdownIsNotRetried(t *testing.T) {
 	require.Zero(t, sub.batchesContended.Load(),
 		"contention concurrent with cancellation must not be handed to the serial pass")
 	require.Equal(t, totalRows, sub.Length(), "the rows must stay buffered for the next flush")
+}
+
+// budgetBlockingApplier fails its first upsert with a deadlock — enough to send
+// the batch to pass 2 — and then blocks every later call until its context is
+// cancelled. That models an attempt still waiting (on MySQL, or on an applier
+// worker) at the moment pass 2's budget expires.
+type budgetBlockingApplier struct {
+	countingApplier
+	calls atomic.Int64
+}
+
+func (a *budgetBlockingApplier) UpsertRows(ctx context.Context, _ *table.ColumnMapping, _ []applier.LogicalRow, _ []*dbconn.TableLock) (int64, error) {
+	if a.calls.Add(1) == 1 {
+		return 0, deadlockErr()
+	}
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+// TestRetryBudgetExpiryMidStatementDefers pins the production defect this
+// change was written for.
+//
+// The budget can expire *during* an attempt, not only between them. flushBatch
+// then reports the cancellation rather than 1205/1213, so classifying on the
+// error alone sent it down the hard-error path and the drain failed with a bare
+// "failed to execute upsert: context deadline exceeded" — which reads like a
+// statement timeout and is nothing of the sort. It has to be recognised as our
+// own impatience and deferred like any other unresolved contention.
+func TestRetryBudgetExpiryMidStatementDefers(t *testing.T) {
+	shortenContentionBackoff(t)
+	shortenContentionBudget(t, 50*time.Millisecond)
+
+	fake := &budgetBlockingApplier{}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	const totalRows = DefaultBatchSize
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "the budget's own deadline must not surface as a drain failure")
+	require.False(t, allFlushed, "the unlanded batch must hold the position back")
+	require.Equal(t, int64(1), sub.batchesDeferred.Load(), "the batch must be deferred")
+	require.Equal(t, totalRows, sub.Length(), "the rows must stay buffered")
+}
+
+// TestHardErrorDuringSerialRetryStillFailsDrain is the other side of the
+// deferral: pass 2 absorbs contention and its own budget, and nothing else. A
+// non-retryable error discovered during the serial pass must still fail the
+// drain, exactly as it would in pass 1.
+func TestHardErrorDuringSerialRetryStillFailsDrain(t *testing.T) {
+	shortenContentionBackoff(t)
+	// First call contends (sending the batch to pass 2), the retry hits a
+	// non-retryable error.
+	fake := &sequencedApplier{errs: []error{deadlockErr(), errInjected}}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	const totalRows = DefaultBatchSize
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.ErrorIs(t, err, errInjected, "a hard error in pass 2 must surface")
+	require.False(t, allFlushed)
+	require.Zero(t, sub.batchesDeferred.Load(), "a hard error is not a deferral")
+	require.Equal(t, totalRows, sub.Length(), "the rows must stay buffered")
 }

--- a/pkg/change/subscription_buffered_contention_test.go
+++ b/pkg/change/subscription_buffered_contention_test.go
@@ -530,37 +530,63 @@ func TestContentionAtShutdownIsNotRetried(t *testing.T) {
 	require.Equal(t, totalRows, sub.Length(), "the rows must stay buffered for the next flush")
 }
 
-// budgetBlockingApplier fails its first upsert with a deadlock — enough to send
-// the batch to pass 2 — and then blocks every later call until its context is
-// cancelled. That models an attempt still waiting (on MySQL, or on an applier
-// worker) at the moment pass 2's budget expires.
-type budgetBlockingApplier struct {
+// budgetBurningApplier contends on its first contendingCalls upserts — enough
+// to send every batch to pass 2 — and then makes the first serial attempt take
+// longer than the whole retry budget before succeeding. That is the shape of a
+// real slow batch: the budget expires while a statement is legitimately in
+// flight, not because anything is wrong.
+//
+// It also records whether it was ever handed an already-cancelled context,
+// which is the property the budget must never violate.
+type budgetBurningApplier struct {
 	countingApplier
-	calls atomic.Int64
+	contendingCalls int64
+	burn            time.Duration
+
+	calls          atomic.Int64
+	burned         atomic.Bool
+	sawCanceledCtx atomic.Bool
 }
 
-func (a *budgetBlockingApplier) UpsertRows(ctx context.Context, _ *table.ColumnMapping, _ []applier.LogicalRow, _ []*dbconn.TableLock) (int64, error) {
-	if a.calls.Add(1) == 1 {
+func (a *budgetBurningApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, locks []*dbconn.TableLock) (int64, error) {
+	if ctx.Err() != nil {
+		a.sawCanceledCtx.Store(true)
+	}
+	if a.calls.Add(1) <= a.contendingCalls {
 		return 0, deadlockErr()
 	}
-	<-ctx.Done()
-	return 0, ctx.Err()
+	if a.burn > 0 && a.burned.CompareAndSwap(false, true) {
+		time.Sleep(a.burn)
+	}
+	// The interesting check: after outlasting the budget, is our context still
+	// live? Under the old context-based budget it would not be.
+	if ctx.Err() != nil {
+		a.sawCanceledCtx.Store(true)
+		return 0, ctx.Err()
+	}
+	return a.countingApplier.UpsertRows(ctx, mapping, rows, locks)
 }
 
-// TestRetryBudgetExpiryMidStatementDefers pins the production defect this
-// change was written for.
+// TestRetryBudgetNeverCancelsAnAttempt pins the production defect this change
+// was written for.
 //
-// The budget can expire *during* an attempt, not only between them. flushBatch
-// then reports the cancellation rather than 1205/1213, so classifying on the
-// error alone sent it down the hard-error path and the drain failed with a bare
-// "failed to execute upsert: context deadline exceeded" — which reads like a
-// statement timeout and is nothing of the sort. It has to be recognised as our
-// own impatience and deferred like any other unresolved contention.
-func TestRetryBudgetExpiryMidStatementDefers(t *testing.T) {
+// The budget used to be a context.WithTimeout handed to flushBatch, so
+// expiring did not merely stop the pass — it killed the REPLACE that happened
+// to be running. On a table whose batches take longer than the budget that
+// fires on a perfectly healthy statement, and it surfaced as
+//
+//	failed to upsert rows: failed to execute upsert: context deadline exceeded
+//
+// which reads like a statement timeout and is nothing of the sort. It reached
+// the operator as a failed migration.
+//
+// The budget must now gate only the *start* of an attempt. An attempt already
+// under way runs on the parent context and is allowed to finish, so it lands.
+func TestRetryBudgetNeverCancelsAnAttempt(t *testing.T) {
 	shortenContentionBackoff(t)
-	shortenContentionBudget(t, 50*time.Millisecond)
+	shortenContentionBudget(t, 20*time.Millisecond)
 
-	fake := &budgetBlockingApplier{}
+	fake := &budgetBurningApplier{contendingCalls: 1, burn: 200 * time.Millisecond}
 	sub := newByteCapBufferedMap(&fake.countingApplier, false)
 	sub.applier = fake
 	sub.flushConcurrency = 1
@@ -571,10 +597,48 @@ func TestRetryBudgetExpiryMidStatementDefers(t *testing.T) {
 	}
 
 	allFlushed, err := sub.Flush(t.Context(), false, nil)
-	require.NoError(t, err, "the budget's own deadline must not surface as a drain failure")
-	require.False(t, allFlushed, "the unlanded batch must hold the position back")
-	require.Equal(t, int64(1), sub.batchesDeferred.Load(), "the batch must be deferred")
-	require.Equal(t, totalRows, sub.Length(), "the rows must stay buffered")
+	require.NoError(t, err, "the budget must never surface as an apply failure")
+	require.False(t, fake.sawCanceledCtx.Load(),
+		"an attempt outlasting the budget must still have a live context")
+	require.True(t, allFlushed, "the attempt was allowed to finish, so the batch landed")
+	require.Zero(t, sub.Length(), "and the rows are gone from the buffer")
+	require.Zero(t, sub.batchesDeferred.Load(), "nothing needed deferring")
+}
+
+// The budget still does its job: once spent, the batches pass 2 has not reached
+// yet are deferred to the next flush rather than holding flushMu indefinitely.
+// Deferring is not an error, and the batch that did land stays landed.
+func TestRetryBudgetExpiryDefersRemainingBatches(t *testing.T) {
+	shortenContentionBackoff(t)
+	shortenContentionBudget(t, 20*time.Millisecond)
+
+	const batches = 3
+	const totalRows = batches * DefaultBatchSize
+	fake := &budgetBurningApplier{contendingCalls: batches, burn: 200 * time.Millisecond}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "running out of budget is not a failure")
+	require.False(t, fake.sawCanceledCtx.Load())
+	require.False(t, allFlushed, "the deferred batches must hold the position back")
+	require.Equal(t, int64(batches-1), sub.batchesDeferred.Load(),
+		"the first batch outlasted the budget and landed; the rest were never started")
+	require.Equal(t, (batches-1)*DefaultBatchSize, sub.Length(),
+		"exactly the deferred batches stay buffered")
+
+	// Not a one-way door: with the budget restored the next flush finishes.
+	shortenContentionBudget(t, time.Minute)
+	fake.burn = 0
+	allFlushed, err = sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
 }
 
 // TestHardErrorDuringSerialRetryStillFailsDrain is the other side of the

--- a/pkg/change/subscription_buffered_drainbound_test.go
+++ b/pkg/change/subscription_buffered_drainbound_test.go
@@ -184,6 +184,87 @@ func TestDrainDispatchBudgetDefersTheRemainder(t *testing.T) {
 	require.Zero(t, sub.Length())
 }
 
+// TestDrainDispatchBudgetBoundsQueueModeToo covers the store the map drain's
+// backstop does not reach. Queue mode is where non-memory-comparable PKs spend
+// the post-copy phase, and it runs under the same flushMu, so leaving it
+// unbounded would exempt exactly those tables from the bound.
+func TestDrainDispatchBudgetBoundsQueueModeToo(t *testing.T) {
+	shortenDrainDispatchBudget(t, 30*time.Millisecond)
+	const segments = 4
+	const totalRows = segments * DefaultBatchSize
+	fake := &slowApplier{perCall: 40 * time.Millisecond}
+	sub := newByteCapBufferedMap(&fake.countingApplier, true) // queue mode
+	sub.applier = fake
+	require.True(t, sub.queueModeActive(), "this test must exercise the queue drain")
+
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "running out of budget is not an error")
+	require.False(t, allFlushed, "the queue remainder must hold the position back")
+	require.Positive(t, sub.drainsTimedOut.Load())
+
+	applied := 0
+	for _, call := range fake.upserts() {
+		applied += len(call)
+	}
+	require.Positive(t, applied, "the drain must make progress before giving up")
+	require.Less(t, applied, totalRows, "the budget must actually truncate the drain")
+	require.Equal(t, totalRows-applied, sub.Length(), "the remainder must be reattached in order")
+
+	expectedBytes := recomputeSizeBytes(sub)
+	sub.Lock()
+	require.Equal(t, expectedBytes, sub.sizeBytes)
+	sub.Unlock()
+
+	// The remainder is still ordered and still drains on the next flush.
+	shortenDrainDispatchBudget(t, time.Minute)
+	fake.perCall = 0
+	allFlushed, err = sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
+}
+
+// TestDrainDispatchBudgetIsNotDefeatedByASlotWait pins the gap between checking
+// the budget and actually starting work.
+//
+// The dispatch loop's check goes stale: g.Go blocks once the concurrency limit
+// is full, so a check that passes can be followed by an arbitrarily long wait
+// for a slot, and the batch then starts on a budget that has long since
+// expired. At concurrency 1 that is enough for a second batch to run in full
+// after the deadline.
+//
+// One batch is slower than the whole budget, so the second batch's slot opens
+// only after the deadline has passed. It must not run.
+func TestDrainDispatchBudgetIsNotDefeatedByASlotWait(t *testing.T) {
+	shortenDrainDispatchBudget(t, 30*time.Millisecond)
+	const batches = 3
+	const totalRows = batches * DefaultBatchSize
+	fake := &slowApplier{perCall: 300 * time.Millisecond}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1
+
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.False(t, allFlushed)
+
+	applied := 0
+	for _, call := range fake.upserts() {
+		applied += len(call)
+	}
+	require.Equal(t, DefaultBatchSize, applied,
+		"exactly the batch that started before the deadline may run")
+	require.Equal(t, totalRows-DefaultBatchSize, sub.Length())
+}
+
 // A drain that fits inside its budget must report success. Guards against a
 // too-eager truncation check turning every healthy flush into a deferral,
 // which would freeze the checkpoint in the name of unfreezing it.

--- a/pkg/change/subscription_buffered_drainbound_test.go
+++ b/pkg/change/subscription_buffered_drainbound_test.go
@@ -1,0 +1,221 @@
+package change
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/stretchr/testify/require"
+)
+
+// shortenDrainDispatchBudget makes the drain's dispatch backstop observable in
+// a unit test. In production it is deliberately far longer than any healthy
+// drain (see drainDispatchBudget) and is expected never to fire.
+func shortenDrainDispatchBudget(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := drainDispatchBudget
+	drainDispatchBudget = d
+	t.Cleanup(func() { drainDispatchBudget = prev })
+}
+
+// slowApplier makes every applier round trip take a fixed amount of wall clock,
+// which is what the dispatch budget is measured against.
+type slowApplier struct {
+	countingApplier
+	perCall time.Duration
+}
+
+func (s *slowApplier) UpsertRows(ctx context.Context, mapping *table.ColumnMapping, rows []applier.LogicalRow, locks []*dbconn.TableLock) (int64, error) {
+	time.Sleep(s.perCall)
+	return s.countingApplier.UpsertRows(ctx, mapping, rows, locks)
+}
+
+// TestSoftLimitOnChangeCountParksTheReader is the regression test for the
+// second half of the frozen-checkpoint problem. The byte cap alone let a
+// narrow-row table buffer over 450k changes inside 256MiB, and the drain that
+// followed ran for 21m37s holding flushMu the whole time. Count is what sets
+// drain length — the applier does one round trip per batch of rows, whatever
+// they weigh — so the buffer needs a cap in that unit too.
+func TestSoftLimitOnChangeCountParksTheReader(t *testing.T) {
+	const limit = 8
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.softLimitChanges = limit
+	// No byte cap at all, so this test can only pass on the count cap.
+	sub.softLimitBytes = 0
+
+	for i := range limit {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+	require.Equal(t, limit, sub.Length())
+
+	// The next distinct key must park: the cap is checked against the
+	// pre-add length, and the buffer is already at it.
+	parked := make(chan struct{})
+	go func() {
+		defer close(parked)
+		sub.HasChanged([]any{int64(limit)}, []any{int64(limit), "blocked"}, false)
+	}()
+	select {
+	case <-parked:
+		t.Fatal("HasChanged must park once the change-count cap is reached")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Draining releases capacity and the parked reader resumes.
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	select {
+	case <-parked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HasChanged must unpark once the drain frees capacity")
+	}
+	require.Equal(t, 1, sub.Length(), "only the previously parked change remains")
+}
+
+// A map-mode overwrite of an already-buffered key does not grow the buffer, so
+// it must stay exempt from the count cap exactly as it is from the byte cap.
+// Parking it would clamp the apply rate to the applier's raw drain rate on
+// precisely the workload dedup handles for free.
+func TestChangeCountCapExemptsDedupOverwrites(t *testing.T) {
+	const limit = 4
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.softLimitChanges = limit
+	sub.softLimitBytes = 0
+
+	for i := range limit {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+	require.Equal(t, limit, sub.Length())
+
+	// At the cap, but every one of these is an overwrite of a key already
+	// present. None may park, and the length must not move.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range limit {
+			sub.HasChanged([]any{int64(i)}, []any{int64(i), "updated"}, false)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dedup overwrites must not park on the change-count cap")
+	}
+	require.Equal(t, limit, sub.Length())
+}
+
+// In-flight drain entries count toward the cap. Without this the reader would
+// refill to the full cap while a whole previous buffer was still being applied,
+// and the pending total — which is what Length() and AllChangesFlushed() see —
+// would be twice the cap.
+func TestChangeCountCapIncludesInFlightEntries(t *testing.T) {
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.softLimitChanges = 4
+	sub.softLimitBytes = 0
+
+	sub.Lock()
+	sub.flushingCount = 4
+	over := sub.overSoftLimitLocked()
+	sub.Unlock()
+	require.True(t, over, "entries mid-drain are still pending changes")
+}
+
+// A zero cap disables the check outright. Both clients normalise a negative
+// SubscriptionSoftLimitChanges to zero, so this is the shape an explicit
+// opt-out reaches the subscription in.
+func TestChangeCountCapOptOut(t *testing.T) {
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.softLimitChanges = 0
+	sub.softLimitBytes = 0
+	sub.Lock()
+	sub.flushingCount = 1 << 20
+	over := sub.overSoftLimitLocked()
+	sub.Unlock()
+	require.False(t, over, "a zero cap disables the check entirely")
+}
+
+// TestDrainDispatchBudgetDefersTheRemainder covers the backstop: when per-row
+// cost is high enough that even a capped buffer cannot drain in a sane time,
+// the drain stops scheduling, hands flushMu back, and reports itself
+// incomplete. The batches it never scheduled must still be in the buffer.
+func TestDrainDispatchBudgetDefersTheRemainder(t *testing.T) {
+	shortenDrainDispatchBudget(t, 50*time.Millisecond)
+	const totalRows = 6 * DefaultBatchSize
+	fake := &slowApplier{perCall: 40 * time.Millisecond}
+	sub := newByteCapBufferedMap(&fake.countingApplier, false)
+	sub.applier = fake
+	sub.flushConcurrency = 1 // serial, so the budget is spent predictably
+
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err, "running out of budget is not an error")
+	require.False(t, allFlushed, "a truncated drain must not report the position as advanceable")
+	require.Positive(t, sub.drainsTimedOut.Load())
+
+	// Some batches landed and the rest are still buffered — nothing was lost.
+	applied := 0
+	for _, call := range fake.upserts() {
+		applied += len(call)
+	}
+	require.Positive(t, applied, "the drain must have made progress before giving up")
+	require.Less(t, applied, totalRows, "the budget must actually have truncated the drain")
+	require.Equal(t, totalRows-applied, sub.Length(), "the remainder must be reattached, not dropped")
+
+	// Accounting still balances against the entries that are really there.
+	expectedBytes := recomputeSizeBytes(sub)
+	sub.Lock()
+	require.Equal(t, expectedBytes, sub.sizeBytes)
+	sub.Unlock()
+
+	// And the deferral is not a one-way door: with the budget restored the
+	// next flush finishes the job.
+	shortenDrainDispatchBudget(t, time.Minute)
+	fake.perCall = 0
+	allFlushed, err = sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
+}
+
+// A drain that fits inside its budget must report success. Guards against a
+// too-eager truncation check turning every healthy flush into a deferral,
+// which would freeze the checkpoint in the name of unfreezing it.
+func TestDrainWithinBudgetStillReportsComplete(t *testing.T) {
+	const totalRows = 3 * DefaultBatchSize
+	fake := &countingApplier{}
+	sub := newByteCapBufferedMap(fake, false)
+	sub.flushConcurrency = 4
+
+	for i := range totalRows {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	require.Zero(t, sub.Length())
+	require.Zero(t, sub.drainsTimedOut.Load())
+}
+
+// The production defaults must be ordered so the count cap binds first and the
+// dispatch budget stays a backstop. If the budget were tight enough to fire on
+// a normal full-buffer drain, every such drain would report itself incomplete
+// and the flushed position would stop advancing — the exact failure both
+// changes exist to fix.
+func TestDrainBoundDefaultsAreOrdered(t *testing.T) {
+	require.Greater(t, drainDispatchBudget, DefaultFlushInterval,
+		"the backstop must outlast a single flush interval")
+	require.Greater(t, DefaultSubscriptionSoftLimitChanges, binlogTrivialThreshold,
+		"the cap must sit above the threshold the flush-until-trivial loops use")
+	// One drain of a full buffer is DefaultSubscriptionSoftLimitChanges rows,
+	// which at DefaultBatchSize is this many applier round trips.
+	roundTrips := DefaultSubscriptionSoftLimitChanges / DefaultBatchSize
+	require.LessOrEqual(t, roundTrips, 64,
+		"a full buffer should drain in a few dozen round trips, not hundreds")
+}

--- a/pkg/change/subscription_buffered_drainbound_test.go
+++ b/pkg/change/subscription_buffered_drainbound_test.go
@@ -2,6 +2,7 @@ package change
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -299,4 +300,82 @@ func TestDrainBoundDefaultsAreOrdered(t *testing.T) {
 	roundTrips := DefaultSubscriptionSoftLimitChanges / DefaultBatchSize
 	require.LessOrEqual(t, roundTrips, 64,
 		"a full buffer should drain in a few dozen round trips, not hundreds")
+}
+
+// The status block has to be able to show a park while it is happening, not
+// only after the fact: a reader held off for minutes is the case that risks
+// running past the source's binlog retention, and it is indistinguishable from
+// a healthy feed if the only evidence is a counter that stopped moving.
+func TestParkStatsReportsAnInFlightPark(t *testing.T) {
+	const limit = 4
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.softLimitChanges = limit
+	sub.softLimitBytes = 0
+
+	parks, parked := sub.ParkStats()
+	require.Zero(t, parks)
+	require.False(t, parked)
+
+	for i := range limit {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+	parks, parked = sub.ParkStats()
+	require.Zero(t, parks, "filling to the cap does not park; the next add does")
+	require.False(t, parked)
+
+	blocked := make(chan struct{})
+	go func() {
+		defer close(blocked)
+		sub.HasChanged([]any{int64(limit)}, []any{int64(limit), "blocked"}, false)
+	}()
+
+	// ParkStats must observe the park from another goroutine, which it can only
+	// do because the parked caller is inside cond.Wait() and has released the
+	// Mutex for the duration.
+	require.Eventually(t, func() bool {
+		parks, parked = sub.ParkStats()
+		return parked
+	}, 5*time.Second, 5*time.Millisecond, "an in-flight park must be visible")
+	require.Equal(t, int64(1), parks)
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	<-blocked
+
+	parks, parked = sub.ParkStats()
+	require.False(t, parked, "the flag must clear when the caller resumes")
+	require.Equal(t, int64(1), parks, "the count is cumulative and does not clear")
+}
+
+// End to end: a park on any of a feed's subscriptions has to reach the feed's
+// status row, which is the whole point of moving this off the subscription's
+// own log lines.
+func TestFeedStatsReportsSubscriptionParks(t *testing.T) {
+	const limit = 2
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.softLimitChanges = limit
+	sub.softLimitBytes = 0
+
+	c := &gtidClient{subs: newSubscriptionRegistry()}
+	require.True(t, c.subs.Add("test.t1", sub))
+	require.Contains(t, StatusRow(c), "parks=0 is-parked=false")
+
+	for i := range limit {
+		sub.HasChanged([]any{int64(i)}, []any{int64(i), "seed"}, false)
+	}
+	blocked := make(chan struct{})
+	go func() {
+		defer close(blocked)
+		sub.HasChanged([]any{int64(limit)}, []any{int64(limit), "blocked"}, false)
+	}()
+	require.Eventually(t, func() bool {
+		return strings.Contains(StatusRow(c), "parks=1 is-parked=true")
+	}, 5*time.Second, 5*time.Millisecond)
+
+	allFlushed, err := sub.Flush(t.Context(), false, nil)
+	require.NoError(t, err)
+	require.True(t, allFlushed)
+	<-blocked
+	require.Contains(t, StatusRow(c), "parks=1 is-parked=false")
 }

--- a/pkg/change/subscription_buffered_drainbound_test.go
+++ b/pkg/change/subscription_buffered_drainbound_test.go
@@ -291,8 +291,6 @@ func TestDrainWithinBudgetStillReportsComplete(t *testing.T) {
 // and the flushed position would stop advancing — the exact failure both
 // changes exist to fix.
 func TestDrainBoundDefaultsAreOrdered(t *testing.T) {
-	require.Greater(t, drainDispatchBudget, DefaultFlushInterval,
-		"the backstop must outlast a single flush interval")
 	require.Greater(t, DefaultSubscriptionSoftLimitChanges, binlogTrivialThreshold,
 		"the cap must sit above the threshold the flush-until-trivial loops use")
 	// One drain of a full buffer is DefaultSubscriptionSoftLimitChanges rows,
@@ -300,6 +298,26 @@ func TestDrainBoundDefaultsAreOrdered(t *testing.T) {
 	roundTrips := DefaultSubscriptionSoftLimitChanges / DefaultBatchSize
 	require.LessOrEqual(t, roundTrips, 64,
 		"a full buffer should drain in a few dozen round trips, not hundreds")
+
+	// The load-bearing ordering, expressed against the figure the cap was
+	// actually tuned from rather than against a flush interval. The production
+	// drain this PR was written for worked through at most 452,571 rows in
+	// 21m37s; scaled to a full buffer that is ~2m23s, and it is a floor (the
+	// row count is the backlog at flush start, so if fewer rows really landed
+	// the per-row cost is higher).
+	//
+	// Asserting only "budget > one DefaultFlushInterval" would admit a 31s
+	// budget, which would truncate that drain every single time — and a
+	// truncated drain never reports allChangesFlushed=true, so the flushed
+	// position would freeze exactly as it did in production. The margin below
+	// is what makes the budget a backstop instead of the binding constraint.
+	const (
+		observedDrain = 21*time.Minute + 37*time.Second
+		observedRows  = 452571
+	)
+	fullBufferDrain := observedDrain * DefaultSubscriptionSoftLimitChanges / observedRows
+	require.Greater(t, drainDispatchBudget, 2*fullBufferDrain,
+		"the backstop must leave a full-buffer drain (~%v) room to finish", fullBufferDrain)
 }
 
 // The status block has to be able to show a park while it is happening, not

--- a/pkg/move/reversefeed.go
+++ b/pkg/move/reversefeed.go
@@ -304,6 +304,29 @@ func (rf *ReverseFeed) Flush(ctx context.Context) error {
 	return nil
 }
 
+// AllChangesFlushed reports whether every feed has applied its whole buffer.
+//
+// Flush returning nil is not the same question, and callers that are about to
+// discard the buffer must ask this one instead. A drain may decline to finish —
+// lock contention it could not resolve in its budget, or a drain cut short to
+// bound how long it holds the flush mutex — and reports that by leaving the
+// changes buffered rather than by erroring, because for the periodic flusher
+// "try again next tick" is the right response and failing the whole change is
+// not. Flush's own loop compounds it: it exits once the backlog is merely
+// *trivial*, not empty, so a residual below that threshold returns nil by
+// design.
+//
+// Mirrors the forward cutover's check in cutover.go, which pairs the two calls
+// for exactly this reason.
+func (rf *ReverseFeed) AllChangesFlushed() bool {
+	for _, client := range rf.clients {
+		if !client.AllChangesFlushed() {
+			return false
+		}
+	}
+	return true
+}
+
 // Positions returns each source's current safe-to-resume position, in the same
 // order as the configured sources. Intended for the caller's checkpoint so the
 // window can resume in reverse mode after a restart.

--- a/pkg/move/reversefeed_test.go
+++ b/pkg/move/reversefeed_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/change"
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/testutils"
@@ -343,4 +344,31 @@ func TestReverseFeedShardedConfigValidation(t *testing.T) {
 		TargetTables: map[string]*table.TableInfo{"t1": oldTbl},
 	})
 	require.ErrorContains(t, err, "target 1 DB must be non-nil")
+}
+
+// TestReverseFeedAllChangesFlushed pins the check the reverse cutover depends
+// on before it discards the buffer.
+//
+// The reverse cutover flushes, then Closes the feed — and Close discards
+// pending changes rather than applying them — then renames the source's _old
+// tables back into service. So anything still buffered at that point is a
+// target-era write that is lost. A nil error from Flush does not rule that out:
+// a drain can decline to finish (lock contention it could not resolve in its
+// budget, or a drain cut short to bound how long it holds the flush mutex) and
+// reports that by leaving the changes buffered, and Flush's own loop exits on a
+// *trivial* backlog rather than an empty one.
+func TestReverseFeedAllChangesFlushed(t *testing.T) {
+	clean := &fakeChangeSource{}
+	stuck := &fakeChangeSource{}
+	stuck.notFlushed.Store(true)
+
+	require.True(t, (&ReverseFeed{clients: []change.Source{clean}}).AllChangesFlushed())
+	require.True(t, (&ReverseFeed{clients: []change.Source{clean, clean}}).AllChangesFlushed())
+
+	// One feed holding changes is enough: the renames put every source's _old
+	// tables back, so a single un-applied shard loses writes.
+	require.False(t, (&ReverseFeed{clients: []change.Source{clean, stuck}}).AllChangesFlushed(),
+		"one feed still holding changes must fail the check")
+	require.False(t, (&ReverseFeed{clients: []change.Source{stuck, clean}}).AllChangesFlushed(),
+		"order must not matter")
 }

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -337,8 +337,21 @@ func (w *reverseWindow) reverseCutover(ctx context.Context) error {
 
 	// 2. Flush the reverse feed so the source's _old tables reflect every target
 	//    write, then stop it (no more writes to _old during the renames below).
+	//
+	// Both calls, in this order, and neither is optional. Close discards the
+	// buffer rather than flushing it, and the renames below put the source's
+	// _old tables back into service — so a change still buffered here is a
+	// target-era write that is silently lost. A nil error from Flush does not
+	// rule that out: a drain can decline to finish and report it by leaving the
+	// changes buffered, and Flush's loop exits on a *trivial* backlog rather
+	// than an empty one. AllChangesFlushed is the question that matters, and
+	// asking it is what the forward cutover already does (cutover.go).
 	if err := w.feed.Flush(ctx); err != nil {
 		return fmt.Errorf("reverse cutover: final flush: %w", err)
+	}
+	if !w.feed.AllChangesFlushed() {
+		return fmt.Errorf("reverse cutover: %w; refusing to discard buffered target writes",
+			change.ErrChangesNotFlushed)
 	}
 	w.feed.Close()
 

--- a/pkg/move/runner_close_test.go
+++ b/pkg/move/runner_close_test.go
@@ -162,6 +162,9 @@ func TestFatalErrorReasonCheckpointHandling(t *testing.T) {
 // failed.
 type fakeChangeSource struct {
 	closed atomic.Bool
+	// notFlushed makes AllChangesFlushed report a feed still holding buffered
+	// changes. Defaults to false so the zero value is a healthy feed.
+	notFlushed atomic.Bool
 }
 
 func (f *fakeChangeSource) AddSubscription(_, _ *table.TableInfo, _ table.MappedChunker) error {
@@ -184,7 +187,7 @@ func (f *fakeChangeSource) SetWatermarkOptimization(_ context.Context, _ bool) e
 }
 func (f *fakeChangeSource) StartPeriodicFlush(_ context.Context, _ time.Duration) {}
 func (f *fakeChangeSource) StopPeriodicFlush()                                    {}
-func (f *fakeChangeSource) AllChangesFlushed() bool                               { return true }
+func (f *fakeChangeSource) AllChangesFlushed() bool                               { return !f.notFlushed.Load() }
 func (f *fakeChangeSource) Stop()                                                 {}
 func (f *fakeChangeSource) Close()                                                { f.closed.Store(true) }
 


### PR DESCRIPTION
Follow-up to #1168, from watching it run in production. Three changes, all aimed at the same symptom: the flushed position stops advancing and nothing on screen explains why.

## 1. The retry budget was cancelling healthy statements

```
21:46:18 [WRN] flush batches lost to lock contention; retrying serially
21:46:38 [WRN] reducing flush concurrency after lock contention
21:46:38 [ERR] error flushing GTID changeset: failed to upsert rows: failed to execute upsert: context deadline exceeded
```

Exactly 20s apart — that is `contentionRetryBudget`, and it was the only `context.WithTimeout` in the flush path. It recurred overnight, this time escalated to a migration failure:

```
04:09:37 [WRN] Apply paused for operator retry (1 of 10 recovery attempts remaining):
  table balance_accounts failed: schema change failed: failed to upsert rows:
  failed to execute upsert: context deadline exceeded [running -> failed_retryable]
```

The budget was derived from the drain's context and handed to `flushBatch`, so expiring did not merely stop the retry pass — it killed whatever `REPLACE` was running at the time.

**And 20s was far below one attempt's cost on this table.** A drain there worked through at most 452,571 rows in 21m37s, so average per-batch latency was *at least* ~11s, and a single `flushBatch` can spend several times that inside `RetryableTransaction`, which retries up to `MaxRetries` with `innodb_lock_wait_timeout` on each. So the budget was guillotining perfectly ordinary statements, every time.

Two fixes:

- The budget is now a **plain deadline that gates only the decision to start another attempt**. Attempts run on the parent context and finish. That is safe because an attempt is already bounded from below — `RetryableTransaction` makes at most `MaxRetries` tries, each capped by `innodb_lock_wait_timeout` — so overrun is one attempt's worth, and no deadline of ours can surface as an apply failure. Same shape as `drainDispatchBudget` below, which also stops scheduling rather than cancelling.
- The budget goes **20s → 2 minutes**, so it is in scale with a single attempt. Below that, pass 2 is decorative: it expires before the first batch has had a fair try. Two minutes still sits well inside `drainDispatchBudget`, so the drain's own bound remains the outer one.

## 2. Unresolved contention is deferred, not failed

Failing the drain on leftover contention discards the whole pass, which is ruinous when a pass runs for minutes. Leftover batches now stay in the snapshot, get reattached, and are retried on the next flush; the drain returns `allChangesFlushed=false` with a nil error.

**The safety property is unchanged, and never depended on the error.** Clients gate position advancement on `allChangesFlushed` — the same mechanism watermark-deferred keys already use — so a deferred batch holds the flushed position back exactly as a failed drain would. What changes is only that the batches which *did* land count as progress.

Hard errors and real cancellations still fail the drain, in pass 2 as in pass 1.

## 3. One drain no longer takes twenty minutes

This is the larger one, and it came out of watching the run continue.

```
binlog  deltas=453453  flushed 11m34s ago (took 21m37.166252s, 452571 rows)
```

A drain was sized by the buffer, and the buffer was capped only in **bytes**. At ~600 bytes per buffered change on this table, 256MiB of soft limit is over 450k pending changes — so the buffer legitimately filled to 453k, and the drain that followed ran for 21m37s.

That is not merely slow:

- `flushMu` is held for the whole drain, and almost everything else in the flush path queues behind it. `SetWatermarkOptimization` takes `flushMu` as its first act and the runner calls it the moment the copy finishes, so the post-copy phase sat blocked for over half an hour on a copy that had already completed:
  ```
  22:38:05 [INF] copy rows complete
  ...
  22:42:41 [ERR] error flushing GTID changeset: context canceled     <- 4m36s later
  22:42:49 [INF] migration status: state=applyChangeset
  ```
- It starves the AIMD controller, which is fed once per drain and needs `cleanDrainsToRecover` of them to give a halving back. At one sample per twenty minutes, "~90s of proven quiet" becomes an hour, so a width reduced by a single transient 1213 stays reduced for the rest of the migration.
- `flushed 21m ago` is not a status line an operator can act on.

**The fix is a second soft cap on the buffer, in changes rather than bytes:** `DefaultSubscriptionSoftLimitChanges = 50000`, applied alongside the byte cap, whichever binds first.

Bytes and count measure different costs. Bytes bound the migrator's memory, which is what a handful of wide LONGTEXT rows threatens. Count bounds how long the resulting drain takes, because the applier does one round trip per batch of rows whatever they weigh — so a narrow-row table reaches an unworkable drain long before it reaches 256MiB. Scaling the observed rate, 50k should drain in roughly two minutes instead of twenty.

Dedup overwrites stay exempt, exactly as they are from the byte cap — that is the traffic dedup collapses for free, and parking it would clamp the apply rate to the applier's raw drain rate. In-flight drain entries count toward the cap, so the reader cannot refill to a second full buffer while the first is still landing.

**Plus a backstop:** `drainDispatchBudget` stops a drain scheduling new batches after 10 flush intervals. It is deliberately far longer than a full buffer should need and is expected never to fire; it exists because per-row cost is not bounded and a struggling target can make even 50k changes take an hour.

Capping *time* aggressively would have been the wrong instinct, and it is worth being explicit about why: only a **complete** drain reports `allChangesFlushed=true`, and only that advances the flushed position. A tight time cap would truncate every drain, and the checkpoint would freeze just as before — with a livelier status line. Bounding the buffer is what makes drains *finish*; the time budget only stops a pathological one from holding the mutex indefinitely.

Neither bound applies to `flushMapLocked`, the serial path used under the cutover lock and by `SetWatermarkOptimization`. Those must drain completely.

Truncating costs nothing in throughput — the next flush resumes where this one stopped — and does not weaken the checkpoint, for the same reason deferral does not.

## 4. The status block now shows the unflushed position

While the checkpoint is held back, the ckpt row is the *flushed* position and there was nothing on screen for the position the reader had actually reached. Half an hour on the same GTID looks identical to a dead feed:

```
binlog  deltas=453392  rotations=400 (0 forced)  flushed 29m4s ago (took 21m37s, 452571 rows)
ckpt    20s ago  f50a3ec0-...:1-38880294638
```

`FeedStats` gains `BufferedPosition`, populated by both clients from the field each already keeps under `c.mu`, and the binlog row renders it as `read=<pos>`. If it moves between status blocks the reader is fine and only publication is blocked; the gap to the ckpt row is how much re-reading a restart would cost.

It goes last on the row and is not abbreviated. A middle-eliding helper was written and removed: the ckpt row prints its position in full and the point is to compare the two by eye, and since `MysqlGTIDSet.String()` sorts by UUID the interval that moves need not be last — an elision can hide exactly the digits that are changing and make a healthy reader look frozen, which is the misreading the field exists to prevent. Feeds that have read nothing omit it, so pre-existing status lines are byte-identical.

## 5. Reader backpressure moves from the log to the status block

The subscription logged a park/unpark pair whenever a soft limit held the binlog reader back. Capacity returns one applied batch at a time, so a single episode of sustained backpressure emits that pair every few seconds for the whole drain — with the count cap from §3 in place, that is now the *expected* steady state on a busy table, and at Warn/Info it buried the periodic status block it was meant to complement:

```
04:10:12 [WRN] subscription parked on soft memory limit ...
04:10:14 [INF] subscription unparked from soft memory limit ...
04:10:19 [WRN] subscription parked on soft memory limit ...
04:10:21 [INF] subscription unparked from soft memory limit ...
```

Both lines drop to Debug. The binlog row carries `parks=N is-parked=bool` instead:

```
binlog  deltas=50000  rotations=400 (0 forced)  parks=1184 is-parked=true  flushed 2m10s ago (took 2m3s, 50000 rows)  read=f50a3ec0-...:1-38881204120
```

That answers the two questions the log lines were being read for, at the cadence an operator actually reads. The pair is what carries the information: a climbing `parks` with `is-parked=false` is a reader recovering between short parks, which is normal under a write rate the applier cannot match; `is-parked=true` across consecutive reports is a reader not consuming the source's binary log for minutes at a time, which is what eats into `binlog_expire_logs_seconds`. Neither number alone separates those.

Both fields render unconditionally, unlike `read=`: a field that appears only while something is wrong cannot be eye-diffed against the previous report, and the reading that matters is the delta between them.

`timesParked` becomes cumulative instead of being `Swap(0)`'d by the watermark-toggle bookend log — a counter that silently restarts mid-migration reads as the parking having stopped. `parked` is guarded by the subscription's Mutex, which the parked goroutine releases inside `cond.Wait()`, so a status reader can observe a park while it is in progress. Park stats are collected via an optional `ParkReporter` interface (same reasoning as `StatsReporter`: out-of-tree subscriptions don't have to grow a method) and gathered *before* the client takes `c.mu`, since subscriptions take `c.mu` on their flush paths.

`docs/migrate.md` documents `parks`, `is-parked` and `read` in the status-output reference.

## 6. Callers that discard the buffer must ask `AllChangesFlushed`, not just check the error

The safety argument for deferral is "clients gate position advancement on `allChangesFlushed`, so a deferred batch holds the flushed position back exactly as a failed drain would". That is a claim about *every* client, and it needed a repo-wide grep rather than the two obvious callers. `grep -rn AllChangesFlushed` returns `move/cutover.go`, `migration/cutover.go`, `checksum/single.go`, `checksum/distributed.go` — and `move/reversewindow.go` is absent.

`reverseCutover` flushed the reverse feed, `Close()`d it — which **discards** the buffer rather than applying it — and then renamed the source's `_old` tables back into service:

```go
if err := w.feed.Flush(ctx); err != nil { ... }
w.feed.Close()
```

Before this PR that was sound: the reverse feed disables the watermark filter, and a drain could not return nil with rows unapplied, so `Flush() == nil` provably meant the buffer was empty. Both §2 and §3 break that — a deferred batch and a budget-truncated drain each return `(false, nil)` — so a target-era write could be silently dropped immediately before the source went back into service. The dangerous window is a residual *under* `binlogTrivialThreshold`, because `Flush`'s loop exits on a trivial backlog rather than an empty one; at or above it you get an indefinite spin instead.

`ReverseFeed` now has `AllChangesFlushed`, checked before `Close` and failing closed with `ErrChangesNotFlushed` — the pair the forward cutover already does in `cutover.go`. That restores base's fail-closed behaviour for this caller while leaving the periodic flusher free to defer.

Credit to @Kiran01bm's review agent, which found it by sweeping outside `pkg/change` after its own in-package check had returned a false all-clear.

### Known gap, not fixed here

`binlogClient.Flush`'s loop — `for { flush; BlockWait; if GetDeltaLen() < binlogTrivialThreshold { break } }` — has no exit if the residual is pinned at or above the threshold. Base exited via the error this PR removes. The fix is not a max-iteration count: separating "stuck" from "a large backlog making progress" needs progress detection, and the loop's own comment documents the legitimate case a naive bound would abort (resuming from a checkpoint into a big backlog, where a busy source can hold the delta flat for several iterations while still converging). That needs live-MySQL coverage of the busy-source case, so it is a follow-up rather than a line in this PR. Same for `checksum/continuous.go`, where a contention-deferred drain is now diagnosed as permanent divergence — the outcome is unchanged from base (the migration aborts, safely, before cutover) but the message sends an operator to the wrong place.

## What this does *not* fix

The copier and the flush still compete for the target's write capacity with nothing arbitrating between them; the autoscaler steers the copier on *server* load, which is blind to the change buffer being saturated. The lever is copier backpressure while the subscription is parked, not anything in the applier queue (`UpsertRows` is synchronous and never enters the write-worker pool). Left for a separate change.

## Testing

New and reworked tests across `pkg/change` and `pkg/dbconn`. The load-bearing ones were each verified against the mutation they exist to catch — mutation applied, confirmed to survive the old suite, confirmed killed by the new test:

| Test | Mutation it kills |
|---|---|
| `TestSerialRetryExhaustionDefersWithoutFailing` | deferral reporting `allChangesFlushed=true` |
| `TestPartialContentionKeepsLandedBatches` | same, with only one batch stubborn |
| `TestRetryBudgetNeverCancelsAnAttempt` | making the budget a context again |
| `TestRetryBudgetExpiryDefersRemainingBatches` | the budget never gating at all |
| `TestHardErrorDuringSerialRetryStillFailsDrain` | pass 2 absorbing something that isn't contention |
| `TestContentionAtShutdownIsNotRetried` | spending pass 2's budget on a dead context |
| `TestSoftLimitOnChangeCountParksTheReader` | the count cap never binding |
| `TestChangeCountCapIncludesInFlightEntries` | excluding `flushingCount` from the cap |
| `TestChangeCountCapExemptsDedupOverwrites` | parking on overwrites that cost nothing |
| `TestDrainDispatchBudgetDefersTheRemainder` | budget expiry not marking the drain incomplete |
| `TestDrainWithinBudgetStillReportsComplete` | a too-eager truncation check |
| `TestDrainBoundDefaultsAreOrdered` | retuning the budget below the cap's drain time |
| `TestStatusRowBufferedPositionFollowsStalestFeed` | taking the freshest feed's position |
| `TestMergeParkStatsAcrossSubscriptions` | park counts overwriting instead of summing, `is-parked` last-wins instead of OR |
| `TestStatusRowMergesParkStats` | the same two, across feeds |
| `TestParkStatsReportsAnInFlightPark` | never clearing `parked` on wake; reading it without the Mutex (`-race`) |
| `TestFeedStatsReportsSubscriptionParks` | a park that never reaches the feed's status row |
| `TestIsLockContentionError` | widening/narrowing the 1205/1213 classification |
| `TestReverseFeedAllChangesFlushed` | one feed still holding changes passing the reverse cutover's pre-Close check |
| `TestStubbornBatchDoesNotStrandItsSiblings` | reverting to base's give-up-at-the-first-exhausted-batch |
| `TestBudgetExpiryCountsAlreadyDeferredBatches` | the budget checks dropping batches already counted as deferred |
| `TestHardErrorAfterADeferralStillCountsIt` | the hard-error path discarding deferrals from the same pass |
| `TestRetryBudgetIsNotDefeatedByTheBackoffSleep` | an attempt starting after the deadline, from the far side of the backoff |
| `TestSerialRetryExhaustionDefersWithoutFailing` (narrowing half) | a deferred drain feeding the AIMD controller nothing |

`pkg/change` and `pkg/dbconn` pass, `-race` clean, `golangci-lint` reports 0 issues.

## Credit

Two review agents found things I had not. @aparajon's noticed that deferring returns nil, so `gtidClient.flush` now reaches `recordFlush` on a partial drain where the error return skipped it — which quietly restores a detection channel: `flushResidual`, `flushCount` and `lastFlushAt` all update, so the checksum autoscaler's rising-residual backlog veto can fire on a shard losing ground. Base froze all three under contention. That is an improvement over base on a second axis beyond the checkpoint one, and neither the code nor this description had noticed it. @Kiran01bm's found §6 above, and was explicit that its own first pass had cleared the safety claim before sweeping outside `pkg/change` — which is the part worth remembering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


