### PR TITLE
change: report how far behind the source the read position is

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -648,7 +648,7 @@ The report is a header line plus one indented row per subsystem:
 2026/08/14 11:47:10 INFO migration status: state=copyRows total-time=2m30s copier-time=2m30s
   copier   46.13%  7550855/16370180  chunk-size=8097  eta=3m29s  throttled=false
   applier queue=128/128  workers=4  wait-p50=1.564s  write-p50=37ms  write-p90=131ms
-  binlog  deltas=0  rotations=56 (0 forced)  parks=0 is-parked=false  flush=8x1000  flushed 30s ago (took 9µs, 0 rows)  read=binlog.000047:104861122
+  binlog  deltas=0  rotations=56 (0 forced)  parks=0 is-parked=false  flush=8x1000  flushed 30s ago (took 9µs, 0 rows)  read=binlog.000047:104861122 (1s behind)
   ckpt    50s ago  binlog.000047:104857600
 ```
 
@@ -690,8 +690,22 @@ Spirit keeps the new table in sync with writes that land during the copy by subs
 | `flush` | How wide a flush currently runs: concurrent `REPLACE` statements × rows per statement. There is no flag for this — it is `8x1000` by default, derived from the instance under [`--enable-experimental-autoscaling`](#enable-experimental-autoscaling), and adjusted at runtime by the change feed's lock-contention controller either way, so the status report is where you read it. A second figure in parentheses, as in `flush=2x250 (of 8x1000)`, means that controller has narrowed the flush after deadlocks or lock waits: the first pair is what is running now, the second is what it would run without the back-off. Each step halves *both* terms, so one step costs 4×. The parenthetical's appearance is the signal, and its disappearance — after enough clean drains — is the recovery. One that stays for the rest of a run means the contention never cleared, and the `flushed` figures below are where its cost shows up. |
 | `flushed X ago (took Y, n rows)` | When the change feed last flushed its buffered changes to the new table, how long that flush took, and how many buffered changes it started with. Flushes are periodic (every 30 seconds by default), so `X` reads somewhere between `0s` and the interval during a healthy copy; a value that keeps climbing well past it means flushes are not completing. `0 rows` is the normal reading for a feed that is keeping up — there was nothing left to write. |
 | `read` | How far the feed has *read* the binary log, in the run's coordinate scheme. This is not the resume point: it is ahead of the `ckpt` position by whatever is still buffered and unflushed. Omitted before the feed has read anything. |
+| `(X behind)` | How old the events at that position are — the source's own timestamp on the last event read, against the clock now. This is the field to read as *time to catch up*: `(2s behind)` is a healthy feed, and `(14h32m behind)` is a feed replaying yesterday. It comes from the event headers the reader already has, so it costs no extra query. Omitted before the feed has read an event. |
 
 The `read` field is there to tell "the reader is fine, only publication is blocked" apart from "the feed has stalled" — two situations the `ckpt` row cannot distinguish, because it shows the flushed position, which is frozen in both. Spirit only advances the flushed position when a flush lands *every* buffered change, so while any change is held back the checkpoint stops moving by design. If `read` advances between reports the reader is working normally; if it is also standing still, the feed itself has stopped. The gap between `read` and the `ckpt` position is how much re-reading a resume would have to do.
+
+The age next to it answers the question the coordinate cannot: a GTID or file
+offset looks the same whether the feed is a second or a week behind, and the
+number of GTIDs still to go is not a time unless you also know the source's
+commit rate, which nothing here reports. So the age is what tells you whether a
+resumed migration can converge. A run that resumes from a checkpoint written
+days ago has to replay those days of binary log before it can cut over, and this
+is where that shows up — as a large `behind` figure that shrinks slowly. Watch
+its *rate* of decline against the run's remaining time: an age that is falling
+means the feed is gaining on the source, and one that is flat or growing means it
+is not, whatever the coordinate is doing. Note it is measured against the Spirit
+host's clock, so it is only as accurate as the clock skew to the source — which
+matters not at all at the multi-hour lags that are worth acting on.
 
 ### `ckpt` row
 
@@ -699,7 +713,7 @@ Reads `<age> ago  <position>`, or `never` before the first checkpoint. The
 position is in the run's coordinate scheme — `<file>:<offset>` or a GTID set,
 per [GTID auto-detection](#gtid-auto-detection).
 
-The age is how long ago the resume checkpoint was last written. Checkpoints are attempted every 50 seconds but are skipped while the copier has no resumable watermark yet, so `never` early in a run is expected. If the age keeps growing, an interrupted migration will resume from further back than you would like. A checkpoint that cannot be written at all is fatal — Spirit stops rather than working for hours without being able to record progress.
+The age is how long ago the resume checkpoint was last written. Checkpoints are attempted every 50 seconds but are skipped while the copier has no resumable watermark yet, so `never` early in a run is expected. If the age keeps growing, an interrupted migration will resume from further back than you would like. Note that this age says nothing about how *stale the position inside it* is: a run that resumed from a week-old checkpoint rewrites that row every 50 seconds, so the age reads seconds while the position is a week behind. The `(X behind)` figure on the `binlog` row is the one that answers that. A checkpoint that cannot be written at all is fatal — Spirit stops rather than working for hours without being able to record progress.
 
 The position is the binlog coordinate that checkpoint saved: the point a resumed migration would start reading from. Read it against `rotations` and the server's binlog retention, because resuming only works while this position is still on the server — a run with heavy rotation and a short `binlog_expire_logs_seconds` can become unresumable long before it fails.
 

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -96,6 +96,12 @@ type binlogClient struct {
 	// FeedStats.Rotations.
 	rotations atomic.Int64
 
+	// lastEventTime is the source's own wall-clock timestamp on the newest
+	// binlog event the reader has seen, as unix seconds. Written by
+	// recordEventTime from the read loop, read back by eventTime; see
+	// FeedStats.BufferedEventAt.
+	lastEventTime atomic.Int64
+
 	// periodicFlushLock protects the cancel/done pair below. The cancel
 	// signals the periodic-flush goroutine to exit; the done channel is
 	// closed by the goroutine on its way out, so StopPeriodicFlush can
@@ -726,6 +732,11 @@ func (c *binlogClient) readStream(ctx context.Context) {
 		if ev == nil {
 			continue
 		}
+		// Stamp before the switch, not inside it: RotateEvent `continue`s out
+		// below, and one call site per client is what keeps the two clients
+		// from drifting on this. The published position is at most one
+		// transaction behind the event stamped here.
+		recordEventTime(&c.lastEventTime, ev.Header.Timestamp)
 		// Handle the event.
 		switch event := ev.Event.(type) {
 		case *replication.RotateEvent:
@@ -1249,6 +1260,7 @@ func (c *binlogClient) FeedStats() FeedStats {
 	stats.LastFlushRows = c.lastFlushRows
 	stats.Rotations = c.rotations.Load()
 	stats.ForcedRotations = c.flushedBinlogs.Load()
+	stats.BufferedEventAt = eventTime(&c.lastEventTime)
 	// Already under c.mu, which is what guards bufferedPos.
 	if c.bufferedPos.Name != "" {
 		stats.BufferedPosition = formatBinlogPosition(c.bufferedPos)

--- a/pkg/change/event_age_test.go
+++ b/pkg/change/event_age_test.go
@@ -1,0 +1,58 @@
+package change
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecordEventTime pins both guards on the stamp the read loop takes from
+// every event header. Each one is there for a specific way the number can lie
+// in a field an operator reads as "how far behind are we".
+func TestRecordEventTime(t *testing.T) {
+	var ts atomic.Int64
+	require.True(t, eventTime(&ts).IsZero(), "no event read yet is not 'behind since 1970'")
+
+	// A real event stamps the source's commit time.
+	noon := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	recordEventTime(&ts, uint32(noon.Unix()))
+	require.Equal(t, noon, eventTime(&ts).UTC())
+
+	// A zero timestamp is ignored. The syncer manufactures rotate events
+	// locally with no source time, and taking 0 would report the feed as
+	// decades behind.
+	recordEventTime(&ts, 0)
+	require.Equal(t, noon, eventTime(&ts).UTC())
+
+	// Only forward. On reconnect the server re-sends the file's
+	// FormatDescriptionEvent, stamped when that file was created — which can be
+	// hours older than the position we resumed at. Reporting that would show a
+	// jump backwards in a monotonic-looking field.
+	recordEventTime(&ts, uint32(noon.Add(-3*time.Hour).Unix()))
+	require.Equal(t, noon, eventTime(&ts).UTC(), "a stale header must not drag the age backwards")
+
+	// A newer event does advance it.
+	later := noon.Add(90 * time.Second)
+	recordEventTime(&ts, uint32(later.Unix()))
+	require.Equal(t, later, eventTime(&ts).UTC())
+}
+
+// The stamp has to reach FeedStats from both clients. They keep separate read
+// loops and separate FeedStats bodies, so a field added to one and missed on the
+// other compiles and passes every other test — the binlog client would just
+// silently never report an age.
+func TestBothClientsReportTheEventAge(t *testing.T) {
+	behind := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+
+	gtid := &gtidClient{subs: newSubscriptionRegistry()}
+	require.True(t, gtid.FeedStats().BufferedEventAt.IsZero())
+	recordEventTime(&gtid.lastEventTime, uint32(behind.Unix()))
+	require.Equal(t, behind, gtid.FeedStats().BufferedEventAt)
+
+	binlog := &binlogClient{subs: newSubscriptionRegistry()}
+	require.True(t, binlog.FeedStats().BufferedEventAt.IsZero())
+	recordEventTime(&binlog.lastEventTime, uint32(behind.Unix()))
+	require.Equal(t, behind, binlog.FeedStats().BufferedEventAt)
+}

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -99,6 +99,12 @@ type gtidClient struct {
 	// tracking here is by GTID, so this is reported for diagnostics only.
 	rotations atomic.Int64
 
+	// lastEventTime is the source's own wall-clock timestamp on the newest
+	// binlog event the reader has seen, as unix seconds. Written by
+	// recordEventTime from the read loop, read back by eventTime; see
+	// FeedStats.BufferedEventAt.
+	lastEventTime atomic.Int64
+
 	periodicFlushLock   sync.Mutex
 	periodicFlushCancel context.CancelFunc
 	periodicFlushDone   chan struct{}
@@ -664,6 +670,11 @@ func (c *gtidClient) readStream(ctx context.Context) {
 		if ev == nil {
 			continue
 		}
+		// Stamp before the switch, not inside it: several cases below
+		// `continue` out, and one call site per client is what keeps the two
+		// clients from drifting on this. The published position is at most one
+		// transaction behind the event stamped here.
+		recordEventTime(&c.lastEventTime, ev.Header.Timestamp)
 		switch event := ev.Event.(type) {
 		case *replication.GTIDEvent:
 			// The server emits a GTIDEvent at the start of every
@@ -1232,6 +1243,7 @@ func (c *gtidClient) FeedStats() FeedStats {
 	stats.LastFlushDuration = c.lastFlushDuration
 	stats.LastFlushRows = c.lastFlushRows
 	stats.Rotations = c.rotations.Load()
+	stats.BufferedEventAt = eventTime(&c.lastEventTime)
 	// Already under c.mu, which is what guards bufferedGTID.
 	if c.bufferedGTID != nil && !c.bufferedGTID.IsEmpty() {
 		stats.BufferedPosition = c.bufferedGTID.String()

--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -159,6 +159,49 @@ func periodicFlushStopping(ctx context.Context) bool {
 	return ctx.Err() != nil
 }
 
+// recordEventTime advances dst to the wall-clock timestamp carried in a binlog
+// event header, which is when the source committed that transaction. Both
+// clients call it once per event read; see FeedStats.BufferedEventAt for what
+// the number is for.
+//
+// Two guards, both load-bearing:
+//
+//   - A zero timestamp is ignored. Artificial events the syncer manufactures
+//     locally (the rotate it fabricates when re-opening a file) carry no source
+//     time, and treating 0 as a timestamp would report the reader as 56 years
+//     behind.
+//   - It only ever moves forward. Timestamps are non-decreasing in commit
+//     order, so this is a no-op on a healthy stream — but on reconnect the
+//     server re-sends the FormatDescriptionEvent from the head of the file,
+//     stamped when that file was created, which can be hours older than the
+//     position we resumed at. Taking the max ignores it instead of reporting a
+//     jump backwards in a field an operator is reading as progress.
+func recordEventTime(dst *atomic.Int64, headerTimestamp uint32) {
+	if headerTimestamp == 0 {
+		return
+	}
+	secs := int64(headerTimestamp)
+	for {
+		prev := dst.Load()
+		if secs <= prev {
+			return
+		}
+		if dst.CompareAndSwap(prev, secs) {
+			return
+		}
+	}
+}
+
+// eventTime reads back a timestamp stored by recordEventTime, or the zero time
+// if no event has been seen yet.
+func eventTime(src *atomic.Int64) time.Time {
+	secs := src.Load()
+	if secs == 0 {
+		return time.Time{}
+	}
+	return time.Unix(secs, 0)
+}
+
 // backlogWorthDraining reports whether a Flush loop should drain again
 // immediately rather than calling BlockWait. Both clients' Flush loops consult
 // it between the drain and the wait.

--- a/pkg/change/stats.go
+++ b/pkg/change/stats.go
@@ -38,6 +38,33 @@ type FeedStats struct {
 	// only publication is blocked, and the gap to the ckpt row is how much
 	// re-reading a restart would cost.
 	BufferedPosition string
+	// BufferedEventAt is the source's own wall-clock timestamp on the newest
+	// event the reader has read — i.e. when the source committed the
+	// transaction that BufferedPosition names. Zero before the feed has read
+	// an event carrying a timestamp.
+	//
+	// Rendered as an age next to BufferedPosition, which is the only form in
+	// which the position is legible as *progress*. A GTID coordinate says
+	// nothing about how far behind the feed is: on a resumed run the number
+	// looks the same whether it is seconds or a week stale, and the count of
+	// GTIDs to go cannot be turned into a time without knowing the source's
+	// commit rate, which nothing in the status block reports. The age answers
+	// it directly — and it answers it from data the reader already has, with no
+	// extra query against the source.
+	//
+	// This is the field to read when deciding whether a resumed migration can
+	// converge. A migration that resumes from a week-old checkpoint has to
+	// replay a week of binlog before it can cut over, and until now the only
+	// tell was the copier starting at 99.x%. It is also the honest measure of
+	// checkpoint staleness that Record.Age() is not: that measures when the
+	// checkpoint row was last written, which on a progressing run is always
+	// seconds ago no matter how stale the position inside it is.
+	//
+	// Measured against this host's clock, so clock skew against the source
+	// shifts it. At the multi-hour lags it exists to expose that is noise; at
+	// "caught up" it is why the rendering floors at zero rather than showing a
+	// negative age.
+	BufferedEventAt time.Time
 	// Rotations counts binlog rotations the feed has followed. Duplicate
 	// rotate events (the server sends a real one and an artificial one
 	// carrying the same position) are counted once.
@@ -304,9 +331,29 @@ func (s FeedStats) String() string {
 		// need not sort last in the set — a middle elision could hide exactly
 		// the digits that are changing and make a healthy reader look frozen,
 		// which is the misreading this field exists to prevent.
-		out += "  read=" + s.BufferedPosition
+		out += "  read=" + s.BufferedPosition + s.bufferedAgeField()
 	}
 	return out
+}
+
+// bufferedAgeField renders how far behind the source's clock the buffered
+// position is, with a leading separator, or "" when no event has been read yet.
+//
+// It goes immediately after the coordinate, despite read= being deliberately
+// last for length reasons, because the two are one reading: the coordinate says
+// where the reader is, this says how far back that is. Splitting them would put
+// the age somewhere an operator has to pair it up by eye on a multi-source
+// status block. It is short and bounded, so unlike the flush phrase it costs
+// nothing to sit behind an unbounded GTID set.
+func (s FeedStats) bufferedAgeField() string {
+	if s.BufferedEventAt.IsZero() {
+		return ""
+	}
+	// max(0, ...) because the source's clock can be ahead of ours: "(-3s
+	// behind)" reads as a bug in the migration rather than as the caught-up
+	// feed it actually is.
+	age := max(time.Since(s.BufferedEventAt), 0)
+	return fmt.Sprintf(" (%v behind)", age.Round(time.Second))
 }
 
 // flushShapeField renders the drain width, with a leading separator, or "" when
@@ -367,6 +414,13 @@ func StatusRow(srcs ...Source) string {
 			// useful choice: that is the feed holding the position back, and
 			// therefore the one whose reader progress is in question.
 			merged.BufferedPosition = s.BufferedPosition
+			// Travels with the position it describes, for the reason on
+			// bufferedAgeField: an age from one feed next to another feed's
+			// coordinate would be actively misleading. Not maxed across feeds
+			// independently, even though the furthest-behind feed is the
+			// interesting one, because that could pair a coordinate and an age
+			// from different sources.
+			merged.BufferedEventAt = s.BufferedEventAt
 		}
 		merged.Rotations += s.Rotations
 		merged.ForcedRotations += s.ForcedRotations

--- a/pkg/change/stats.go
+++ b/pkg/change/stats.go
@@ -295,6 +295,21 @@ type StatsReporter interface {
 	FeedStats() FeedStats
 }
 
+// nowFunc is the clock the ages in String() are measured against. A var rather
+// than a direct time.Now call so tests can pin it, mirroring contentionBackoff
+// in subscription_buffered.go.
+//
+// Pinning is what lets those tests assert the exact rendered string. Without it
+// every "flushed 10s ago" / "(1m30s behind)" assertion is a race against
+// Duration.Round's half-second boundary: the test builds the timestamp from
+// time.Now() and String() reads the clock again a moment later, so enough
+// scheduling delay between the two renders 11s instead. Unlikely per run, but
+// the alternative — asserting each age within a tolerance — gives up the exact
+// expected strings that make these tests readable.
+//
+// Package state, so pinning it is not safe under t.Parallel(); see pinClock.
+var nowFunc = time.Now
+
 // String renders the stats as the binlog row of a runner's status block.
 //
 // The flush figures read as a phrase — "flushed 30s ago (took 9µs, 0 rows)" —
@@ -303,10 +318,17 @@ type StatsReporter interface {
 // took. Side by side as bare `key=0s` pairs those are genuinely ambiguous;
 // as a phrase the reading is forced.
 func (s FeedStats) String() string {
+	// Read once and threaded through, so the row's two ages — how long ago the
+	// flush was, and how far behind the read position is — are measured against
+	// the same instant. Separate clock reads would let one status block report
+	// two different "now"s, and these two fields are read against each other: a
+	// feed whose read position is falling behind while its flushes stay recent
+	// is a different situation from one where both are stale.
+	now := nowFunc()
 	flush := "never flushed"
 	if !s.LastFlushAt.IsZero() {
 		flush = fmt.Sprintf("flushed %v ago (took %v, %d rows)",
-			time.Since(s.LastFlushAt).Round(time.Second),
+			now.Sub(s.LastFlushAt).Round(time.Second),
 			s.LastFlushDuration.Round(time.Microsecond),
 			s.LastFlushRows,
 		)
@@ -331,7 +353,7 @@ func (s FeedStats) String() string {
 		// need not sort last in the set — a middle elision could hide exactly
 		// the digits that are changing and make a healthy reader look frozen,
 		// which is the misreading this field exists to prevent.
-		out += "  read=" + s.BufferedPosition + s.bufferedAgeField()
+		out += "  read=" + s.BufferedPosition + s.bufferedAgeField(now)
 	}
 	return out
 }
@@ -345,14 +367,16 @@ func (s FeedStats) String() string {
 // the age somewhere an operator has to pair it up by eye on a multi-source
 // status block. It is short and bounded, so unlike the flush phrase it costs
 // nothing to sit behind an unbounded GTID set.
-func (s FeedStats) bufferedAgeField() string {
+// Takes now from the caller rather than reading the clock itself, so the age
+// here and the flush age above describe the same instant; see String.
+func (s FeedStats) bufferedAgeField(now time.Time) string {
 	if s.BufferedEventAt.IsZero() {
 		return ""
 	}
 	// max(0, ...) because the source's clock can be ahead of ours: "(-3s
 	// behind)" reads as a bug in the migration rather than as the caught-up
 	// feed it actually is.
-	age := max(time.Since(s.BufferedEventAt), 0)
+	age := max(now.Sub(s.BufferedEventAt), 0)
 	return fmt.Sprintf(" (%v behind)", age.Round(time.Second))
 }
 

--- a/pkg/change/stats_test.go
+++ b/pkg/change/stats_test.go
@@ -49,6 +49,29 @@ func (f *statsFeed) AllChangesFlushed() bool                                    
 func (f *statsFeed) Stop()                                                              {}
 func (f *statsFeed) Close()                                                             {}
 
+// pinClock freezes the clock String() measures its ages against and returns the
+// instant it froze at, so a test can build timestamps relative to it and assert
+// the exact rendered age.
+//
+// Every assertion in this file of the form "flushed 10s ago" or "(1m30s behind)"
+// needs it. The timestamp is constructed from time.Now() and String() reads the
+// clock again a moment later, so without a pinned clock each one is a race
+// against Duration.Round's half-second boundary — improbable per assertion, but
+// there are eight of them and CI runs the package under -race on shared
+// hardware. Widening them to a tolerance instead would cost the exact expected
+// strings, which are the most readable part of these tests.
+//
+// Not safe under t.Parallel(): nowFunc is package state, so a parallel test
+// rendering a status row would see the frozen clock. Nothing in this package is
+// parallel, and contentionBackoff carries the same constraint.
+func pinClock(t *testing.T) time.Time {
+	t.Helper()
+	at := time.Now()
+	nowFunc = func() time.Time { return at }
+	t.Cleanup(func() { nowFunc = time.Now })
+	return at
+}
+
 func TestFeedStatsStringNeverFlushed(t *testing.T) {
 	require.Equal(t,
 		"rotations=0 (0 forced)  parks=0 is-parked=false  never flushed",
@@ -56,8 +79,9 @@ func TestFeedStatsStringNeverFlushed(t *testing.T) {
 }
 
 func TestFeedStatsString(t *testing.T) {
+	now := pinClock(t)
 	s := FeedStats{
-		LastFlushAt:       time.Now().Add(-10 * time.Second),
+		LastFlushAt:       now.Add(-10 * time.Second),
 		LastFlushDuration: 2854617 * time.Nanosecond,
 		LastFlushRows:     5583,
 		Rotations:         4,
@@ -77,8 +101,9 @@ func TestStatusRowNoReporter(t *testing.T) {
 }
 
 func TestStatusRowSingleSource(t *testing.T) {
+	now := pinClock(t)
 	src := &statsFeed{stats: FeedStats{
-		LastFlushAt:       time.Now().Add(-3 * time.Second),
+		LastFlushAt:       now.Add(-3 * time.Second),
 		LastFlushDuration: 5 * time.Millisecond,
 		LastFlushRows:     12,
 		Rotations:         2,
@@ -93,15 +118,16 @@ func TestStatusRowSingleSource(t *testing.T) {
 // set: counters sum, and the flush figures come from the feed that flushed
 // least recently, because that is the one holding the position back.
 func TestStatusRowMergesSources(t *testing.T) {
+	now := pinClock(t)
 	recent := &statsFeed{stats: FeedStats{
-		LastFlushAt:       time.Now().Add(-time.Second),
+		LastFlushAt:       now.Add(-time.Second),
 		LastFlushDuration: time.Millisecond,
 		LastFlushRows:     1,
 		Rotations:         2,
 		ForcedRotations:   1,
 	}}
 	stale := &statsFeed{stats: FeedStats{
-		LastFlushAt:       time.Now().Add(-90 * time.Second),
+		LastFlushAt:       now.Add(-90 * time.Second),
 		LastFlushDuration: 7 * time.Millisecond,
 		LastFlushRows:     900,
 		Rotations:         3,
@@ -174,6 +200,10 @@ func TestGTIDFeedStats(t *testing.T) {
 	require.Equal(t, 42, stats.LastFlushRows)
 	require.False(t, stats.LastFlushAt.IsZero())
 	require.GreaterOrEqual(t, stats.LastFlushDuration, 5*time.Millisecond)
+	// Not pinClock'd, unlike the rendering tests above: the timestamp here comes
+	// from recordFlush rather than from the test, so freezing only the rendering
+	// clock would leave the two halves reading different instants. The 0s has
+	// most of a second of slack against a flush recorded microseconds ago.
 	require.Contains(t, StatusRow(c), "rotations=2 (0 forced)  parks=0 is-parked=false  flushed 0s ago")
 }
 
@@ -264,8 +294,9 @@ func TestFeedStatsFromLiveFeed(t *testing.T) {
 // publication is blocked" apart from "the feed has stalled". The ckpt row
 // cannot: it shows the flushed position, which is frozen in both cases.
 func TestFeedStatsStringWithBufferedPosition(t *testing.T) {
+	now := pinClock(t)
 	s := FeedStats{
-		LastFlushAt:       time.Now().Add(-10 * time.Second),
+		LastFlushAt:       now.Add(-10 * time.Second),
 		LastFlushDuration: 2854617 * time.Nanosecond,
 		LastFlushRows:     5583,
 		BufferedPosition:  "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638",
@@ -282,6 +313,7 @@ func TestFeedStatsStringWithBufferedPosition(t *testing.T) {
 // anywhere else it would push the flush phrase off a narrow terminal, and
 // truncating it would stop it being comparable with the ckpt row.
 func TestFeedStatsStringRendersLongPositionInFullAtTheEnd(t *testing.T) {
+	now := pinClock(t)
 	long := "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-38880294638," +
 		"a1b2c3d4-154f-3776-8f0f-ced626dbde36:1-42," +
 		"b7c8d9e0-154f-3776-8f0f-ced626dbde36:1-7"
@@ -293,7 +325,7 @@ func TestFeedStatsStringRendersLongPositionInFullAtTheEnd(t *testing.T) {
 	// it cannot push anything else off the line the way the flush phrase would.
 	withAge := FeedStats{
 		BufferedPosition: long,
-		BufferedEventAt:  time.Now().Add(-90 * time.Second),
+		BufferedEventAt:  now.Add(-90 * time.Second),
 	}.String()
 	require.True(t, strings.HasSuffix(withAge, long+" (1m30s behind)"))
 }
@@ -303,9 +335,10 @@ func TestFeedStatsStringRendersLongPositionInFullAtTheEnd(t *testing.T) {
 // identical whether it is seconds or a week stale, and the count of GTIDs to go
 // is not a time without the source's commit rate, which is not reported here.
 func TestFeedStatsStringRendersTheBufferedPositionAge(t *testing.T) {
+	now := pinClock(t)
 	s := FeedStats{
 		BufferedPosition: "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-39441498306",
-		BufferedEventAt:  time.Now().Add(-(14*time.Hour + 32*time.Minute + 11*time.Second)),
+		BufferedEventAt:  now.Add(-(14*time.Hour + 32*time.Minute + 11*time.Second)),
 	}
 	require.Contains(t, s.String(),
 		"read=f50a3ec0-154f-3776-8f0f-ced626dbde36:1-39441498306 (14h32m11s behind)")
@@ -317,14 +350,14 @@ func TestFeedStatsStringRendersTheBufferedPositionAge(t *testing.T) {
 	// Sub-second lag is a caught-up feed, not a missing field.
 	require.Contains(t, FeedStats{
 		BufferedPosition: "pos",
-		BufferedEventAt:  time.Now().Add(-200 * time.Millisecond),
+		BufferedEventAt:  now.Add(-200 * time.Millisecond),
 	}.String(), "(0s behind)")
 
 	// The source's clock running ahead of ours floors at zero. "(-3s behind)"
 	// reads as a bug in the migration rather than as the caught-up feed it is.
 	require.Contains(t, FeedStats{
 		BufferedPosition: "pos",
-		BufferedEventAt:  time.Now().Add(3 * time.Second),
+		BufferedEventAt:  now.Add(3 * time.Second),
 	}.String(), "(0s behind)")
 }
 
@@ -339,16 +372,17 @@ func TestFeedStatsStringOmitsEmptyBufferedPosition(t *testing.T) {
 // merged: positions from different sources are not comparable, and the stalest
 // feed is the one whose reader progress is in question.
 func TestStatusRowBufferedPositionFollowsStalestFeed(t *testing.T) {
+	now := pinClock(t)
 	recent := &statsFeed{stats: FeedStats{
-		LastFlushAt:      time.Now().Add(-time.Second),
+		LastFlushAt:      now.Add(-time.Second),
 		BufferedPosition: "recent-feed-pos",
-		BufferedEventAt:  time.Now().Add(-5 * time.Second),
+		BufferedEventAt:  now.Add(-5 * time.Second),
 		Rotations:        2,
 	}}
 	stale := &statsFeed{stats: FeedStats{
-		LastFlushAt:      time.Now().Add(-90 * time.Second),
+		LastFlushAt:      now.Add(-90 * time.Second),
 		BufferedPosition: "stale-feed-pos",
-		BufferedEventAt:  time.Now().Add(-2 * time.Minute),
+		BufferedEventAt:  now.Add(-2 * time.Minute),
 		Rotations:        3,
 	}}
 	row := StatusRow(recent, stale)

--- a/pkg/change/stats_test.go
+++ b/pkg/change/stats_test.go
@@ -223,6 +223,17 @@ func TestFeedStatsFromLiveFeed(t *testing.T) {
 	stats := client.FeedStats()
 	require.False(t, stats.LastFlushAt.IsZero(), "a completed flush must be recorded")
 	require.Equal(t, 2, stats.LastFlushRows, "batch size is the pending count at the start of the flush")
+
+	// The event age has to come from a real event header, against a real
+	// server: it is the one field here that cannot be checked by constructing a
+	// FeedStats, because the read loop is what stamps it and the value has to
+	// be a plausible wall-clock time rather than, say, a raw unix second
+	// rendered as 56 years. Bounds not equality — the insert above happened a
+	// moment ago on a clock we do not control.
+	require.False(t, stats.BufferedEventAt.IsZero(), "reading an event must stamp the event time")
+	require.WithinDuration(t, time.Now(), stats.BufferedEventAt, time.Minute,
+		"a feed reading a live server is seconds behind, not hours")
+	require.Contains(t, StatusRow(client), " behind)")
 	residual, flushes := client.FlushResidual()
 	require.Equal(t, 1, flushes)
 	require.Zero(t, residual, "the flush drained everything")
@@ -277,6 +288,44 @@ func TestFeedStatsStringRendersLongPositionInFullAtTheEnd(t *testing.T) {
 	got := FeedStats{BufferedPosition: long}.String()
 	require.Equal(t, "rotations=0 (0 forced)  parks=0 is-parked=false  never flushed  read="+long, got)
 	require.True(t, strings.HasSuffix(got, long), "nothing may follow the position")
+
+	// The age is the one exception, and it is allowed because it is bounded:
+	// it cannot push anything else off the line the way the flush phrase would.
+	withAge := FeedStats{
+		BufferedPosition: long,
+		BufferedEventAt:  time.Now().Add(-90 * time.Second),
+	}.String()
+	require.True(t, strings.HasSuffix(withAge, long+" (1m30s behind)"))
+}
+
+// The age is what makes the coordinate legible as progress. Nothing else in the
+// status block can answer "how far behind is this feed" — the GTID number looks
+// identical whether it is seconds or a week stale, and the count of GTIDs to go
+// is not a time without the source's commit rate, which is not reported here.
+func TestFeedStatsStringRendersTheBufferedPositionAge(t *testing.T) {
+	s := FeedStats{
+		BufferedPosition: "f50a3ec0-154f-3776-8f0f-ced626dbde36:1-39441498306",
+		BufferedEventAt:  time.Now().Add(-(14*time.Hour + 32*time.Minute + 11*time.Second)),
+	}
+	require.Contains(t, s.String(),
+		"read=f50a3ec0-154f-3776-8f0f-ced626dbde36:1-39441498306 (14h32m11s behind)")
+
+	// A feed that has read nothing renders no age, which keeps every
+	// pre-existing status line byte-identical.
+	require.NotContains(t, FeedStats{BufferedPosition: "pos"}.String(), "behind)")
+
+	// Sub-second lag is a caught-up feed, not a missing field.
+	require.Contains(t, FeedStats{
+		BufferedPosition: "pos",
+		BufferedEventAt:  time.Now().Add(-200 * time.Millisecond),
+	}.String(), "(0s behind)")
+
+	// The source's clock running ahead of ours floors at zero. "(-3s behind)"
+	// reads as a bug in the migration rather than as the caught-up feed it is.
+	require.Contains(t, FeedStats{
+		BufferedPosition: "pos",
+		BufferedEventAt:  time.Now().Add(3 * time.Second),
+	}.String(), "(0s behind)")
 }
 
 // A feed that has not read anything yet omits the field rather than rendering
@@ -293,16 +342,22 @@ func TestStatusRowBufferedPositionFollowsStalestFeed(t *testing.T) {
 	recent := &statsFeed{stats: FeedStats{
 		LastFlushAt:      time.Now().Add(-time.Second),
 		BufferedPosition: "recent-feed-pos",
+		BufferedEventAt:  time.Now().Add(-5 * time.Second),
 		Rotations:        2,
 	}}
 	stale := &statsFeed{stats: FeedStats{
 		LastFlushAt:      time.Now().Add(-90 * time.Second),
 		BufferedPosition: "stale-feed-pos",
+		BufferedEventAt:  time.Now().Add(-2 * time.Minute),
 		Rotations:        3,
 	}}
 	row := StatusRow(recent, stale)
 	require.Contains(t, row, "read=stale-feed-pos")
 	require.NotContains(t, row, "recent-feed-pos")
+	// The age must come from the same feed as the coordinate. Taking the
+	// furthest-behind age independently would pair one source's position with
+	// another source's lag, which is worse than reporting neither.
+	require.Contains(t, row, "read=stale-feed-pos (2m0s behind)")
 	require.Contains(t, row, "rotations=5 (0 forced)", "counters still sum")
 
 	// Order must not matter.


### PR DESCRIPTION
## Problem

During `applyChangeset` the only question that matters is *will this converge, and when* — and the status block could not answer it.

```
binlog  deltas=50000  ... read=f50a3ec0-...:1-39441498306
```

A GTID coordinate says nothing about how far behind the feed is. The number looks identical whether the position is two seconds or a week stale. Nor can the gap be turned into a time: the count of GTIDs still to go only becomes an ETA if you also know the source's commit rate, which nothing in the status block reports — so answering it meant querying the source for `@@global.gtid_executed`, guessing its commit rate, and doing arithmetic by hand, repeatedly.

The same blind spot hides checkpoint staleness. `Record.Age()` measures when the checkpoint *row was last written*, and a progressing run rewrites it every 50s — so a migration that resumed from a week-old position reads "ckpt 10s ago" forever. Every field looks healthy except one oblique tell: the copier starting at 99.x%.

## Change

Binlog event headers already carry the source's own commit timestamp, so the reader has the answer in hand. The read loop stamps it once per event, and the binlog row renders it next to the coordinate:

```
binlog  ...  read=f50a3ec0-...:1-39441498306 (14h32m behind)
```

Healthy feed reads `(1s behind)`. A feed replaying yesterday reads `(14h32m behind)`, and its *rate of decline* between reports is the convergence signal — falling means the feed is gaining on the source, flat or rising means it is not, whatever the coordinate is doing.

No new queries. Nothing else on the row moves.

## Details worth review

- **Two guards on the stamp.** A zero timestamp is ignored — the syncer manufactures rotate events locally with no source time, and treating 0 as a timestamp would report the feed as 56 years behind. And it only ever moves forward: on reconnect the server re-sends the file's `FormatDescriptionEvent`, stamped when that file was *created*, which can be hours older than the position we resumed at. Taking the max ignores it rather than showing a jump backwards in a field being read as progress.
- **One call site per client**, before the event switch rather than inside it, because several cases `continue` out and because two read loops with two separate stamping sites will drift. The published position is therefore at most one transaction behind the event stamped — microseconds, against a field measured in hours.
- **It sits after `read=`**, which is otherwise deliberately last because a GTID set has no bounded length. The age is short and bounded, so unlike the flush phrase it costs nothing to sit behind one, and splitting the pair would make an operator match a coordinate to a lag by eye on a multi-source row. The existing "nothing may follow the position" test is tightened to state the exception rather than silently losing it.
- **Multi-source merge takes the age from the same feed as the coordinate**, not the furthest-behind age independently — one source's position beside another's lag is worse than reporting neither.
- **Measured against this host's clock**, so skew to the source shifts it. Irrelevant at the multi-hour lags it exists to expose, and it floors at zero so a source clock running slightly ahead reads `(0s behind)` rather than `(-3s behind)`.

## Testing

`TestRecordEventTime` pins both guards. `TestBothClientsReportTheEventAge` pins the wiring in each client separately — they have separate read loops and separate `FeedStats` bodies, so a field added to one and missed on the other compiles and passes everything else. `TestFeedStatsStringRendersTheBufferedPositionAge` covers the rendering, the omission before the first event, sub-second lag, and the negative-skew floor. The live-server test in `TestFeedStatsFromLiveFeed` asserts a real event header produces a plausible wall-clock time, which is the one thing a hand-built `FeedStats` cannot check.

`golangci-lint` clean; `pkg/change`, `pkg/migration`, `pkg/move`, `pkg/datasync` green with and without `-tags singleversion`.

## Field context

This came out of a migration whose change feed was ~474M GTIDs behind on resume. Estimating its catch-up took ten manual `@@global.gtid_executed` diffs over 15 hours, and the source's commit rate stayed uncertain by a factor of two throughout — a factor-of-two uncertainty in *the answer*. This field would have shown it directly, from the first status block.

## Not in this PR

The `ckpt` row could carry the same age — that is the honest fix for the `CheckpointMaxAge` guard, which today can never fire on the runs it exists for. It needs the timestamp of the last *flushed* event rather than the last read one, which is per-subscription plumbing and a checkpoint record format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
