### PR TITLE
change: report the buffered (unflushed) position on the binlog status row

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1195,13 +1195,18 @@ func (c *binlogClient) FlushResidual() (int, int) {
 func (c *binlogClient) FeedStats() FeedStats {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return FeedStats{
+	stats := FeedStats{
 		LastFlushAt:       c.lastFlushAt,
 		LastFlushDuration: c.lastFlushDuration,
 		LastFlushRows:     c.lastFlushRows,
 		Rotations:         c.rotations.Load(),
 		ForcedRotations:   c.flushedBinlogs.Load(),
 	}
+	// Already under c.mu, which is what guards bufferedPos.
+	if c.bufferedPos.Name != "" {
+		stats.BufferedPosition = formatBinlogPosition(c.bufferedPos)
+	}
+	return stats
 }
 
 // Flush empties the changeset in a loop until the amount of changes is considered "trivial".

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -1179,12 +1179,17 @@ func (c *gtidClient) countRotation(currentLogName, nextLogName string) string {
 func (c *gtidClient) FeedStats() FeedStats {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return FeedStats{
+	stats := FeedStats{
 		LastFlushAt:       c.lastFlushAt,
 		LastFlushDuration: c.lastFlushDuration,
 		LastFlushRows:     c.lastFlushRows,
 		Rotations:         c.rotations.Load(),
 	}
+	// Already under c.mu, which is what guards bufferedGTID.
+	if c.bufferedGTID != nil && !c.bufferedGTID.IsEmpty() {
+		stats.BufferedPosition = c.bufferedGTID.String()
+	}
+	return stats
 }
 
 // Flush satisfies Source. Same shape as binlogClient.Flush.

--- a/pkg/change/stats.go
+++ b/pkg/change/stats.go
@@ -24,6 +24,20 @@ type FeedStats struct {
 	// Source.Flush always ends on (it loops until the backlog is trivial and
 	// then flushes once more).
 	LastFlushRows int
+	// BufferedPosition is how far the feed has *read*, in the same opaque
+	// encoding Source.Position uses. Empty before the feed has read anything.
+	//
+	// This is deliberately not the resume coordinate. Source.Position and the
+	// ckpt row both report the *flushed* position, which only advances when a
+	// flush lands every buffered change — so while any change is held back the
+	// checkpoint is frozen by design, and the status block goes silent about
+	// the reader even though it is working normally. That is indistinguishable
+	// from a genuinely stalled feed, which is the case an operator most needs
+	// to tell apart. Reporting the buffered position alongside restores the
+	// distinction: if it advances between status blocks the reader is fine and
+	// only publication is blocked, and the gap to the ckpt row is how much
+	// re-reading a restart would cost.
+	BufferedPosition string
 	// Rotations counts binlog rotations the feed has followed. Duplicate
 	// rotate events (the server sends a real one and an artificial one
 	// carrying the same position) are counted once.
@@ -61,7 +75,24 @@ func (s FeedStats) String() string {
 			s.LastFlushRows,
 		)
 	}
-	return fmt.Sprintf("rotations=%d (%d forced)  %s", s.Rotations, s.ForcedRotations, flush)
+	out := fmt.Sprintf("rotations=%d (%d forced)  %s", s.Rotations, s.ForcedRotations, flush)
+	if s.BufferedPosition != "" {
+		// Last, and rendered whole. A GTID set gains a UUID per failover and
+		// has no upper bound on length, so putting it anywhere but the end of
+		// the row would push the flush phrase off a narrow terminal — and the
+		// flush phrase is the other half of the answer.
+		//
+		// It is not abbreviated, for two reasons. The ckpt row prints the
+		// flushed position in full, and the point of this field is to be
+		// compared against that one: elide one copy and they stop being
+		// diffable by eye. And the interval that moves between status blocks
+		// belongs to whichever server is currently being written to, which
+		// need not sort last in the set — a middle elision could hide exactly
+		// the digits that are changing and make a healthy reader look frozen,
+		// which is the misreading this field exists to prevent.
+		out += "  read=" + s.BufferedPosition
+	}
+	return out
 }
 
 // StatusRow renders the feed stats of srcs as the binlog row of a runner status
@@ -88,6 +119,14 @@ func StatusRow(srcs ...Source) string {
 			merged.LastFlushAt = s.LastFlushAt
 			merged.LastFlushDuration = s.LastFlushDuration
 			merged.LastFlushRows = s.LastFlushRows
+			// The buffered position comes from the same feed as the flush
+			// figures rather than being merged across feeds. Positions from
+			// different sources are not comparable — a sharded move reads one
+			// feed per source, each with its own coordinate space — so there is
+			// nothing to sum or average. Taking the stalest feed's is the
+			// useful choice: that is the feed holding the position back, and
+			// therefore the one whose reader progress is in question.
+			merged.BufferedPosition = s.BufferedPosition
 		}
 		merged.Rotations += s.Rotations
 		merged.ForcedRotations += s.ForcedRotations

--- a/pkg/change/stats_test.go
+++ b/pkg/change/stats_test.go
@@ -2,6 +2,7 @@ package change
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -238,4 +239,64 @@ func TestFeedStatsFromLiveFeed(t *testing.T) {
 		return client.FeedStats().Rotations > before
 	}, 10*time.Second, 50*time.Millisecond,
 		"rotation was not counted (still %d)", client.FeedStats().Rotations)
+}
+
+// The buffered position is the field that tells "the reader is fine, only
+// publication is blocked" apart from "the feed has stalled". The ckpt row
+// cannot: it shows the flushed position, which is frozen in both cases.
+func TestFeedStatsStringWithBufferedPosition(t *testing.T) {
+	s := FeedStats{
+		LastFlushAt:       time.Now().Add(-10 * time.Second),
+		LastFlushDuration: 2854617 * time.Nanosecond,
+		LastFlushRows:     5583,
+		BufferedPosition:  "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638",
+		Rotations:         4,
+		ForcedRotations:   1,
+	}
+	require.Equal(t,
+		"rotations=4 (1 forced)  flushed 10s ago (took 2.855ms, 5583 rows)  "+
+			"read=f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638",
+		s.String())
+}
+
+// The position goes last and whole. A GTID set has no bounded length, so
+// anywhere else it would push the flush phrase off a narrow terminal, and
+// truncating it would stop it being comparable with the ckpt row.
+func TestFeedStatsStringRendersLongPositionInFullAtTheEnd(t *testing.T) {
+	long := "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638," +
+		"a1b2c3d4-154f-3776-8f0f-ced626dbde36:1-42," +
+		"b7c8d9e0-154f-3776-8f0f-ced626dbde36:1-7"
+	got := FeedStats{BufferedPosition: long}.String()
+	require.Equal(t, "rotations=0 (0 forced)  never flushed  read="+long, got)
+	require.True(t, strings.HasSuffix(got, long), "nothing may follow the position")
+}
+
+// A feed that has not read anything yet omits the field rather than rendering
+// an empty one, which also keeps every pre-existing status line byte-identical.
+func TestFeedStatsStringOmitsEmptyBufferedPosition(t *testing.T) {
+	require.Equal(t, "rotations=0 (0 forced)  never flushed", FeedStats{}.String())
+	require.NotContains(t, FeedStats{Rotations: 3}.String(), "read=")
+}
+
+// The buffered position is taken from the same feed as the flush figures, not
+// merged: positions from different sources are not comparable, and the stalest
+// feed is the one whose reader progress is in question.
+func TestStatusRowBufferedPositionFollowsStalestFeed(t *testing.T) {
+	recent := &statsFeed{stats: FeedStats{
+		LastFlushAt:      time.Now().Add(-time.Second),
+		BufferedPosition: "recent-feed-pos",
+		Rotations:        2,
+	}}
+	stale := &statsFeed{stats: FeedStats{
+		LastFlushAt:      time.Now().Add(-90 * time.Second),
+		BufferedPosition: "stale-feed-pos",
+		Rotations:        3,
+	}}
+	row := StatusRow(recent, stale)
+	require.Contains(t, row, "read=stale-feed-pos")
+	require.NotContains(t, row, "recent-feed-pos")
+	require.Contains(t, row, "rotations=5 (0 forced)", "counters still sum")
+
+	// Order must not matter.
+	require.Equal(t, row, StatusRow(stale, recent))
 }


### PR DESCRIPTION
The status block only ever showed the *flushed* position, on the ckpt row. That position advances only when a flush lands every buffered change, so while anything is held back — a watermark-deferred key, or a batch deferred by #1169's retry pass — the checkpoint is frozen by design and the block goes silent about the reader.

That is indistinguishable from a genuinely stalled feed, which is the case an operator most needs to tell apart. From a run this week:

```
binlog  deltas=453392  rotations=400 (0 forced)  flushed 29m4s ago (took 21m37s, 452571 rows)
ckpt    20s ago  f50a3ec0-...:1-38880294638
```

Half an hour on the same GTID. The reader was working normally throughout — `rotations` was climbing several files per status block — but nothing on screen tied that to a position, so there was no way to see how far ahead of the checkpoint it had got, or whether the gap was still growing.

## The change

`FeedStats` gains `BufferedPosition`. Both clients populate it from the field they already keep under `c.mu` (`bufferedGTID` / `bufferedPos`), so there is no new state and no new locking. The binlog row renders it as `read=<pos>`:

```
binlog  deltas=453392  rotations=400 (0 forced)  flushed 29m4s ago (took 21m37s, 452571 rows)  read=f50a3ec0-...:1-38891204771
ckpt    20s ago  f50a3ec0-...:1-38880294638
```

If `read=` moves between status blocks the reader is fine and only publication is blocked. The gap to the ckpt row is how much re-reading a restart would cost.

## Two deliberate choices

**It goes last on the row.** A GTID set gains a UUID per failover and has no bounded length. Anywhere but the end, a long one pushes the flush phrase — the other half of the answer — off a narrow terminal.

**It is not abbreviated.** I wrote a middle-eliding helper first and removed it:

- The ckpt row prints its position in full, and the entire point of this field is to compare the two by eye. Elide one copy and they stop being diffable.
- The interval that moves between status blocks belongs to whichever server is currently being written to. `MysqlGTIDSet.String()` sorts by UUID bytes, so that server need not sort last — a middle elision can hide exactly the digits that are changing and make a healthy reader look frozen. That is the precise misreading this field exists to prevent.

## Merging

For a sharded move the position is taken from the same feed as the flush figures rather than merged. Positions from different sources are not comparable — one coordinate space per feed — so there is nothing to sum. The stalest feed's is the useful one: that is the feed holding publication back, so its reader progress is the question.

## Compatibility

A feed that has not read anything yet omits the field, so every pre-existing status line is byte-identical. The existing stats tests were not touched and still pass.

## Testing

Four tests. Two were verified against mutations: taking the last feed's position instead of the stalest is caught by `TestStatusRowBufferedPositionFollowsStalestFeed`, and (while the helper still existed) tail-elision instead of middle-elision was caught by its test.

`pkg/change` passes, `-race` clean, `golangci-lint` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
