### PR TITLE
change: partition flush batches by unique secondary index range

### DIFF
--- a/pkg/change/README.md
+++ b/pkg/change/README.md
@@ -45,11 +45,15 @@ applies it through the applier interface:
 - Higher memory usage than a key-only map: stores full row data for each changed key.
 - Watermark optimizations (`KeyAboveHighWatermark` and `KeyBelowLowWatermark`) are available on `MappedChunker` implementations (both optimistic and composite chunkers). They work correctly for numeric, binary, and temporal primary key types. For `VARCHAR`/`TEXT` columns with collations, Go's byte-order comparison may differ from MySQL's collation order; any discrepancies are caught by the checksum phase (see [issue #479](https://github.com/block/spirit/issues/479)).
 
-**Map iteration order is irrelevant** because the applier issues
+**Map iteration order is irrelevant to correctness** because the applier issues
 `REPLACE INTO target VALUES (...)`, which deletes any row that conflicts
 on PRIMARY KEY or any UNIQUE index before each insert. That makes the
 multi-row VALUES list order-independent — see "Applier idempotence via
 REPLACE INTO" below.
+
+It is not irrelevant to *lock contention*, which is a separate matter and the
+reason a drain no longer batches in iteration order — see
+[Flush partitioning by unique secondary index](#flush-partitioning-by-unique-secondary-index).
 
 **Example scenario:**
 ```
@@ -337,6 +341,82 @@ if !client.AllChangesFlushed() {
 ```
 
 The `client.Flush()` will retry in a loop until the number of pending changes is considered trivial (currently <10K). It is important to handle errors correctly here, because `FlushUnderTableLock` may fail if it can't flush the pending changes fast enough. This is your cue to abandon the cutover operation for now, and try again when the server is under less load.
+
+### Flush partitioning by unique secondary index
+
+A map-mode drain splits its rows into batches and runs several through the
+applier at once. Those batches are disjoint by primary key — a map holds one
+image per key — and for a long time that was assumed to be enough. It is not.
+
+Two concurrent `REPLACE` statements on PK-disjoint rows can still deadlock, and
+in [issue #1168](https://github.com/block/spirit/issues/1168) they did: the
+InnoDB cycle inverted between the clustered index and a `UNIQUE` secondary
+index. `REPLACE`'s duplicate detection takes a **next-key** lock on each unique
+secondary index — the gap below the record included — so two batches collide
+whenever any of their rows land in *adjacent* slots of any such index. Secondary
+key order is unrelated to primary key order, so PK disjointness says nothing
+about it.
+
+The conflict surface is therefore exactly **the set of `UNIQUE` secondary
+indexes**, and that is a precise claim rather than a cautious one. It is
+established against a real server by `TestReplaceContendsOnlyOnUniqueIndexes`
+in `pkg/applier`:
+
+| Two rows are… | Contend? | Why |
+| --- | --- | --- |
+| adjacent in the PRIMARY KEY | **no** | a `REPLACE`'s clustered-index conflict is with the row bearing that exact PK, so under `READ COMMITTED` it takes a record lock and no gap |
+| equal in a *non-unique* secondary index | **no** | those records are keyed `(indexed columns, PK)`, so PK-disjoint rows always occupy distinct records |
+| adjacent in a *`UNIQUE`* secondary index | **yes** | duplicate detection takes a next-key lock, gap included |
+
+So primary-key separation buys nothing, and an earlier attempt at PK-sorting the
+drain was aimed at the wrong index. The drain instead:
+
+1. **Chooses** the unique secondary index whose values are most *clustered*
+   across this drain's own rows — measured, not configured, because whether a
+   key correlates with anything is a property of the workload rather than of the
+   schema. A repeating leading column means physically adjacent sibling records
+   and a near-certain collision; a uniformly distributed key has an adjacency
+   probability of roughly `n²/N` per drain (about 0.3 for 50,000 rows in 8.5
+   billion) and needs no help.
+2. **Sorts** by that index and cuts **contiguous** batches, nudging cut points
+   to fall where the leading key value changes so a run of siblings is not split
+   across two batches. Range partitioning, not hashing: hashing spreads
+   equal-ish values across buckets, which is the arrangement that collides.
+3. **Stripes** the batches into evens and odds, running one group at a time, so
+   no two batches in flight together are neighbours in the sort order. Handing
+   the sorted list straight to the limiter would undo most of the benefit — the
+   in-flight window is roughly contiguous, so neighbours would run together and
+   every batch boundary would become a candidate collision.
+
+Rows that are close together in the chosen index end up in the *same* statement,
+where they cannot conflict, and statements that do run together are separated by
+at least one whole batch of intervening rows. Note that the separation is
+measured in **rows**, not in value distance: whether two values are adjacent in
+the B-tree depends on the whole table, not on the drain, so no value-space
+margin would mean anything.
+
+**Getting it wrong costs throughput, never correctness.** Batches remain
+disjoint by key and map mode makes no cross-key ordering promises, so a
+misordered sort or a poorly chosen index simply reproduces the old collision
+behaviour, which the AIMD contention controller still catches. That is what
+makes it acceptable to sort row images with a best-effort comparator.
+
+The controller therefore stays, and covers what partitioning cannot:
+
+- **Deletes.** A buffered delete keeps only its primary key (the before image is
+  discarded at buffer time), so there is no way to know where it sits in a
+  unique secondary index. Deleted rows are grouped at the tail.
+- **Second and subsequent unique indexes.** Sorting by one says nothing about
+  the others.
+- **`REPLACE`'s out-of-partition deletion cascade.** A `REPLACE` deletes any row
+  conflicting on any unique index, including primary keys not in the batch,
+  whose other unique values are unknowable from here.
+
+Partitioning is automatic, has no flag, and turns itself off when there is
+nothing to do: a table with no usable unique secondary index has no conflict
+surface between PK-disjoint batches at all, so the sort would be pure cost. A
+`flush partitioning enabled` line at Info reports the candidates once per
+subscription.
 
 ### Memory backpressure
 

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -1189,7 +1189,23 @@ func (s *bufferedMap) buildBatches(rows []drainRow, idx *partitionIndex) []*mapF
 	batchSize := s.effectiveBatchSize()
 	var batches []*mapFlushBatch
 	for i := 0; i < len(rows); {
-		end := min(i+batchSize, len(rows))
+		// Every batch must consume at least one row. The loop's only progress
+		// is i = j at the bottom, so a batch that ended where it started would
+		// spin here forever, allocating an empty batch per turn until the
+		// process died.
+		//
+		// It cannot happen today: effectiveBatchSize floors at 1, and every
+		// return in cutAtValueBoundary is past its start. The clamp is here
+		// because that invariant lives in two other functions — one of them in
+		// another file — and neither says a caller's loop termination depends
+		// on it. One comparison per batch against a hung migration is worth
+		// making even at probability zero.
+		//
+		// Clamped *before* the cut rather than after, because
+		// cutAtValueBoundary reads rows[hardEnd-1] and so needs the same
+		// guarantee its caller does; a guard placed after the call would only
+		// have replaced the hang with a panic.
+		end := max(min(i+batchSize, len(rows)), i+1)
 		if idx != nil {
 			end = cutAtValueBoundary(rows, idx, i, end)
 		}

--- a/pkg/change/subscription_buffered.go
+++ b/pkg/change/subscription_buffered.go
@@ -134,6 +134,11 @@ type bufferedMap struct {
 	// means DefaultBatchSize. See effectiveBatchSize.
 	batchSize int
 
+	// partitioner holds the unique secondary indexes a drain may partition
+	// its batches by, resolved lazily on first use. See
+	// subscription_buffered_partition.go.
+	partitioner flushPartitioner
+
 	// logger is supplied by the change.Source that owns this subscription.
 	// We keep only a *slog.Logger (not a back-pointer to the source) so the
 	// bufferedMap stays source-agnostic and can be reused by alternative
@@ -984,31 +989,25 @@ type mapFlushBatch struct {
 // cancellation) stay in the snapshot for the caller to merge back.
 // Returns false when any entry was deferred.
 func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]bufferedChange, applyWatermarkFilter bool) (bool, error) {
-	var batches []*mapFlushBatch
-	current := &mapFlushBatch{}
-	var batchStmtBytes int64
 	allChangesFlushed := true
 
-	cutBatch := func() {
-		if len(current.keys) > 0 {
-			batches = append(batches, current)
-			current = &mapFlushBatch{}
-			batchStmtBytes = 0
-		}
-	}
-
-	// Map iteration order is randomized, so batch membership differs between
-	// flushes. That does not affect the retry below: pass 2 re-applies the very
-	// same mapFlushBatch values pass 1 built, so a contended batch retries as
-	// itself regardless of iteration order.
+	// Map iteration order is randomized, so unpartitioned batch membership
+	// differs between flushes. That does not affect the retry below: pass 2
+	// re-applies the very same mapFlushBatch values pass 1 built, so a contended
+	// batch retries as itself regardless of how it was assembled.
 	//
-	// An earlier revision sorted by primary key here, on the theory that a
-	// consistent lock-acquisition order would help. It would not: the observed
+	// An earlier revision sorted by *primary key* here, on the theory that a
+	// consistent lock-acquisition order would help. It would not, and the reason
+	// is worth keeping because it is what points at the sort below: the observed
 	// deadlock cycle inverts between the clustered index and a secondary UNIQUE
 	// index, and secondary key order is unrelated to primary key order, so
-	// PK-sorted batches still interleave there. Narrowing concurrency is what
-	// breaks the cycle. See block/spirit#1168.
-	batchSize := s.effectiveBatchSize()
+	// PK-sorted batches still interleave there. The clustered index was never
+	// the conflict surface to begin with — a REPLACE's conflict there is with an
+	// exact PK, so under READ COMMITTED it takes a record lock and no gap, and
+	// PK neighbours cannot collide at all. Sorting by a *unique secondary* index
+	// is the version of that idea which addresses the surface that does collide.
+	// See block/spirit#1168 and subscription_buffered_partition.go.
+	rows := make([]drainRow, 0, len(snapshot))
 	for key, change := range snapshot {
 		// Keys the copier may have a read in flight for are deferred to a
 		// later flush; see mustDeferKey. The chunker is internally
@@ -1019,28 +1018,22 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 			allChangesFlushed = false
 			continue
 		}
-		// Cut the batch when either cap is reached: the (possibly reduced)
-		// batch-size limit, or the estimated rendered statement size would
-		// exceed the byte budget the copy path also uses. Without the byte
-		// cap, buffered wide rows (LONGTEXT / BLOB) can render into a single
-		// REPLACE larger than max_allowed_packet — a deterministic,
-		// non-retryable failure. A single row over the budget still flushes,
-		// alone in its own batch (a row can't be split).
-		rowBytes := renderedBytesOfChange(change.logicalRow, change.originalKey)
-		if batchLen := len(current.keys); batchLen >= batchSize ||
-			(batchLen > 0 && batchStmtBytes+rowBytes > applier.MaxStatementSizeBytes) {
-			cutBatch()
-		}
-		current.keys = append(current.keys, key)
-		current.storedBytes += sizeOfBufferedChange(key, change)
-		if change.logicalRow.IsDeleted {
-			current.deleteKeys = append(current.deleteKeys, change.originalKey)
-		} else {
-			current.upsertRows = append(current.upsertRows, change.logicalRow)
-		}
-		batchStmtBytes += rowBytes
+		rows = append(rows, drainRow{key: key, change: change})
 	}
-	cutBatch()
+
+	// Pick the unique secondary index whose values are most clustered across
+	// this drain's own rows, and sort by it. Sorting is what turns "batches are
+	// disjoint by key" into "batches are disjoint by *index range*": rows that
+	// sit close together in that index end up in the same statement, where they
+	// cannot conflict, instead of being scattered across concurrent ones by map
+	// iteration order. nil means there is nothing worth partitioning by — no
+	// usable unique secondary index, or a drain with no rows — in which case
+	// batching stays exactly as it was.
+	chosen := choosePartitionIndex(s.partitionIndexes(ctx), rows)
+	if chosen != nil {
+		sortRowsByIndex(rows, chosen)
+	}
+	batches := s.buildBatches(rows, chosen)
 
 	if len(batches) == 0 {
 		// Every key was watermark-deferred. The drain produced no evidence about
@@ -1054,7 +1047,47 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 	// Batches that lose to lock contention are collected rather than failing
 	// the drain — see retryContendedBatches for why that is safe and why the
 	// retry has to be serial.
-	contended, complete, err := s.applyBatchesConcurrent(ctx, snapshot, batches)
+	//
+	// When the drain is partitioned, the batches are contiguous ranges of the
+	// chosen index and go out in two stripes — evens, then odds — so that no
+	// two batches in flight together are neighbours in that index. Handing the
+	// sorted list straight to the limiter would undo most of the benefit: the
+	// in-flight window is roughly contiguous, so neighbours would run together
+	// and every batch boundary would become a candidate collision. See
+	// stripeBatches.
+	//
+	// The dispatch budget spans the whole drain, not each stripe. It is
+	// computed here and passed down for that reason — two stripes each granted
+	// a full drainDispatchBudget would silently double how long one flush may
+	// hold flushMu.
+	stripes := [][]*mapFlushBatch{batches}
+	if chosen != nil {
+		stripes = stripeBatches(batches)
+	}
+	deadline := time.Now().Add(drainDispatchBudget)
+	var (
+		contended []*mapFlushBatch
+		complete  = true
+		err       error
+	)
+	for _, stripe := range stripes {
+		var (
+			stripeContended []*mapFlushBatch
+			stripeComplete  bool
+		)
+		stripeContended, stripeComplete, err = s.applyBatchesConcurrent(ctx, snapshot, stripe, deadline)
+		contended = append(contended, stripeContended...)
+		if err != nil {
+			break
+		}
+		if !stripeComplete {
+			// The budget is spent. Do not start the next stripe: its batches are
+			// still in the snapshot and will be reattached, which is strictly
+			// better than beginning work the budget does not cover.
+			complete = false
+			break
+		}
+	}
 	if !complete {
 		// The dispatch budget expired. Everything unscheduled is still in the
 		// snapshot and will be reattached; report the drain as incomplete so no
@@ -1137,9 +1170,60 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 	return allChangesFlushed, nil
 }
 
+// buildBatches turns the drain's rows into applier round trips.
+//
+// When idx is non-nil the rows arrive sorted by that index and each batch is a
+// contiguous range of it, with cut points nudged to fall where the leading key
+// value changes (cutAtValueBoundary) so a run of rows sharing a leading value —
+// physically adjacent records, the guaranteed-collision case — is not split
+// across two batches.
+//
+// Both caps from before still apply and in the same order of precedence: the
+// (possibly AIMD-reduced) batch size, and the estimated rendered statement
+// size. The byte cap is not negotiable for correctness the way the row cap is —
+// buffered wide rows (LONGTEXT / BLOB) can render into a single REPLACE larger
+// than max_allowed_packet, which is a deterministic, non-retryable failure — so
+// it overrides the boundary alignment and cuts early. A single row over the
+// budget still flushes alone in its own batch, since a row cannot be split.
+func (s *bufferedMap) buildBatches(rows []drainRow, idx *partitionIndex) []*mapFlushBatch {
+	batchSize := s.effectiveBatchSize()
+	var batches []*mapFlushBatch
+	for i := 0; i < len(rows); {
+		end := min(i+batchSize, len(rows))
+		if idx != nil {
+			end = cutAtValueBoundary(rows, idx, i, end)
+		}
+		batch := &mapFlushBatch{}
+		var batchStmtBytes int64
+		j := i
+		for ; j < end; j++ {
+			r := rows[j]
+			rowBytes := renderedBytesOfChange(r.change.logicalRow, r.change.originalKey)
+			if len(batch.keys) > 0 && batchStmtBytes+rowBytes > applier.MaxStatementSizeBytes {
+				break
+			}
+			batch.keys = append(batch.keys, r.key)
+			batch.storedBytes += sizeOfBufferedChange(r.key, r.change)
+			if r.change.logicalRow.IsDeleted {
+				batch.deleteKeys = append(batch.deleteKeys, r.change.originalKey)
+			} else {
+				batch.upsertRows = append(batch.upsertRows, r.change.logicalRow)
+			}
+			batchStmtBytes += rowBytes
+		}
+		batches = append(batches, batch)
+		i = j
+	}
+	return batches
+}
+
 // applyBatchesConcurrent runs batches through the applier with up to
 // effectiveFlushConcurrency in flight, returning the batches that failed on
 // InnoDB lock contention (1205/1213) for the caller to retry serially.
+//
+// deadline bounds *dispatch* and is supplied by the caller rather than computed
+// here, because a partitioned drain calls this once per stripe and the budget
+// belongs to the drain.
 //
 // Contention does *not* cancel the group. Every other error class does, exactly
 // as before: those are not self-inflicted and retrying at a narrower width
@@ -1149,7 +1233,7 @@ func (s *bufferedMap) drainMapSnapshot(ctx context.Context, snapshot map[string]
 // (the previous behaviour) threw away batches that were about to land and made
 // the whole drain fail, which is what pinned the buffer at its soft limit and
 // froze the flushed position.
-func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[string]bufferedChange, batches []*mapFlushBatch) ([]*mapFlushBatch, bool, error) {
+func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[string]bufferedChange, batches []*mapFlushBatch, deadline time.Time) ([]*mapFlushBatch, bool, error) {
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(s.effectiveFlushConcurrency())
 	// Workers delete their batch's entries as they land, so they only
@@ -1174,7 +1258,6 @@ func (s *bufferedMap) applyBatchesConcurrent(ctx context.Context, snapshot map[s
 	// batch *starts* after the deadline"; the loop check is just a cheap early
 	// exit. Overrun is therefore one in-flight batch's latency, which is the
 	// least that can be promised without abandoning work already under way.
-	deadline := time.Now().Add(drainDispatchBudget)
 	var budgetSpent atomic.Bool
 	for _, batch := range batches {
 		if gctx.Err() != nil {

--- a/pkg/change/subscription_buffered_partition.go
+++ b/pkg/change/subscription_buffered_partition.go
@@ -1,0 +1,534 @@
+package change
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/block/spirit/pkg/table"
+)
+
+// This file makes a map-mode drain's batches disjoint *by unique secondary
+// index range* rather than only by primary key.
+//
+// The problem it solves. Two concurrent REPLACE statements on PK-disjoint rows
+// can still deadlock, and in production (block/spirit#1168) they did: the
+// InnoDB cycle inverted between the clustered index and a UNIQUE secondary
+// index. The reason is that a REPLACE's duplicate detection takes a *next-key*
+// lock on each unique secondary index — the gap below the record included — so
+// two batches collide whenever any of their rows land in adjacent slots of any
+// such index. Primary-key disjointness says nothing about that, because
+// secondary key order is unrelated to PK order.
+//
+// The existing defence is an AIMD controller that narrows the flush until the
+// deadlocks stop. It works, but it pays for safety in throughput and it never
+// stops paying: each contention step costs 4x (both concurrency and batch size
+// halve), and a table whose unique key correlates with anything keeps
+// re-triggering it. On the table that motivated this, the drain never converged.
+//
+// The approach. Sort the drain by one unique secondary index, cut *contiguous*
+// batches, and never run two adjacent batches at the same time. Then rows that
+// are close together in that index land in the same statement — where they
+// cannot conflict, since a statement does not deadlock against itself — and
+// statements that do run together are separated by at least one whole batch of
+// intervening rows.
+//
+// Three things make this work that are worth stating plainly, because each one
+// is a claim that could have gone the other way:
+//
+//   - It must be *range* partitioning, not hashing the key into buckets.
+//     Hashing spreads equal-ish values across buckets, which is precisely the
+//     arrangement that collides. The risk is gap adjacency, not shared records.
+//
+//   - Separation must be by *rows*, not by value distance. Whether two values
+//     are adjacent in the B-tree depends on the 8.5-billion-row table, not on
+//     the 50,000 rows in hand, so no value-space margin is meaningful. One
+//     whole batch of intervening rows from this drain is a margin that is,
+//     because those rows are themselves records sitting between the two.
+//
+//   - Being wrong is a throughput cost, never a correctness one. Batches remain
+//     disjoint by key and map mode makes no cross-key ordering promises, so a
+//     misordered sort or a badly chosen index produces the *old* collision
+//     behaviour and the AIMD controller still catches it. Nothing here is
+//     load-bearing for data integrity. That is what makes it safe to sort row
+//     images with a best-effort comparator, which an earlier attempt at
+//     PK-sorting could not safely do.
+//
+// What it does not cover, and why the AIMD controller stays:
+//
+//   - Deletes. A buffered delete keeps only its PK (`LogicalRow{IsDeleted:
+//     true}` — the before image is discarded at buffer time), so there is no
+//     way to know where it sits in a unique secondary index. Deleted rows are
+//     grouped together at the tail and keep today's behaviour.
+//   - Second and subsequent unique indexes. Sorting by one index says nothing
+//     about the others. Choosing the *most clustered* index is what makes this
+//     worthwhile: an index whose values are uniformly distributed has an
+//     adjacency probability of about n^2/N per drain (~0.3 for 50,000 rows in
+//     8.5 billion), while a correlated one is a near-certainty.
+//   - REPLACE's out-of-partition deletion cascade. A REPLACE deletes any row
+//     conflicting on any unique index, including PKs not in the batch, whose
+//     other unique values are unknowable from here. This is documented at
+//     applier.UpsertRows and is irreducible.
+
+// partitionIndex is a resolved unique secondary index: its columns' positions
+// in the source row image, so extracting a row's key is a slice index rather
+// than a name lookup per row.
+type partitionIndex struct {
+	name string
+	// ordinals are positions in bufferedChange.logicalRow.RowImage, in key
+	// order. Empty is impossible — resolvePartitionIndexes drops such an index.
+	ordinals []int
+}
+
+// flushPartitioner holds the candidate indexes for a subscription. Resolution
+// needs a query, and NewBufferedSubscription has no context, so it happens
+// lazily on the first drain that could use it.
+type flushPartitioner struct {
+	once       sync.Once
+	candidates []partitionIndex
+}
+
+// resolvePartitionIndexes reads the *new* table's unique secondary indexes and
+// maps each one's columns onto positions in the source row image.
+//
+// The new table is the right side to read: the REPLACE runs there, so its
+// indexes are the locks being taken. An ALTER may have added or dropped one,
+// which is exactly why this cannot be read from the source. But the row image
+// comes from the source's binlog, so an index is only usable if every one of
+// its columns also exists on the source — an index on a column the ALTER *adds*
+// has no value to sort by here. Those are dropped rather than partially used.
+func resolvePartitionIndexes(ctx context.Context, sourceTable, newTable *table.TableInfo) ([]partitionIndex, error) {
+	// Both handles are optional as far as this file is concerned. Queue-mode
+	// subscriptions and the package's own bare test maps carry no new table, and
+	// a metadata-only TableInfo has no server to ask. None of those is a fault:
+	// they just mean the drain batches as it did before.
+	if sourceTable == nil || newTable == nil {
+		return nil, nil
+	}
+	unique, err := newTable.UniqueSecondaryIndexes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []partitionIndex
+	for _, idx := range unique {
+		ordinals := make([]int, 0, len(idx.Columns))
+		usable := true
+		for _, col := range idx.Columns {
+			ord := slices.Index(sourceTable.Columns, col)
+			if ord < 0 {
+				usable = false
+				break
+			}
+			ordinals = append(ordinals, ord)
+		}
+		if usable {
+			out = append(out, partitionIndex{name: idx.Name, ordinals: ordinals})
+		}
+	}
+	return out, nil
+}
+
+// partitionIndexes returns the resolved candidates, resolving them on first
+// use. A failure is cached as "no candidates": the query is against
+// information_schema on the same connection the drain is about to use, so if it
+// fails the drain has bigger problems, and partitioning is an optimization that
+// must never be the reason a flush fails.
+func (s *bufferedMap) partitionIndexes(ctx context.Context) []partitionIndex {
+	s.partitioner.once.Do(func() {
+		candidates, err := resolvePartitionIndexes(ctx, s.table, s.newTable)
+		if err != nil {
+			s.logger.Warn("could not read unique indexes for flush partitioning; flush batches will be partitioned by primary key only",
+				"table", s.table.SchemaName+"."+s.table.TableName,
+				"error", err.Error())
+			return
+		}
+		s.partitioner.candidates = candidates
+		switch len(candidates) {
+		case 0:
+			// Not a warning. No unique secondary index means there is no
+			// conflict surface to partition: the clustered index takes record
+			// locks without gaps, so PK-disjoint batches already cannot collide.
+			s.logger.Debug("flush partitioning inactive: no usable unique secondary index",
+				"table", s.table.SchemaName+"."+s.table.TableName)
+		default:
+			names := make([]string, len(candidates))
+			for i, c := range candidates {
+				names[i] = c.name
+			}
+			s.logger.Info("flush partitioning enabled: batches will be cut into contiguous ranges of a unique secondary index",
+				"table", s.table.SchemaName+"."+s.table.TableName,
+				"candidate_indexes", names)
+		}
+	})
+	return s.partitioner.candidates
+}
+
+// drainRow is one snapshot entry with its map key, so the sort can carry both.
+type drainRow struct {
+	key    string
+	change bufferedChange
+}
+
+// keyOf extracts a row's value for the leading column of idx, or nil when the
+// row has no usable image (a delete, or a truncated image).
+func (idx partitionIndex) leadingValue(change bufferedChange) (any, bool) {
+	img := change.logicalRow.RowImage
+	if change.logicalRow.IsDeleted || len(img) <= idx.ordinals[0] {
+		return nil, false
+	}
+	return img[idx.ordinals[0]], true
+}
+
+// choosePartitionIndex picks the candidate whose values are most clustered
+// across this drain's rows, or nil when there is nothing to choose from.
+//
+// The score is the number of rows that share a leading-column value with some
+// other row: `len(rows) - distinct(leading values)`. That is the signal that
+// matters, and it is measured from the data in hand rather than configured —
+// which is the only way to get it right, since whether a key correlates with
+// anything is a property of the workload and not of the schema.
+//
+// A correlated index (sibling rows sharing a leading value, so they are
+// physically adjacent and *guaranteed* to collide once random map iteration
+// scatters them across batches) scores near len(rows). An opaque, uniformly
+// distributed key scores 0, because every value is distinct. Sorting by the
+// former is what buys something.
+//
+// One consequence is worth being explicit about, because it looks like a bug
+// otherwise: a *single-column* unique index always scores exactly 0. It has to
+// — its values cannot repeat, that is what unique means. Clustering can only
+// ever show up as a repeating *leading* column of a composite unique key, with
+// a discriminator after it. That is not a limitation so much as a description
+// of the production shape: a correlated leading column is precisely how a
+// composite unique key ends up with adjacent sibling records.
+//
+// So an all-zero score does not mean "don't partition", and the tie is not
+// arbitrary neglect:
+//
+//   - A uniform key still has B-tree-adjacent pairs by chance (~n^2/N per
+//     drain), and sorting brings any such pair into one batch.
+//   - A single-column key can be *sequentially allocated* — 'tok-0001',
+//     'tok-0002' — which is adjacency this score cannot see but the sort
+//     handles anyway.
+//
+// Both are served by sorting at all, so the first candidate wins ties and the
+// score only decides *which* index when one of them is measurably clustered.
+// Scoring lexical closeness rather than equality would also catch the
+// sequential-allocation case in the choice, at the cost of sorting once per
+// candidate; it has not been needed, and this note is here so the option is
+// visible if it ever is.
+func choosePartitionIndex(candidates []partitionIndex, rows []drainRow) *partitionIndex {
+	if len(candidates) == 0 || len(rows) == 0 {
+		return nil
+	}
+	best, bestScore := -1, -1
+	seen := make(map[any]struct{}, len(rows))
+	for i, idx := range candidates {
+		clear(seen)
+		counted := 0
+		for _, r := range rows {
+			v, ok := idx.leadingValue(r.change)
+			if !ok {
+				continue
+			}
+			counted++
+			seen[normalizeForSet(v)] = struct{}{}
+		}
+		if counted == 0 {
+			continue // every row is a delete, or the image is too short
+		}
+		if score := counted - len(seen); score > bestScore {
+			best, bestScore = i, score
+		}
+	}
+	if best < 0 {
+		return nil
+	}
+	return &candidates[best]
+}
+
+// normalizeForSet makes a row-image value usable as a map key. []byte is not
+// comparable, so it becomes a string; everything else already is. Numeric
+// widths are deliberately *not* unified here — this only counts distinct
+// values, and go-mysql decodes a given column to one consistent Go type, so
+// int32(1) and int64(1) never both appear for the same column.
+func normalizeForSet(v any) any {
+	if b, ok := v.([]byte); ok {
+		return string(b)
+	}
+	return v
+}
+
+// sortRowsByIndex orders rows by idx's key values, rows with no usable key
+// last. Rows are compared component by component in key order.
+//
+// The ordering only has to *cluster*; it does not have to match InnoDB's
+// collation. Where it disagrees — a non-binary collation, a locale-specific
+// ordering — the affected rows land in a neighbouring batch instead of this
+// one, which costs a little separation and nothing else. See this file's header
+// for why that is a throughput property rather than a correctness one.
+func sortRowsByIndex(rows []drainRow, idx *partitionIndex) {
+	slices.SortStableFunc(rows, func(a, b drainRow) int {
+		aImg, aOK := usableImage(a.change, idx)
+		bImg, bOK := usableImage(b.change, idx)
+		switch {
+		case !aOK && !bOK:
+			return 0
+		case !aOK:
+			return 1 // no key sorts last
+		case !bOK:
+			return -1
+		}
+		for _, ord := range idx.ordinals {
+			if c := compareRowValues(aImg[ord], bImg[ord]); c != 0 {
+				return c
+			}
+		}
+		return 0
+	})
+}
+
+func usableImage(change bufferedChange, idx *partitionIndex) ([]any, bool) {
+	img := change.logicalRow.RowImage
+	if change.logicalRow.IsDeleted {
+		return nil, false
+	}
+	for _, ord := range idx.ordinals {
+		if ord >= len(img) {
+			return nil, false
+		}
+	}
+	return img, true
+}
+
+// valueKind ranks the type families so a column that somehow yields mixed types
+// still produces a total order instead of an arbitrary one. Within a real
+// column this never fires — go-mysql decodes a column to one Go type — but the
+// comparator must be total regardless, because sort.Interface's contract is
+// not "total when the data is well-formed".
+type valueKind int
+
+const (
+	kindNull valueKind = iota
+	kindNumber
+	kindBytes
+	kindOther
+)
+
+func kindOf(v any) valueKind {
+	switch v.(type) {
+	case nil:
+		return kindNull
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return kindNumber
+	case string, []byte:
+		return kindBytes
+	default:
+		return kindOther
+	}
+}
+
+// compareRowValues orders two row-image values of the same column.
+//
+// Every integer width go-mysql can produce is handled explicitly. That is not
+// defensive boilerplate: an earlier PK-sorting attempt in this package had arms
+// for int64/uint64/float64/string/[]byte only, and because go-mysql decodes
+// MYSQL_TYPE_LONG to int32, TINY to int8, SHORT to int16 and INT24 to int32,
+// an ordinary INT column fell through to a string comparison and sorted 100
+// before 9 — the exact inversion the sort existed to prevent. Falling through
+// silently is the failure mode to design against here.
+func compareRowValues(a, b any) int {
+	ka, kb := kindOf(a), kindOf(b)
+	if ka != kb {
+		return int(ka) - int(kb)
+	}
+	switch ka {
+	case kindNull:
+		return 0
+	case kindNumber:
+		return compareNumbers(a, b)
+	case kindBytes:
+		return bytes.Compare(asBytes(a), asBytes(b))
+	case kindOther:
+		// time.Time, decimal types rendered as a custom type, anything a future
+		// go-mysql adds. Comparing the rendered form is a poor order but a
+		// consistent one, and it is reached only by types no MySQL column
+		// currently decodes to.
+		return bytes.Compare(fmt.Append(nil, a), fmt.Append(nil, b))
+	}
+	return 0
+}
+
+func asBytes(v any) []byte {
+	switch t := v.(type) {
+	case string:
+		return []byte(t)
+	case []byte:
+		return t
+	}
+	return nil
+}
+
+// compareNumbers compares two numeric row-image values without going through
+// float64 for the integer cases: a bigint PK or unique key past 2^53 would lose
+// its low bits, and adjacent values differing only there are exactly the ones
+// this whole mechanism cares about keeping together.
+func compareNumbers(a, b any) int {
+	if ai, ok := asInt64(a); ok {
+		if bi, ok := asInt64(b); ok {
+			return cmpOrdered(ai, bi)
+		}
+		if bu, ok := asUint64(b); ok {
+			if ai < 0 {
+				return -1
+			}
+			return cmpOrdered(uint64(ai), bu)
+		}
+	}
+	if au, ok := asUint64(a); ok {
+		if bu, ok := asUint64(b); ok {
+			return cmpOrdered(au, bu)
+		}
+		if bi, ok := asInt64(b); ok {
+			if bi < 0 {
+				return 1
+			}
+			return cmpOrdered(au, uint64(bi))
+		}
+	}
+	// At least one side is a float; compare in float space. Precision loss is
+	// acceptable here in a way it is not for integers, because a float column's
+	// adjacent values are not meaningfully orderable at the ulp level anyway.
+	return cmpOrdered(asFloat64(a), asFloat64(b))
+}
+
+func cmpOrdered[T int64 | uint64 | float64](a, b T) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func asInt64(v any) (int64, bool) {
+	switch t := v.(type) {
+	case int:
+		return int64(t), true
+	case int8:
+		return int64(t), true
+	case int16:
+		return int64(t), true
+	case int32:
+		return int64(t), true
+	case int64:
+		return t, true
+	}
+	return 0, false
+}
+
+func asUint64(v any) (uint64, bool) {
+	switch t := v.(type) {
+	case uint:
+		return uint64(t), true
+	case uint8:
+		return uint64(t), true
+	case uint16:
+		return uint64(t), true
+	case uint32:
+		return uint64(t), true
+	case uint64:
+		return t, true
+	}
+	return 0, false
+}
+
+func asFloat64(v any) float64 {
+	switch t := v.(type) {
+	case float32:
+		return float64(t)
+	case float64:
+		return t
+	}
+	if i, ok := asInt64(v); ok {
+		return float64(i)
+	}
+	if u, ok := asUint64(v); ok {
+		return float64(u)
+	}
+	return 0
+}
+
+// minCutFill is the fraction of a full batch below which a cut point will not
+// be pulled back in search of a leading-value change. Without a floor, a table
+// whose leading value repeats every few rows would let every batch shrink to
+// almost nothing and multiply the statement count.
+const minCutFill = 2
+
+// cutAtValueBoundary returns where to end a batch that started at `start` and
+// would otherwise end at `hardEnd`, preferring a position where the leading key
+// value changes.
+//
+// Splitting a run of rows that share a leading value is the one thing worth
+// avoiding: those rows are physically adjacent in the index, so a split puts a
+// guaranteed-adjacent pair in two different batches — the production failure
+// exactly. Walking back to the last value change instead keeps the run whole.
+//
+// The walk-back is bounded to half a batch. A run longer than that cannot be
+// kept whole without unbounded batches, so it is split at the hard limit and
+// left to the stripe scheme below, which at least guarantees the two halves do
+// not run concurrently.
+func cutAtValueBoundary(rows []drainRow, idx *partitionIndex, start, hardEnd int) int {
+	if hardEnd >= len(rows) {
+		return len(rows)
+	}
+	floor := start + max(1, (hardEnd-start)/minCutFill)
+	prev, prevOK := idx.leadingValue(rows[hardEnd-1].change)
+	if !prevOK {
+		return hardEnd // in the delete tail; nothing to align to
+	}
+	for i := hardEnd - 1; i > floor; i-- {
+		v, ok := idx.leadingValue(rows[i-1].change)
+		if !ok {
+			return hardEnd
+		}
+		if compareRowValues(v, prev) != 0 {
+			return i // rows[i-1] and rows[i] differ: a real boundary
+		}
+	}
+	return hardEnd
+}
+
+// stripeBatches splits a list of *contiguous, sorted* batches into groups that
+// may each be run with full concurrency, such that no two batches in the same
+// group are adjacent in the sort order.
+//
+// Two groups is all it takes: evens, then odds. Any two batches in one group
+// have at least one whole batch of this drain's rows between them in unique-key
+// order, and those rows are themselves index records — so the two batches
+// cannot be holding adjacent slots. That is a structural guarantee rather than
+// a probabilistic one, and it is why the batches are not simply handed to the
+// existing limiter in sorted order: with a limiter, the in-flight window is
+// roughly contiguous, so neighbours run together and every batch boundary
+// becomes a candidate collision.
+//
+// The cost is one barrier: the slowest batch of the even group delays the odd
+// group. That is real, and it is much cheaper than what it replaces — an AIMD
+// contention step costs 4x and persists for several drains, while this costs
+// the tail of one group, once.
+func stripeBatches(batches []*mapFlushBatch) [][]*mapFlushBatch {
+	if len(batches) < 2 {
+		return [][]*mapFlushBatch{batches}
+	}
+	stripes := make([][]*mapFlushBatch, 2)
+	for i, b := range batches {
+		stripes[i%2] = append(stripes[i%2], b)
+	}
+	return stripes
+}

--- a/pkg/change/subscription_buffered_partition.go
+++ b/pkg/change/subscription_buffered_partition.go
@@ -484,6 +484,14 @@ const minCutFill = 2
 // kept whole without unbounded batches, so it is split at the hard limit and
 // left to the stripe scheme below, which at least guarantees the two halves do
 // not run concurrently.
+//
+// Given hardEnd > start, the result is always strictly greater than start: the
+// walk-back is floored at start+1, and both early returns (hardEnd, len(rows))
+// are past it. buildBatches advances its cursor to the cut, so a cut at start
+// would be a batch of no rows and a loop that never terminates. It keeps its
+// own guard rather than relying on this — but a change here that could return
+// start is a bug on this side of the boundary, and
+// TestCutAtValueBoundaryAlwaysAdvances is what says so.
 func cutAtValueBoundary(rows []drainRow, idx *partitionIndex, start, hardEnd int) int {
 	if hardEnd >= len(rows) {
 		return len(rows)

--- a/pkg/change/subscription_buffered_partition_live_test.go
+++ b/pkg/change/subscription_buffered_partition_live_test.go
@@ -1,0 +1,261 @@
+package change
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	mysql2 "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// partitionProbeDDL is the shape that motivated this whole mechanism: a bigint
+// auto-increment PK, one UNIQUE secondary key whose leading column is
+// *correlated* (siblings share it, so their records are physically adjacent),
+// and one whose value is opaque and unique per row.
+func partitionProbeDDL(name string) string {
+	return fmt.Sprintf(`CREATE TABLE %s (
+		id bigint NOT NULL AUTO_INCREMENT,
+		token varchar(255) NOT NULL,
+		key_a varchar(255) NOT NULL,
+		key_b varchar(255) NOT NULL,
+		key_c varchar(50) NOT NULL,
+		payload bigint NOT NULL DEFAULT 0,
+		PRIMARY KEY (id),
+		UNIQUE KEY unq_token (token),
+		UNIQUE KEY unq_composite (key_a, key_b, key_c),
+		KEY idx_payload (payload)
+	)`, name)
+}
+
+// TestFlushPartitioningAppliesEveryRow is the correctness half. Partitioning
+// reorders and regroups a drain's rows, so the thing that must be pinned first
+// is that reordering changes nothing about the outcome: every buffered change
+// still lands, exactly once, with its final value.
+//
+// This runs the real subscription against a real server rather than a fake
+// applier, because the reordering happens in the same code path that builds the
+// statements and the two are only worth testing together.
+func TestFlushPartitioningAppliesEveryRow(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS partprobe_t1, partprobe_t2")
+	testutils.RunSQL(t, partitionProbeDDL("partprobe_t1"))
+	testutils.RunSQL(t, partitionProbeDDL("partprobe_t2"))
+
+	// 400 rows in sibling groups of 8 sharing key_a. Note what has to be true
+	// for this to be a legal table *and* a clustered one: the composite key's
+	// leading column repeats while a trailing component varies, which is exactly
+	// the production shape — a correlated leading column with a discriminator
+	// after it. A UNIQUE key cannot repeat in full, so a repeating *leading*
+	// column is the only form clustering can take.
+	const rows, siblings = 400, 8
+	tuples := make([]string, 0, rows)
+	for i := range rows {
+		tuples = append(tuples, fmt.Sprintf("(%d, 'tok-%05d', 'grp-%04d', 'b', 'c%d', %d)",
+			i+1, i, i/siblings, i%siblings, i*10))
+	}
+	testutils.RunSQL(t, "INSERT INTO partprobe_t1 (id, token, key_a, key_b, key_c, payload) VALUES "+
+		strings.Join(tuples, ","))
+
+	t1 := table.NewTableInfo(db, "test", "partprobe_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "partprobe_t2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	cfg, err := mysql2.ParseDSN(testutils.DSN())
+	require.NoError(t, err)
+	client := NewBinlogClient(db, cfg.Addr, cfg.User, cfg.Passwd,
+		applier.NewSingleTargetForTest(t, db), NewClientDefaultConfig()).(*binlogClient)
+	chunker, err := table.NewChunker(t1, table.ChunkerConfig{NewTable: t2})
+	require.NoError(t, err)
+	require.NoError(t, client.AddSubscription(t1, t2, chunker))
+	require.NoError(t, client.Start(t.Context()))
+	t.Cleanup(client.Close)
+
+	// Update every row, then update a subset again so dedup collapses those to
+	// one image — the flush must land the *last* value for each key.
+	testutils.RunSQL(t, "UPDATE partprobe_t1 SET payload = payload + 1")
+	testutils.RunSQL(t, "UPDATE partprobe_t1 SET payload = payload + 1 WHERE id % 3 = 0")
+	// And delete a few, which exercise the no-row-image tail of the sort.
+	testutils.RunSQL(t, "DELETE FROM partprobe_t1 WHERE id % 97 = 0")
+
+	require.NoError(t, client.BlockWait(t.Context()))
+	require.NoError(t, client.Flush(t.Context()))
+
+	sub := client.subs.Snapshot()[0].(*bufferedMap)
+	require.NotEmpty(t, sub.partitioner.candidates,
+		"the probe table has two UNIQUE secondary indexes; both should have resolved")
+
+	// The target now matches the source, row for row and value for value. A
+	// misordered sort, a dropped batch, or a row batched twice all show up here.
+	var diff int
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*) FROM (
+			SELECT id FROM (
+				SELECT id, token, key_a, key_b, key_c, payload FROM partprobe_t1
+				UNION ALL
+				SELECT id, token, key_a, key_b, key_c, payload FROM partprobe_t2
+			) u
+			GROUP BY id, token, key_a, key_b, key_c, payload
+			HAVING COUNT(*) <> 2
+		) mismatched`).Scan(&diff))
+	require.Zero(t, diff, "every buffered change must land with its final value")
+
+	var srcCount, dstCount int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM partprobe_t1").Scan(&srcCount))
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM partprobe_t2").Scan(&dstCount))
+	require.Equal(t, srcCount, dstCount)
+	require.Less(t, srcCount, rows, "the deletes must actually have been applied")
+}
+
+// TestFlushPartitioningChoosesTheCorrelatedIndex pins the self-configuration
+// against a real table's index metadata, rather than against hand-built
+// partitionIndex values. The chooser has to pick the *correlated* key: sorting
+// by an opaque one buys almost nothing (its adjacency probability is about
+// n^2/N per drain), while sorting by a key whose leading column repeats brings
+// guaranteed-adjacent sibling records into a single statement.
+func TestFlushPartitioningChoosesTheCorrelatedIndex(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS partchoose_t1, partchoose_t2")
+	testutils.RunSQL(t, partitionProbeDDL("partchoose_t1"))
+	testutils.RunSQL(t, partitionProbeDDL("partchoose_t2"))
+
+	t1 := table.NewTableInfo(db, "test", "partchoose_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "partchoose_t2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	candidates, err := resolvePartitionIndexes(t.Context(), t1, t2)
+	require.NoError(t, err)
+	require.Len(t, candidates, 2, "unq_token and unq_composite")
+
+	// key_a is the leading column of unq_composite; ordinals index the source
+	// row image, so this also pins the column-name-to-ordinal mapping.
+	byName := map[string]partitionIndex{}
+	for _, c := range candidates {
+		byName[c.name] = c
+	}
+	require.Equal(t, []int{1}, byName["unq_token"].ordinals, "token is column 1")
+	require.Equal(t, []int{2, 3, 4}, byName["unq_composite"].ordinals, "key_a, key_b, key_c")
+
+	// Rows whose composite key has a leading column repeating every 8, and a
+	// token that is unique per row as a UNIQUE single-column key must be.
+	newRows := func(clustered bool) []drainRow {
+		var rows []drainRow
+		for i := range int64(160) {
+			leading := fmt.Sprintf("grp-%05d", i)
+			if clustered {
+				leading = fmt.Sprintf("grp-%04d", i/8)
+			}
+			rows = append(rows, drainRow{
+				key: fmt.Sprintf("k%d", i),
+				change: bufferedChange{
+					originalKey: []any{i},
+					logicalRow: applier.LogicalRow{RowImage: []any{
+						i,
+						fmt.Sprintf("tok-%05d", i),
+						leading,
+						"b", fmt.Sprintf("c%d", i%8), i * 10,
+					}},
+				},
+			})
+		}
+		return rows
+	}
+
+	chosen := choosePartitionIndex(candidates, newRows(true))
+	require.NotNil(t, chosen)
+	require.Equal(t, "unq_composite", chosen.name,
+		"the correlated key must win: its leading column repeats, so its records are adjacent")
+
+	// With no clustering anywhere — every leading value distinct in both keys —
+	// there is nothing to discriminate on and any candidate is as good as the
+	// other. The contract in that case is only that partitioning still happens:
+	// sorting is what brings a chance-adjacent pair into one batch, and it costs
+	// one sort whichever key it is.
+	chosen = choosePartitionIndex(candidates, newRows(false))
+	require.NotNil(t, chosen, "an unclustered drain is still worth sorting")
+}
+
+// TestFlushPartitioningInactiveWithoutUniqueIndex pins the degradation path. A
+// table with no unique secondary index has no conflict surface for two
+// PK-disjoint batches to fight over — the clustered index takes record locks
+// with no gap — so the sort would be pure cost and must not happen.
+func TestFlushPartitioningInactiveWithoutUniqueIndex(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS partnone_t1, partnone_t2")
+	for _, name := range []string{"partnone_t1", "partnone_t2"} {
+		testutils.RunSQL(t, fmt.Sprintf(`CREATE TABLE %s (
+			id bigint NOT NULL AUTO_INCREMENT,
+			name varchar(255) NOT NULL,
+			PRIMARY KEY (id),
+			KEY idx_name (name)
+		)`, name))
+	}
+
+	t1 := table.NewTableInfo(db, "test", "partnone_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "partnone_t2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	candidates, err := resolvePartitionIndexes(t.Context(), t1, t2)
+	require.NoError(t, err)
+	require.Empty(t, candidates, "a non-unique index is not a conflict surface between PK-disjoint rows")
+	require.Nil(t, choosePartitionIndex(candidates, []drainRow{
+		{key: "k", change: bufferedChange{logicalRow: applier.LogicalRow{RowImage: []any{int64(1), "a"}}}},
+	}))
+}
+
+// TestFlushPartitioningSkipsIndexesOnAddedColumns covers the ALTER that adds a
+// unique index on a column the source does not have. The row images come from
+// the source's binlog, so there is no value to sort by — and a partially mapped
+// index would be worse than none, since the drain would sort by a prefix while
+// believing it had the whole key.
+func TestFlushPartitioningSkipsIndexesOnAddedColumns(t *testing.T) {
+	db, err := dbconn.New(testutils.DSN(), dbconn.NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS partadded_t1, partadded_t2")
+	testutils.RunSQL(t, `CREATE TABLE partadded_t1 (
+		id bigint NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY unq_name (name)
+	)`)
+	// The new table has unq_name plus a unique index on a column the source
+	// lacks entirely.
+	testutils.RunSQL(t, `CREATE TABLE partadded_t2 (
+		id bigint NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		added varchar(255) NOT NULL DEFAULT '',
+		PRIMARY KEY (id),
+		UNIQUE KEY unq_name (name),
+		UNIQUE KEY unq_added (added)
+	)`)
+
+	t1 := table.NewTableInfo(db, "test", "partadded_t1")
+	require.NoError(t, t1.SetInfo(t.Context()))
+	t2 := table.NewTableInfo(db, "test", "partadded_t2")
+	require.NoError(t, t2.SetInfo(t.Context()))
+
+	candidates, err := resolvePartitionIndexes(t.Context(), t1, t2)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, "unq_name", candidates[0].name,
+		"unq_added covers a column the source row image does not contain")
+}

--- a/pkg/change/subscription_buffered_partition_test.go
+++ b/pkg/change/subscription_buffered_partition_test.go
@@ -306,3 +306,92 @@ func abs(n int) int {
 	}
 	return n
 }
+
+// TestCutAtValueBoundaryAlwaysAdvances sweeps the cut over adversarial row
+// shapes and asserts the one property buildBatches' loop termination depends
+// on. The cut is the loop's only source of progress, so a return at `start`
+// would not be an off-by-one — it would be a hang that allocates an empty
+// batch per turn until the process dies.
+//
+// The shapes are chosen to press on every branch: one value everywhere (no
+// boundary to walk back to, so the floor must hold), all values distinct
+// (a boundary at every position), long runs (the walk-back travels), and a
+// delete tail (leadingValue stops reporting partway through).
+func TestCutAtValueBoundaryAlwaysAdvances(t *testing.T) {
+	shapes := map[string][]drainRow{}
+
+	var oneValue, distinct, runs, withDeletes []drainRow
+	for i := range int64(40) {
+		key := fmt.Sprintf("k%03d", i)
+		oneValue = append(oneValue, upsertRow(key, i, "same", ""))
+		distinct = append(distinct, upsertRow(key, i, fmt.Sprintf("v%03d", i), ""))
+		runs = append(runs, upsertRow(key, i, fmt.Sprintf("g%03d", i/7), ""))
+		if i < 25 {
+			withDeletes = append(withDeletes, upsertRow(key, i, fmt.Sprintf("g%03d", i/7), ""))
+		} else {
+			withDeletes = append(withDeletes, deleteRow(key, i))
+		}
+	}
+	shapes["one value"] = oneValue
+	shapes["all distinct"] = distinct
+	shapes["runs of 7"] = runs
+	shapes["delete tail"] = withDeletes
+	shapes["single row"] = oneValue[:1]
+
+	for name, rows := range shapes {
+		t.Run(name, func(t *testing.T) {
+			for _, idx := range []*partitionIndex{&leadingIdx, &compositeIdx} {
+				for start := range len(rows) {
+					// Every batch size, including 1 — the size an AIMD-floored
+					// drain of narrow batches reaches, and the tightest case
+					// for the walk-back floor.
+					for _, batchSize := range []int{1, 2, 3, 7, 10, 64} {
+						hardEnd := min(start+batchSize, len(rows))
+						got := cutAtValueBoundary(rows, idx, start, hardEnd)
+						require.Greater(t, got, start,
+							"idx=%s start=%d batchSize=%d: a cut at or before the start "+
+								"is an infinite loop in buildBatches", idx.name, start, batchSize)
+						require.LessOrEqual(t, got, len(rows),
+							"idx=%s start=%d batchSize=%d: cut past the rows", idx.name, start, batchSize)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBuildBatchesAlwaysConsumesRows is the same property one level up, where
+// it actually bites. Termination is asserted by the test completing: the loop
+// under test is the one that would hang.
+func TestBuildBatchesAlwaysConsumesRows(t *testing.T) {
+	for _, batchSize := range []int{1, 2, minAdaptiveBatchSize, DefaultBatchSize} {
+		for _, partitioned := range []bool{false, true} {
+			sub := newByteCapBufferedMap(&countingApplier{}, false)
+			sub.batchSize = batchSize
+
+			// One leading value across the whole set: the shape with no
+			// boundary to align to, so the walk-back finds nothing and the
+			// floor is the only thing keeping the cut ahead of the cursor.
+			var rows []drainRow
+			for i := range int64(120) {
+				rows = append(rows, upsertRow(fmt.Sprintf("k%03d", i), i, "same", ""))
+			}
+
+			var idx *partitionIndex
+			if partitioned {
+				idx = &leadingIdx
+			}
+			batches := sub.buildBatches(rows, idx)
+
+			total := 0
+			for _, b := range batches {
+				require.NotEmpty(t, b.keys,
+					"batchSize=%d partitioned=%t: an empty batch means the cursor did not advance",
+					batchSize, partitioned)
+				total += len(b.keys)
+			}
+			require.Equal(t, len(rows), total,
+				"batchSize=%d partitioned=%t: every row batched exactly once", batchSize, partitioned)
+		}
+	}
+}

--- a/pkg/change/subscription_buffered_partition_test.go
+++ b/pkg/change/subscription_buffered_partition_test.go
@@ -1,0 +1,308 @@
+package change
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/stretchr/testify/require"
+)
+
+// upsertRow builds a drainRow whose row image is [id, leading, trailing], which
+// matches the partition indexes the tests below construct.
+func upsertRow(key string, id int64, leading, trailing any) drainRow {
+	return drainRow{
+		key: key,
+		change: bufferedChange{
+			logicalRow:  applier.LogicalRow{RowImage: []any{id, leading, trailing}},
+			originalKey: []any{id},
+		},
+	}
+}
+
+func deleteRow(key string, id int64) drainRow {
+	return drainRow{
+		key: key,
+		change: bufferedChange{
+			logicalRow:  applier.LogicalRow{IsDeleted: true},
+			originalKey: []any{id},
+		},
+	}
+}
+
+// leadingIdx partitions on the row image's column 1 alone; compositeIdx on
+// columns 1 and 2, so only the leading one decides coarse placement.
+var (
+	leadingIdx   = partitionIndex{name: "unq_leading", ordinals: []int{1}}
+	compositeIdx = partitionIndex{name: "unq_composite", ordinals: []int{1, 2}}
+)
+
+// TestCompareRowValuesHandlesEveryIntegerWidth is the regression guard for the
+// bug that killed the previous sorting attempt in this package. go-mysql decodes
+// MYSQL_TYPE_LONG to int32, TINY to int8, SHORT to int16 and INT24 to int32, so
+// a comparator with only an int64 arm sends an ordinary INT column through a
+// string comparison — where "100" sorts before "9" and the sort actively
+// inverts the order it was added to establish.
+func TestCompareRowValuesHandlesEveryIntegerWidth(t *testing.T) {
+	// Every width go-mysql can produce, each asserting 9 < 100 numerically.
+	widths := []struct {
+		name  string
+		small any
+		large any
+	}{
+		{"int", int(9), int(100)},
+		{"int8", int8(9), int8(100)},
+		{"int16", int16(9), int16(100)},
+		{"int32", int32(9), int32(100)},
+		{"int64", int64(9), int64(100)},
+		{"uint", uint(9), uint(100)},
+		{"uint8", uint8(9), uint8(100)},
+		{"uint16", uint16(9), uint16(100)},
+		{"uint32", uint32(9), uint32(100)},
+		{"uint64", uint64(9), uint64(100)},
+		{"float32", float32(9), float32(100)},
+		{"float64", float64(9), float64(100)},
+	}
+	for _, w := range widths {
+		t.Run(w.name, func(t *testing.T) {
+			require.Negative(t, compareRowValues(w.small, w.large),
+				"9 must sort before 100 — a string comparison would invert this")
+			require.Positive(t, compareRowValues(w.large, w.small))
+			require.Zero(t, compareRowValues(w.small, w.small))
+		})
+	}
+
+	// Integers must not be compared through float64: past 2^53 that loses the
+	// low bits, and values differing only there are exactly the adjacent ones
+	// this mechanism exists to keep in one batch.
+	a, b := int64(1<<53), int64(1<<53)+1
+	require.Negative(t, compareRowValues(a, b), "bigint precision must survive the comparison")
+	require.InDelta(t, float64(a), float64(b), 0,
+		"the premise: these are indistinguishable as float64, which is why the integer path matters")
+
+	ua, ub := uint64(math.MaxUint64), uint64(math.MaxUint64)-1
+	require.Positive(t, compareRowValues(ua, ub), "a uint64 past MaxInt64 must not wrap")
+
+	// A signed/unsigned mix cannot arise from one column, but the comparator has
+	// to stay total rather than returning a wrong answer if it ever does.
+	require.Negative(t, compareRowValues(int64(-1), uint64(1)))
+	require.Positive(t, compareRowValues(uint64(1), int64(-1)))
+}
+
+// TestCompareRowValuesIsTotal pins the properties sort.Interface requires. A
+// comparator that is merely usually-right produces an arbitrary permutation
+// rather than a slightly worse one, so the ordering must be total across type
+// families too — not only within a well-formed column.
+func TestCompareRowValuesIsTotal(t *testing.T) {
+	values := []any{
+		nil, int64(-5), int64(0), int64(7), float64(1.5),
+		"", "a", "b", []byte("a"), []byte("z"),
+		struct{ X int }{1},
+	}
+	for _, a := range values {
+		for _, b := range values {
+			ab, ba := compareRowValues(a, b), compareRowValues(b, a)
+			require.Equal(t, ab, -ba, "antisymmetry for (%v, %v)", a, b)
+		}
+		require.Zero(t, compareRowValues(a, a), "reflexivity for %v", a)
+	}
+	// NULL sorts first and string/[]byte compare as the same family, so a
+	// varchar column that go-mysql sometimes hands back as []byte still orders
+	// with its string neighbours instead of forming a second cluster.
+	require.Negative(t, compareRowValues(nil, int64(0)))
+	require.Zero(t, compareRowValues("abc", []byte("abc")))
+	require.Negative(t, compareRowValues([]byte("abc"), "abd"))
+}
+
+// TestChoosePartitionIndexPrefersTheClusteredKey is the heart of the design's
+// self-configuration: with two unique indexes, the one whose values repeat is
+// the one worth sorting by, because repeated leading values mean physically
+// adjacent records and therefore guaranteed collisions once map iteration
+// scatters them. An opaque, uniformly distributed key has an adjacency
+// probability of roughly n^2/N per drain and needs no help.
+func TestChoosePartitionIndexPrefersTheClusteredKey(t *testing.T) {
+	// column 1 is correlated (10 rows per value); column 2 is unique per row.
+	var rows []drainRow
+	for i := range int64(100) {
+		rows = append(rows, upsertRow(fmt.Sprintf("k%d", i), i,
+			fmt.Sprintf("group-%02d", i/10), fmt.Sprintf("opaque-%04d", i)))
+	}
+	clustered := partitionIndex{name: "unq_clustered", ordinals: []int{1}}
+	opaque := partitionIndex{name: "unq_opaque", ordinals: []int{2}}
+
+	// Offered in either order, the clustered index wins on its own merits
+	// rather than on its position in the candidate list.
+	for _, candidates := range [][]partitionIndex{
+		{clustered, opaque},
+		{opaque, clustered},
+	} {
+		chosen := choosePartitionIndex(candidates, rows)
+		require.NotNil(t, chosen)
+		require.Equal(t, "unq_clustered", chosen.name)
+	}
+
+	// With only the opaque key on offer it is still chosen: every value being
+	// distinct scores zero, but sorting by it costs one sort and still brings
+	// any chance-adjacent pair into a single batch.
+	chosen := choosePartitionIndex([]partitionIndex{opaque}, rows)
+	require.NotNil(t, chosen)
+	require.Equal(t, "unq_opaque", chosen.name)
+
+	// Degenerate inputs must yield nil rather than a partitioning that cannot
+	// be computed.
+	require.Nil(t, choosePartitionIndex(nil, rows), "no candidates")
+	require.Nil(t, choosePartitionIndex([]partitionIndex{clustered}, nil), "no rows")
+	deletes := []drainRow{deleteRow("d1", 1), deleteRow("d2", 2)}
+	require.Nil(t, choosePartitionIndex([]partitionIndex{clustered}, deletes),
+		"a delete keeps no row image, so there is no value to cluster on")
+}
+
+// TestSortRowsByIndexClustersAndTailsDeletes pins the two things the sort has
+// to get right: the composite key is compared component by component, and rows
+// with no usable key go to the end rather than being interleaved (which would
+// split otherwise-contiguous ranges around them).
+func TestSortRowsByIndexClustersAndTailsDeletes(t *testing.T) {
+	rows := []drainRow{
+		upsertRow("e", 5, "b", "2"),
+		deleteRow("del1", 90),
+		upsertRow("c", 3, "a", "3"),
+		upsertRow("a", 1, "a", "1"),
+		upsertRow("d", 4, "b", "1"),
+		deleteRow("del2", 91),
+		upsertRow("b", 2, "a", "2"),
+	}
+	sortRowsByIndex(rows, &compositeIdx)
+
+	var got []string
+	for _, r := range rows {
+		got = append(got, r.key)
+	}
+	require.Equal(t, []string{"a", "b", "c", "d", "e", "del1", "del2"}, got,
+		"sorted by (col1, col2) with the image-less rows tailed")
+}
+
+// TestCutAtValueBoundaryKeepsRunsWhole covers the cut-point nudge. Splitting a
+// run of rows that share a leading value is the production failure in
+// miniature: those records are adjacent, so a split guarantees an adjacent pair
+// in two different batches.
+func TestCutAtValueBoundaryKeepsRunsWhole(t *testing.T) {
+	// 12 rows: values "a" x5, "b" x4, "c" x3, already sorted.
+	var rows []drainRow
+	for i, v := range []string{"a", "a", "a", "a", "a", "b", "b", "b", "b", "c", "c", "c"} {
+		rows = append(rows, upsertRow(fmt.Sprintf("k%d", i), int64(i), v, ""))
+	}
+
+	// A hard end of 7 falls inside the "b" run; the cut walks back to 5, where
+	// "a" becomes "b".
+	require.Equal(t, 5, cutAtValueBoundary(rows, &leadingIdx, 0, 7))
+
+	// A hard end that already sits on a boundary is left alone.
+	require.Equal(t, 9, cutAtValueBoundary(rows, &leadingIdx, 5, 9))
+
+	// The walk-back is floored at half a batch. Here the whole span is one
+	// value, so there is no boundary to find and the hard limit stands — a run
+	// longer than a batch cannot be kept whole without unbounded batches, and
+	// the stripe scheme is what protects it instead.
+	var oneValue []drainRow
+	for i := range 20 {
+		oneValue = append(oneValue, upsertRow(fmt.Sprintf("s%d", i), int64(i), "same", ""))
+	}
+	require.Equal(t, 10, cutAtValueBoundary(oneValue, &leadingIdx, 0, 10))
+
+	// Past the end of the rows the cut is the end of the rows.
+	require.Equal(t, len(rows), cutAtValueBoundary(rows, &leadingIdx, 0, 99))
+}
+
+// TestBuildBatchesProducesContiguousRanges pins that a partitioned drain's
+// batches are contiguous in the sorted order and that no leading-value run is
+// split across two of them.
+func TestBuildBatchesProducesContiguousRanges(t *testing.T) {
+	sub := newByteCapBufferedMap(&countingApplier{}, false)
+	sub.batchSize = 10
+
+	// 200 rows in runs of 4 sharing a leading value.
+	var rows []drainRow
+	for i := range int64(200) {
+		rows = append(rows, upsertRow(fmt.Sprintf("k%03d", i), i,
+			fmt.Sprintf("g%03d", i/4), fmt.Sprintf("t%03d", i)))
+	}
+	sortRowsByIndex(rows, &leadingIdx)
+	batches := sub.buildBatches(rows, &leadingIdx)
+	require.Greater(t, len(batches), 1)
+
+	// Every row appears exactly once, and batches tile the sorted order in
+	// order — the property the stripe scheme's separation argument rests on.
+	seen := 0
+	for _, b := range batches {
+		for i, key := range b.keys {
+			require.Equal(t, rows[seen+i].key, key, "batches must tile the sorted order")
+		}
+		seen += len(b.keys)
+		require.LessOrEqual(t, len(b.keys), 10, "the row cap still binds")
+		require.NotEmpty(t, b.keys, "an empty batch would spin the build loop")
+	}
+	require.Equal(t, len(rows), seen, "every row must be batched exactly once")
+
+	// No leading value spans two batches.
+	owner := make(map[string]int)
+	for bi, b := range batches {
+		for _, key := range b.keys {
+			idx := 0
+			for i, r := range rows {
+				if r.key == key {
+					idx = i
+					break
+				}
+			}
+			v, _ := leadingIdx.leadingValue(rows[idx].change)
+			val := v.(string)
+			if prev, ok := owner[val]; ok {
+				require.Equal(t, prev, bi,
+					"leading value %q was split across batches %d and %d", val, prev, bi)
+			}
+			owner[val] = bi
+		}
+	}
+}
+
+// TestStripeBatchesSeparatesNeighbours is the invariant the whole design
+// reduces to: two batches that may be in flight together must never be
+// neighbours in the sorted order, because neighbours share a boundary and a
+// boundary is where a next-key lock on a unique index can overlap.
+func TestStripeBatchesSeparatesNeighbours(t *testing.T) {
+	for _, n := range []int{2, 3, 4, 5, 16, 33} {
+		batches := make([]*mapFlushBatch, n)
+		position := make(map[*mapFlushBatch]int, n)
+		for i := range batches {
+			batches[i] = &mapFlushBatch{keys: []string{fmt.Sprintf("b%d", i)}}
+			position[batches[i]] = i
+		}
+		stripes := stripeBatches(batches)
+
+		total := 0
+		for _, stripe := range stripes {
+			total += len(stripe)
+			for i, a := range stripe {
+				for _, b := range stripe[i+1:] {
+					require.Greater(t, abs(position[a]-position[b]), 1,
+						"batches %d and %d may run concurrently but are adjacent (n=%d)",
+						position[a], position[b], n)
+				}
+			}
+		}
+		require.Equal(t, n, total, "striping must not drop or duplicate a batch (n=%d)", n)
+	}
+
+	// A single batch has no neighbour, so it is not worth a barrier.
+	one := []*mapFlushBatch{{keys: []string{"only"}}}
+	require.Len(t, stripeBatches(one), 1)
+	require.Empty(t, stripeBatches(nil)[0])
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/pkg/table/tableinfo.go
+++ b/pkg/table/tableinfo.go
@@ -337,6 +337,96 @@ func (t *TableInfo) DescIndex(keyName string) ([]string, error) {
 	return cols, nil
 }
 
+// UniqueIndex describes one UNIQUE secondary index: its name and its columns
+// in key order. The order matters to callers reasoning about adjacency, since
+// only the leading column decides where a record sorts relative to records with
+// a different leading value.
+type UniqueIndex struct {
+	Name    string
+	Columns []string
+}
+
+// UniqueSecondaryIndexes returns the table's UNIQUE secondary indexes, PRIMARY
+// excluded. It is a live query rather than part of SetInfo because only the
+// change feed's flush partitioning needs it, and it needs it once per
+// subscription.
+//
+// This set is exactly the conflict surface between two concurrent REPLACE
+// statements on PK-disjoint rows. A *non-unique* secondary index is keyed
+// (indexed columns, PK), so PK-disjoint rows always occupy distinct records
+// there and cannot collide however equal their indexed values are. A *unique*
+// secondary index is keyed on the indexed columns alone, and InnoDB's duplicate
+// detection takes a next-key lock — gap included — so rows with merely
+// *adjacent* values collide. The clustered index does not belong here either:
+// a REPLACE's conflict there is with the row bearing that exact PK, which under
+// READ COMMITTED is a record lock with no gap. See
+// TestReplaceContendsOnlyOnUniqueIndexes in pkg/applier, which establishes all
+// three against a real server.
+//
+// Indexes with a NULL COLUMN_NAME are skipped: those are functional indexes,
+// whose key is an expression rather than a stored column, so a caller holding a
+// row image cannot compute where the row sorts in them.
+func (t *TableInfo) UniqueSecondaryIndexes(ctx context.Context) ([]UniqueIndex, error) {
+	// A TableInfo built by NewTableInfoFromMeta carries metadata with no server
+	// behind it (strata's pkg/vstream does this), so this is an ordinary state to
+	// be in rather than a caller error — but it must be an error and not a nil
+	// dereference, which is what an unguarded t.db gives.
+	if t.db == nil {
+		return nil, fmt.Errorf("table %s.%s has no database handle: index metadata is unavailable", t.SchemaName, t.TableName)
+	}
+	rows, err := t.db.QueryContext(ctx, `SELECT INDEX_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE table_schema=DATABASE() AND TABLE_NAME=? AND NON_UNIQUE=0 AND INDEX_NAME<>'PRIMARY'
+		ORDER BY INDEX_NAME, SEQ_IN_INDEX`,
+		t.TableName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("failed to close rows", "error", err)
+		}
+	}()
+	var (
+		indexes  []UniqueIndex
+		skipping = make(map[string]bool)
+	)
+	byName := make(map[string]int)
+	for rows.Next() {
+		var name string
+		var col sql.NullString
+		if err := rows.Scan(&name, &col); err != nil {
+			return nil, err
+		}
+		if !col.Valid {
+			// A functional index. Drop whatever was collected for it: a
+			// partially usable key order is worse than none, because a caller
+			// would sort by a prefix and believe it had the whole key.
+			skipping[name] = true
+			continue
+		}
+		if skipping[name] {
+			continue
+		}
+		pos, ok := byName[name]
+		if !ok {
+			byName[name] = len(indexes)
+			indexes = append(indexes, UniqueIndex{Name: name})
+			pos = len(indexes) - 1
+		}
+		indexes[pos].Columns = append(indexes[pos].Columns, col.String)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	// A functional column may appear after a stored one, so the drop above can
+	// leave a half-built entry behind. Filter at the end rather than trying to
+	// unwind in the loop.
+	return slices.DeleteFunc(indexes, func(idx UniqueIndex) bool {
+		return skipping[idx.Name] || len(idx.Columns) == 0
+	}), nil
+}
+
 // setPrimaryKey sets the primary key and also the primary key type.
 // A primary key can contain multiple columns.
 func (t *TableInfo) setPrimaryKey(ctx context.Context) error {

--- a/pkg/table/unique_indexes_test.go
+++ b/pkg/table/unique_indexes_test.go
@@ -1,0 +1,103 @@
+package table
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUniqueSecondaryIndexes pins the set the change feed's flush partitioning
+// treats as its conflict surface. Getting the *membership* right matters more
+// than the mechanics: a non-unique index wrongly included would send the drain
+// sorting by a key that cannot collide, and PRIMARY wrongly included would send
+// it sorting by one whose neighbours provably do not collide either.
+func TestUniqueSecondaryIndexes(t *testing.T) {
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS unique_idx_probe`)
+	testutils.RunSQL(t, `CREATE TABLE unique_idx_probe (
+		id bigint NOT NULL AUTO_INCREMENT,
+		token varchar(255) NOT NULL,
+		key_a varchar(255) NOT NULL,
+		key_b varchar(255) NOT NULL,
+		key_c varchar(50) NOT NULL,
+		created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		payload bigint NOT NULL DEFAULT 0,
+		PRIMARY KEY (id),
+		UNIQUE KEY unq_token (token),
+		UNIQUE KEY unq_composite (key_a, key_b, key_c),
+		KEY idx_created_at (created_at),
+		KEY idx_payload (payload)
+	)`)
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ti := NewTableInfo(db, "test", "unique_idx_probe")
+	require.NoError(t, ti.SetInfo(t.Context()))
+
+	got, err := ti.UniqueSecondaryIndexes(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []UniqueIndex{
+		{Name: "unq_composite", Columns: []string{"key_a", "key_b", "key_c"}},
+		{Name: "unq_token", Columns: []string{"token"}},
+	}, got, "only UNIQUE secondary indexes, composite columns in key order")
+
+	// The non-unique indexes and PRIMARY are all absent, which is the whole
+	// point — assert it by name so a query change that widened the filter is
+	// unmistakable rather than showing up as a length mismatch.
+	for _, idx := range got {
+		require.NotContains(t, []string{"PRIMARY", "idx_created_at", "idx_payload"}, idx.Name)
+	}
+}
+
+// TestUniqueSecondaryIndexesSkipsFunctionalIndexes covers the index a caller
+// holding a row image cannot use: a functional index's key is an expression, so
+// information_schema reports a NULL COLUMN_NAME and there is no stored column to
+// read a value from. Returning it with its columns silently dropped would be the
+// bad outcome — a caller would sort by a partial key believing it had the whole
+// one.
+func TestUniqueSecondaryIndexesSkipsFunctionalIndexes(t *testing.T) {
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS unique_idx_functional`)
+	testutils.RunSQL(t, `CREATE TABLE unique_idx_functional (
+		id bigint NOT NULL AUTO_INCREMENT,
+		name varchar(255) NOT NULL,
+		other varchar(255) NOT NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY unq_lower ((lower(name))),
+		UNIQUE KEY unq_mixed (other, (lower(name))),
+		UNIQUE KEY unq_plain (other)
+	)`)
+
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ti := NewTableInfo(db, "test", "unique_idx_functional")
+	require.NoError(t, ti.SetInfo(t.Context()))
+
+	got, err := ti.UniqueSecondaryIndexes(t.Context())
+	require.NoError(t, err)
+	// unq_mixed is the case that needs the end-of-loop filter rather than a
+	// `continue`: its stored column is collected *before* the functional one is
+	// seen, so it has to be removed after the fact.
+	require.Equal(t, []UniqueIndex{
+		{Name: "unq_plain", Columns: []string{"other"}},
+	}, got)
+}
+
+// TestUniqueSecondaryIndexesWithoutDB pins that a metadata-only TableInfo — the
+// shape NewTableInfoFromMeta returns, used by callers holding DDL and no server
+// — gets an error rather than a nil-pointer panic. The change feed calls this on
+// a table it did not construct, so the nil case is reachable from outside this
+// package.
+func TestUniqueSecondaryIndexesWithoutDB(t *testing.T) {
+	ti, err := NewTableInfoFromMeta("test", "meta_only",
+		[]ColumnMeta{{Name: "id", MySQLType: "bigint"}}, []string{"id"})
+	require.NoError(t, err)
+
+	got, err := ti.UniqueSecondaryIndexes(t.Context())
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "no database handle")
+}


### PR DESCRIPTION
## Problem

A map-mode drain's batches are disjoint by primary key, and for a long time that was assumed to be enough. It is not.

Two concurrent `REPLACE` statements on PK-disjoint rows can still deadlock, and in [#1168](https://github.com/block/spirit/issues/1168) they did: the InnoDB cycle inverted between the clustered index and a `UNIQUE` secondary index. `REPLACE`'s duplicate detection takes a **next-key** lock on each unique secondary index — the gap below the record included — so two batches collide whenever any of their rows land in *adjacent* slots of any such index. Secondary key order is unrelated to primary key order, so PK disjointness says nothing about it.

The existing defence is the AIMD controller that narrows the flush until the deadlocks stop. It works, but it pays for safety in throughput and never stops paying: each contention step costs **4×** (concurrency and batch size both halve), and a table whose unique key correlates with anything keeps re-triggering it. On the table that motivated this, the drain never converged — the migration was cancelled.

## The conflict surface, measured

This is the part the design rests on, and it is a precise claim rather than a cautious one. `TestReplaceContendsOnlyOnUniqueIndexes` (merged in #1173) establishes it against a real server:

| Two rows are… | Contend? | Why |
| --- | --- | --- |
| adjacent in the PRIMARY KEY | **no** | a `REPLACE`'s clustered-index conflict is with the row bearing that exact PK, so under `READ COMMITTED` it is a record lock with no gap |
| equal in a *non-unique* secondary index | **no** | those records are keyed `(indexed columns, PK)`, so PK-disjoint rows always occupy distinct records |
| adjacent in a *`UNIQUE`* secondary index | **yes** | duplicate detection takes a next-key lock, gap included |

So **primary-key separation buys nothing**, and the earlier PK-sorting attempt was aimed at an index whose neighbours provably do not collide.

## What this does

The drain now:

1. **Chooses** the unique secondary index whose values are most *clustered* across this drain's own rows — measured, not configured, because whether a key correlates with anything is a property of the workload rather than the schema. A repeating leading column means physically adjacent sibling records and a near-certain collision; a uniformly distributed key has an adjacency probability of roughly `n²/N` per drain (~0.3 for 50,000 rows in 8.5 billion) and needs no help.
2. **Sorts** by it and cuts **contiguous** batches, nudging cut points to fall where the leading key value changes so a run of siblings is not split across two batches.
3. **Stripes** the batches into evens and odds, running one group at a time, so no two batches in flight together are neighbours in the sort order.

Rows close together in the chosen index therefore land in the *same statement*, where they cannot conflict, and statements that do run together are separated by at least one whole batch of intervening rows.

Three design points worth flagging because each could have gone the other way:

- **Range partitioning, not hashing.** Hashing spreads equal-ish values across buckets, which is precisely the arrangement that collides. The risk is gap adjacency, not shared records.
- **Separation is in *rows*, not value distance.** Whether two values are adjacent in the B-tree depends on the 8.5-billion-row table, not the 50,000 rows in hand, so no value-space margin means anything. A whole batch of intervening rows is a margin that does, because those rows are themselves records sitting between the two.
- **Striping is needed, not just sorting.** Handing the sorted list straight to the limiter would undo most of the benefit: the in-flight window is roughly contiguous, so neighbours would run together and every batch boundary would become a candidate collision. The cost is one barrier per drain, which is far cheaper than a 4× AIMD step that persists for several drains.

## Getting it wrong costs throughput, never correctness

Batches stay disjoint by key and map mode makes no cross-key ordering promises, so a misordered sort or a badly chosen index simply reproduces the *old* collision behaviour — which the AIMD controller still catches. Nothing here is load-bearing for data integrity.

That is what makes a best-effort comparator acceptable, where the earlier PK-sorting attempt's comparator bug was silent and harmful. That one had `int64`/`uint64`/`float64`/`string`/`[]byte` arms only, and go-mysql decodes `MYSQL_TYPE_LONG` to `int32`, `TINY` to `int8`, `SHORT` to `int16` and `INT24` to `int32` — so an ordinary `INT` column fell through to a string comparison and sorted `100` before `9`, the exact inversion the sort existed to prevent. Every integer width is handled explicitly here and tested for it, including the `>2^53` case where routing integers through `float64` would lose exactly the low bits that distinguish adjacent values.

## What partitioning cannot cover (so the AIMD controller stays)

- **Deletes.** A buffered delete keeps only its PK — `LogicalRow{IsDeleted: true}`, the before image is discarded at buffer time — so its position in a unique secondary index is unknowable. Deleted rows are grouped at the tail.
- **Second and subsequent unique indexes.** Sorting by one says nothing about the others; choosing the most clustered one is what makes this worthwhile.
- **`REPLACE`'s out-of-partition deletion cascade.** A `REPLACE` deletes any row conflicting on any unique index, including PKs not in the batch, whose other unique values are unknowable from here. Documented at `applier.UpsertRows`; irreducible.

## Degradation

No flag, and it turns itself off when there is nothing to do — a table with no usable unique secondary index has no conflict surface between PK-disjoint batches at all, so the sort would be pure cost. Also skipped: functional indexes (the key is an expression, so a row image cannot be placed in them) and indexes covering a column the ALTER *adds*, which the source's row images do not contain. A `flush partitioning enabled` line at Info reports the candidates once per subscription.

## Two incidental fixes

- **`TableInfo.UniqueSecondaryIndexes` guards a nil `db` handle** instead of dereferencing it. `NewTableInfoFromMeta` returns a `TableInfo` with no server behind it (strata's `pkg/vstream` builds these) and the change feed calls this on a table it did not construct, so the nil case is reachable from outside the package. The existing suite caught this.
- **The dispatch budget is computed by the drain and passed down** rather than created inside `applyBatchesConcurrent`, which is now called once per stripe. Two stripes each granted a full `drainDispatchBudget` would have silently doubled how long one flush may hold `flushMu`.

## Testing

`pkg/change`, `pkg/table`, `pkg/applier`, `pkg/autoscale`, `pkg/migration`, `pkg/move`, `pkg/datasync` all green; `golangci-lint run ./pkg/...` reports 0 issues.

New coverage, in rough order of what would worry me most:

- **`TestFlushPartitioningAppliesEveryRow`** — the correctness half, against a real server through the real subscription: 400 rows updated, a subset updated again so dedup collapses them, some deleted, then a full symmetric-difference check that the target matches the source value for value. A misordered sort, a dropped batch, or a row batched twice all surface here.
- **`TestCompareRowValuesHandlesEveryIntegerWidth` / `…IsTotal`** — every width go-mysql can produce, the `>2^53` precision case, and the antisymmetry/reflexivity properties `sort` requires (a comparator that is merely usually-right yields an arbitrary permutation, not a slightly worse one).
- **`TestStripeBatchesSeparatesNeighbours`** — the invariant the whole design reduces to, over several batch counts.
- **`TestBuildBatchesProducesContiguousRanges`** — batches tile the sorted order, no row appears twice, no leading-value run is split.
- **`TestFlushPartitioningChoosesTheCorrelatedIndex`** — self-configuration against real index metadata, including that the choice follows the *data* when the correlation moves.
- Degradation paths: no unique index, index on an added column, functional indexes, metadata-only `TableInfo`.

One thing the tests taught that is now documented in the code: a **single-column** unique index always scores exactly 0 on the clustering metric — its values cannot repeat, that is what unique means. Clustering can only ever appear as a repeating *leading* column of a composite unique key with a discriminator after it, which is exactly the production shape. My first draft of the integration seed got a duplicate-key error for assuming otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
