### PR TITLE
check: refuse ALTERs on tables without a primary key at statement scope

### DIFF
--- a/pkg/migration/check/primarykeyexists.go
+++ b/pkg/migration/check/primarykeyexists.go
@@ -1,0 +1,35 @@
+package check
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+func init() {
+	registerCheck("primarykeyexists", primaryKeyExistsCheck, ScopeStatement)
+}
+
+// primaryKeyExistsCheck refuses every ALTER against a table that has no
+// primary key. The migration runner requires one to chunk the copy: it fails
+// table setup with "no primary key found (not supported)" before attempting
+// even MySQL's native DDL, so the refusal holds for every ALTER shape on
+// every server — including statements the native DDL could otherwise
+// complete, and including ADD PRIMARY KEY itself.
+//
+// The verdict needs the table's current definition, so the check runs only at
+// statement scope, where the caller may supply Resources.Table built from the
+// table's DDL; without it the check skips rather than guesses. It is not
+// registered at preflight: a migration on such a table fails setup before any
+// check runs.
+func primaryKeyExistsCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
+	if r.Table == nil {
+		logger.Debug("skipping check: no table metadata supplied, cannot tell whether the table has a primary key",
+			"check", "primarykeyexists")
+		return nil
+	}
+	if len(r.Table.KeyColumns) == 0 {
+		return errors.New("altering a table without a primary key is not supported")
+	}
+	return nil
+}

--- a/pkg/migration/check/primarykeyexists.go
+++ b/pkg/migration/check/primarykeyexists.go
@@ -22,6 +22,13 @@ func init() {
 // table's DDL; without it the check skips rather than guesses. It is not
 // registered at preflight: a migration on such a table fails setup before any
 // check runs.
+//
+// The verdict is only as good as the supplied definition. On MySQL 8.0.30+ a
+// generated invisible primary key is a real primary key that SHOW CREATE TABLE
+// omits when show_gipk_in_create_table_and_information_schema is disabled; a
+// definition collected that way misreports the table as unkeyed, and the check
+// would refuse a statement the runner accepts. Collect the definition with
+// that variable at its default (ON).
 func primaryKeyExistsCheck(ctx context.Context, r Resources, logger *slog.Logger) error {
 	if r.Table == nil {
 		logger.Debug("skipping check: no table metadata supplied, cannot tell whether the table has a primary key",

--- a/pkg/migration/check/primarykeyexists_test.go
+++ b/pkg/migration/check/primarykeyexists_test.go
@@ -1,0 +1,65 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/block/spirit/pkg/statement"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noPKTable is the current definition of a table without a primary key, in the
+// form SHOW CREATE TABLE reports it. A unique key does not stand in for a
+// primary key: the migration runner only accepts the PRIMARY constraint.
+const noPKTable = "CREATE TABLE `schema_version` (\n" +
+	"  `version` varchar(50) NOT NULL,\n" +
+	"  `installed_by` varchar(30) DEFAULT NULL,\n" +
+	"  UNIQUE KEY `version` (`version`)\n" +
+	") ENGINE=InnoDB DEFAULT CHARSET=latin1"
+
+func TestPrimaryKeyExists(t *testing.T) {
+	stmt := statement.MustNew("ALTER TABLE `schema_version` MODIFY COLUMN `version` varchar(50) NOT NULL, DEFAULT CHARACTER SET = latin1")[0]
+
+	noPK, err := tableMetadataFor(stmt, noPKTable)
+	require.NoError(t, err)
+	err = primaryKeyExistsCheck(t.Context(), Resources{Statement: stmt, Table: noPK}, discardLogger())
+	require.Error(t, err)
+	assert.Equal(t, "altering a table without a primary key is not supported", err.Error())
+
+	ordersStmt := statement.MustNew("ALTER TABLE `orders` ADD COLUMN shipped_at DATETIME")[0]
+	withPK, err := tableMetadataFor(ordersStmt, ordersTable)
+	require.NoError(t, err)
+	require.NoError(t, primaryKeyExistsCheck(t.Context(), Resources{Statement: ordersStmt, Table: withPK}, discardLogger()))
+
+	// A statement-scope caller may omit the table metadata; the check skips
+	// rather than guessing.
+	require.NoError(t, primaryKeyExistsCheck(t.Context(), Resources{Statement: stmt}, discardLogger()))
+}
+
+// TestStatementRefusalNoPrimaryKeyTable classifies statements against a table
+// that has no primary key, the way a planning tool does. Every ALTER on such a
+// table is refused — the runner fails table setup before attempting native
+// DDL, so even a metadata-only change or adding the missing primary key cannot
+// run through the copy process. Without the table's definition the condition
+// is unknowable from the statement, so nothing is reported.
+func TestStatementRefusalNoPrimaryKeyTable(t *testing.T) {
+	const wantReason = "altering a table without a primary key is not supported"
+	for _, stmt := range []string{
+		"ALTER TABLE `schema_version` MODIFY COLUMN `version` varchar(50) NOT NULL, DEFAULT CHARACTER SET = latin1",
+		"ALTER TABLE `schema_version` ADD COLUMN `checksum` int",
+		"ALTER TABLE `schema_version` ADD PRIMARY KEY (`version`)",
+	} {
+		t.Run(stmt, func(t *testing.T) {
+			reason, refused, err := StatementRefusal(t.Context(), stmt, noPKTable, discardLogger())
+			require.NoError(t, err)
+			require.True(t, refused)
+			assert.Equal(t, wantReason, reason)
+		})
+	}
+
+	reason, refused, err := StatementRefusal(t.Context(),
+		"ALTER TABLE `schema_version` ADD COLUMN `checksum` int", "", discardLogger())
+	require.NoError(t, err)
+	assert.False(t, refused, "the check must skip without table metadata")
+	assert.Empty(t, reason)
+}

--- a/pkg/migration/check/primarykeyexists_test.go
+++ b/pkg/migration/check/primarykeyexists_test.go
@@ -63,3 +63,25 @@ func TestStatementRefusalNoPrimaryKeyTable(t *testing.T) {
 	assert.False(t, refused, "the check must skip without table metadata")
 	assert.Empty(t, reason)
 }
+
+// TestStatementRefusalNoPrimaryKeyReasonSelection classifies a statement that
+// trips more than one refusal on a table without a primary key. The verdict is
+// what a caller acts on; the reported reason follows the fixed check name
+// order, so a statement-level refusal may be reported ahead of the table-level
+// one. Every reported reason is a true refusal, and reclassifying after fixing
+// it surfaces the next.
+func TestStatementRefusalNoPrimaryKeyReasonSelection(t *testing.T) {
+	reason, refused, err := StatementRefusal(t.Context(),
+		"ALTER TABLE `schema_version` ADD CONSTRAINT fk FOREIGN KEY (`installed_by`) REFERENCES users (id)",
+		noPKTable, discardLogger())
+	require.NoError(t, err)
+	require.True(t, refused)
+	assert.Equal(t, "adding foreign key constraints is not supported", reason)
+
+	reason, refused, err = StatementRefusal(t.Context(),
+		"ALTER TABLE `schema_version` ADD COLUMN `checksum` int, ADD CONSTRAINT fk FOREIGN KEY (`installed_by`) REFERENCES users (id)",
+		noPKTable, discardLogger())
+	require.NoError(t, err)
+	require.True(t, refused)
+	assert.Equal(t, "adding foreign key constraints is not supported", reason)
+}

--- a/pkg/migration/check/statement_refusal.go
+++ b/pkg/migration/check/statement_refusal.go
@@ -25,8 +25,9 @@ import (
 // currentCreateTable is the table's current definition, normally its
 // SHOW CREATE TABLE. It must describe the table stmt alters. Pass an empty
 // string when it is not available: coverage then narrows to the checks that need
-// only the statement, and the ENUM/SET checks — which compare a redeclared
-// column against its current type — are skipped.
+// only the statement — the ENUM/SET checks, which compare a redeclared column
+// against its current type, and the missing-primary-key refusal, which reads
+// the current key definition, are skipped.
 //
 // logger may be nil, in which case the checks' own logging is discarded.
 //

--- a/pkg/migration/check/statement_refusal.go
+++ b/pkg/migration/check/statement_refusal.go
@@ -27,7 +27,10 @@ import (
 // string when it is not available: coverage then narrows to the checks that need
 // only the statement — the ENUM/SET checks, which compare a redeclared column
 // against its current type, and the missing-primary-key refusal, which reads
-// the current key definition, are skipped.
+// the current key definition, are skipped. The definition must also reflect
+// the table's true key set: SHOW CREATE TABLE output collected with
+// show_gipk_in_create_table_and_information_schema disabled omits a generated
+// invisible primary key and misreports the table as unkeyed.
 //
 // logger may be nil, in which case the checks' own logging is discarded.
 //


### PR DESCRIPTION
Spirit requires a primary key to chunk the copy: the runner fails table setup with `no primary key found (not supported)` before attempting even MySQL's native DDL, so every ALTER on such a table is deterministically refused on every server — including metadata-only changes the native DDL could otherwise complete, and including `ADD PRIMARY KEY` itself. Today that refusal only surfaces at execution.

This adds a `ScopeStatement` check so `StatementRefusal` reports it at classification time, when the caller supplies the table's current definition. A planning tool can then present the refusal up front (and route the statement to whatever alternative path it has) instead of starting an apply that is guaranteed to fail at setup.

```
StatementRefusal(ctx, stmt, currentCreateTable, logger)
   │ currentCreateTable supplied?
   ├─ no  ──► check skips (condition is unknowable from the statement)
   └─ yes ──► table has no PRIMARY KEY? ──► refused:
              "altering a table without a primary key is not supported"
```

The check meets the `ScopeStatement` contract ("no earlier stage can bypass it on any server"): `SetInfo` runs before the native-DDL attempt in `Runner.Run`, so the failure is unconditional — unlike the dropadd/rename checks that stay excluded because native DDL may complete them. It is not registered at preflight, which a migration on such a table never reaches.

*This PR was drafted by Armand's AI agent (Claude Fable 5).*