### PR TITLE
lint: quote column lists and unsafe operations like other SQL tokens

### DIFF
--- a/pkg/lint/declarative_test.go
+++ b/pkg/lint/declarative_test.go
@@ -200,8 +200,8 @@ func TestPlanChanges_DropColumnsHaveColumnDetails(t *testing.T) {
 		columnMessages[*violation.Location.Column] = violation.Message
 	}
 	require.Equal(t, map[string]string{
-		"email": "Unsafe operation detected: DROP COLUMN `email`",
-		"phone": "Unsafe operation detected: DROP COLUMN `phone`",
+		"email": "Unsafe operation detected: \"DROP COLUMN `email`\"",
+		"phone": "Unsafe operation detected: \"DROP COLUMN `phone`\"",
 	}, columnMessages)
 }
 

--- a/pkg/lint/lint_datetime_index_position.go
+++ b/pkg/lint/lint_datetime_index_position.go
@@ -142,7 +142,7 @@ func indexLabel(idx statement.Index) string {
 	if idx.Name != "" {
 		return fmt.Sprintf("index %q", idx.Name)
 	}
-	return fmt.Sprintf("unnamed index on (%s)", strings.Join(idx.Columns, ", "))
+	return "unnamed index on " + quotedList(idx.Columns)
 }
 
 func capitalize(s string) string {

--- a/pkg/lint/lint_datetime_index_position_test.go
+++ b/pkg/lint/lint_datetime_index_position_test.go
@@ -257,12 +257,12 @@ func TestDatetimeIndexPositionLinter_AlterAddUnnamedBadIndex(t *testing.T) {
 
 	require.Len(t, violations, 1)
 	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "Unnamed index on (updated_at, attempt)")
+	require.Contains(t, violations[0].Message, `Unnamed index on ("updated_at", "attempt")`)
 	require.NotContains(t, violations[0].Message, `Index ""`)
 	require.Nil(t, violations[0].Location.Index, "Location.Index should be nil when the index has no name")
 	require.Equal(t, "updated_at", *violations[0].Location.Column)
 	require.NotNil(t, violations[0].Suggestion)
-	require.Contains(t, *violations[0].Suggestion, "unnamed index on (updated_at, attempt)")
+	require.Contains(t, *violations[0].Suggestion, `unnamed index on ("updated_at", "attempt")`)
 }
 
 func TestDatetimeIndexPositionLinter_AlterAddGoodIndex(t *testing.T) {

--- a/pkg/lint/lint_invisible_index.go
+++ b/pkg/lint/lint_invisible_index.go
@@ -108,7 +108,7 @@ func (l *InvisibleIndexBeforeDropLinter) Lint(existingTables []*statement.Create
 				violations = append(violations, Violation{
 					Linter:   l,
 					Severity: severity,
-					Message:  fmt.Sprintf("Index '%s' should be made invisible before dropping to ensure it's not needed", indexName),
+					Message:  fmt.Sprintf("Index %q should be made invisible before dropping to ensure it's not needed", indexName),
 					Location: &Location{
 						Table: tableName,
 						Index: &indexName,

--- a/pkg/lint/lint_invisible_index_test.go
+++ b/pkg/lint/lint_invisible_index_test.go
@@ -19,7 +19,7 @@ func TestInvisibleIndexBeforeDropLinter_DropWithoutInvisible(t *testing.T) {
 	require.Len(t, violations, 1)
 	require.Equal(t, "invisible_index_before_drop", violations[0].Linter.Name())
 	require.Equal(t, SeverityWarning, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "should be made invisible before dropping")
+	require.Equal(t, `Index "idx_email" should be made invisible before dropping to ensure it's not needed`, violations[0].Message)
 	require.Equal(t, "users", violations[0].Location.Table)
 	require.NotNil(t, violations[0].Location.Index)
 	require.Equal(t, "idx_email", *violations[0].Location.Index)

--- a/pkg/lint/lint_multiple_alter.go
+++ b/pkg/lint/lint_multiple_alter.go
@@ -72,7 +72,7 @@ func (l *MultipleAlterTableLinter) Lint(_ []*statement.CreateTable, changes []*s
 		violation := Violation{
 			Linter:   l,
 			Severity: SeverityInfo,
-			Message:  fmt.Sprintf("Table '%s' has %d separate ALTER TABLE statements that could be combined into one for better performance", tableName, len(indices)),
+			Message:  fmt.Sprintf("Table %q has %d separate ALTER TABLE statements that could be combined into one for better performance", tableName, len(indices)),
 			Location: &Location{
 				Table: tableName,
 			},

--- a/pkg/lint/lint_multiple_alter_test.go
+++ b/pkg/lint/lint_multiple_alter_test.go
@@ -32,7 +32,7 @@ func TestMultipleAlterTableLinter_TwoAltersOnSameTable(t *testing.T) {
 	require.Len(t, violations, 1)
 	require.Equal(t, "multiple_alter_table", violations[0].Linter.Name())
 	require.Equal(t, SeverityInfo, violations[0].Severity)
-	require.Contains(t, violations[0].Message, "2 separate ALTER TABLE statements")
+	require.Equal(t, `Table "users" has 2 separate ALTER TABLE statements that could be combined into one for better performance`, violations[0].Message)
 	require.Equal(t, "users", violations[0].Location.Table)
 	require.NotNil(t, violations[0].Suggestion)
 	require.Contains(t, *violations[0].Suggestion, "Combine into")

--- a/pkg/lint/lint_redundant_indexes.go
+++ b/pkg/lint/lint_redundant_indexes.go
@@ -169,21 +169,37 @@ func renderIndexPart(p statement.IndexColumn) string {
 	return rendered
 }
 
-// renderIndexParts formats a list of key parts for human-readable messages.
-func renderIndexParts(parts []statement.IndexColumn) string {
+// renderedIndexParts renders each key part for human-readable messages.
+func renderedIndexParts(parts []statement.IndexColumn) []string {
 	rendered := make([]string, 0, len(parts))
 	for _, p := range parts {
 		rendered = append(rendered, renderIndexPart(p))
 	}
-	return strings.Join(rendered, ", ")
+	return rendered
 }
 
-// renderIndexColumns formats an index's columns for human-readable messages.
-// It uses the structured key parts (which carry prefix lengths and
-// expressions), falling back to the flat Columns slice for synthesized indexes
-// (e.g. column-level PRIMARY KEY / UNIQUE) via indexParts.
-func renderIndexColumns(index statement.Index) string {
-	return renderIndexParts(indexParts(index))
+// renderIndexParts formats a list of key parts as a bare comma-separated list
+// for SQL-snippet suggestions (Redefine index ... as INDEX (...)) — quoting
+// inside a runnable statement would corrupt it. Message prose uses the quoted
+// phrase helpers below instead.
+func renderIndexParts(parts []statement.IndexColumn) string {
+	return strings.Join(renderedIndexParts(parts), ", ")
+}
+
+// keyPartsPhrase formats key parts for message prose, quoting each rendered
+// part the way %q quotes a single identifier so a column list carries the
+// same marker as the quoted index name beside it, with the "column"/"columns"
+// noun in number agreement.
+func keyPartsPhrase(parts []statement.IndexColumn) string {
+	return columnsPhrase(renderedIndexParts(parts))
+}
+
+// indexColumnsPhrase formats an index's columns for message prose. It uses the
+// structured key parts (which carry prefix lengths and expressions), falling
+// back to the flat Columns slice for synthesized indexes (e.g. column-level
+// PRIMARY KEY / UNIQUE) via indexParts.
+func indexColumnsPhrase(index statement.Index) string {
+	return keyPartsPhrase(indexParts(index))
 }
 
 // indexColumnPartCovers reports whether key part b can serve every lookup that
@@ -426,30 +442,30 @@ func hasRedundantPKSuffix(index statement.Index, primaryKey statement.Index) (bo
 func createRedundancyViolation(tableName string, redundantIndex statement.Index, coveringIndex statement.Index, isDuplicate bool, redundantToPK bool) Violation {
 	var message, suggestion string
 
-	redundantCols := renderIndexColumns(redundantIndex)
-	coveringCols := renderIndexColumns(coveringIndex)
+	redundantCols := indexColumnsPhrase(redundantIndex)
+	coveringCols := indexColumnsPhrase(coveringIndex)
 
 	if isDuplicate {
 		if redundantToPK {
 			message = fmt.Sprintf(
-				"Index '%s' on columns (%s) is a duplicate of the PRIMARY KEY",
+				"Index %q on %s is a duplicate of the PRIMARY KEY",
 				redundantIndex.Name,
 				redundantCols,
 			)
 			suggestion = fmt.Sprintf(
-				"Drop index '%s' as it duplicates the PRIMARY KEY. "+
+				"Drop index %q as it duplicates the PRIMARY KEY. "+
 					"The PRIMARY KEY already provides all the functionality of this index.",
 				redundantIndex.Name,
 			)
 		} else {
 			message = fmt.Sprintf(
-				"Index '%s' on columns (%s) is a duplicate of index '%s'",
+				"Index %q on %s is a duplicate of index %q",
 				redundantIndex.Name,
 				redundantCols,
 				coveringIndex.Name,
 			)
 			suggestion = fmt.Sprintf(
-				"Drop index '%s' as it is an exact duplicate of '%s'. "+
+				"Drop index %q as it is an exact duplicate of %q. "+
 					"Duplicate indexes waste space and slow down writes with no benefit.",
 				redundantIndex.Name,
 				coveringIndex.Name,
@@ -459,26 +475,26 @@ func createRedundancyViolation(tableName string, redundantIndex statement.Index,
 		// Prefix redundancy
 		if redundantToPK {
 			message = fmt.Sprintf(
-				"Index '%s' on columns (%s) is redundant - covered by PRIMARY KEY on columns (%s)",
+				"Index %q on %s is redundant - covered by PRIMARY KEY on %s",
 				redundantIndex.Name,
 				redundantCols,
 				coveringCols,
 			)
 			suggestion = fmt.Sprintf(
-				"Consider dropping index '%s' as it is fully covered by the PRIMARY KEY. "+
+				"Consider dropping index %q as it is fully covered by the PRIMARY KEY. "+
 					"In InnoDB, the PRIMARY KEY is the clustered index and provides prefix lookup capability.",
 				redundantIndex.Name,
 			)
 		} else {
 			message = fmt.Sprintf(
-				"Index '%s' on columns (%s) is redundant - covered by index '%s' on columns (%s)",
+				"Index %q on %s is redundant - covered by index %q on %s",
 				redundantIndex.Name,
 				redundantCols,
 				coveringIndex.Name,
 				coveringCols,
 			)
 			suggestion = fmt.Sprintf(
-				"Consider dropping index '%s' as it is fully covered by '%s'. "+
+				"Consider dropping index %q as it is fully covered by %q. "+
 					"The longer index can satisfy all queries that would use the shorter index.",
 				redundantIndex.Name,
 				coveringIndex.Name,
@@ -510,7 +526,8 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 	usefulPrefix := parts[:len(parts)-redundantColCount]
 	pkCols := primaryKey.Columns[:redundantColCount]
 
-	fullCols := renderIndexParts(parts)
+	fullColsPhrase := keyPartsPhrase(parts)
+	quotedSuffix := quotedList(renderedIndexParts(redundantSuffix))
 	redundantSuffixStr := renderIndexParts(redundantSuffix)
 	usefulPrefixStr := renderIndexParts(usefulPrefix)
 
@@ -519,37 +536,37 @@ func createPKSuffixViolation(tableName string, index statement.Index, primaryKey
 	if redundantColCount == len(primaryKey.Columns) {
 		// Full PK is redundant
 		message = fmt.Sprintf(
-			"Index '%s' on columns (%s) has redundant PRIMARY KEY suffix (%s). "+
+			"Index %q on %s has redundant PRIMARY KEY suffix %s. "+
 				"InnoDB automatically appends PK columns to secondary indexes.",
 			index.Name,
-			fullCols,
-			redundantSuffixStr,
+			fullColsPhrase,
+			quotedSuffix,
 		)
 		suggestion = fmt.Sprintf(
-			"Redefine index '%s' as INDEX (%s). "+
-				"InnoDB will automatically append the PK columns (%s) internally, "+
-				"so explicitly including them wastes space and provides no benefit.",
+			"Redefine index %q as INDEX (%s). "+
+				"InnoDB will automatically append the PK %s internally, "+
+				"so explicitly including the PK wastes space and provides no benefit.",
 			index.Name,
 			usefulPrefixStr,
-			strings.Join(pkCols, ", "),
+			columnsPhrase(pkCols),
 		)
 	} else {
 		// Prefix of PK is redundant
 		message = fmt.Sprintf(
-			"Index '%s' on columns (%s) has a redundant PRIMARY KEY suffix (%s) — a leading prefix of the PRIMARY KEY appearing at the end of the index. "+
-				"InnoDB automatically appends the full PK columns (%s) to secondary indexes, "+
+			"Index %q on %s has a redundant PRIMARY KEY suffix %s — a leading prefix of the PRIMARY KEY appearing at the end of the index. "+
+				"InnoDB automatically appends the full PK %s to secondary indexes, "+
 				"so spelling out part of the PK at the end of the index is redundant.",
 			index.Name,
-			fullCols,
-			redundantSuffixStr,
-			strings.Join(primaryKey.Columns, ", "),
+			fullColsPhrase,
+			quotedSuffix,
+			columnsPhrase(primaryKey.Columns),
 		)
 		suggestion = fmt.Sprintf(
-			"Redefine index '%s' as INDEX (%s). "+
-				"InnoDB will automatically append the full PK (%s) internally.",
+			"Redefine index %q as INDEX (%s). "+
+				"InnoDB will automatically append the full PK %s internally.",
 			index.Name,
 			usefulPrefixStr,
-			strings.Join(primaryKey.Columns, ", "),
+			quotedList(primaryKey.Columns),
 		)
 	}
 
@@ -577,20 +594,19 @@ func createPKPrefixViolation(tableName string, index statement.Index, primaryKey
 	redundantPrefix := parts[:redundantColCount]
 	usefulSuffix := parts[redundantColCount:]
 
-	fullCols := renderIndexParts(parts)
 	redundantPrefixStr := renderIndexParts(redundantPrefix)
 	usefulSuffixStr := renderIndexParts(usefulSuffix)
 
 	message := fmt.Sprintf(
-		"Index '%s' on columns (%s) leads with PRIMARY KEY columns (%s). "+
+		"Index %q on %s leads with PRIMARY KEY %s. "+
 			"Point and equality lookups by PRIMARY KEY are served by the clustered index directly, "+
 			"and InnoDB appends PK columns to secondary indexes — the leading PK columns add no capability.",
 		index.Name,
-		fullCols,
-		redundantPrefixStr,
+		keyPartsPhrase(parts),
+		keyPartsPhrase(redundantPrefix),
 	)
 	suggestion := fmt.Sprintf(
-		"Redefine index '%s' as INDEX (%s) — InnoDB will append PRIMARY KEY (%s) internally — "+
+		"Redefine index %q as INDEX (%s) — InnoDB will append PRIMARY KEY (%s) internally — "+
 			"or drop it entirely if the PRIMARY KEY alone covers the queries that use it.",
 		index.Name,
 		usefulSuffixStr,

--- a/pkg/lint/lint_redundant_indexes_test.go
+++ b/pkg/lint/lint_redundant_indexes_test.go
@@ -155,7 +155,7 @@ func TestRedundantIndexLinter_RedundantToUniqueIndex(t *testing.T) {
 	violations := linter.Lint([]*statement.CreateTable{ct}, nil)
 
 	require.Len(t, violations, 1, "Expected one violation")
-	require.Contains(t, violations[0].Message, "Index 'idx_XYZ_id' on columns (XYZ_id) is redundant")
+	require.Contains(t, violations[0].Message, `Index "idx_XYZ_id" on column "XYZ_id" is redundant`)
 }
 
 func TestRedundantIndexLinter_DuplicateIndexes(t *testing.T) {

--- a/pkg/lint/lint_unsafe.go
+++ b/pkg/lint/lint_unsafe.go
@@ -79,7 +79,7 @@ func (l *UnsafeLinter) Lint(_ []*statement.CreateTable, changes []*statement.Abs
 					violations = append(violations, Violation{
 						Linter:   l,
 						Location: &Location{Table: change.Table},
-						Message:  "Unsafe operation detected: " + AlterTableTypeToString(spec.Tp),
+						Message:  fmt.Sprintf("Unsafe operation detected: %q", AlterTableTypeToString(spec.Tp)),
 						Severity: SeverityError,
 					})
 				case ast.AlterTableModifyColumn, ast.AlterTableChangeColumn:
@@ -117,17 +117,17 @@ func (l *UnsafeLinter) Lint(_ []*statement.CreateTable, changes []*statement.Abs
 
 func unsafeDropColumnViolation(l *UnsafeLinter, tableName string, spec *ast.AlterTableSpec) Violation {
 	location := &Location{Table: tableName}
-	message := "Unsafe operation detected: DROP COLUMN"
+	operation := "DROP COLUMN"
 	if spec.OldColumnName != nil {
 		columnName := spec.OldColumnName.Name.O
 		location.Column = &columnName
-		message += " " + sqlescape.EscapeIdentifier(columnName)
+		operation += " " + sqlescape.EscapeIdentifier(columnName)
 	}
 
 	return Violation{
 		Linter:   l,
 		Location: location,
-		Message:  message,
+		Message:  fmt.Sprintf("Unsafe operation detected: %q", operation),
 		Severity: SeverityError,
 	}
 }

--- a/pkg/lint/lint_unsafe_test.go
+++ b/pkg/lint/lint_unsafe_test.go
@@ -66,7 +66,7 @@ func TestUnsafeLinter_AlterTableDropColumn(t *testing.T) {
 	require.Equal(t, "unsafe", violations[0].Linter.Name())
 	require.Equal(t, SeverityError, violations[0].Severity)
 	require.Contains(t, violations[0].Message, "Unsafe operation")
-	require.Equal(t, "Unsafe operation detected: DROP COLUMN `email`", violations[0].Message)
+	require.Equal(t, "Unsafe operation detected: \"DROP COLUMN `email`\"", violations[0].Message)
 	t.Log(violations[0].Message)
 	require.Equal(t, "users", violations[0].Location.Table)
 	require.NotNil(t, violations[0].Location.Column)
@@ -128,7 +128,7 @@ func TestUnsafeLinter_AlterTableTruncatePartition(t *testing.T) {
 	require.Len(t, violations, 1)
 	require.Equal(t, "unsafe", violations[0].Linter.Name())
 	require.Equal(t, SeverityError, violations[0].Severity)
-	require.Equal(t, "Unsafe operation detected: TRUNCATE PARTITION", violations[0].Message)
+	require.Equal(t, "Unsafe operation detected: \"TRUNCATE PARTITION\"", violations[0].Message)
 	require.Equal(t, "users", violations[0].Location.Table)
 }
 
@@ -144,7 +144,7 @@ func TestUnsafeLinter_AlterTableTruncatePartitionAll(t *testing.T) {
 	require.Len(t, violations, 1)
 	require.Equal(t, "unsafe", violations[0].Linter.Name())
 	require.Equal(t, SeverityError, violations[0].Severity)
-	require.Equal(t, "Unsafe operation detected: TRUNCATE PARTITION", violations[0].Message)
+	require.Equal(t, "Unsafe operation detected: \"TRUNCATE PARTITION\"", violations[0].Message)
 	require.Equal(t, "users", violations[0].Location.Table)
 }
 
@@ -316,7 +316,7 @@ func TestUnsafeLinter_AlterTableMultipleSpecs(t *testing.T) {
 	require.Equal(t, "users", violations[0].Location.Table)
 	require.NotNil(t, violations[0].Location.Column)
 	require.Equal(t, "phone", *violations[0].Location.Column)
-	require.Equal(t, "Unsafe operation detected: DROP COLUMN `phone`", violations[0].Message)
+	require.Equal(t, "Unsafe operation detected: \"DROP COLUMN `phone`\"", violations[0].Message)
 }
 
 func TestUnsafeLinter_AlterTableMultipleUnsafeSpecs(t *testing.T) {
@@ -344,8 +344,8 @@ func TestUnsafeLinter_AlterTableMultipleUnsafeSpecs(t *testing.T) {
 		columnMessages[*v.Location.Column] = v.Message
 	}
 	require.Equal(t, map[string]string{
-		"email": "Unsafe operation detected: DROP COLUMN `email`",
-		"phone": "Unsafe operation detected: DROP COLUMN `phone`",
+		"email": "Unsafe operation detected: \"DROP COLUMN `email`\"",
+		"phone": "Unsafe operation detected: \"DROP COLUMN `phone`\"",
 	}, columnMessages)
 }
 

--- a/pkg/lint/violation.go
+++ b/pkg/lint/violation.go
@@ -82,6 +82,26 @@ func quoteJoin(items []string) string {
 	return strings.Join(quoted, ", ")
 }
 
+// quotedList renders SQL tokens for message prose with number agreement: a
+// single token stands alone like any quoted identifier, and only a real list
+// earns parentheses — `"a"` versus `("a", "b")`.
+func quotedList(items []string) string {
+	if len(items) == 1 {
+		return fmt.Sprintf("%q", items[0])
+	}
+	return "(" + quoteJoin(items) + ")"
+}
+
+// columnsPhrase renders a column list with its noun in number agreement —
+// `column "a"` versus `columns ("a", "b")` — so messages never read
+// `columns ("a")` for a single column.
+func columnsPhrase(items []string) string {
+	if len(items) == 1 {
+		return "column " + fmt.Sprintf("%q", items[0])
+	}
+	return "columns (" + quoteJoin(items) + ")"
+}
+
 // Location provides information about where a violation occurred
 type Location struct {
 	// Table is the name of the table where the violation occurred


### PR DESCRIPTION
Follow-up to #1171, which established that lint messages quote SQL tokens with `%q`. Three spots still wrote tokens bare or with mixed markers:

- Redundant-index and datetime-index-position messages wrote column lists bare (`on columns (category, price)`, `unnamed index on (a, b)`) while the index name beside them was quoted.
- The unsafe linter used a different marker per message shape: full statements were `%q`-quoted, ALTER operation names were bare, and DROP COLUMN identifiers used raw backticks.
- Three linters still single-quoted index/table names (`'idx_a'`) while the rest of the suite uses `%q`.

This quotes every rendered column part and unsafe operation fragment with `%q`, unifies the remaining single-quoted names onto `%q` so all messages use one quote style, and makes column phrases agree in number: a single column renders as `column "a"` with no parentheses, a list as `columns ("a", "b")`. SQL-snippet suggestions (`Redefine index ... as INDEX (...)`) stay bare — quoting inside a runnable statement would corrupt it.

Before:

```
Index 'idx_cat_price' on columns (category, price) is redundant - covered by index 'idx_cat_price_qty' on columns (category, price, quantity)
Index 'idx_XYZ_id' on columns (XYZ_id) is redundant - covered by index 'idx_XYZ_id_2' on columns (XYZ_id)
Unsafe operation detected: DROP COLUMN `email`
Unsafe operation detected: TRUNCATE PARTITION
```

After:

```
Index "idx_cat_price" on columns ("category", "price") is redundant - covered by index "idx_cat_price_qty" on columns ("category", "price", "quantity")
Index "idx_XYZ_id" on column "XYZ_id" is redundant - covered by index "idx_XYZ_id_2" on column "XYZ_id"
Unsafe operation detected: "DROP COLUMN `email`"
Unsafe operation detected: "TRUNCATE PARTITION"
```

*This PR was written by Claude Code (Fable 5).*