### PR TITLE
migration: size the connection pool with --max-connections

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -411,7 +411,7 @@ Chunk sizing is separate from worker count: the checksum's chunks are sized by t
 
 The size of Spirit's main connection pool. It is set once, verbatim, and never recomputed: no phase ratchets it, and no thread ceiling derived from the instance raises it.
 
-That is deliberate, because the number has to be one an operator can budget against. Spirit's connections come out of the server's `max_connections`, shared with the production workload, and if the migration user has a `max_user_connections` the pool has to be a value you can subtract — not a sum with a ratchet in the middle of it. It used to be the latter: a seed at startup, a re-derivation once the autoscaling ceilings were known, and a `+2` the checksum added when it began. Every one of those was a chance to step over the limit.
+That is deliberate, because the number has to be one an operator can budget against. Spirit's connections come out of the server's `max_connections`, shared with the production workload, and if the migration user has a `max_user_connections` the pool has to be a value you can subtract — not a sum that moves when Spirit reaches a particular phase.
 
 Everything shares that one pool — copier reads, applier writes, the change feed's drain, and the periodic control-plane queries (see [threads](#threads) for the full list). Their ceilings can add up to more than the pool, and on a large instance under [autoscaling](#enable-experimental-autoscaling) they will. Above the pool size those workers contend for connections instead of each being guaranteed one, which costs throughput and nothing else: a worker waiting on connection checkout is a worker that will eventually run. The alternative on a busy server is `Error 1040: Too many connections`, which is not a slower migration but a dead one.
 
@@ -425,9 +425,14 @@ For a full accounting against `max_user_connections`, Spirit also opens two conn
 
 So the worst case on the target is `max-connections + 2`.
 
-Values that cannot work are rejected at startup rather than discovered mid-migration. The floor is `5`, which the cutover needs for its `LOCK TABLES` connection, its `RENAME TABLE` connection and the flush threads; and the value must also be at least `threads + 2`, because the checksum's read transactions each pin a connection for the whole phase whether or not a worker has one checked out, leaving nothing for chunk dispatch to check out. Both are hard stops: below them a migration does not run slower, it stalls holding a lock or an open read view.
+Values that cannot work are rejected at startup rather than discovered mid-migration:
 
-A negative value is rejected. It used to mean "unbounded"; a pool that Spirit cannot state a size for is exactly what this flag exists to remove.
+- **At least `5`**, which the cutover needs for its `LOCK TABLES` connection, its `RENAME TABLE` connection and the flush threads. This is also the one case where Spirit will exceed a configured pool size: a `CutOver` handed a smaller pool raises it to `5`, because the alternative is a cutover that cannot run.
+- **At least `threads + 2`**, because the checksum's read transactions each pin a connection for the whole phase whether or not a worker has one checked out, and its chunk repair and boundary prefetch run outside that pool. A pool that cannot hold both leaves chunk dispatch with nothing to check out.
+
+Both are hard stops rather than slow paths: below them a migration does not run slower, it stalls holding a table lock or an open read view.
+
+A negative value is rejected. A pool whose size Spirit cannot state is what this flag exists to remove.
 
 ### max-commit-latency
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -297,7 +297,7 @@ The write side of the copy — the applier's write workers — is controlled sep
 
 This flag is **ignored** when [enable-experimental-autoscaling](#enable-experimental-autoscaling) engages: the autoscaler sizes both pools from the instance instead.
 
-Internal to Spirit, the database pool is sized as `threads + write-threads + flush-concurrency + control-plane + checksum-off-pool`, then bounded by [max-connections](#max-connections). Adding the terms up is intentional because the work runs concurrently: `threads` covers the copier/checksum reads, `write-threads` covers the applier's write workers, `flush-concurrency` covers the change feed's drain, and the two headroom terms keep the periodic work from queueing behind a saturated hot path:
+Internal to Spirit, the database pool is sized as `threads + write-threads + flush-concurrency + control-plane + checksum-off-pool`, then capped at [max-connections](#max-connections). Adding the terms up is intentional because the work runs concurrently: `threads` covers the copier/checksum reads, `write-threads` covers the applier's write workers, `flush-concurrency` covers the change feed's drain, and the two headroom terms keep the periodic work from queueing behind a saturated hot path:
 
 - **flush-concurrency** is the number of `REPLACE` batches a map-mode drain has in flight (`8` by default; derived from the instance under [autoscaling](#enable-experimental-autoscaling), up to `32`). A periodic flush overlaps the copy, so these really do add rather than borrow.
 - **control-plane** is `2 + one per changed table`, for the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater — all of which run on the same pool as the copier and applier.
@@ -405,13 +405,13 @@ Chunk sizing is separate from worker count: the checksum's chunks are sized by t
 - Type: Integer
 - Default value: `128`
 
-Bounds the size of Spirit's main connection pool.
+A hard upper bound on the size of Spirit's main connection pool. It is a safety net and nothing more — a `min()` applied wherever the pool is sized, with no phase-awareness and nothing derived from it.
 
 The pool is otherwise sized by *adding up* every worker ceiling — read, write and flush, plus headroom (see [threads](#threads)) — so that no pool can ever starve another. That sum is a statement of what Spirit would use if nothing else were running. It is not Spirit's to spend: the connections come out of the server's `max_connections`, shared with the production workload. On a large instance under [autoscaling](#enable-experimental-autoscaling) the derived ceilings add up to well over a hundred, and when the server has less spare than that the migration does not slow down — it fails outright on `Error 1040: Too many connections`.
 
-Above the bound, write and flush workers contend for connections instead of each holding one. That costs throughput and nothing else: a worker waiting on connection checkout is a worker that will eventually run. The default is set high enough that no hand-configured [threads](#threads)/[write-threads](#write-threads) pair reaches it — it binds on the derived ceilings, which is where the problem is.
+Above the cap, workers contend for connections instead of each holding one. That costs throughput and nothing else: a worker waiting on connection checkout is a worker that will eventually run. The default is set high enough that no hand-configured [threads](#threads)/[write-threads](#write-threads) pair reaches it — it binds on the derived ceilings, which is where the problem is.
 
-One term does not give way. During the checksum, every transaction in the read pool pins a connection for the whole phase whether or not a worker has it checked out, so a pool below the read ceiling plus headroom would leave chunk dispatch with no connection to get — the phase would hang rather than run slower. A `max-connections` below that floor is logged and raised to it. The checksum also ratchets the pool `+2` for the two queries it runs outside its transaction pool (see **checksum-off-pool** under [threads](#threads)), so the effective ceiling is `max-connections + 2`.
+Because it is obeyed literally, a very low value can stall a migration rather than slow it. During the checksum, every transaction in the read pool pins a connection for the whole phase whether or not a worker has it checked out, so a pool below the read ceiling plus headroom leaves chunk dispatch with no connection to get. Spirit will not silently raise a limit it was given, so keep the value comfortably above `threads` plus a handful of connections for headroom. The default leaves an enormous margin.
 
 A negative value restores the unbounded behaviour. This is not recommended, and is available for programmatic callers that were relying on it.
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -432,6 +432,8 @@ Values that cannot work are rejected at startup rather than discovered mid-migra
 
 Both are hard stops rather than slow paths: below them a migration does not run slower, it stalls holding a table lock or an open read view.
 
+Under [autoscaling](#enable-experimental-autoscaling) the read ceiling comes from the instance rather than from `threads`, so it is not known at startup and cannot be validated there. If that derived ceiling does not fit the pool, Spirit lowers the ceiling — it will not grow the pool past the number you set. This is logged, and only bites if you set `max-connections` below half the target's vCPU count.
+
 A negative value is rejected. A pool whose size Spirit cannot state is what this flag exists to remove.
 
 ### max-commit-latency

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -297,11 +297,15 @@ The write side of the copy — the applier's write workers — is controlled sep
 
 This flag is **ignored** when [enable-experimental-autoscaling](#enable-experimental-autoscaling) engages: the autoscaler sizes both pools from the instance instead.
 
-Internal to Spirit, the database pool is sized as `threads + write-threads + flush-concurrency + control-plane + checksum-off-pool`, then capped at [max-connections](#max-connections). Adding the terms up is intentional because the work runs concurrently: `threads` covers the copier/checksum reads, `write-threads` covers the applier's write workers, `flush-concurrency` covers the change feed's drain, and the two headroom terms keep the periodic work from queueing behind a saturated hot path:
+`threads` does not size the connection pool. The pool is [max-connections](#max-connections) and nothing else, and everything below shares it concurrently:
 
-- **flush-concurrency** is the number of `REPLACE` batches a map-mode drain has in flight (`8` by default; derived from the instance under [autoscaling](#enable-experimental-autoscaling), up to `32`). A periodic flush overlaps the copy, so these really do add rather than borrow.
-- **control-plane** is `2 + one per changed table`, for the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater — all of which run on the same pool as the copier and applier.
-- **checksum-off-pool** is a fixed `2`, for the two things the checksum does outside its `REPEATABLE READ` transaction pool: repairing a mismatched chunk, and the chunker's `LIMIT 1 OFFSET n` boundary prefetch. Both are serialized, so one connection each. The transaction pool itself is provisioned separately and every one of its transactions pins a connection for the whole phase, so there is no incidental slack for these to borrow.
+- **the copier and checksum reads**, `threads` of them.
+- **the applier's write workers**, [write-threads](#write-threads) of them, or up to twice that under [autoscaling](#enable-experimental-autoscaling).
+- **the change feed's drain**, `8` concurrent `REPLACE` batches by default and up to `32` under autoscaling. A periodic flush overlaps the copy, so these really do add rather than borrow.
+- **the control plane**, `2 + one per changed table`: the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater.
+- **the checksum's off-pool queries**, a fixed `2`: repairing a mismatched chunk, and the chunker's `LIMIT 1 OFFSET n` boundary prefetch. Both are serialized, so one connection each. The checksum's `REPEATABLE READ` transaction pool is separate, and every one of its transactions pins a connection for the whole phase, so there is no incidental slack for these two to borrow — which is why a `max-connections` below `threads + 2` is rejected at startup.
+
+Added up, those can exceed `max-connections` on a large instance under autoscaling. That is expected: they queue on connection checkout instead of each being guaranteed one, which costs throughput and nothing else.
 
 Throttler polling is not counted: it runs on a dedicated monitoring pool.
 
@@ -370,9 +374,9 @@ This exists because the sizes above are derived entirely from the target, on the
 
 A `--threads`/`--write-threads` you set yourself is *not* capped — an explicitly named number is yours — but the same mismatch is warned about once.
 
-There is a second cap, on the target side: the connection pool is sized for the sum of the ceilings above, and from `12xlarge` upward that sum exceeds the [max-connections](#max-connections) default of `128` (at 48 vCPUs: `92 + 24 + 32` plus headroom). Past that point the pools contend for connections rather than each being guaranteed one — which is the intended behaviour, since the alternative on a busy server is `Error 1040: Too many connections`. Raise `--max-connections` if the server has the headroom to give.
+There is a second cap, on the target side: these are thread ceilings, not connections. The connection pool is [max-connections](#max-connections) regardless, and from `12xlarge` upward the ceilings above add up to more than its default of `128` (at 48 vCPUs: `92 + 24 + 32` plus headroom). Past that point the scaled-up workers contend for connections rather than each being guaranteed one — which is the intended behaviour, since the alternative on a busy server is `Error 1040: Too many connections`. Raise `--max-connections` if the server has the headroom to give.
 
-The connection pool is pre-sized for every ceiling, so scaled-up threads never starve on connections. When budgeting proxy or server connection limits, assume up to `ceil(vCPUs / 2)` read connections, `2 × (vCPUs - 2)` write connections, and the flush concurrency from the table above (up to 32) rather than the fixed-pool formula above. The flush term is a recent addition to that budget: the change feed has always run concurrent `REPLACE` statements on this pool, and a periodic flush overlaps the copy, but until the flush width became derivable those connections were borrowed from the copier's share instead of being provisioned. (One exception: when the threads signal is running in its redo-aware mode *and* [max-commit-latency](#max-commit-latency) is disabled with `--max-commit-latency=0`, the write-side upper bound stays at the starting value — see below.)
+When budgeting proxy or server connection limits, use `max-connections` and do not try to reconstruct it from the ceilings: it is one number for the whole migration, by design. (One exception to the ceilings themselves: when the threads signal is running in its redo-aware mode *and* [max-commit-latency](#max-commit-latency) is disabled with `--max-commit-latency=0`, the write-side upper bound stays at the starting value — see below.)
 
 One consequence to be aware of: on a well-provisioned target where the writers always keep pace, the queue is drained the instant chunks arrive — which is exactly what "read-limited" looks like — so the read pool tends to ramp well above its starting size early in the copy. That ramp is additive (one thread per ~15s), so on a large instance the read side takes a few minutes to reach its ceiling; overall load remains governed by the utilization band and, ultimately, the hard-stop throttle.
 
@@ -405,15 +409,25 @@ Chunk sizing is separate from worker count: the checksum's chunks are sized by t
 - Type: Integer
 - Default value: `128`
 
-A hard upper bound on the size of Spirit's main connection pool. It is a safety net and nothing more — a `min()` applied wherever the pool is sized, with no phase-awareness and nothing derived from it.
+The size of Spirit's main connection pool. It is set once, verbatim, and never recomputed: no phase ratchets it, and no thread ceiling derived from the instance raises it.
 
-The pool is otherwise sized by *adding up* every worker ceiling — read, write and flush, plus headroom (see [threads](#threads)) — so that no pool can ever starve another. That sum is a statement of what Spirit would use if nothing else were running. It is not Spirit's to spend: the connections come out of the server's `max_connections`, shared with the production workload. On a large instance under [autoscaling](#enable-experimental-autoscaling) the derived ceilings add up to well over a hundred, and when the server has less spare than that the migration does not slow down — it fails outright on `Error 1040: Too many connections`.
+That is deliberate, because the number has to be one an operator can budget against. Spirit's connections come out of the server's `max_connections`, shared with the production workload, and if the migration user has a `max_user_connections` the pool has to be a value you can subtract — not a sum with a ratchet in the middle of it. It used to be the latter: a seed at startup, a re-derivation once the autoscaling ceilings were known, and a `+2` the checksum added when it began. Every one of those was a chance to step over the limit.
 
-Above the cap, workers contend for connections instead of each holding one. That costs throughput and nothing else: a worker waiting on connection checkout is a worker that will eventually run. The default is set high enough that no hand-configured [threads](#threads)/[write-threads](#write-threads) pair reaches it — it binds on the derived ceilings, which is where the problem is.
+Everything shares that one pool — copier reads, applier writes, the change feed's drain, and the periodic control-plane queries (see [threads](#threads) for the full list). Their ceilings can add up to more than the pool, and on a large instance under [autoscaling](#enable-experimental-autoscaling) they will. Above the pool size those workers contend for connections instead of each being guaranteed one, which costs throughput and nothing else: a worker waiting on connection checkout is a worker that will eventually run. The alternative on a busy server is `Error 1040: Too many connections`, which is not a slower migration but a dead one.
 
-Because it is obeyed literally, a very low value can stall a migration rather than slow it. During the checksum, every transaction in the read pool pins a connection for the whole phase whether or not a worker has it checked out, so a pool below the read ceiling plus headroom leaves chunk dispatch with no connection to get. Spirit will not silently raise a limit it was given, so keep the value comfortably above `threads` plus a handful of connections for headroom. The default leaves an enormous margin.
+For a full accounting against `max_user_connections`, Spirit also opens two connection pools outside this one, both small and both fixed:
 
-A negative value restores the unbounded behaviour. This is not recommended, and is available for programmatic callers that were relying on it.
+| Pool | Size | When |
+| ---- | ---- | ---- |
+| main | `max-connections` | always |
+| throttler monitor | `2` | only on a target with a continuous load signal (currently Aurora) |
+| replica lag checker | `max-connections` | only with [replica-dsn](#replica-dsn) — and on the *replica*, not the target |
+
+So the worst case on the target is `max-connections + 2`.
+
+Values that cannot work are rejected at startup rather than discovered mid-migration. The floor is `5`, which the cutover needs for its `LOCK TABLES` connection, its `RENAME TABLE` connection and the flush threads; and the value must also be at least `threads + 2`, because the checksum's read transactions each pin a connection for the whole phase whether or not a worker has one checked out, leaving nothing for chunk dispatch to check out. Both are hard stops: below them a migration does not run slower, it stalls holding a lock or an open read view.
+
+A negative value is rejected. It used to mean "unbounded"; a pool that Spirit cannot state a size for is exactly what this flag exists to remove.
 
 ### max-commit-latency
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -22,6 +22,7 @@ spirit migrate --host mydb:3306 --username root --password secret \
 - [host](#host)
 - [lock-wait-timeout](#lock-wait-timeout)
 - [max-commit-latency](#max-commit-latency)
+- [max-connections](#max-connections)
 - [password](#password)
 - [replica-dsn](#replica-dsn)
   - [Replica TLS Behavior](#replica-tls-behavior)
@@ -296,9 +297,10 @@ The write side of the copy — the applier's write workers — is controlled sep
 
 This flag is **ignored** when [enable-experimental-autoscaling](#enable-experimental-autoscaling) engages: the autoscaler sizes both pools from the instance instead.
 
-Internal to Spirit, the database pool is sized as `threads + write-threads + control-plane + checksum-off-pool`. This is intentional because copy writes run concurrently to copy reads and checksums: `threads` covers the copier/checksum work and `write-threads` covers the applier's write workers, while the two headroom terms keep the periodic work from queueing behind a saturated hot path:
+Internal to Spirit, the database pool is sized as `threads + write-threads + flush-concurrency + control-plane + checksum-off-pool`, then bounded by [max-connections](#max-connections). Adding the terms up is intentional because the work runs concurrently: `threads` covers the copier/checksum reads, `write-threads` covers the applier's write workers, `flush-concurrency` covers the change feed's drain, and the two headroom terms keep the periodic work from queueing behind a saturated hot path:
 
-- **control-plane** is `2 + one per changed table`, for the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater — all of which run on the same pool as the copier and applier. The replication flush itself has no dedicated per-connection budget: a map-mode drain applies up to `8` batches concurrently (see [write-threads](#write-threads)) from the shared pool, borrowing capacity the copier is not using. Worst case — a drain overlapping a saturated copy — the flush batches briefly queue on connection checkout; during post-copy catch-up, when only the flush is running, the idle copier's share of the pool is available to it.
+- **flush-concurrency** is the number of `REPLACE` batches a map-mode drain has in flight (`8` by default; derived from the instance under [autoscaling](#enable-experimental-autoscaling), up to `32`). A periodic flush overlaps the copy, so these really do add rather than borrow.
+- **control-plane** is `2 + one per changed table`, for the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater — all of which run on the same pool as the copier and applier.
 - **checksum-off-pool** is a fixed `2`, for the two things the checksum does outside its `REPEATABLE READ` transaction pool: repairing a mismatched chunk, and the chunker's `LIMIT 1 OFFSET n` boundary prefetch. Both are serialized, so one connection each. The transaction pool itself is provisioned separately and every one of its transactions pins a connection for the whole phase, so there is no incidental slack for these to borrow.
 
 Throttler polling is not counted: it runs on a dedicated monitoring pool.
@@ -368,6 +370,8 @@ This exists because the sizes above are derived entirely from the target, on the
 
 A `--threads`/`--write-threads` you set yourself is *not* capped — an explicitly named number is yours — but the same mismatch is warned about once.
 
+There is a second cap, on the target side: the connection pool is sized for the sum of the ceilings above, and from `12xlarge` upward that sum exceeds the [max-connections](#max-connections) default of `128` (at 48 vCPUs: `92 + 24 + 32` plus headroom). Past that point the pools contend for connections rather than each being guaranteed one — which is the intended behaviour, since the alternative on a busy server is `Error 1040: Too many connections`. Raise `--max-connections` if the server has the headroom to give.
+
 The connection pool is pre-sized for every ceiling, so scaled-up threads never starve on connections. When budgeting proxy or server connection limits, assume up to `ceil(vCPUs / 2)` read connections, `2 × (vCPUs - 2)` write connections, and the flush concurrency from the table above (up to 32) rather than the fixed-pool formula above. The flush term is a recent addition to that budget: the change feed has always run concurrent `REPLACE` statements on this pool, and a periodic flush overlaps the copy, but until the flush width became derivable those connections were borrowed from the copier's share instead of being provisioned. (One exception: when the threads signal is running in its redo-aware mode *and* [max-commit-latency](#max-commit-latency) is disabled with `--max-commit-latency=0`, the write-side upper bound stays at the starting value — see below.)
 
 One consequence to be aware of: on a well-provisioned target where the writers always keep pace, the queue is drained the instant chunks arrive — which is exactly what "read-limited" looks like — so the read pool tends to ramp well above its starting size early in the copy. That ramp is additive (one thread per ~15s), so on a large instance the read side takes a few minutes to reach its ceiling; overall load remains governed by the utilization band and, ultimately, the hard-stop throttle.
@@ -395,6 +399,21 @@ As with the copy phase, a signal that stops updating does not keep being acted o
 One structural constraint shapes this: the checksum's snapshot transaction pool **cannot grow** once the brief table lock is released, because every transaction must take its read view at the same instant. It is therefore provisioned up front at whatever ceiling scaling could actually reach: `ceil(vCPUs / 2)` where the flag engages on Aurora, and plain [threads](#threads) everywhere else — both without the flag, and with the flag on a target where growth is impossible anyway (non-Aurora, or under 4 vCPUs). It reuses the read-side connection budget, since the copier's readers have finished by the time the checksum runs. An idle pooled transaction costs one connection and no extra history retention, so over-provisioning is cheap in resources. What it is not cheap in is lock time: the transactions are started serially under the table lock, so the ceiling directly lengthens that window. This is the reason the read-side ceiling is half the instance rather than all of it.
 
 Chunk sizing is separate from worker count: the checksum's chunks are sized by the dynamic chunker against a fixed 5s time budget (`table.ChunkerDefaultTarget`, not a flag — and not the copier's [`--target-chunk-size`](#target-chunk-size) byte budget), and scaling only changes how many are in flight at once.
+
+### max-connections
+
+- Type: Integer
+- Default value: `128`
+
+Bounds the size of Spirit's main connection pool.
+
+The pool is otherwise sized by *adding up* every worker ceiling — read, write and flush, plus headroom (see [threads](#threads)) — so that no pool can ever starve another. That sum is a statement of what Spirit would use if nothing else were running. It is not Spirit's to spend: the connections come out of the server's `max_connections`, shared with the production workload. On a large instance under [autoscaling](#enable-experimental-autoscaling) the derived ceilings add up to well over a hundred, and when the server has less spare than that the migration does not slow down — it fails outright on `Error 1040: Too many connections`.
+
+Above the bound, write and flush workers contend for connections instead of each holding one. That costs throughput and nothing else: a worker waiting on connection checkout is a worker that will eventually run. The default is set high enough that no hand-configured [threads](#threads)/[write-threads](#write-threads) pair reaches it — it binds on the derived ceilings, which is where the problem is.
+
+One term does not give way. During the checksum, every transaction in the read pool pins a connection for the whole phase whether or not a worker has it checked out, so a pool below the read ceiling plus headroom would leave chunk dispatch with no connection to get — the phase would hang rather than run slower. A `max-connections` below that floor is logged and raised to it. The checksum also ratchets the pool `+2` for the two queries it runs outside its transaction pool (see **checksum-off-pool** under [threads](#threads)), so the effective ceiling is `max-connections + 2`.
+
+A negative value restores the unbounded behaviour. This is not recommended, and is available for programmatic callers that were relying on it.
 
 ### max-commit-latency
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -303,9 +303,14 @@ This flag is **ignored** when [enable-experimental-autoscaling](#enable-experime
 - **the applier's write workers**, [write-threads](#write-threads) of them, or up to twice that under [autoscaling](#enable-experimental-autoscaling).
 - **the change feed's drain**, `8` concurrent `REPLACE` batches by default and up to `32` under autoscaling. A periodic flush overlaps the copy, so these really do add rather than borrow.
 - **the control plane**, `2 + one per changed table`: the checkpoint `INSERT`, the replication-flush poll, and the per-table statistics updater.
-- **the checksum's off-pool queries**, a fixed `2`: repairing a mismatched chunk, and the chunker's `LIMIT 1 OFFSET n` boundary prefetch. Both are serialized, so one connection each. The checksum's `REPEATABLE READ` transaction pool is separate, and every one of its transactions pins a connection for the whole phase, so there is no incidental slack for these two to borrow — which is why a `max-connections` below `threads + 2` is rejected at startup.
+- **the checksum's off-pool queries**, a fixed `2`: repairing a mismatched chunk, and the chunker's `LIMIT 1 OFFSET n` boundary prefetch. Both are serialized, so one connection each. The checksum's `REPEATABLE READ` transaction pool is separate, and every one of its transactions pins a connection for the whole phase, so there is no incidental slack for these two to borrow.
 
-Added up, those can exceed `max-connections` on a large instance under autoscaling. That is expected: they queue on connection checkout instead of each being guaranteed one, which costs throughput and nothing else.
+Added up, those can exceed `max-connections` on a large instance under autoscaling. For the copier and the applier that is expected and harmless: they queue on connection checkout instead of each being guaranteed one, which costs throughput and nothing else — a worker waiting on checkout is a worker that will eventually run, and the work it was going to do is still there when it does.
+
+Two of them are not like that, and both are protected:
+
+- **Read workers**, because the checksum pins a connection per transaction for a whole phase. Bounds the pool cannot hold would block on checkout with a table lock held, so `threads` is validated against the pool at startup and any ceiling derived later is fitted to it.
+- **The drain**, because its work expires. A flush batch queueing behind a saturated copy is spending the binlog retention window, and running out of that window ends the migration rather than slowing it. The drain therefore keeps a reserved connection through the checksum instead of contending for one.
 
 Throttler polling is not counted: it runs on a dedicated monitoring pool.
 
@@ -413,7 +418,7 @@ The size of Spirit's main connection pool. It is set once, verbatim, and never r
 
 That is deliberate, because the number has to be one an operator can budget against. Spirit's connections come out of the server's `max_connections`, shared with the production workload, and if the migration user has a `max_user_connections` the pool has to be a value you can subtract — not a sum that moves when Spirit reaches a particular phase.
 
-Everything shares that one pool — copier reads, applier writes, the change feed's drain, and the periodic control-plane queries (see [threads](#threads) for the full list). Their ceilings can add up to more than the pool, and on a large instance under [autoscaling](#enable-experimental-autoscaling) they will. Above the pool size those workers contend for connections instead of each being guaranteed one, which costs throughput and nothing else: a worker waiting on connection checkout is a worker that will eventually run. The alternative on a busy server is `Error 1040: Too many connections`, which is not a slower migration but a dead one.
+Everything shares that one pool — copier reads, applier writes, the change feed's drain, and the periodic control-plane queries (see [threads](#threads) for the full list). Their ceilings can add up to more than the pool, and on a large instance under [autoscaling](#enable-experimental-autoscaling) they will. Above the pool size the copier and applier contend for connections instead of each being guaranteed one, which costs throughput and nothing else. The alternative on a busy server is `Error 1040: Too many connections`, which is not a slower migration but a dead one. Read workers and the drain are the two exceptions, and are given reserved capacity rather than left to contend — see [threads](#threads).
 
 For a full accounting against `max_user_connections`, Spirit also opens two connection pools outside this one, both small and both fixed:
 
@@ -428,11 +433,11 @@ So the worst case on the target is `max-connections + 2`.
 Values that cannot work are rejected at startup rather than discovered mid-migration:
 
 - **At least `5`**, which the cutover needs for its `LOCK TABLES` connection, its `RENAME TABLE` connection and the flush threads. This is also the one case where Spirit will exceed a configured pool size: a `CutOver` handed a smaller pool raises it to `5`, because the alternative is a cutover that cannot run.
-- **At least `threads + 2`**, because the checksum's read transactions each pin a connection for the whole phase whether or not a worker has one checked out, and its chunk repair and boundary prefetch run outside that pool. A pool that cannot hold both leaves chunk dispatch with nothing to check out.
+- **At least `threads + 6`**, because the checksum's read transactions each pin a connection for the whole phase whether or not a worker has one checked out. The `6` is what has to keep running alongside them: `2` for the checksum's own chunk repair and boundary prefetch, `3` for the control plane on a single-table migration, and `1` for the drain. A pool that only just fits the transactions is not a slow checksum — it is a checksum during which the drain cannot check out a connection at all.
 
 Both are hard stops rather than slow paths: below them a migration does not run slower, it stalls holding a table lock or an open read view.
 
-Under [autoscaling](#enable-experimental-autoscaling) the read ceiling comes from the instance rather than from `threads`, so it is not known at startup and cannot be validated there. If that derived ceiling does not fit the pool, Spirit lowers the ceiling — it will not grow the pool past the number you set. This is logged, and only bites if you set `max-connections` below half the target's vCPU count.
+Under [autoscaling](#enable-experimental-autoscaling) both read bounds come from the instance rather than from `threads`, so they are not known at startup and cannot be validated there. If they do not fit the pool, Spirit lowers them — it will not grow the pool past the number you set. Both the starting count and the ceiling are lowered, not just the ceiling: the checksum and the copier each floor their ceiling at the starting count, so lowering one without the other would have no effect. This is logged, and only bites if you set `max-connections` below half the target's vCPU count.
 
 A negative value is rejected. A pool whose size Spirit cannot state is what this flag exists to remove.
 

--- a/pkg/autoscale/README.md
+++ b/pkg/autoscale/README.md
@@ -27,7 +27,7 @@ The shape is "gentle in the normal regime, abrupt only in emergencies". The full
 
   Increases and decreases hold independent cooldowns. A decrease also arms the increase cooldown (so a shed is not immediately undone by a signal that has not yet reflected the cut), but not the reverse: a fresh overload must be answerable at once, even right after the increase that likely caused it.
 
-- **`Ceiling`** resolves a scalable pool's upper bound: the start value when scaling is off, twice it when on. The migration runner sizes the connection pool from the same number the phases cap themselves with, so a scaled-up pool never starves on connections.
+- **`Ceiling`** resolves a scalable pool's upper bound: the start value when scaling is off, twice it when on. This bounds threads, not connections — the connection pool is `--max-connections` and does not grow to meet a ceiling, so workers scaled past it queue on checkout instead of each being guaranteed a connection.
 
 - **`ReadBounds`** derives the read side's starting size and ceiling from the instance vCPU count — `max(2, ceil((vCPUs - VCPUReserve) / 4))` up to `ceil(vCPUs / 2)`, so a `4xlarge` reads with 4 workers and may grow to 8, a `24xlarge` with 24 growing to 48. This is where the asymmetry with the write side lives: write threads mostly sit parked on a redo-log flush, so a count above the vCPU count is not oversubscription (and the redo-aware signal excludes those waiters), whereas a read thread scanning an in-buffer-pool table is pure CPU and does compete with the application for cores. The read side therefore starts at about a quarter of the instance and earns its way up through the band.
 

--- a/pkg/autoscale/controller.go
+++ b/pkg/autoscale/controller.go
@@ -11,17 +11,20 @@ import (
 // Ceiling resolves the upper bound of a scalable pool: the start value when
 // scaling is disabled (so the pool cannot move), twice it when enabled.
 //
-// It is here rather than in either phase because the migration runner sizes the
-// connection pool from the same number the phases cap themselves with — threads
-// scaled above the connection budget would just queue on the sql.DB pool,
-// buying no parallelism — and three copies of "2 ×" invite drift. Callers with
-// an extra rule of their own wrap this rather than reimplementing it (see
-// throttler.ResolveMaxWriteThreads, which additionally refuses to grow the write
-// pool when the redo-aware signal has no commit-latency backstop).
+// It is here rather than in either phase because three copies of "2 ×" invite
+// drift, and because the migration runner resolves the same ceilings itself to
+// hand back to the phases. Callers with an extra rule of their own wrap this
+// rather than reimplementing it (see throttler.ResolveMaxWriteThreads, which
+// additionally refuses to grow the write pool when the redo-aware signal has no
+// commit-latency backstop).
 //
-// The floor of 1 matters for pool sizing: a zero or negative start would
-// otherwise under-budget the connection pool for a phase that always runs at
-// least one worker.
+// This is a thread ceiling and not a connection budget. Threads scaled past the
+// size of the sql.DB pool they share queue on checkout and buy no parallelism;
+// the pool is --max-connections and does not grow to meet them.
+//
+// The floor of 1: a zero or negative start would hand a phase that always runs
+// at least one worker a ceiling it already exceeds, which its controller has no
+// way to steer down from.
 func Ceiling(start int, enabled bool) int {
 	start = max(start, 1)
 	if !enabled {

--- a/pkg/copier/autoscaler.go
+++ b/pkg/copier/autoscaler.go
@@ -117,19 +117,21 @@ var acTick = autoscale.Tick
 
 // ResolveMaxReadThreads resolves the upper bound the read-worker pool may
 // scale to: the read-side mirror of throttler.ResolveMaxWriteThreads, and like
-// it a thin naming of autoscale.Ceiling. Exported so the migration runner sizes
-// the connection pool from the same formula the copier caps the pool with —
-// readers scaled above the connection budget would just queue on the sql.DB
-// pool, silently buying no extra parallelism.
+// it a thin naming of autoscale.Ceiling. Exported because the migration runner
+// resolves this ceiling itself when it has no instance to derive one from, and
+// passes it back through CopierConfig.
+//
+// It bounds threads, not connections. Readers scaled past the size of the
+// sql.DB pool queue on checkout and buy no extra parallelism — the pool is
+// --max-connections and does not grow to meet a raised ceiling.
 func ResolveMaxReadThreads(start int, autoscaleEnabled bool) int {
 	return autoscale.Ceiling(start, autoscaleEnabled)
 }
 
 // resolveReadCeiling picks the ceiling for the read-worker pool. A positive
 // configured value wins: the migration runner derives one from the instance
-// (autoscale.ReadBounds) and sizes its connection pool to match, so a scaled-up
-// pool never starves on connections. Callers with no view of the instance leave
-// it zero and get the Concurrency-relative formula instead. Either way the
+// (autoscale.ReadBounds) and passes it in. Callers with no view of the instance
+// leave it zero and get the Concurrency-relative formula instead. Either way the
 // ceiling is floored at the starting count, since a pool that begins above its
 // cap cannot be controlled.
 func resolveReadCeiling(configured, concurrency int) int {

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -81,7 +81,7 @@ func NewDBConfig() *DBConfig {
 		LockWaitTimeout:          30,
 		InnodbLockWaitTimeout:    3,
 		MaxRetries:               3,
-		MaxOpenConnections:       32,    // default is high for historical tests. It's overwritten by the user threads count + 2 for headroom.
+		MaxOpenConnections:       32,    // default is high for historical tests; every real caller overwrites it (migrate with --max-connections, move from its thread counts).
 		RangeOptimizerMaxMemSize: 0,     // default is 8M, we set to unlimited. Not user configurable (may reconsider in the future).
 		InterpolateParams:        false, // default is false
 		ForceKill:                true,  // default is true

--- a/pkg/migration/cutover.go
+++ b/pkg/migration/cutover.go
@@ -89,9 +89,12 @@ func (c *CutOver) Run(ctx context.Context) error {
 		// - The RENAME TABLE connection
 		// - The Flush() threads
 		// Because we want to safely flush quickly, we set the limit to 5.
-		// Pool size grows monotonically and is not restored — the
-		// migration ends after cutover, so there is nothing to shrink
-		// back for. See the MaxOpenConnections doc in (*Runner).Run.
+		//
+		// A migration cannot reach here under that number: Migration.Validate
+		// rejects a --max-connections below minPoolSize, which is this 5. The
+		// guard stays for callers that build a CutOver directly, and it is the
+		// one place spirit will exceed a configured pool size — because the
+		// alternative is a cutover that cannot run at all.
 		dbconn.SetPoolSize(c.db, 5)
 	}
 	// Collect every attempt's error and join them on exit, so an operator

--- a/pkg/migration/helpers_test.go
+++ b/pkg/migration/helpers_test.go
@@ -107,6 +107,15 @@ func WithWriteThreads(n int) RunnerOption {
 	}
 }
 
+// WithMaxConnections sets the size of the main connection pool. It is the pool
+// size verbatim, not a ceiling on a computed one — see the MaxOpenConnections
+// assignment in (*Runner).Run.
+func WithMaxConnections(n int) RunnerOption {
+	return func(m *Migration) {
+		m.MaxConnections = n
+	}
+}
+
 // WithAutoscaling enables the experimental thread autoscaler. Note that it only
 // engages against an Aurora target, and when it does it overrides both Threads
 // and WriteThreads (see setupCopierCheckerAndReplClient).

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -51,24 +51,15 @@ type Migration struct {
 	// MaxConnections is the size of the main connection pool, set verbatim and
 	// never recomputed (see the MaxOpenConnections assignment in Runner.Run).
 	//
-	// It exists because the pool used to be a sum of every worker ceiling —
-	// read, write, and change-feed flush, plus headroom — resized again whenever
-	// one of those ceilings moved, and ratcheted a further +2 when the checksum
-	// began. That sum was spirit's demand, and it is not spirit's to spend: the
-	// budget it draws on is the server's max_connections, shared with the
-	// production workload. On a large instance the derived ceilings add up to
-	// well over a hundred connections, and when the server has less spare than
-	// that the copy does not slow down, it dies on `Error 1040: Too many
-	// connections`.
+	// The connections it spends are the server's max_connections, shared with
+	// the production workload, so this is spirit's claim on someone else's
+	// budget rather than a description of what spirit could use. Ask for more
+	// than the server can spare and the copy does not slow down, it dies on
+	// `Error 1040: Too many connections`.
 	//
-	// A single number is also the only shape an operator can budget against.
-	// With a max_user_connections on the migration user, a pool that grows when
-	// spirit reaches a particular phase is not something you can subtract.
-	//
-	// The ceilings still exist — they bound how far the copier scales its own
-	// workers — and they can exceed this. When they do, the workers contend for
-	// connections instead of each being guaranteed one, which costs throughput
-	// and nothing else.
+	// The thread ceilings bound how far the copier scales its own workers and
+	// can exceed this. When they do, the workers contend for connections instead
+	// of each being guaranteed one, which costs throughput and nothing else.
 	//
 	// Zero means "use the default" (normalizeOptions fills it in), matching
 	// Threads and WriteThreads. Negative is rejected by Validate, as is any

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -48,20 +48,22 @@ type Migration struct {
 	Threads      int     `name:"threads" help:"Number of concurrent threads for copy and checksum tasks. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
 	WriteThreads int     `name:"write-threads" help:"Number of concurrent apply (write) threads. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
 
-	// MaxConnections bounds the main connection pool. It exists because the
-	// pool is otherwise sized by *adding up* every worker ceiling — read,
-	// write, and change-feed flush — so that no pool can ever starve another.
-	// That sum is spirit's demand, and it is not spirit's to spend: the budget
-	// it draws on is the server's max_connections, shared with the production
-	// workload. On a large instance the derived ceilings add up to well over a
-	// hundred connections, and when the server has less spare than that the
-	// copy does not slow down, it dies on `Error 1040: Too many connections`.
+	// MaxConnections is a hard upper bound on the main connection pool — a
+	// loose safety net, applied as a min() wherever the pool is sized and
+	// nothing else. It exists because the pool is otherwise sized by *adding
+	// up* every worker ceiling — read, write, and change-feed flush — so that
+	// no pool can ever starve another. That sum is spirit's demand, and it is
+	// not spirit's to spend: the budget it draws on is the server's
+	// max_connections, shared with the production workload. On a large instance
+	// the derived ceilings add up to well over a hundred connections, and when
+	// the server has less spare than that the copy does not slow down, it dies
+	// on `Error 1040: Too many connections`.
 	//
-	// Above this bound the pools contend for connections instead of each
-	// holding its own, which costs throughput and nothing else. The default is
-	// set high enough that no hand-configured thread count reaches it — it
-	// binds on the derived ceilings, which is where the problem is. See
-	// Runner.boundedPoolSize for the one term that cannot give way.
+	// Above this cap the pools contend for connections instead of each holding
+	// its own, which costs throughput and nothing else. The default is set high
+	// enough that no hand-configured thread count reaches it — it binds on the
+	// derived ceilings, which is where the problem is. See Runner.capPoolSize,
+	// including the note on setting it low enough to stall the checksum.
 	//
 	// Zero means "use the default" (normalizeOptions fills it in), matching
 	// Threads and WriteThreads. A negative value means unbounded, for callers

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -22,6 +22,12 @@ import (
 // tag (pkg/move), since the two flags are independently defaulted.
 const defaultWriteThreads = 4
 
+// defaultThreads must match the `default:"4"` kong tag on Migration.Threads, for
+// the same reason defaultWriteThreads does. Validate reads it because it runs
+// before normalizeOptions, so a programmatic caller's zero has to be resolved to
+// the number the migration will actually use before it can be checked.
+const defaultThreads = 4
+
 // defaultMaxConnections must match the `default:"128"` kong tag on
 // Migration.MaxConnections, for the same reason defaultWriteThreads does: a
 // programmatic caller that leaves the field unset must land where the CLI does.
@@ -156,13 +162,23 @@ func (m *Migration) Validate() error {
 				minPoolSize, m.MaxConnections)
 		}
 		// The checksum's read transactions each pin a connection for the whole
-		// phase whether or not a worker has one checked out, and the chunk
-		// repair and boundary prefetch run outside that pool (see
-		// checksumOffPoolConns). A pool that cannot hold both leaves chunk
-		// dispatch with nothing to check out, which is a stall, not slowness.
-		if pinned := m.Threads + checksumOffPoolConns; m.MaxConnections < pinned {
-			return fmt.Errorf("--max-connections (%d) is below what the checksum holds open for the whole phase: %d read transactions plus %d off-pool queries; use at least %d, or lower --threads",
-				m.MaxConnections, m.Threads, checksumOffPoolConns, pinned)
+		// phase whether or not a worker has one checked out, so the pool has to
+		// hold them *plus* everything that has to keep running alongside them:
+		// the checksum's own off-pool queries, the control plane, and the drain
+		// (see checksumPhaseReserve). A pool that only just fits the
+		// transactions is not a slow checksum, it is a checksum during which the
+		// drain cannot check out a connection at all.
+		//
+		// Threads is read through defaultThreads because zero here means "use
+		// the default" and normalizeOptions has not run yet — validating the 0
+		// would accept a pool that the 4 it becomes cannot run on.
+		threads := m.Threads
+		if threads == 0 {
+			threads = defaultThreads
+		}
+		if pinned := threads + minChecksumPhaseReserve; m.MaxConnections < pinned {
+			return fmt.Errorf("--max-connections (%d) is below what the checksum phase needs: %d pinned read transactions plus %d reserved for off-pool queries, the control plane and the drain; use at least %d, or lower --threads",
+				m.MaxConnections, threads, minChecksumPhaseReserve, pinned)
 		}
 	}
 	return nil
@@ -191,7 +207,7 @@ func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, er
 		m.TargetChunkSize = table.DefaultTargetChunkBytes
 	}
 	if m.Threads == 0 {
-		m.Threads = 4
+		m.Threads = defaultThreads
 	}
 	// A non-positive WriteThreads is filled in rather than rejected, matching
 	// Threads above. Zero used to mean "auto-size from the instance", so anyone

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -22,6 +22,14 @@ import (
 // tag (pkg/move), since the two flags are independently defaulted.
 const defaultWriteThreads = 4
 
+// defaultMaxConnections must match the `default:"128"` kong tag on
+// Migration.MaxConnections, for the same reason defaultWriteThreads does: a
+// programmatic caller that leaves the field unset must land where the CLI does.
+// This one matters more than most, because the bound only earns its keep on the
+// large instances where the derived ceilings overflow — and those migrations are
+// as likely to be driven by an embedding orchestrator as by the CLI.
+const defaultMaxConnections = 128
+
 var (
 	defaultHost     = "127.0.0.1"
 	defaultPort     = 3306
@@ -39,6 +47,26 @@ type Migration struct {
 	ConfFile     string  `name:"conf" help:"MySQL conf file" optional:"" type:"existingfile"`
 	Threads      int     `name:"threads" help:"Number of concurrent threads for copy and checksum tasks. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
 	WriteThreads int     `name:"write-threads" help:"Number of concurrent apply (write) threads. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
+
+	// MaxConnections bounds the main connection pool. It exists because the
+	// pool is otherwise sized by *adding up* every worker ceiling — read,
+	// write, and change-feed flush — so that no pool can ever starve another.
+	// That sum is spirit's demand, and it is not spirit's to spend: the budget
+	// it draws on is the server's max_connections, shared with the production
+	// workload. On a large instance the derived ceilings add up to well over a
+	// hundred connections, and when the server has less spare than that the
+	// copy does not slow down, it dies on `Error 1040: Too many connections`.
+	//
+	// Above this bound the pools contend for connections instead of each
+	// holding its own, which costs throughput and nothing else. The default is
+	// set high enough that no hand-configured thread count reaches it — it
+	// binds on the derived ceilings, which is where the problem is. See
+	// Runner.boundedPoolSize for the one term that cannot give way.
+	//
+	// Zero means "use the default" (normalizeOptions fills it in), matching
+	// Threads and WriteThreads. A negative value means unbounded, for callers
+	// that want the pre-cap behaviour back.
+	MaxConnections int `name:"max-connections" help:"Maximum size of the main connection pool. Read, write and flush workers contend for connections above this rather than each being guaranteed one" optional:"" default:"128"`
 
 	// EnableExperimentalAutoscaling turns on dynamic thread scaling driven by
 	// throttler feedback. When it engages (an Aurora target with at least
@@ -143,6 +171,9 @@ func (m *Migration) normalizeOptions() (stmts []*statement.AbstractStatement, er
 				"write_threads", defaultWriteThreads)
 		}
 		m.WriteThreads = defaultWriteThreads
+	}
+	if m.MaxConnections == 0 {
+		m.MaxConnections = defaultMaxConnections
 	}
 	if m.ReplicaMaxLag == 0 {
 		m.ReplicaMaxLag = 120 * time.Second

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -25,9 +25,9 @@ const defaultWriteThreads = 4
 // defaultMaxConnections must match the `default:"128"` kong tag on
 // Migration.MaxConnections, for the same reason defaultWriteThreads does: a
 // programmatic caller that leaves the field unset must land where the CLI does.
-// This one matters more than most, because the bound only earns its keep on the
-// large instances where the derived ceilings overflow — and those migrations are
-// as likely to be driven by an embedding orchestrator as by the CLI.
+// This one matters more than most, because it is the pool size itself rather
+// than a knob on one: a programmatic caller that landed somewhere else would be
+// running with a differently-sized pool than the same migration from the CLI.
 const defaultMaxConnections = 128
 
 var (
@@ -48,27 +48,32 @@ type Migration struct {
 	Threads      int     `name:"threads" help:"Number of concurrent threads for copy and checksum tasks. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
 	WriteThreads int     `name:"write-threads" help:"Number of concurrent apply (write) threads. Ignored when --enable-experimental-autoscaling engages" optional:"" default:"4"`
 
-	// MaxConnections is a hard upper bound on the main connection pool — a
-	// loose safety net, applied as a min() wherever the pool is sized and
-	// nothing else. It exists because the pool is otherwise sized by *adding
-	// up* every worker ceiling — read, write, and change-feed flush — so that
-	// no pool can ever starve another. That sum is spirit's demand, and it is
-	// not spirit's to spend: the budget it draws on is the server's
-	// max_connections, shared with the production workload. On a large instance
-	// the derived ceilings add up to well over a hundred connections, and when
-	// the server has less spare than that the copy does not slow down, it dies
-	// on `Error 1040: Too many connections`.
+	// MaxConnections is the size of the main connection pool, set verbatim and
+	// never recomputed (see the MaxOpenConnections assignment in Runner.Run).
 	//
-	// Above this cap the pools contend for connections instead of each holding
-	// its own, which costs throughput and nothing else. The default is set high
-	// enough that no hand-configured thread count reaches it — it binds on the
-	// derived ceilings, which is where the problem is. See Runner.capPoolSize,
-	// including the note on setting it low enough to stall the checksum.
+	// It exists because the pool used to be a sum of every worker ceiling —
+	// read, write, and change-feed flush, plus headroom — resized again whenever
+	// one of those ceilings moved, and ratcheted a further +2 when the checksum
+	// began. That sum was spirit's demand, and it is not spirit's to spend: the
+	// budget it draws on is the server's max_connections, shared with the
+	// production workload. On a large instance the derived ceilings add up to
+	// well over a hundred connections, and when the server has less spare than
+	// that the copy does not slow down, it dies on `Error 1040: Too many
+	// connections`.
+	//
+	// A single number is also the only shape an operator can budget against.
+	// With a max_user_connections on the migration user, a pool that grows when
+	// spirit reaches a particular phase is not something you can subtract.
+	//
+	// The ceilings still exist — they bound how far the copier scales its own
+	// workers — and they can exceed this. When they do, the workers contend for
+	// connections instead of each being guaranteed one, which costs throughput
+	// and nothing else.
 	//
 	// Zero means "use the default" (normalizeOptions fills it in), matching
-	// Threads and WriteThreads. A negative value means unbounded, for callers
-	// that want the pre-cap behaviour back.
-	MaxConnections int `name:"max-connections" help:"Maximum size of the main connection pool. Read, write and flush workers contend for connections above this rather than each being guaranteed one" optional:"" default:"128"`
+	// Threads and WriteThreads. Negative is rejected by Validate, as is any
+	// value too small for the migration to finish on; see minPoolSize.
+	MaxConnections int `name:"max-connections" help:"Size of the main connection pool. Copier, applier and flush workers all share it, and contend for connections rather than each being guaranteed one" optional:"" default:"128"`
 
 	// EnableExperimentalAutoscaling turns on dynamic thread scaling driven by
 	// throttler feedback. When it engages (an Aurora target with at least
@@ -116,10 +121,28 @@ type Migration struct {
 	useTestThrottler bool
 }
 
+// minPoolSize is the smallest --max-connections a migration can complete on.
+//
+// The cutover sets the number: it needs the LOCK TABLES connection, the RENAME
+// TABLE connection and the flush threads, and unlike every other phase it
+// cannot trade connections for time — below the minimum it does not run slower,
+// it cannot run. See CutOver.Run, which holds the same number and will raise a
+// pool that arrives under it.
+//
+// Nothing else gets a say. The copy, the checksum and the drain all queue on a
+// small pool and finish eventually, so a low --max-connections is the operator
+// asking for a slow migration, which is theirs to ask for.
+const minPoolSize = 5
+
 // Validate is called by Kong after parsing to reject invalid flag values.
 // Zero values mean "use the default" (normalizeOptions fills them in), so they
 // are not rejected here; only explicitly-negative or otherwise invalid values
-// are caught. There are currently no cross-flag combination checks.
+// are caught.
+//
+// The cross-flag check on MaxConnections is the exception, and it is here
+// because it has nowhere else to be: the pool is set to that number verbatim
+// and never recomputed, so a number too small to work is a migration that
+// stalls somewhere in the middle rather than one that fails at startup.
 func (m *Migration) Validate() error {
 	if m.Threads < 0 {
 		return fmt.Errorf("--threads must be non-negative, got %d", m.Threads)
@@ -132,6 +155,24 @@ func (m *Migration) Validate() error {
 	}
 	if m.CheckpointMaxAge < 0 {
 		return fmt.Errorf("--checkpoint-max-age must be non-negative, got %s", m.CheckpointMaxAge)
+	}
+	if m.MaxConnections < 0 {
+		return fmt.Errorf("--max-connections must be non-negative, got %d", m.MaxConnections)
+	}
+	if m.MaxConnections > 0 {
+		if m.MaxConnections < minPoolSize {
+			return fmt.Errorf("--max-connections must be at least %d for the cutover to run, got %d",
+				minPoolSize, m.MaxConnections)
+		}
+		// The checksum's read transactions each pin a connection for the whole
+		// phase whether or not a worker has one checked out, and the chunk
+		// repair and boundary prefetch run outside that pool (see
+		// checksumOffPoolConns). A pool that cannot hold both leaves chunk
+		// dispatch with nothing to check out, which is a stall, not slowness.
+		if pinned := m.Threads + checksumOffPoolConns; m.MaxConnections < pinned {
+			return fmt.Errorf("--max-connections (%d) is below what the checksum holds open for the whole phase: %d read transactions plus %d off-pool queries; use at least %d, or lower --threads",
+				m.MaxConnections, m.Threads, checksumOffPoolConns, pinned)
+		}
 	}
 	return nil
 }

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -223,46 +223,6 @@ func (r *Runner) controlPlaneConns() int {
 	return len(r.changes) + 2
 }
 
-// capPoolSize clamps a main-pool size to Migration.MaxConnections. Every place
-// that sizes r.db goes through it, so the flag is an upper bound on the pool for
-// the whole migration rather than for one phase of it.
-//
-// Everything that sizes the pool sizes it for a guarantee: every ceiling added
-// together, so no pool can ever starve another. As a statement of what spirit
-// would use if nothing else were running that is correct; as a claim on the
-// server it is not spirit's to make. The connections come out of the server's
-// max_connections, shared with the production workload, and on a large instance
-// the derived ceilings add up to well over a hundred. When the server has less
-// spare than that the migration does not degrade — it fails outright on
-// `Error 1040: Too many connections`, which is worse than any amount of queueing.
-//
-// So this is a loose upper bound and nothing more: a number and a min(). It does
-// not ask which pool wants the connections or which phase is running, it does
-// not recompute anything, and it never hands back more than it was asked for.
-// Above the bound the workers give way and queue on the pool instead of each
-// holding a connection, which trades throughput for survival — a worker waiting
-// on a connection is a worker that will eventually run.
-//
-// The default is far above anything spirit derives for itself, so this is inert
-// unless an operator sets it deliberately. Set very low it is still obeyed, and
-// there is a floor below which that hurts: the checksum's read transactions pin
-// their connections for the whole phase whether or not a worker has one checked
-// out (see checksumOffPoolConns), so a pool under the read ceiling plus those
-// reserves leaves chunk dispatch nothing to check out and the phase stalls. That
-// is the operator's number to get right — see the flag docs in docs/migrate.md.
-// A safety net that quietly ignored the limit it was handed would be the worse
-// failure.
-func (r *Runner) capPoolSize(want int) int {
-	limit := r.migration.MaxConnections
-	if limit <= 0 || want <= limit {
-		return want // unbounded, or it already fits
-	}
-	r.logger.Warn("connection pool capped by --max-connections; workers will contend for connections",
-		"max_connections", limit,
-		"requested", want)
-	return limit
-}
-
 func (r *Runner) SetMetricsSink(sink metrics.Sink) {
 	r.metricsSink = sink
 }
@@ -333,31 +293,28 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 	// Map TLS configuration from migration to dbConfig
 	r.dbConfig.TLSMode = r.migration.TLSMode
 	r.dbConfig.TLSCertificatePath = r.migration.TLSCertificatePath
-	// Size the connection pool as:
+	// The pool is --max-connections, verbatim and once. Nothing recomputes it,
+	// no phase ratchets it, and no ceiling derived later raises it.
 	//
-	//	pool = threads + write-threads + controlPlaneConns() + checksumOffPoolConns
+	// It used to be a sum of every worker ceiling — read, write, flush, plus
+	// headroom for the periodic control-plane queries — resized again whenever
+	// one of those ceilings moved. That sum stated what spirit would use if it
+	// were the only thing on the server, which it never is: the connections come
+	// out of the server's max_connections, shared with the production workload,
+	// and on a large instance the derived ceilings add up to well over a hundred.
+	// A migration that wants more than the server can spare does not slow down,
+	// it dies on `Error 1040: Too many connections`.
 	//
-	//	- threads              copier + checksum read concurrency
-	//	- write-threads        replication-applier write concurrency
-	//	- controlPlaneConns()  headroom for the periodic control-plane queries
-	//	                       that also run on the main pool (checkpoint,
-	//	                       replication-flush poll, per-table stats), so they
-	//	                       don't serialize behind a single spare connection
-	//	                       once the copier + applier saturate the budget.
-	//	- checksumOffPoolConns the two queries the checksum runs outside its
-	//	                       fully-checked-out transaction pool (chunk repair
-	//	                       and chunker prefetch).
+	// A single number is also the only shape an operator can budget against. If
+	// the migration user has a max_user_connections, the pool has to be a value
+	// they can subtract, not a sum with a ratchet in the middle of it — see the
+	// note on the other pools in the max-connections docs.
 	//
-	// This seeds the pool from the configured thread counts. Autoscaling can
-	// replace both counts (and raise their ceilings) once there is a connection
-	// to probe the instance with, so setupCopierCheckerAndReplClient sizes the
-	// pool finally there. After that point it only ever grows: later phases
-	// (checksum, cutover) ratchet it further but never shrink it.
-	//
-	// Every one of those sizings, this one included, is clamped by
-	// --max-connections; see capPoolSize.
-	r.dbConfig.MaxOpenConnections = r.capPoolSize(
-		r.migration.Threads + r.migration.WriteThreads + r.controlPlaneConns() + checksumOffPoolConns)
+	// Above it the workers contend for connections instead of each holding one,
+	// which costs throughput and nothing else: a worker waiting on checkout is a
+	// worker that will eventually run. Below minPoolSize the migration cannot
+	// finish at all, which Migration.Validate rejects up front.
+	r.dbConfig.MaxOpenConnections = r.migration.MaxConnections
 	r.db, err = dbconn.New(r.dsn(), r.dbConfig)
 	if err != nil {
 		return fmt.Errorf("failed to connect to main database (DSN: %s): %w", dbconn.RedactDSN(r.dsn()), err)
@@ -912,44 +869,6 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	if maxRead == 0 {
 		maxRead = copier.ResolveMaxReadThreads(r.migration.Threads, false)
 	}
-	// Finalize the pool now that every ceiling is known, clamped by
-	// --max-connections (see capPoolSize). Sizing for the ceilings ensures a
-	// scaled-up applier or reader pool never starves on connections.
-	//
-	// This resizes even when autoscaling never engaged. Run seeded the pool from
-	// the configured thread counts with no flush term at all, and the sum below
-	// adds one, plus a write ceiling that is 2x the configured count on any
-	// target. Autoscaling and the cap change how far the pool moves from that
-	// seed, not whether it moves.
-	//
-	// The maxRead term covers the checksum as well as the copy: the checksum's
-	// transaction pool is sized to the same ceiling (see the checker's
-	// AutoscaleConfig below) and the copier's readers have finished by then, so
-	// the two phases reuse one allocation rather than each needing their own.
-	//
-	// The flush term is the drain's concurrent REPLACE statements. It was
-	// missing from this sum entirely before the derivation above existed, which
-	// meant the (then fixed) 8 concurrent flush REPLACEs were borrowing from the
-	// copier's and control plane's budget: a periodic flush overlaps the copy,
-	// so the two really do add. That was survivable at 8 and would not be at 32,
-	// so it is fixed here rather than left as a separate change — raising the
-	// concurrency without this would take the throughput straight back out
-	// through connection queueing.
-	maxFlush := flushConcurrency
-	if maxFlush == 0 {
-		maxFlush = change.DefaultFlushConcurrency // no derivation: the default applies
-	}
-	want := maxRead + maxWrite + maxFlush + r.controlPlaneConns() + checksumOffPoolConns
-	if poolSize := r.capPoolSize(want); poolSize != r.dbConfig.MaxOpenConnections {
-		// Unlike before the cap existed this may also *shrink* the pool: Run
-		// sized it from the configured thread counts, and a cap below that has
-		// to be able to take it back down. database/sql handles a lowered
-		// SetMaxOpenConns by closing idle connections and making the next
-		// checkout wait, so in-flight work finishes rather than failing.
-		r.dbConfig.MaxOpenConnections = poolSize
-		dbconn.SetPoolSize(r.db, poolSize)
-	}
-
 	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, r.checkpointTableName())
 
 	// We always create an applier — the replication client requires one to
@@ -1841,23 +1760,18 @@ func (r *Runner) initChunkers() error {
 // checksum creates the checksum which opens the read view
 func (r *Runner) checksum(ctx context.Context) error {
 	if err := r.status.Do(status.Checksum, func() error {
-		// The checksum keeps the pool threads open, so we need to extend
-		// by more than +1 on threads as we did previously. We have:
-		// - background flushing
-		// - checkpoint thread
-		// - checksum "replaceChunk" DB connections
-		// Handle a case just in the tests not having a dbConfig.
+		// No pool resize here. This used to ratchet +2 for background flushing,
+		// the checkpoint thread and replaceChunk's off-pool connections, back
+		// when the pool was sized to the copy phase's needs and the checksum's
+		// were extra. The pool is now --max-connections for the whole migration
+		// (see the MaxOpenConnections doc in (*Runner).Run), so a phase that
+		// stepped over it would be the one thing that made the number unusable
+		// as a budget: an operator with a max_user_connections cannot subtract a
+		// value that grows when spirit reaches a particular phase.
 		//
-		// Not restored when checksum completes — by then we are past the copy
-		// phase, so the +1 backpressure between copier and applier no longer
-		// applies, and the only thing left is cutover, which itself wants at
-		// least 5 connections. Pool size grows monotonically; see the
-		// MaxOpenConnections doc in (*Runner).Run.
-		//
-		// Clamped like every other sizing: --max-connections is an upper bound
-		// on the pool, not on one phase of it, so this ratchet does not get to
-		// step over it. At the cap the call is a no-op.
-		dbconn.SetPoolSize(r.db, r.capPoolSize(r.dbConfig.MaxOpenConnections+2))
+		// The checksum's own needs did not go away — they are why
+		// Migration.Validate refuses a --max-connections that cannot hold the
+		// read transactions it pins for the whole phase.
 
 		// Run the checksum with internal retry logic.
 		//

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -294,26 +294,14 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 	r.dbConfig.TLSMode = r.migration.TLSMode
 	r.dbConfig.TLSCertificatePath = r.migration.TLSCertificatePath
 	// The pool is --max-connections, verbatim and once. Nothing recomputes it,
-	// no phase ratchets it, and no ceiling derived later raises it.
+	// no phase ratchets it, and no ceiling derived later raises it — an operator
+	// budgeting against max_user_connections needs a number they can subtract.
 	//
-	// It used to be a sum of every worker ceiling — read, write, flush, plus
-	// headroom for the periodic control-plane queries — resized again whenever
-	// one of those ceilings moved. That sum stated what spirit would use if it
-	// were the only thing on the server, which it never is: the connections come
-	// out of the server's max_connections, shared with the production workload,
-	// and on a large instance the derived ceilings add up to well over a hundred.
-	// A migration that wants more than the server can spare does not slow down,
-	// it dies on `Error 1040: Too many connections`.
-	//
-	// A single number is also the only shape an operator can budget against. If
-	// the migration user has a max_user_connections, the pool has to be a value
-	// they can subtract, not a sum with a ratchet in the middle of it — see the
-	// note on the other pools in the max-connections docs.
-	//
-	// Above it the workers contend for connections instead of each holding one,
-	// which costs throughput and nothing else: a worker waiting on checkout is a
-	// worker that will eventually run. Below minPoolSize the migration cannot
-	// finish at all, which Migration.Validate rejects up front.
+	// The copier, applier, drain and control-plane queries all share it, and
+	// their ceilings can add up to more than it holds. Then they contend for
+	// connections instead of each holding one, which costs throughput and
+	// nothing else: a worker waiting on checkout is a worker that will
+	// eventually run. Migration.Validate rejects a value too small to finish on.
 	r.dbConfig.MaxOpenConnections = r.migration.MaxConnections
 	r.db, err = dbconn.New(r.dsn(), r.dbConfig)
 	if err != nil {
@@ -1760,19 +1748,6 @@ func (r *Runner) initChunkers() error {
 // checksum creates the checksum which opens the read view
 func (r *Runner) checksum(ctx context.Context) error {
 	if err := r.status.Do(status.Checksum, func() error {
-		// No pool resize here. This used to ratchet +2 for background flushing,
-		// the checkpoint thread and replaceChunk's off-pool connections, back
-		// when the pool was sized to the copy phase's needs and the checksum's
-		// were extra. The pool is now --max-connections for the whole migration
-		// (see the MaxOpenConnections doc in (*Runner).Run), so a phase that
-		// stepped over it would be the one thing that made the number unusable
-		// as a budget: an operator with a max_user_connections cannot subtract a
-		// value that grows when spirit reaches a particular phase.
-		//
-		// The checksum's own needs did not go away — they are why
-		// Migration.Validate refuses a --max-connections that cannot hold the
-		// read transactions it pins for the whole phase.
-
 		// Run the checksum with internal retry logic.
 		//
 		// We do not invalidate the checkpoint on a checksum error. The dumper

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -223,64 +223,43 @@ func (r *Runner) controlPlaneConns() int {
 	return len(r.changes) + 2
 }
 
-// boundedPoolSize is the main pool's size for the ceilings the caller settled
-// on, bounded by Migration.MaxConnections.
+// capPoolSize clamps a main-pool size to Migration.MaxConnections. Every place
+// that sizes r.db goes through it, so the flag is an upper bound on the pool for
+// the whole migration rather than for one phase of it.
 //
-// The unbounded sum is every ceiling added together, so that no pool can ever
-// starve another. As a statement of what spirit would use if nothing else were
-// running it is correct; as a claim on the server it is not spirit's to make.
-// The connections come out of the server's max_connections, shared with the
-// production workload, and on a large instance the derived ceilings add up to
-// well over a hundred. When the server has less spare than that, the migration
-// does not degrade — it fails outright on `Error 1040: Too many connections`,
-// which is a worse outcome than any amount of queueing.
+// Everything that sizes the pool sizes it for a guarantee: every ceiling added
+// together, so no pool can ever starve another. As a statement of what spirit
+// would use if nothing else were running that is correct; as a claim on the
+// server it is not spirit's to make. The connections come out of the server's
+// max_connections, shared with the production workload, and on a large instance
+// the derived ceilings add up to well over a hundred. When the server has less
+// spare than that the migration does not degrade — it fails outright on
+// `Error 1040: Too many connections`, which is worse than any amount of queueing.
 //
-// Above the bound, write and flush workers give way: they queue on the pool
-// instead of each holding a connection. That trades throughput for survival,
-// which is the right trade, because a worker waiting on a connection is a
-// worker that will eventually run.
+// So this is a loose upper bound and nothing more: a number and a min(). It does
+// not ask which pool wants the connections or which phase is running, it does
+// not recompute anything, and it never hands back more than it was asked for.
+// Above the bound the workers give way and queue on the pool instead of each
+// holding a connection, which trades throughput for survival — a worker waiting
+// on a connection is a worker that will eventually run.
 //
-// maxRead does not give way, and this is the part worth stating plainly.
-// During the checksum every transaction in the read pool pins a connection for
-// the whole phase whether or not a worker has it checked out (see
-// checksumOffPoolConns). A pool below maxRead plus the two reserves therefore
-// does not make that phase slower — it leaves chunk dispatch with no connection
-// to get, and the phase hangs. So the bound is floored there, and a bound set
-// below the floor is reported and raised rather than obeyed: refusing to hang
-// is worth more than honouring the number exactly.
-//
-// One deliberate leak: the checksum ratchets the live pool +2 above whatever
-// this returns (the SetPoolSize call in (*Runner).checksum). That ratchet
-// predates this budget, and the three things its comment names — background
-// flushing, the checkpoint thread, and replaceChunk's off-pool connections —
-// are all already accounted for in the sum above, by controlPlaneConns and
-// checksumOffPoolConns respectively. So it is now plain headroom rather than a
-// reserve for anything in particular, and the effective ceiling is bound+2
-// rather than bound. Left alone here on purpose: two connections is not the
-// difference between fitting on a server and not, and removing it belongs in a
-// change that can argue about the checksum's own budget.
-func (r *Runner) boundedPoolSize(maxRead, maxWrite, maxFlush int) int {
-	reserved := r.controlPlaneConns() + checksumOffPoolConns
-	want := maxRead + maxWrite + maxFlush + reserved
+// The default is far above anything spirit derives for itself, so this is inert
+// unless an operator sets it deliberately. Set very low it is still obeyed, and
+// there is a floor below which that hurts: the checksum's read transactions pin
+// their connections for the whole phase whether or not a worker has one checked
+// out (see checksumOffPoolConns), so a pool under the read ceiling plus those
+// reserves leaves chunk dispatch nothing to check out and the phase stalls. That
+// is the operator's number to get right — see the flag docs in docs/migrate.md.
+// A safety net that quietly ignored the limit it was handed would be the worse
+// failure.
+func (r *Runner) capPoolSize(want int) int {
 	limit := r.migration.MaxConnections
 	if limit <= 0 || want <= limit {
-		return want // unbounded, or the ceilings already fit
+		return want // unbounded, or it already fits
 	}
-	if floor := maxRead + reserved; limit < floor {
-		r.logger.Warn("--max-connections is below what the checksum phase pins for the whole phase; using the floor instead",
-			"max_connections", limit,
-			"pool_size", floor,
-			"read_ceiling", maxRead,
-			"reserved", reserved)
-		return floor
-	}
-	r.logger.Warn("connection budget capped; read, write and flush workers will contend for connections",
+	r.logger.Warn("connection pool capped by --max-connections; workers will contend for connections",
 		"max_connections", limit,
-		"requested", want,
-		"read_ceiling", maxRead,
-		"write_ceiling", maxWrite,
-		"flush_concurrency", maxFlush,
-		"reserved", reserved)
+		"requested", want)
 	return limit
 }
 
@@ -372,11 +351,13 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 	// This seeds the pool from the configured thread counts. Autoscaling can
 	// replace both counts (and raise their ceilings) once there is a connection
 	// to probe the instance with, so setupCopierCheckerAndReplClient sizes the
-	// pool finally there — bounded by --max-connections, which is the one thing
-	// that can take it back *down* from the seed here. After that point it only
-	// ever grows: later phases (checksum, cutover) ratchet it further but never
-	// shrink it.
-	r.dbConfig.MaxOpenConnections = r.migration.Threads + r.migration.WriteThreads + r.controlPlaneConns() + checksumOffPoolConns
+	// pool finally there. After that point it only ever grows: later phases
+	// (checksum, cutover) ratchet it further but never shrink it.
+	//
+	// Every one of those sizings, this one included, is clamped by
+	// --max-connections; see capPoolSize.
+	r.dbConfig.MaxOpenConnections = r.capPoolSize(
+		r.migration.Threads + r.migration.WriteThreads + r.controlPlaneConns() + checksumOffPoolConns)
 	r.db, err = dbconn.New(r.dsn(), r.dbConfig)
 	if err != nil {
 		return fmt.Errorf("failed to connect to main database (DSN: %s): %w", dbconn.RedactDSN(r.dsn()), err)
@@ -931,14 +912,14 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	if maxRead == 0 {
 		maxRead = copier.ResolveMaxReadThreads(r.migration.Threads, false)
 	}
-	// Finalize the pool now that every ceiling is known, bounded by
-	// --max-connections (see boundedPoolSize). Sizing for the ceilings ensures a
+	// Finalize the pool now that every ceiling is known, clamped by
+	// --max-connections (see capPoolSize). Sizing for the ceilings ensures a
 	// scaled-up applier or reader pool never starves on connections.
 	//
 	// This resizes even when autoscaling never engaged. Run seeded the pool from
 	// the configured thread counts with no flush term at all, and the sum below
 	// adds one, plus a write ceiling that is 2x the configured count on any
-	// target. Autoscaling and the bound change how far the pool moves from that
+	// target. Autoscaling and the cap change how far the pool moves from that
 	// seed, not whether it moves.
 	//
 	// The maxRead term covers the checksum as well as the copy: the checksum's
@@ -958,10 +939,11 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	if maxFlush == 0 {
 		maxFlush = change.DefaultFlushConcurrency // no derivation: the default applies
 	}
-	if poolSize := r.boundedPoolSize(maxRead, maxWrite, maxFlush); poolSize != r.dbConfig.MaxOpenConnections {
-		// Unlike before the bound existed this may also *shrink* the pool: Run
-		// sized it from the configured thread counts, and a bound below that
-		// has to be able to take it back down. database/sql handles a lowered
+	want := maxRead + maxWrite + maxFlush + r.controlPlaneConns() + checksumOffPoolConns
+	if poolSize := r.capPoolSize(want); poolSize != r.dbConfig.MaxOpenConnections {
+		// Unlike before the cap existed this may also *shrink* the pool: Run
+		// sized it from the configured thread counts, and a cap below that has
+		// to be able to take it back down. database/sql handles a lowered
 		// SetMaxOpenConns by closing idle connections and making the next
 		// checkout wait, so in-flight work finishes rather than failing.
 		r.dbConfig.MaxOpenConnections = poolSize
@@ -1871,7 +1853,11 @@ func (r *Runner) checksum(ctx context.Context) error {
 		// applies, and the only thing left is cutover, which itself wants at
 		// least 5 connections. Pool size grows monotonically; see the
 		// MaxOpenConnections doc in (*Runner).Run.
-		dbconn.SetPoolSize(r.db, r.dbConfig.MaxOpenConnections+2)
+		//
+		// Clamped like every other sizing: --max-connections is an upper bound
+		// on the pool, not on one phase of it, so this ratchet does not get to
+		// step over it. At the cap the call is a no-op.
+		dbconn.SetPoolSize(r.db, r.capPoolSize(r.dbConfig.MaxOpenConnections+2))
 
 		// Run the checksum with internal retry logic.
 		//

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -249,11 +249,16 @@ func (r *Runner) controlPlaneConns() int {
 // below the floor is reported and raised rather than obeyed: refusing to hang
 // is worth more than honouring the number exactly.
 //
-// One deliberate leak: the checksum ratchets the pool +2 above whatever this
-// returns, for the two queries it runs outside its checked-out transaction
-// pool. Those are the connections that must not queue behind anything, so the
-// effective ceiling is bound+2 rather than bound. Two connections is not the
-// difference between fitting on a server and not.
+// One deliberate leak: the checksum ratchets the live pool +2 above whatever
+// this returns (the SetPoolSize call in (*Runner).checksum). That ratchet
+// predates this budget, and the three things its comment names — background
+// flushing, the checkpoint thread, and replaceChunk's off-pool connections —
+// are all already accounted for in the sum above, by controlPlaneConns and
+// checksumOffPoolConns respectively. So it is now plain headroom rather than a
+// reserve for anything in particular, and the effective ceiling is bound+2
+// rather than bound. Left alone here on purpose: two connections is not the
+// difference between fitting on a server and not, and removing it belongs in a
+// change that can argue about the checksum's own budget.
 func (r *Runner) boundedPoolSize(maxRead, maxWrite, maxFlush int) int {
 	reserved := r.controlPlaneConns() + checksumOffPoolConns
 	want := maxRead + maxWrite + maxFlush + reserved
@@ -928,8 +933,13 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	}
 	// Finalize the pool now that every ceiling is known, bounded by
 	// --max-connections (see boundedPoolSize). Sizing for the ceilings ensures a
-	// scaled-up applier or reader pool never starves on connections. This is a
-	// no-op unless autoscaling raised a ceiling or the bound binds.
+	// scaled-up applier or reader pool never starves on connections.
+	//
+	// This resizes even when autoscaling never engaged. Run seeded the pool from
+	// the configured thread counts with no flush term at all, and the sum below
+	// adds one, plus a write ceiling that is 2x the configured count on any
+	// target. Autoscaling and the bound change how far the pool moves from that
+	// seed, not whether it moves.
 	//
 	// The maxRead term covers the checksum as well as the copy: the checksum's
 	// transaction pool is sized to the same ceiling (see the checker's

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -223,6 +223,62 @@ func (r *Runner) controlPlaneConns() int {
 	return len(r.changes) + 2
 }
 
+// boundedPoolSize is the main pool's size for the ceilings the caller settled
+// on, bounded by Migration.MaxConnections.
+//
+// The unbounded sum is every ceiling added together, so that no pool can ever
+// starve another. As a statement of what spirit would use if nothing else were
+// running it is correct; as a claim on the server it is not spirit's to make.
+// The connections come out of the server's max_connections, shared with the
+// production workload, and on a large instance the derived ceilings add up to
+// well over a hundred. When the server has less spare than that, the migration
+// does not degrade — it fails outright on `Error 1040: Too many connections`,
+// which is a worse outcome than any amount of queueing.
+//
+// Above the bound, write and flush workers give way: they queue on the pool
+// instead of each holding a connection. That trades throughput for survival,
+// which is the right trade, because a worker waiting on a connection is a
+// worker that will eventually run.
+//
+// maxRead does not give way, and this is the part worth stating plainly.
+// During the checksum every transaction in the read pool pins a connection for
+// the whole phase whether or not a worker has it checked out (see
+// checksumOffPoolConns). A pool below maxRead plus the two reserves therefore
+// does not make that phase slower — it leaves chunk dispatch with no connection
+// to get, and the phase hangs. So the bound is floored there, and a bound set
+// below the floor is reported and raised rather than obeyed: refusing to hang
+// is worth more than honouring the number exactly.
+//
+// One deliberate leak: the checksum ratchets the pool +2 above whatever this
+// returns, for the two queries it runs outside its checked-out transaction
+// pool. Those are the connections that must not queue behind anything, so the
+// effective ceiling is bound+2 rather than bound. Two connections is not the
+// difference between fitting on a server and not.
+func (r *Runner) boundedPoolSize(maxRead, maxWrite, maxFlush int) int {
+	reserved := r.controlPlaneConns() + checksumOffPoolConns
+	want := maxRead + maxWrite + maxFlush + reserved
+	limit := r.migration.MaxConnections
+	if limit <= 0 || want <= limit {
+		return want // unbounded, or the ceilings already fit
+	}
+	if floor := maxRead + reserved; limit < floor {
+		r.logger.Warn("--max-connections is below what the checksum phase pins for the whole phase; using the floor instead",
+			"max_connections", limit,
+			"pool_size", floor,
+			"read_ceiling", maxRead,
+			"reserved", reserved)
+		return floor
+	}
+	r.logger.Warn("connection budget capped; read, write and flush workers will contend for connections",
+		"max_connections", limit,
+		"requested", want,
+		"read_ceiling", maxRead,
+		"write_ceiling", maxWrite,
+		"flush_concurrency", maxFlush,
+		"reserved", reserved)
+	return limit
+}
+
 func (r *Runner) SetMetricsSink(sink metrics.Sink) {
 	r.metricsSink = sink
 }
@@ -310,10 +366,11 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 	//
 	// This seeds the pool from the configured thread counts. Autoscaling can
 	// replace both counts (and raise their ceilings) once there is a connection
-	// to probe the instance with, so setupCopierCheckerAndReplClient grows the
-	// pool to its final size there. The pool only ever grows (via
-	// SetMaxOpenConns); later phases (checksum, cutover) ratchet it further but
-	// never shrink it.
+	// to probe the instance with, so setupCopierCheckerAndReplClient sizes the
+	// pool finally there — bounded by --max-connections, which is the one thing
+	// that can take it back *down* from the seed here. After that point it only
+	// ever grows: later phases (checksum, cutover) ratchet it further but never
+	// shrink it.
 	r.dbConfig.MaxOpenConnections = r.migration.Threads + r.migration.WriteThreads + r.controlPlaneConns() + checksumOffPoolConns
 	r.db, err = dbconn.New(r.dsn(), r.dbConfig)
 	if err != nil {
@@ -869,11 +926,10 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	if maxRead == 0 {
 		maxRead = copier.ResolveMaxReadThreads(r.migration.Threads, false)
 	}
-	// Finalize the pool now that both ceilings are known: maxRead + maxWrite +
-	// controlPlaneConns() + checksumOffPoolConns (see the MaxOpenConnections doc
-	// in Run). Sizing for the ceilings ensures a scaled-up applier or reader pool
-	// never starves on connections. This is a no-op unless autoscaling raised a
-	// ceiling; the pool only ever grows.
+	// Finalize the pool now that every ceiling is known, bounded by
+	// --max-connections (see boundedPoolSize). Sizing for the ceilings ensures a
+	// scaled-up applier or reader pool never starves on connections. This is a
+	// no-op unless autoscaling raised a ceiling or the bound binds.
 	//
 	// The maxRead term covers the checksum as well as the copy: the checksum's
 	// transaction pool is sized to the same ceiling (see the checker's
@@ -892,7 +948,12 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	if maxFlush == 0 {
 		maxFlush = change.DefaultFlushConcurrency // no derivation: the default applies
 	}
-	if poolSize := maxRead + maxWrite + maxFlush + r.controlPlaneConns() + checksumOffPoolConns; poolSize > r.dbConfig.MaxOpenConnections {
+	if poolSize := r.boundedPoolSize(maxRead, maxWrite, maxFlush); poolSize != r.dbConfig.MaxOpenConnections {
+		// Unlike before the bound existed this may also *shrink* the pool: Run
+		// sized it from the configured thread counts, and a bound below that
+		// has to be able to take it back down. database/sql handles a lowered
+		// SetMaxOpenConns by closing idle connections and making the next
+		// checkout wait, so in-flight work finishes rather than failing.
 		r.dbConfig.MaxOpenConnections = poolSize
 		dbconn.SetPoolSize(r.db, poolSize)
 	}

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -223,6 +223,32 @@ func (r *Runner) controlPlaneConns() int {
 	return len(r.changes) + 2
 }
 
+// readCeilingForPool bounds a read ceiling to what the connection pool can hold.
+//
+// Read workers are the one kind that cannot simply queue. The checksum turns
+// this ceiling into transactions, opens all of them serially under the table
+// lock (they must share one snapshot instant, so none can be added later — see
+// SingleChecker.initConnPool), and each holds its connection for the whole phase
+// whether or not a worker has it checked out. A ceiling the pool cannot hold is
+// therefore not a slow checksum, it is one that blocks on connection checkout
+// with a table lock held.
+//
+// Migration.Validate covers the configured thread count. It cannot cover this
+// one: under autoscaling the ceiling comes from an instance vCPU count that is
+// only known after the probe, long after flag parsing. So it is bounded here
+// instead — and bounding the ceiling rather than growing the pool is the right
+// way round, because the ceiling is a number spirit derived for itself while the
+// pool is one the operator gave it.
+//
+// A non-positive maxConnections means no pool size was resolved (a Runner built
+// directly, bypassing normalizeOptions); there is nothing to fit to.
+func readCeilingForPool(maxRead, maxConnections int) int {
+	if maxConnections <= 0 {
+		return maxRead
+	}
+	return min(maxRead, maxConnections-checksumOffPoolConns)
+}
+
 func (r *Runner) SetMetricsSink(sink metrics.Sink) {
 	r.metricsSink = sink
 }
@@ -301,7 +327,12 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 	// their ceilings can add up to more than it holds. Then they contend for
 	// connections instead of each holding one, which costs throughput and
 	// nothing else: a worker waiting on checkout is a worker that will
-	// eventually run. Migration.Validate rejects a value too small to finish on.
+	// eventually run.
+	//
+	// Read workers are the exception, because the checksum pins one connection
+	// per transaction for a whole phase. Migration.Validate rejects a pool that
+	// cannot hold the configured count; readCeilingForPool handles the count
+	// autoscaling derives later.
 	r.dbConfig.MaxOpenConnections = r.migration.MaxConnections
 	r.db, err = dbconn.New(r.dsn(), r.dbConfig)
 	if err != nil {
@@ -839,9 +870,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 			"write_threads", r.migration.WriteThreads)
 	}
 	// The read side's ceiling is half the instance when autoscaling engaged above
-	// (autoscale.ReadBounds). The pool below is sized for it, since readers scaled
-	// above the connection budget would just queue on the sql.DB pool, buying no
-	// extra parallelism.
+	// (autoscale.ReadBounds).
 	//
 	// A zero readCeiling means the gate above did not derive one, which is also
 	// exactly the case where neither read pool can grow: growth needs the
@@ -856,6 +885,13 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	maxRead := readCeiling
 	if maxRead == 0 {
 		maxRead = copier.ResolveMaxReadThreads(r.migration.Threads, false)
+	}
+	if fitted := readCeilingForPool(maxRead, r.migration.MaxConnections); fitted != maxRead {
+		r.logger.Warn("read ceiling derived from the instance does not fit the connection pool; capping it",
+			"read_ceiling", maxRead,
+			"max_connections", r.migration.MaxConnections,
+			"capped_to", fitted)
+		maxRead = fitted
 	}
 	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, r.checkpointTableName())
 

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -220,33 +220,78 @@ const checksumOffPoolConns = 2
 // Throttler polls are NOT counted here — they run on the dedicated monitorDB
 // pool (see the monitorDB field).
 func (r *Runner) controlPlaneConns() int {
-	return len(r.changes) + 2
+	return len(r.changes) + controlPlaneFixedConns
 }
 
-// readCeilingForPool bounds a read ceiling to what the connection pool can hold.
+// controlPlaneFixedConns is the part of controlPlaneConns that does not scale
+// with the number of change tables: the checkpoint INSERT and the
+// replication-flush poll.
+const controlPlaneFixedConns = 2
+
+// drainReserveConns is what the change-feed drain keeps while the checksum runs.
+// One connection, not the flush concurrency: a narrow drain is a slow drain and
+// that is a fine trade, but a drain with nothing to check out does not advance
+// the binlog position at all, and that position has to keep moving or the
+// migration runs out its retention window. Slow is a late migration; stopped is
+// a failed one.
+const drainReserveConns = 1
+
+// checksumPhaseReserve is the number of connections that must stay checkout-able
+// while the checksum holds its read transactions open.
 //
-// Read workers are the one kind that cannot simply queue. The checksum turns
-// this ceiling into transactions, opens all of them serially under the table
-// lock (they must share one snapshot instant, so none can be added later — see
+// The checksum is the only phase that pins connections rather than borrowing
+// them: every transaction in its pool holds one for the whole phase whether or
+// not a worker has it checked out. So anything that has to keep running
+// alongside it needs its share carved out of the pool up front — the checksum's
+// own off-pool queries (checksumOffPoolConns), the control-plane queries, and
+// the drain. The copier and applier are not in the reserve because they have
+// finished by the time the checksum starts.
+func (r *Runner) checksumPhaseReserve() int {
+	return checksumOffPoolConns + r.controlPlaneConns() + drainReserveConns
+}
+
+// minChecksumPhaseReserve is checksumPhaseReserve for the smallest migration
+// there is, one change table. Migration.Validate needs the number before the
+// statement has been parsed into change tables, so it uses this lower bound; the
+// runtime fit in setupCopierCheckerAndReplClient uses the real count.
+const minChecksumPhaseReserve = checksumOffPoolConns + controlPlaneFixedConns + 1 + drainReserveConns
+
+// readBoundsForPool fits a read start and ceiling into the connection pool.
+//
+// Read workers are the one kind that cannot simply queue. The checksum turns the
+// ceiling into transactions, opens all of them serially under the table lock
+// (they must share one snapshot instant, so none can be added later — see
 // SingleChecker.initConnPool), and each holds its connection for the whole phase
 // whether or not a worker has it checked out. A ceiling the pool cannot hold is
 // therefore not a slow checksum, it is one that blocks on connection checkout
 // with a table lock held.
 //
+// The start is fitted along with the ceiling, and that is the whole reason this
+// takes both. A ceiling alone does not survive its consumers: checksum.NewChecker
+// resolves max(Autoscale.MaxThreads, Concurrency) and the copier's
+// resolveReadCeiling does the same, because a pool that begins above its cap
+// cannot be controlled. Both are right on their own terms, so lowering only the
+// ceiling gets floored straight back up to the start and the fit becomes a no-op
+// in exactly the case it was written for — autoscaling, where the start is
+// instance-derived and can be larger than the pool the operator configured.
+//
 // Migration.Validate covers the configured thread count. It cannot cover this
-// one: under autoscaling the ceiling comes from an instance vCPU count that is
-// only known after the probe, long after flag parsing. So it is bounded here
-// instead — and bounding the ceiling rather than growing the pool is the right
-// way round, because the ceiling is a number spirit derived for itself while the
-// pool is one the operator gave it.
+// one: under autoscaling both numbers come from an instance vCPU count that is
+// only known after the probe, long after flag parsing. And fitting the bounds
+// rather than growing the pool is the right way round, because these are numbers
+// spirit derived for itself while the pool is one the operator gave it.
 //
 // A non-positive maxConnections means no pool size was resolved (a Runner built
 // directly, bypassing normalizeOptions); there is nothing to fit to.
-func readCeilingForPool(maxRead, maxConnections int) int {
+func readBoundsForPool(start, ceiling, maxConnections, reserve int) (int, int) {
 	if maxConnections <= 0 {
-		return maxRead
+		return start, ceiling
 	}
-	return min(maxRead, maxConnections-checksumOffPoolConns)
+	// At least one reader, even on a pool too small to honour the reserve:
+	// zero read workers is a migration that cannot make progress at all, which
+	// is strictly worse than one contending with its own control plane.
+	fit := max(1, maxConnections-reserve)
+	return min(start, fit), min(ceiling, fit)
 }
 
 func (r *Runner) SetMetricsSink(sink metrics.Sink) {
@@ -324,15 +369,23 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 	// budgeting against max_user_connections needs a number they can subtract.
 	//
 	// The copier, applier, drain and control-plane queries all share it, and
-	// their ceilings can add up to more than it holds. Then they contend for
-	// connections instead of each holding one, which costs throughput and
-	// nothing else: a worker waiting on checkout is a worker that will
-	// eventually run.
+	// their ceilings can add up to more than it holds. For the copier and the
+	// applier that costs throughput and nothing else: a worker waiting on
+	// checkout is a worker that will eventually run, and the work it was going
+	// to do is still there when it does.
 	//
-	// Read workers are the exception, because the checksum pins one connection
-	// per transaction for a whole phase. Migration.Validate rejects a pool that
-	// cannot hold the configured count; readCeilingForPool handles the count
-	// autoscaling derives later.
+	// Two paths are not like that:
+	//
+	//   - Read workers, because the checksum pins one connection per transaction
+	//     for a whole phase — a ceiling the pool cannot hold blocks on checkout
+	//     with a table lock held. Migration.Validate rejects a pool that cannot
+	//     hold the configured count; readBoundsForPool handles the count
+	//     autoscaling derives later.
+	//   - The drain, because its work expires. A flush batch queueing behind a
+	//     saturated copy is spending the binlog retention window, and running out
+	//     of that window ends the migration rather than slowing it. It is why the
+	//     drain has a reserve during the checksum (drainReserveConns) rather than
+	//     being left to contend like the copier.
 	r.dbConfig.MaxOpenConnections = r.migration.MaxConnections
 	r.db, err = dbconn.New(r.dsn(), r.dbConfig)
 	if err != nil {
@@ -886,12 +939,19 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	if maxRead == 0 {
 		maxRead = copier.ResolveMaxReadThreads(r.migration.Threads, false)
 	}
-	if fitted := readCeilingForPool(maxRead, r.migration.MaxConnections); fitted != maxRead {
-		r.logger.Warn("read ceiling derived from the instance does not fit the connection pool; capping it",
-			"read_ceiling", maxRead,
+	// Fit both read bounds to the pool. The start matters as much as the ceiling
+	// here: r.migration.Threads is what the checksum takes as its Concurrency and
+	// what the copier takes as its starting read-worker count, and both of them
+	// floor the ceiling back up to it (see readBoundsForPool). Under autoscaling
+	// this is the number the block above replaced with readStart, so it is
+	// instance-derived and has never been checked against the operator's pool.
+	if fitStart, fitCeiling := readBoundsForPool(r.migration.Threads, maxRead, r.migration.MaxConnections, r.checksumPhaseReserve()); fitStart != r.migration.Threads || fitCeiling != maxRead {
+		r.logger.Warn("read thread bounds do not fit the connection pool; capping them",
+			"threads", r.migration.Threads, "capped_threads", fitStart,
+			"read_ceiling", maxRead, "capped_read_ceiling", fitCeiling,
 			"max_connections", r.migration.MaxConnections,
-			"capped_to", fitted)
-		maxRead = fitted
+			"reserved", r.checksumPhaseReserve())
+		r.migration.Threads, maxRead = fitStart, fitCeiling
 	}
 	r.checkpointTable = table.NewTableInfo(r.db, r.changes[0].table.SchemaName, r.checkpointTableName())
 

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -1,6 +1,11 @@
 package migration
 
 import (
+	"context"
+	"log/slog"
+	"reflect"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/block/spirit/pkg/autoscale"
@@ -103,3 +108,146 @@ func TestFlushBoundsPreservesChangeDefaults(t *testing.T) {
 // controller's private distress floor, and the only thing outside that package
 // with an interest in it is the assertion above.
 const minAdaptiveBatchSizeForTest = 50
+
+// warningRecorder keeps the WARN messages a Runner logs. The pool bound's
+// warnings are not decoration: a capped pool is a deliberate throughput trade,
+// and the log line is the only place an operator learns it was made. Warning
+// when nothing was capped is therefore its own small bug — see the exact-fit
+// case below.
+type warningRecorder struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (h *warningRecorder) Enabled(_ context.Context, l slog.Level) bool { return l >= slog.LevelWarn }
+
+func (h *warningRecorder) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, r.Message)
+	return nil
+}
+
+func (h *warningRecorder) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *warningRecorder) WithGroup(string) slog.Handler      { return h }
+
+func (h *warningRecorder) warnings() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.msgs...)
+}
+
+// newPoolSizingRunner builds the smallest Runner boundedPoolSize can be called
+// on: it reads only the change count (for controlPlaneConns), the bound, and
+// the logger it warns through.
+func newPoolSizingRunner(tables, maxConnections int) (*Runner, *warningRecorder) {
+	warnings := &warningRecorder{}
+	return &Runner{
+		changes:   make([]*tableChange, tables),
+		migration: &Migration{MaxConnections: maxConnections},
+		logger:    slog.New(warnings),
+	}, warnings
+}
+
+// TestBoundedPoolSize covers the bound itself. The unbounded sum is every
+// worker ceiling added together so no pool can starve another, which is the
+// right sizing right up until the server cannot spare it — at which point the
+// migration does not slow down, it dies on Error 1040. See boundedPoolSize.
+func TestBoundedPoolSize(t *testing.T) {
+	// One change table, so reserved is controlPlaneConns (3) + the two
+	// off-pool checksum connections = 5 in every case below.
+	const reserved = 3 + checksumOffPoolConns
+
+	t.Run("under the bound the ceilings pass through untouched", func(t *testing.T) {
+		r, warnings := newPoolSizingRunner(1, 128)
+		require.Equal(t, 4+8+8+reserved, r.boundedPoolSize(4, 8, 8))
+		require.Empty(t, warnings.warnings())
+	})
+
+	t.Run("a sum equal to the bound is not capped", func(t *testing.T) {
+		// The comparison is <=, not <: a sum that exactly fits gets to keep
+		// every guaranteed connection. Off-by-one here would silently push the
+		// commonest hand-configured shapes into contention.
+		//
+		// At exactly the bound the two branches happen to return the same
+		// number, so the warning is the only thing that can tell them apart —
+		// and a migration told its pool was capped when it was not is a
+		// migration whose operator goes looking for throughput that was never
+		// taken away.
+		r, warnings := newPoolSizingRunner(1, 16+32+32+reserved)
+		require.Equal(t, 16+32+32+reserved, r.boundedPoolSize(16, 32, 32))
+		require.Empty(t, warnings.warnings(), "an exact fit must not report contention")
+	})
+
+	t.Run("the derived ceilings that produced Error 1040 are capped", func(t *testing.T) {
+		// A large Aurora instance: read ceiling half the box, write ceiling
+		// twice the start, flush at autoscale.MaxFlushConcurrency. 133 wanted
+		// against a default bound of 128.
+		r, warnings := newPoolSizingRunner(1, defaultMaxConnections)
+		require.Equal(t, defaultMaxConnections, r.boundedPoolSize(32, 64, autoscale.MaxFlushConcurrency),
+			"a bound that binds must return the bound exactly, not the sum")
+		require.Len(t, warnings.warnings(), 1, "capping is a throughput trade and must be said out loud")
+	})
+
+	t.Run("more change tables raise the reserve, not the bound", func(t *testing.T) {
+		// controlPlaneConns scales with the change count, so a multi-table
+		// migration wants more; the bound is still the bound.
+		r, _ := newPoolSizingRunner(5, 64)
+		require.Equal(t, 64, r.boundedPoolSize(32, 64, 32))
+	})
+
+	t.Run("a negative bound restores the pre-cap behaviour", func(t *testing.T) {
+		// Programmatic callers only: normalizeOptions turns a zero into the
+		// default, so unbounded has to be asked for explicitly.
+		r, warnings := newPoolSizingRunner(1, -1)
+		require.Equal(t, 32+64+32+reserved, r.boundedPoolSize(32, 64, 32))
+		require.Empty(t, warnings.warnings())
+	})
+
+	t.Run("an unfilled bound is unbounded rather than zero", func(t *testing.T) {
+		// normalizeOptions is what turns a zero into the default, and not every
+		// Runner is built through it (tests and embedders both construct
+		// Migration literals). Reading a literal zero as "cap the pool at zero
+		// connections" would deadlock the migration instantly, so it is read as
+		// "no bound set".
+		r, _ := newPoolSizingRunner(1, 0)
+		require.Equal(t, 32+64+32+reserved, r.boundedPoolSize(32, 64, 32))
+	})
+
+	t.Run("the bound is floored at what the checksum pins", func(t *testing.T) {
+		// Below maxRead+reserved the checksum phase does not get slower, it
+		// hangs: every transaction in the read pool holds its connection for
+		// the whole phase, so chunk dispatch would have nothing left to check
+		// out. Refusing to hang beats honouring the number.
+		r, warnings := newPoolSizingRunner(1, 10)
+		require.Equal(t, 32+reserved, r.boundedPoolSize(32, 64, 32),
+			"a bound below the read pin must be raised to it")
+		require.Len(t, warnings.warnings(), 1, "quietly ignoring the configured number is worse than the number")
+	})
+
+	t.Run("the floor is the read pin exactly, and write and flush get nothing", func(t *testing.T) {
+		// The floor covers the phase that cannot queue and not one connection
+		// more — write and flush workers queue there, which is the trade the
+		// bound is asking for in the first place.
+		r, _ := newPoolSizingRunner(1, 8+reserved-1)
+		require.Equal(t, 8+reserved, r.boundedPoolSize(8, 64, 32))
+	})
+}
+
+// TestMaxConnectionsDefaultMatchesItsFlag pins the constant to the kong tag it
+// says it mirrors. The two are only connected by a comment, and the failure
+// mode of drift is silent: the CLI would keep bounding at one number while
+// every embedding orchestrator bounded at another.
+func TestMaxConnectionsDefaultMatchesItsFlag(t *testing.T) {
+	field, ok := reflect.TypeFor[Migration]().FieldByName("MaxConnections")
+	require.True(t, ok)
+	require.Equal(t, strconv.Itoa(defaultMaxConnections), field.Tag.Get("default"))
+
+	// And an unset field lands on it, so a programmatic caller is bounded too.
+	// That is not incidental: the derived ceilings only overflow on the large
+	// instances, whose migrations are as likely to be driven by an embedder.
+	m := &Migration{Statement: "ALTER TABLE t1 ENGINE=InnoDB", Database: "test"}
+	_, err := m.normalizeOptions()
+	require.NoError(t, err)
+	require.Equal(t, defaultMaxConnections, m.MaxConnections)
+}

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -136,33 +136,93 @@ func TestMaxConnectionsDefaultMatchesItsFlag(t *testing.T) {
 	require.Equal(t, defaultMaxConnections, m.MaxConnections)
 }
 
-// TestReadCeilingForPool covers the one worker count that cannot be left to
+// TestReadBoundsForPool covers the one worker count that cannot be left to
 // queue. The checksum opens a transaction per read thread, serially, under the
-// table lock, and each holds its connection for the whole phase — so a ceiling
-// the pool cannot hold blocks on checkout with that lock held.
+// table lock, and each holds its connection for the whole phase — so bounds the
+// pool cannot hold block on checkout with that lock held.
 //
-// Validate cannot catch this case: under autoscaling the ceiling comes from an
-// instance vCPU count read long after flag parsing, and has nothing to do with
+// Validate cannot catch this case: under autoscaling both numbers come from an
+// instance vCPU count read long after flag parsing, and have nothing to do with
 // --threads.
-func TestReadCeilingForPool(t *testing.T) {
-	// Room to spare: the ceiling is whatever was derived.
-	require.Equal(t, 32, readCeilingForPool(32, defaultMaxConnections))
+func TestReadBoundsForPool(t *testing.T) {
+	// A single-table migration, which is what minChecksumPhaseReserve describes.
+	const reserve = minChecksumPhaseReserve
 
-	// Exactly enough, counting the two off-pool queries the checksum also runs.
-	require.Equal(t, 30, readCeilingForPool(30, 32))
+	// Room to spare: the bounds are whatever was derived.
+	start, ceiling := readBoundsForPool(16, 32, defaultMaxConnections, reserve)
+	require.Equal(t, 16, start)
+	require.Equal(t, 32, ceiling)
+
+	// Exactly enough, counting the reserve the checksum phase cannot run without.
+	start, ceiling = readBoundsForPool(16, 32-reserve, 32, reserve)
+	require.Equal(t, 16, start)
+	require.Equal(t, 32-reserve, ceiling)
 
 	// One short. The ceiling gives way, not the pool: the ceiling is a number
 	// spirit derived for itself, the pool is one the operator set.
-	require.Equal(t, 30, readCeilingForPool(31, 32))
+	_, ceiling = readBoundsForPool(16, 32-reserve+1, 32, reserve)
+	require.Equal(t, 32-reserve, ceiling)
 
-	// A 96-vCPU instance derives a ceiling of 48 from autoscale.ReadBounds, and
-	// --threads was never involved — this is the case Validate cannot see.
-	require.Equal(t, 18, readCeilingForPool(48, 20))
+	// The start is fitted too. This is the case that used to survive the fit:
+	// a 96-vCPU instance derives (24, 48) from autoscale.ReadBounds, the
+	// operator's pool is 20, and both consumers floor the ceiling back up to the
+	// start — so lowering only the ceiling changed nothing.
+	start, ceiling = readBoundsForPool(24, 48, 20, reserve)
+	require.Equal(t, 20-reserve, start)
+	require.Equal(t, 20-reserve, ceiling)
+
+	// Never zero readers. A pool too small to honour the reserve still has to
+	// run: contending with the control plane beats not copying at all.
+	start, ceiling = readBoundsForPool(24, 48, reserve, reserve)
+	require.Equal(t, 1, start)
+	require.Equal(t, 1, ceiling)
 
 	// No pool size resolved (a Runner built directly, bypassing
 	// normalizeOptions): there is nothing to fit to, so nothing is changed.
-	require.Equal(t, 48, readCeilingForPool(48, 0))
-	require.Equal(t, 48, readCeilingForPool(48, -1))
+	start, ceiling = readBoundsForPool(24, 48, 0, reserve)
+	require.Equal(t, 24, start)
+	require.Equal(t, 48, ceiling)
+	start, ceiling = readBoundsForPool(24, 48, -1, reserve)
+	require.Equal(t, 24, start)
+	require.Equal(t, 48, ceiling)
+}
+
+// TestReadBoundsSurviveTheirConsumers is the assertion the unit test above
+// cannot make on its own: that the fitted numbers are still the numbers the
+// checksum builds its transaction pool with.
+//
+// Both consumers deliberately floor the ceiling at the start —
+// checksum.NewChecker takes max(Autoscale.MaxThreads, Concurrency) and the
+// copier's resolveReadCeiling does the same, because a pool that begins above
+// its cap cannot be controlled. That is correct on its own terms and it is
+// exactly why the start has to be fitted as well: fitting the ceiling alone is
+// undone one call later, silently, in the autoscaling regime the fit exists for.
+//
+// So this walks the real derivation — autoscale.ReadBounds for the instance,
+// readBoundsForPool for the pool, then the consumers' max() — and asserts the
+// composed result leaves the reserve intact.
+func TestReadBoundsSurviveTheirConsumers(t *testing.T) {
+	const reserve = minChecksumPhaseReserve
+
+	// vCPU counts spanning autoscale.ReadBounds, against pools from far too
+	// small to comfortable. The small pools are the point: they are the ones
+	// where the derived bounds and the operator's budget disagree.
+	for _, vCPUs := range []int{16, 32, 64, 96, 128} {
+		for _, maxConnections := range []int{8, 16, 20, 32, 64, defaultMaxConnections} {
+			readStart, readCeiling := autoscale.ReadBounds(vCPUs)
+			start, ceiling := readBoundsForPool(readStart, readCeiling, maxConnections, reserve)
+
+			// What checksum.NewChecker and copier.resolveReadCeiling resolve to.
+			effective := max(ceiling, start)
+
+			require.LessOrEqual(t, effective+reserve, maxConnections,
+				"at %d vCPUs with --max-connections=%d: the checksum pins %d connections for the whole phase, leaving %d of %d for the reserve",
+				vCPUs, maxConnections, effective, maxConnections-effective, maxConnections)
+			require.GreaterOrEqual(t, effective, 1,
+				"at %d vCPUs with --max-connections=%d: a migration needs at least one reader",
+				vCPUs, maxConnections)
+		}
+	}
 }
 
 // TestValidateMaxConnections covers the checks that took over from the runtime
@@ -184,7 +244,7 @@ func TestValidateMaxConnections(t *testing.T) {
 	}
 
 	require.NoError(t, valid(defaultMaxConnections).Validate())
-	require.NoError(t, valid(minPoolSize+checksumOffPoolConns).Validate(),
+	require.NoError(t, valid(4+minChecksumPhaseReserve).Validate(),
 		"a small but workable pool is the operator asking for a slow migration, which is allowed")
 
 	// Zero is "use the default" (normalizeOptions fills it in), on the same
@@ -198,12 +258,20 @@ func TestValidateMaxConnections(t *testing.T) {
 	require.ErrorContains(t, valid(minPoolSize-1).Validate(), "for the cutover to run",
 		"below the cutover's minimum the migration cannot finish, only fail late")
 
-	// Above minPoolSize but below what the checksum pins: its read transactions
-	// hold their connections for the whole phase, so chunk dispatch would have
-	// nothing left to check out.
+	// Above minPoolSize but below what the checksum phase needs: its read
+	// transactions hold their connections for the whole phase, so the control
+	// plane and the drain would have nothing left to check out.
 	pinning := valid(minPoolSize + 1)
 	pinning.Threads = 32
 	err := pinning.Validate()
-	require.ErrorContains(t, err, "below what the checksum holds open")
+	require.ErrorContains(t, err, "below what the checksum phase needs")
 	require.ErrorContains(t, err, "lower --threads", "the error must name a way out")
+
+	// A zero Threads means "use the default", and Validate runs before
+	// normalizeOptions fills it in. Checking the 0 rather than the 4 it becomes
+	// would accept a pool the migration then stalls on.
+	unset := valid(defaultThreads + minChecksumPhaseReserve - 1)
+	unset.Threads = 0
+	require.ErrorContains(t, unset.Validate(), "below what the checksum phase needs",
+		"an unset --threads must be validated as the default it resolves to")
 }

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -136,6 +136,35 @@ func TestMaxConnectionsDefaultMatchesItsFlag(t *testing.T) {
 	require.Equal(t, defaultMaxConnections, m.MaxConnections)
 }
 
+// TestReadCeilingForPool covers the one worker count that cannot be left to
+// queue. The checksum opens a transaction per read thread, serially, under the
+// table lock, and each holds its connection for the whole phase — so a ceiling
+// the pool cannot hold blocks on checkout with that lock held.
+//
+// Validate cannot catch this case: under autoscaling the ceiling comes from an
+// instance vCPU count read long after flag parsing, and has nothing to do with
+// --threads.
+func TestReadCeilingForPool(t *testing.T) {
+	// Room to spare: the ceiling is whatever was derived.
+	require.Equal(t, 32, readCeilingForPool(32, defaultMaxConnections))
+
+	// Exactly enough, counting the two off-pool queries the checksum also runs.
+	require.Equal(t, 30, readCeilingForPool(30, 32))
+
+	// One short. The ceiling gives way, not the pool: the ceiling is a number
+	// spirit derived for itself, the pool is one the operator set.
+	require.Equal(t, 30, readCeilingForPool(31, 32))
+
+	// A 96-vCPU instance derives a ceiling of 48 from autoscale.ReadBounds, and
+	// --threads was never involved — this is the case Validate cannot see.
+	require.Equal(t, 18, readCeilingForPool(48, 20))
+
+	// No pool size resolved (a Runner built directly, bypassing
+	// normalizeOptions): there is nothing to fit to, so nothing is changed.
+	require.Equal(t, 48, readCeilingForPool(48, 0))
+	require.Equal(t, 48, readCeilingForPool(48, -1))
+}
+
 // TestValidateMaxConnections covers the checks that took over from the runtime
 // floor. The pool is now the flag verbatim, so a number too small to work is
 // not a slower migration — it is one that stalls partway through, holding a

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -66,10 +66,8 @@ func TestAutoscalingLeavesThreadFlagsAloneWhenItCannotEngage(t *testing.T) {
 // with a max_user_connections can subtract one number and be done.
 //
 // It asserts the live pool rather than the config, and after a full run rather
-// than at setup, because that is where the property used to break. Sizing was
-// spread across a seed in Run, a re-derivation once the autoscaling ceilings
-// were known, and a +2 the checksum ratcheted on when it started — each an
-// independent chance to step over the number, and the last one did.
+// than at setup, because a phase that resizes r.db does so through
+// dbconn.SetPoolSize and would leave the config untouched.
 func TestPoolSizeIsExactlyMaxConnections(t *testing.T) {
 	testutils.NewTestTable(t, "pool_verbatim",
 		`CREATE TABLE pool_verbatim (id INT NOT NULL PRIMARY KEY, pad VARCHAR(32))`)

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -109,11 +109,10 @@ func TestFlushBoundsPreservesChangeDefaults(t *testing.T) {
 // with an interest in it is the assertion above.
 const minAdaptiveBatchSizeForTest = 50
 
-// warningRecorder keeps the WARN messages a Runner logs. The pool bound's
-// warnings are not decoration: a capped pool is a deliberate throughput trade,
-// and the log line is the only place an operator learns it was made. Warning
-// when nothing was capped is therefore its own small bug — see the exact-fit
-// case below.
+// warningRecorder keeps the WARN messages a Runner logs. The cap's warning is
+// not decoration: a capped pool is a deliberate throughput trade, and the log
+// line is the only place an operator learns it was made. Warning when nothing
+// was capped is therefore its own small bug — see the exact-fit case below.
 type warningRecorder struct {
 	mu   sync.Mutex
 	msgs []string
@@ -137,100 +136,86 @@ func (h *warningRecorder) warnings() []string {
 	return append([]string(nil), h.msgs...)
 }
 
-// newPoolSizingRunner builds the smallest Runner boundedPoolSize can be called
-// on: it reads only the change count (for controlPlaneConns), the bound, and
-// the logger it warns through.
-func newPoolSizingRunner(tables, maxConnections int) (*Runner, *warningRecorder) {
+// newPoolSizingRunner builds the smallest Runner capPoolSize can be called on:
+// it reads only the cap and the logger it warns through.
+func newPoolSizingRunner(maxConnections int) (*Runner, *warningRecorder) {
 	warnings := &warningRecorder{}
 	return &Runner{
-		changes:   make([]*tableChange, tables),
 		migration: &Migration{MaxConnections: maxConnections},
 		logger:    slog.New(warnings),
 	}, warnings
 }
 
-// TestBoundedPoolSize covers the bound itself. The unbounded sum is every
-// worker ceiling added together so no pool can starve another, which is the
-// right sizing right up until the server cannot spare it — at which point the
-// migration does not slow down, it dies on Error 1040. See boundedPoolSize.
-func TestBoundedPoolSize(t *testing.T) {
-	// One change table, so reserved is controlPlaneConns (3) + the two
-	// off-pool checksum connections = 5 in every case below.
-	const reserved = 3 + checksumOffPoolConns
-
-	t.Run("under the bound the ceilings pass through untouched", func(t *testing.T) {
-		r, warnings := newPoolSizingRunner(1, 128)
-		require.Equal(t, 4+8+8+reserved, r.boundedPoolSize(4, 8, 8))
+// TestCapPoolSize covers the cap itself. Everything that sizes the pool sizes
+// it for a guarantee — every worker ceiling added together, so no pool can
+// starve another — which is the right sizing right up until the server cannot
+// spare it, at which point the migration does not slow down, it dies on
+// Error 1040. See capPoolSize.
+//
+// The cap is deliberately just min(): no floor, no phase-awareness, nothing
+// derived. A safety net that reasons about what it is catching is a safety net
+// that can be wrong about it.
+func TestCapPoolSize(t *testing.T) {
+	t.Run("under the cap the size passes through untouched", func(t *testing.T) {
+		r, warnings := newPoolSizingRunner(128)
+		require.Equal(t, 25, r.capPoolSize(25))
 		require.Empty(t, warnings.warnings())
 	})
 
-	t.Run("a sum equal to the bound is not capped", func(t *testing.T) {
-		// The comparison is <=, not <: a sum that exactly fits gets to keep
-		// every guaranteed connection. Off-by-one here would silently push the
-		// commonest hand-configured shapes into contention.
+	t.Run("a size equal to the cap is not capped", func(t *testing.T) {
+		// The comparison is <=, not <: a size that exactly fits gets to keep
+		// every guaranteed connection.
 		//
-		// At exactly the bound the two branches happen to return the same
-		// number, so the warning is the only thing that can tell them apart —
-		// and a migration told its pool was capped when it was not is a
-		// migration whose operator goes looking for throughput that was never
-		// taken away.
-		r, warnings := newPoolSizingRunner(1, 16+32+32+reserved)
-		require.Equal(t, 16+32+32+reserved, r.boundedPoolSize(16, 32, 32))
+		// At exactly the cap both branches return the same number, so the
+		// warning is the only thing that can tell them apart — and a migration
+		// told its pool was capped when it was not is a migration whose operator
+		// goes looking for throughput that was never taken away.
+		r, warnings := newPoolSizingRunner(128)
+		require.Equal(t, 128, r.capPoolSize(128))
 		require.Empty(t, warnings.warnings(), "an exact fit must not report contention")
 	})
 
 	t.Run("the derived ceilings that produced Error 1040 are capped", func(t *testing.T) {
 		// A large Aurora instance: read ceiling half the box, write ceiling
-		// twice the start, flush at autoscale.MaxFlushConcurrency. 133 wanted
-		// against a default bound of 128.
-		r, warnings := newPoolSizingRunner(1, defaultMaxConnections)
-		require.Equal(t, defaultMaxConnections, r.boundedPoolSize(32, 64, autoscale.MaxFlushConcurrency),
-			"a bound that binds must return the bound exactly, not the sum")
+		// twice the start, flush at autoscale.MaxFlushConcurrency, plus the
+		// reserves. Comfortably past the default cap.
+		want := 32 + 64 + autoscale.MaxFlushConcurrency + 3 + checksumOffPoolConns
+		require.Greater(t, want, defaultMaxConnections, "or this case proves nothing")
+
+		r, warnings := newPoolSizingRunner(defaultMaxConnections)
+		require.Equal(t, defaultMaxConnections, r.capPoolSize(want),
+			"a cap that binds must return the cap exactly, not the size asked for")
 		require.Len(t, warnings.warnings(), 1, "capping is a throughput trade and must be said out loud")
 	})
 
-	t.Run("more change tables raise the reserve, not the bound", func(t *testing.T) {
-		// controlPlaneConns scales with the change count, so a multi-table
-		// migration wants more; the bound is still the bound.
-		r, _ := newPoolSizingRunner(5, 64)
-		require.Equal(t, 64, r.boundedPoolSize(32, 64, 32))
+	t.Run("a cap below what the checksum pins is still obeyed", func(t *testing.T) {
+		// The floor this used to apply is gone on purpose. Below the read
+		// ceiling plus reserves the checksum phase will stall — every
+		// transaction in its read pool holds a connection for the whole phase —
+		// but that is the operator's number to get right. Silently raising a
+		// limit spirit was handed is the worse failure, and the default sits far
+		// above anything that could trip it.
+		r, warnings := newPoolSizingRunner(10)
+		require.Equal(t, 10, r.capPoolSize(32+64+32+5))
+		require.Len(t, warnings.warnings(), 1)
 	})
 
-	t.Run("a negative bound restores the pre-cap behaviour", func(t *testing.T) {
+	t.Run("a negative cap restores the pre-cap behaviour", func(t *testing.T) {
 		// Programmatic callers only: normalizeOptions turns a zero into the
 		// default, so unbounded has to be asked for explicitly.
-		r, warnings := newPoolSizingRunner(1, -1)
-		require.Equal(t, 32+64+32+reserved, r.boundedPoolSize(32, 64, 32))
+		r, warnings := newPoolSizingRunner(-1)
+		require.Equal(t, 133, r.capPoolSize(133))
 		require.Empty(t, warnings.warnings())
 	})
 
-	t.Run("an unfilled bound is unbounded rather than zero", func(t *testing.T) {
+	t.Run("an unfilled cap is unbounded rather than zero", func(t *testing.T) {
 		// normalizeOptions is what turns a zero into the default, and not every
 		// Runner is built through it (tests and embedders both construct
 		// Migration literals). Reading a literal zero as "cap the pool at zero
 		// connections" would deadlock the migration instantly, so it is read as
-		// "no bound set".
-		r, _ := newPoolSizingRunner(1, 0)
-		require.Equal(t, 32+64+32+reserved, r.boundedPoolSize(32, 64, 32))
-	})
-
-	t.Run("the bound is floored at what the checksum pins", func(t *testing.T) {
-		// Below maxRead+reserved the checksum phase does not get slower, it
-		// hangs: every transaction in the read pool holds its connection for
-		// the whole phase, so chunk dispatch would have nothing left to check
-		// out. Refusing to hang beats honouring the number.
-		r, warnings := newPoolSizingRunner(1, 10)
-		require.Equal(t, 32+reserved, r.boundedPoolSize(32, 64, 32),
-			"a bound below the read pin must be raised to it")
-		require.Len(t, warnings.warnings(), 1, "quietly ignoring the configured number is worse than the number")
-	})
-
-	t.Run("the floor is the read pin exactly, and write and flush get nothing", func(t *testing.T) {
-		// The floor covers the phase that cannot queue and not one connection
-		// more — write and flush workers queue there, which is the trade the
-		// bound is asking for in the first place.
-		r, _ := newPoolSizingRunner(1, 8+reserved-1)
-		require.Equal(t, 8+reserved, r.boundedPoolSize(8, 64, 32))
+		// "no cap set".
+		r, _ := newPoolSizingRunner(0)
+		require.Equal(t, 133, r.capPoolSize(133))
 	})
 }
 

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -1,11 +1,8 @@
 package migration
 
 import (
-	"context"
-	"log/slog"
 	"reflect"
 	"strconv"
-	"sync"
 	"testing"
 
 	"github.com/block/spirit/pkg/autoscale"
@@ -57,23 +54,37 @@ func TestAutoscalingLeavesThreadFlagsAloneWhenItCannotEngage(t *testing.T) {
 		"--threads must survive an autoscaling request that could not engage")
 	require.Equal(t, writeThreads, m.migration.WriteThreads,
 		"--write-threads must survive an autoscaling request that could not engage")
-	// The connection budget is derived from the flags, not from an instance vCPU
-	// count that was never read. The two pools budget differently on purpose:
-	// the write ceiling is still 2x, because the applier's controller can grow
-	// on any target that gains a gradual signal, while the read term stays at
-	// the flag value — with no instance-derived ceiling the readers cannot grow,
-	// and the checksum pre-creates its whole pool under the table lock, so
-	// provisioning 2x would only lengthen that lock window for capacity nothing
-	// can use.
-	//
-	// The flush term is present even here, where nothing was derived: the drain
-	// runs change.DefaultFlushConcurrency concurrent REPLACEs on this same pool
-	// regardless of whether autoscaling engaged, and a periodic flush overlaps
-	// the copy. It was omitted from this sum until the flush shape became
-	// derivable, which meant those connections were quietly borrowed from the
-	// copier's and control plane's share.
-	require.Equal(t, threads+2*writeThreads+change.DefaultFlushConcurrency+m.controlPlaneConns()+checksumOffPoolConns,
-		m.dbConfig.MaxOpenConnections)
+	// The pool is not derived from either flag, engaged or not: it is
+	// --max-connections. What autoscaling would have changed here is the
+	// ceilings the copier scales its own workers against, not the pool they
+	// check connections out of.
+	require.Equal(t, defaultMaxConnections, m.dbConfig.MaxOpenConnections)
+}
+
+// TestPoolSizeIsExactlyMaxConnections is the property an operator budgets
+// against: spirit's main pool is --max-connections and stays there, so a user
+// with a max_user_connections can subtract one number and be done.
+//
+// It asserts the live pool rather than the config, and after a full run rather
+// than at setup, because that is where the property used to break. Sizing was
+// spread across a seed in Run, a re-derivation once the autoscaling ceilings
+// were known, and a +2 the checksum ratcheted on when it started — each an
+// independent chance to step over the number, and the last one did.
+func TestPoolSizeIsExactlyMaxConnections(t *testing.T) {
+	testutils.NewTestTable(t, "pool_verbatim",
+		`CREATE TABLE pool_verbatim (id INT NOT NULL PRIMARY KEY, pad VARCHAR(32))`)
+	testutils.RunSQL(t, `INSERT INTO pool_verbatim VALUES (1, 'a'), (2, 'b')`)
+
+	// Not the default, not any sum of the thread counts, and comfortably above
+	// minPoolSize — a number nothing could arrive at by deriving it.
+	const maxConnections = 37
+	m := NewTestRunner(t, "pool_verbatim", "ENGINE=InnoDB", WithMaxConnections(maxConnections))
+	require.NoError(t, m.Run(t.Context()))
+	t.Cleanup(func() { require.NoError(t, m.Close()) })
+
+	require.Equal(t, maxConnections, m.dbConfig.MaxOpenConnections)
+	require.Equal(t, maxConnections, m.db.Stats().MaxOpenConnections,
+		"the live pool must still be the configured number after copy, checksum and cutover have all run")
 }
 
 // TestFlushBoundsPreservesChangeDefaults pins the agreement between
@@ -109,116 +120,6 @@ func TestFlushBoundsPreservesChangeDefaults(t *testing.T) {
 // with an interest in it is the assertion above.
 const minAdaptiveBatchSizeForTest = 50
 
-// warningRecorder keeps the WARN messages a Runner logs. The cap's warning is
-// not decoration: a capped pool is a deliberate throughput trade, and the log
-// line is the only place an operator learns it was made. Warning when nothing
-// was capped is therefore its own small bug — see the exact-fit case below.
-type warningRecorder struct {
-	mu   sync.Mutex
-	msgs []string
-}
-
-func (h *warningRecorder) Enabled(_ context.Context, l slog.Level) bool { return l >= slog.LevelWarn }
-
-func (h *warningRecorder) Handle(_ context.Context, r slog.Record) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.msgs = append(h.msgs, r.Message)
-	return nil
-}
-
-func (h *warningRecorder) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h *warningRecorder) WithGroup(string) slog.Handler      { return h }
-
-func (h *warningRecorder) warnings() []string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return append([]string(nil), h.msgs...)
-}
-
-// newPoolSizingRunner builds the smallest Runner capPoolSize can be called on:
-// it reads only the cap and the logger it warns through.
-func newPoolSizingRunner(maxConnections int) (*Runner, *warningRecorder) {
-	warnings := &warningRecorder{}
-	return &Runner{
-		migration: &Migration{MaxConnections: maxConnections},
-		logger:    slog.New(warnings),
-	}, warnings
-}
-
-// TestCapPoolSize covers the cap itself. Everything that sizes the pool sizes
-// it for a guarantee — every worker ceiling added together, so no pool can
-// starve another — which is the right sizing right up until the server cannot
-// spare it, at which point the migration does not slow down, it dies on
-// Error 1040. See capPoolSize.
-//
-// The cap is deliberately just min(): no floor, no phase-awareness, nothing
-// derived. A safety net that reasons about what it is catching is a safety net
-// that can be wrong about it.
-func TestCapPoolSize(t *testing.T) {
-	t.Run("under the cap the size passes through untouched", func(t *testing.T) {
-		r, warnings := newPoolSizingRunner(128)
-		require.Equal(t, 25, r.capPoolSize(25))
-		require.Empty(t, warnings.warnings())
-	})
-
-	t.Run("a size equal to the cap is not capped", func(t *testing.T) {
-		// The comparison is <=, not <: a size that exactly fits gets to keep
-		// every guaranteed connection.
-		//
-		// At exactly the cap both branches return the same number, so the
-		// warning is the only thing that can tell them apart — and a migration
-		// told its pool was capped when it was not is a migration whose operator
-		// goes looking for throughput that was never taken away.
-		r, warnings := newPoolSizingRunner(128)
-		require.Equal(t, 128, r.capPoolSize(128))
-		require.Empty(t, warnings.warnings(), "an exact fit must not report contention")
-	})
-
-	t.Run("the derived ceilings that produced Error 1040 are capped", func(t *testing.T) {
-		// A large Aurora instance: read ceiling half the box, write ceiling
-		// twice the start, flush at autoscale.MaxFlushConcurrency, plus the
-		// reserves. Comfortably past the default cap.
-		want := 32 + 64 + autoscale.MaxFlushConcurrency + 3 + checksumOffPoolConns
-		require.Greater(t, want, defaultMaxConnections, "or this case proves nothing")
-
-		r, warnings := newPoolSizingRunner(defaultMaxConnections)
-		require.Equal(t, defaultMaxConnections, r.capPoolSize(want),
-			"a cap that binds must return the cap exactly, not the size asked for")
-		require.Len(t, warnings.warnings(), 1, "capping is a throughput trade and must be said out loud")
-	})
-
-	t.Run("a cap below what the checksum pins is still obeyed", func(t *testing.T) {
-		// The floor this used to apply is gone on purpose. Below the read
-		// ceiling plus reserves the checksum phase will stall — every
-		// transaction in its read pool holds a connection for the whole phase —
-		// but that is the operator's number to get right. Silently raising a
-		// limit spirit was handed is the worse failure, and the default sits far
-		// above anything that could trip it.
-		r, warnings := newPoolSizingRunner(10)
-		require.Equal(t, 10, r.capPoolSize(32+64+32+5))
-		require.Len(t, warnings.warnings(), 1)
-	})
-
-	t.Run("a negative cap restores the pre-cap behaviour", func(t *testing.T) {
-		// Programmatic callers only: normalizeOptions turns a zero into the
-		// default, so unbounded has to be asked for explicitly.
-		r, warnings := newPoolSizingRunner(-1)
-		require.Equal(t, 133, r.capPoolSize(133))
-		require.Empty(t, warnings.warnings())
-	})
-
-	t.Run("an unfilled cap is unbounded rather than zero", func(t *testing.T) {
-		// normalizeOptions is what turns a zero into the default, and not every
-		// Runner is built through it (tests and embedders both construct
-		// Migration literals). Reading a literal zero as "cap the pool at zero
-		// connections" would deadlock the migration instantly, so it is read as
-		// "no cap set".
-		r, _ := newPoolSizingRunner(0)
-		require.Equal(t, 133, r.capPoolSize(133))
-	})
-}
-
 // TestMaxConnectionsDefaultMatchesItsFlag pins the constant to the kong tag it
 // says it mirrors. The two are only connected by a comment, and the failure
 // mode of drift is silent: the CLI would keep bounding at one number while
@@ -235,4 +136,47 @@ func TestMaxConnectionsDefaultMatchesItsFlag(t *testing.T) {
 	_, err := m.normalizeOptions()
 	require.NoError(t, err)
 	require.Equal(t, defaultMaxConnections, m.MaxConnections)
+}
+
+// TestValidateMaxConnections covers the checks that took over from the runtime
+// floor. The pool is now the flag verbatim, so a number too small to work is
+// not a slower migration — it is one that stalls partway through, holding a
+// table lock or an open read view while it does. Validate is the last place
+// that can say so cheaply, which is why these are here rather than treated as
+// the operator's problem to discover.
+func TestValidateMaxConnections(t *testing.T) {
+	// Kong applies defaults before Validate, so a CLI invocation always arrives
+	// with the thread counts filled in. Mirror that.
+	valid := func(maxConnections int) *Migration {
+		return &Migration{
+			Statement:      "ALTER TABLE t1 ENGINE=InnoDB",
+			Threads:        4,
+			WriteThreads:   4,
+			MaxConnections: maxConnections,
+		}
+	}
+
+	require.NoError(t, valid(defaultMaxConnections).Validate())
+	require.NoError(t, valid(minPoolSize+checksumOffPoolConns).Validate(),
+		"a small but workable pool is the operator asking for a slow migration, which is allowed")
+
+	// Zero is "use the default" (normalizeOptions fills it in), on the same
+	// footing as Threads and WriteThreads. Checking it against the minimums
+	// would reject every programmatic caller that left the field unset.
+	require.NoError(t, valid(0).Validate())
+
+	require.ErrorContains(t, valid(-1).Validate(), "must be non-negative",
+		"negative is no longer a way to ask for an unbounded pool")
+
+	require.ErrorContains(t, valid(minPoolSize-1).Validate(), "for the cutover to run",
+		"below the cutover's minimum the migration cannot finish, only fail late")
+
+	// Above minPoolSize but below what the checksum pins: its read transactions
+	// hold their connections for the whole phase, so chunk dispatch would have
+	// nothing left to check out.
+	pinning := valid(minPoolSize + 1)
+	pinning.Threads = 32
+	err := pinning.Validate()
+	require.ErrorContains(t, err, "below what the checksum holds open")
+	require.ErrorContains(t, err, "lower --threads", "the error must name a way out")
 }


### PR DESCRIPTION
## What

Adds `--max-connections` (default `128`) and makes it the size of spirit's main connection pool — set once, verbatim, never recomputed.

## Why

The pool was sized by *adding up* every worker ceiling — read, write, flush, plus control-plane and checksum headroom — so that no pool could ever starve another. That sum is a correct statement of what spirit would use if nothing else were running. It is not spirit's to spend: the connections come out of the server's `max_connections`, shared with the production workload.

With autoscaling on a large instance the derived ceilings add up fast — 193 at 64 vCPUs, 153 at 48 — and when the server has less spare than that the migration doesn't slow down, it dies:

```
Error 1040: Too many connections
```

That is a production failure, not a hypothetical. Queueing on connection checkout is strictly better: a worker waiting for a connection is a worker that will eventually run.

## Why a size and not a cap

The first version of this PR clamped the computed sum. That was worse than it looked, because the sum was computed in three places — a seed in `Run`, a re-derivation once the autoscaling ceilings were known, and a `+2` the checksum ratcheted on when it began — so the flag had to be threaded through each of them, and even then the pool's size depended on which phase was running.

That makes the number unusable for the thing an operator actually wants it for. With a `max_user_connections` on the migration user, you need a value you can subtract, not one that moves when spirit reaches the checksum.

So there is one sizing now:

```go
r.dbConfig.MaxOpenConnections = r.migration.MaxConnections
```

The thread ceilings still exist — they bound how far the copier scales its own workers — they just no longer size the pool. When they exceed it, the workers contend for connections instead of each being guaranteed one, which costs throughput and nothing else.

## Validation instead of runtime floors

Some values genuinely cannot work, and the old design raised them at runtime. Raising a limit spirit was handed is the wrong answer, so they are rejected at startup instead:

- **at least `5`**, for the cutover's `LOCK TABLES` connection, `RENAME TABLE` connection and flush threads
- **at least `threads + 2`**, for the read transactions the checksum pins for the whole phase plus its two off-pool queries

Below either, a migration doesn't run slower — it stalls holding a table lock or an open read view. Negative is now rejected too; it used to mean "unbounded", which is precisely the state this flag exists to remove.

One honest exception, documented in both the code and the flag docs: `CutOver.Run` raises a pool below `5` to `5`. `Validate` makes that unreachable for a real migration, and the alternative is a cutover that cannot run at all.

Static validation is not the whole story, though, and a review caught the gap. Read workers are the one kind that cannot queue: the checksum turns its ceiling into transactions, opens all of them serially under the table lock so they share one snapshot instant (`SingleChecker.initConnPool`), and each holds its connection for the whole phase. Under autoscaling that ceiling comes from `autoscale.ReadBounds(vCPUs)` and has nothing to do with `--threads`, so `Validate` is checking the wrong number in exactly the mode where the ceiling is largest — and a ceiling the pool cannot hold blocks on connection checkout with a table lock held.

`readCeilingForPool` bounds it where `maxRead` is resolved. It lowers the *ceiling* rather than growing the pool, which is the direction that keeps the flag meaning what it says: the ceiling is a number spirit derived for itself, the pool is one the operator gave it. Warned when it binds, which needs `--max-connections` below roughly half the target's vCPU count.

## Budgeting against `max_user_connections`

Spirit opens two pools outside this one, both small and both fixed:

| Pool | Size | When |
| ---- | ---- | ---- |
| main | `max-connections` | always |
| throttler monitor | `2` | only on a target with a continuous load signal (currently Aurora) |
| replica lag checker | `max-connections` | only with `--replica-dsn` — and on the *replica*, not the target |

Worst case on the target is `max-connections + 2`.

## Defaulting

The default is filled in by `normalizeOptions` as well as by the kong tag, following the `defaultWriteThreads` precedent. It matters more than usual here because it is the pool size itself: a programmatic caller landing elsewhere would run the same migration against a differently-sized pool.

## Testing

`TestPoolSizeIsExactlyMaxConnections` asserts the *live* pool (`db.Stats()`) after a full run rather than the config at setup, since a phase that resizes goes through `dbconn.SetPoolSize` and leaves the config untouched. Re-adding the checksum ratchet fails it with 39 against 37. `TestValidateMaxConnections` covers both floors, the negative rejection, and zero-means-default. `TestReadCeilingForPool` covers the exact fit, one-short, the 96-vCPU/48-ceiling case `Validate` cannot see, and the unresolved-pool guard. `TestMaxConnectionsDefaultMatchesItsFlag` pins the constant to the kong tag it says it mirrors — they were previously connected only by a comment.

Mutation-checked: dropping either floor, the negative check, the zero guard, or re-introducing any phase ratchet all fail.

## Docs

`docs/migrate.md` gains a `max-connections` section with the pool table above, and the `threads` section no longer describes the pool as a sum of the thread counts. Four comments outside `pkg/migration` — `autoscale.Ceiling`, `copier.ResolveMaxReadThreads`, `resolveReadCeiling`, and `pkg/autoscale/README.md` — justified their own placement by "the migration runner sizes the connection pool from this"; they now say what they actually bound, which is threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

