### PR TITLE
chunker: gate prefetch on key-space density, not chunk cost

### DIFF
--- a/pkg/copier/buffered.go
+++ b/pkg/copier/buffered.go
@@ -97,6 +97,7 @@ func (c *buffered) CopyChunk(ctx context.Context, chunk *table.Chunk) error {
 		return fmt.Errorf("failed to read chunk data: %w", err)
 	}
 	chunk.ActualBytes = rowsByteSize(rows)
+	chunk.SourceRows = uint64(len(rows))
 	// The callback runs on the applier's feedback coordinator goroutine; done
 	// closes only after feedback and metrics are sent, so both have completed
 	// before CopyChunk returns. Empty chunks take the same path — the applier
@@ -420,6 +421,7 @@ func (c *buffered) readWorker(ctx context.Context, quit <-chan struct{}) error {
 		// size the next chunk against a byte budget (memory-based dynamic
 		// chunking). Harmless when the chunker is in time mode — it ignores it.
 		chunk.ActualBytes = rowsByteSize(rows)
+		chunk.SourceRows = uint64(len(rows))
 
 		// Handle empty chunks immediately
 		if len(rows) == 0 {

--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -25,6 +25,24 @@ type Chunk struct {
 	// time when dynamicChunkSizer.TargetChunkBytes is set. Zero for the
 	// checksum path, which reads server-side and never sees the bytes.
 	ActualBytes uint64
+
+	// SourceRows is the companion of ActualBytes: the number of rows the
+	// producer actually read from the source for this chunk. Like ActualBytes it
+	// is transient and absent from the checkpoint JSON.
+	//
+	// It exists because the row count reaching Feedback() is not the rows
+	// *present*. On the copy path that argument is the applier's affected-row
+	// count from `INSERT IGNORE`, which skips any row the binlog applier had
+	// already written to the new table — so a fully dense chunk can report far
+	// fewer rows than it holds, or zero. The optimistic chunker's key-space
+	// density signal needs rows present, not rows written, or it reads an
+	// insert-hot region as a gap (see chunkerOptimistic.recordKeyDensity).
+	//
+	// Zero from producers that never hold the rows themselves — the checksum
+	// aggregates its CRC server-side — which is also what an empty chunk
+	// reports, and the two are interchangeable for density purposes because an
+	// empty chunk's affected-row count is zero too.
+	SourceRows uint64
 }
 
 // Boundary is used by chunk for lower or upper boundary

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -34,8 +34,24 @@ type chunkerOptimistic struct {
 	// recent chunks, which is what "large gaps in the sequence" means. See
 	// keySpaceDensity for why chunk cost cannot stand in for it.
 	keyDensity keySpaceDensity
-	// prePrefetchChunkSize is the chunk size that was in effect when the
-	// current prefetch episode began, restored when the episode ends.
+	// lastDenseChunkSize is the most recent fixed-width chunk size that was
+	// validated against real rows: a chunk of that width came back holding at
+	// least one row, so its cost (time, or in-memory bytes) was actually
+	// measured. It is what prefetch restores on exit, and it is deliberately
+	// NOT simply the chunk size at entry — see prePrefetchChunkSize.
+	lastDenseChunkSize uint64
+	// prePrefetchChunkSize is the size the current prefetch episode will restore
+	// when it ends, captured at entry from lastDenseChunkSize.
+	//
+	// The chunk size in effect at entry is the wrong thing to restore. Reaching
+	// MaxDynamicRowSize is not evidence the table can sustain 100k-row chunks:
+	// over a gap the chunks are *empty*, and empty chunks are precisely what
+	// drive the size up (near-zero durations on the time signal; see
+	// calculateNewTargetChunkBytes for the byte signal, where a zero-byte p90
+	// deliberately returns a target above the ceiling so prefetch can fire). So
+	// the entry-time size can be one no real row has ever been measured under,
+	// and restoring it would have the copier materialize up to 100k wide rows in
+	// one read before any ActualBytes feedback could shrink it.
 	prePrefetchChunkSize uint64
 	// prefetchChunks counts chunks dispatched in the current prefetch episode,
 	// so an episode abandoned on its first chunk can be recognised as a
@@ -369,6 +385,7 @@ func (t *chunkerOptimistic) Reset() error {
 	t.chunkTimingInfo = []time.Duration{}
 	t.chunkPrefetchingEnabled = false
 	t.keyDensity.reset()
+	t.lastDenseChunkSize = 0
 	t.prePrefetchChunkSize = 0
 	t.prefetchChunks = 0
 	t.prefetchRejections = 0
@@ -451,7 +468,25 @@ func (t *chunkerOptimistic) recordKeyDensity(chunk *Chunk, actualRows uint64) {
 	if err != nil {
 		return
 	}
-	t.keyDensity.record(keys, actualRows)
+	// Prefer the producer's own count of rows read. actualRows is the applier's
+	// affected-row count on the copy path, and `INSERT IGNORE` does not count a
+	// row the binlog applier already wrote to the new table — so in an
+	// insert-hot region a dense chunk can report zero rows and be mistaken for a
+	// gap. See Chunk.SourceRows for why falling back on zero is safe.
+	rows := actualRows
+	if chunk.SourceRows > 0 {
+		rows = chunk.SourceRows
+	}
+	t.keyDensity.record(keys, rows)
+
+	// Remember the last chunk size proven against real rows, which is what
+	// prefetch restores on exit. keys == ChunkSize identifies a fixed-width
+	// chunk (next() builds those as chunkPtr..chunkPtr+chunkSize) and excludes a
+	// prefetch chunk, whose ChunkSize is a row offset while its width is the gap
+	// it crossed — restoring a prefetch offset would defeat the whole point.
+	if rows > 0 && keys == chunk.ChunkSize {
+		t.lastDenseChunkSize = chunk.ChunkSize
+	}
 }
 
 // maybeSwitchToPrefetch is the optimistic chunker's pre-update hook for the
@@ -528,7 +563,7 @@ func (t *chunkerOptimistic) switchToPrefetch(signalAttrs ...any) {
 			"window-rows", rows,
 			"chunk-size", t.chunkSize,
 		}, signalAttrs...)...)
-	t.prePrefetchChunkSize = t.chunkSize
+	t.prePrefetchChunkSize = t.lastDenseChunkSize
 	t.prefetchChunks = 0
 	t.chunkPrefetchingEnabled = true
 	t.setChunkSize(StartingChunkSize)
@@ -539,20 +574,23 @@ func (t *chunkerOptimistic) switchToPrefetch(signalAttrs ...any) {
 // the `offset` rows the prefetch query walked span fewer than MaxDynamicRowSize
 // keys — the gap is behind us.
 //
-// The chunk size is restored to what it was when prefetch was entered rather
+// The chunk size is restored to the last one validated against real rows rather
 // than reset to StartingChunkSize. That reset was the expensive half of the
 // prefetch flap: the sizer grows by at most MaxDynamicStepFactor per feedback
 // window, so climbing StartingChunkSize -> MaxDynamicRowSize costs ~130 chunks,
-// every one of them a fraction of the size the table can sustain. Prefetch is
-// only ever entered from the ceiling, so the restored size is one this table has
-// already been measured to sustain; if the region past the gap cannot, the
-// sizer — and panicShrink ahead of it — brings it down within a window.
-// Caller holds the mutex.
+// every one of them a fraction of the size the table can sustain. Restoring a
+// measured size skips the ramp without betting on a size no row was ever read
+// under (see prePrefetchChunkSize); if the region past the gap cannot sustain
+// it after all, the sizer — and panicShrink ahead of it — brings it down within
+// a window. Caller holds the mutex.
 func (t *chunkerOptimistic) leavePrefetch(minVal, maxVal Datum, keys, offset uint64) {
 	restore := t.prePrefetchChunkSize
 	if restore == 0 {
-		// Prefetch was enabled without going through switchToPrefetch (the test
-		// suite does this). Keep the historical behavior for that case.
+		// Either no fixed-width chunk has ever come back with rows in it (a
+		// table whose gap starts at the very first chunk), or prefetch was
+		// enabled without going through switchToPrefetch (the test suite does
+		// this). Both cases have nothing measured to return to, so fall back to
+		// the historical conservative reset.
 		restore = StartingChunkSize
 	}
 	// An episode abandoned on its very first chunk never crossed a gap: the
@@ -613,8 +651,16 @@ func (t *chunkerOptimistic) open() (err error) {
 	t.chunkSize = StartingChunkSize
 	t.inflightChunks = 0
 	t.keyDensity.reset()
+	t.lastDenseChunkSize = 0
 	t.prePrefetchChunkSize = 0
 	t.prefetchChunks = 0
+	// prefetchRejections is deliberately NOT cleared here, unlike in Reset().
+	// open() also runs on the OpenAtWatermark resume path, and how sparse this
+	// table's key space is does not change because we reopened at a watermark —
+	// so what we learned about prefetch being unhelpful is still true, and
+	// re-learning it costs another two episodes and another two log lines per
+	// resume. Reset() does clear it, because its contract is "as if Open() was
+	// just called" on a fresh chunker.
 
 	// Initialize progress tracking
 	atomic.StoreUint64(&t.rowsCopied, 0)

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -30,6 +30,23 @@ type chunkerOptimistic struct {
 	// The chunk prefetching algorithm is used when the chunker detects
 	// that there are very large gaps in the sequence.
 	chunkPrefetchingEnabled bool
+	// keyDensity is how that detection is made: it measures keys-per-row over
+	// recent chunks, which is what "large gaps in the sequence" means. See
+	// keySpaceDensity for why chunk cost cannot stand in for it.
+	keyDensity keySpaceDensity
+	// prePrefetchChunkSize is the chunk size that was in effect when the
+	// current prefetch episode began, restored when the episode ends.
+	prePrefetchChunkSize uint64
+	// prefetchChunks counts chunks dispatched in the current prefetch episode,
+	// so an episode abandoned on its first chunk can be recognised as a
+	// rejection rather than a completed gap crossing.
+	prefetchChunks int
+	// prefetchRejections counts episodes rejected on their first chunk. After
+	// maxPrefetchRejections we stop trying for the rest of the run: the entry
+	// gate and the exit test read the same key space, so if they disagree twice
+	// this table sits on the boundary between them and re-testing it costs more
+	// than prefetch can win.
+	prefetchRejections int
 
 	// Progress tracking: the implementation here is up to the chunker,
 	// and for the optimistic chunker it is based on the progress
@@ -47,14 +64,24 @@ type chunkerOptimistic struct {
 
 var _ MappedChunker = &chunkerOptimistic{}
 
+// maxPrefetchRejections is how many prefetch episodes may be abandoned on their
+// first chunk before the chunker gives up on prefetch for the rest of the run.
+// See chunkerOptimistic.prefetchRejections.
+const maxPrefetchRejections = 2
+
 // nextChunkByPrefetching uses prefetching instead of feedback to determine the chunk size.
 // It is used when the chunker detects that there are very large gaps in the sequence.
 // When this mode is enabled, the chunkSize is "reset" to 1000 rows, so we know that
 // t.chunkSize is reliable. It is also expanded again based on feedback.
 func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
+	// The OFFSET this chunk is built from, captured before leavePrefetch below
+	// can change t.chunkSize. The returned chunk must be labelled with the size
+	// that produced it, not with whatever the next chunk will use.
+	offset := t.chunkSize
+	t.prefetchChunks++
 	key := QuoteColumns(t.Ti.KeyColumns[:1])
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s > ? ORDER BY %s LIMIT 1 OFFSET %d",
-		key, t.Ti.QuotedTableName, key, key, t.chunkSize,
+		key, t.Ti.QuotedTableName, key, key, offset,
 	)
 	//nolint: noctx // too much refactoring to add context here
 	rows, err := t.Ti.db.Query(query, t.chunkPtr.String())
@@ -84,16 +111,11 @@ func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
 		// on non-numeric Datums (binary PK); in that case the prefetching
 		// optimization simply doesn't apply — fall through.
 		if rng, err := maxVal.Range(minVal); err == nil && rng < MaxDynamicRowSize {
-			t.logger.Warn("disabling chunk prefetching",
-				"min-val", minVal,
-				"max-val", maxVal,
-				"max-dynamic-row-size", MaxDynamicRowSize)
-			t.chunkSize = StartingChunkSize // reset
-			t.chunkPrefetchingEnabled = false
+			t.leavePrefetch(minVal, maxVal, rng, offset)
 		}
 
 		return &Chunk{
-			ChunkSize:  t.chunkSize,
+			ChunkSize:  offset,
 			Key:        t.Ti.KeyColumns,
 			LowerBound: &Boundary{[]Datum{minVal}, true},
 			UpperBound: &Boundary{[]Datum{maxVal}, false},
@@ -111,7 +133,7 @@ func (t *chunkerOptimistic) nextChunkByPrefetching() (*Chunk, error) {
 	// on the final chunk.
 	t.finalChunkSent = true
 	return &Chunk{
-		ChunkSize:  t.chunkSize,
+		ChunkSize:  offset,
 		Key:        t.Ti.KeyColumns,
 		LowerBound: &Boundary{[]Datum{t.chunkPtr}, true},
 		Table:      t.Ti,
@@ -346,6 +368,10 @@ func (t *chunkerOptimistic) Reset() error {
 	t.inflightChunks = 0
 	t.chunkTimingInfo = []time.Duration{}
 	t.chunkPrefetchingEnabled = false
+	t.keyDensity.reset()
+	t.prePrefetchChunkSize = 0
+	t.prefetchChunks = 0
+	t.prefetchRejections = 0
 
 	// Reset progress tracking
 	atomic.StoreUint64(&t.rowsCopied, 0)
@@ -378,6 +404,8 @@ func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, actualRows u
 	atomic.AddUint64(&t.rowsCopied, chunk.ChunkSize)
 	t.chunksCopied.Add(1)
 
+	t.recordKeyDensity(chunk, actualRows)
+
 	// Check if the feedback is based on an earlier chunker size.
 	// if it is, it is misleading to incorporate feedback now.
 	// We should just skip it. We also skip if dynamic chunking is disabled.
@@ -398,23 +426,50 @@ func (t *chunkerOptimistic) Feedback(chunk *Chunk, d time.Duration, actualRows u
 	t.feedbackTime(t.logger, d, t.maybeSwitchToPrefetch)
 }
 
+// recordKeyDensity feeds one completed chunk into the key-space density window
+// that gates prefetch entry: how many keys the chunk spanned, and how many rows
+// were really in it.
+//
+// Deliberately called before Feedback's stale-feedback screen. Unlike a
+// duration, a keys/rows pair is a property of the data rather than of the chunk
+// size that happened to be in effect, so a chunk drawn under an earlier chunk
+// size is still a valid density sample — and under high copy or checksum
+// concurrency most feedback IS stale (dozens of chunks are in flight when the
+// size changes), so screening those out would leave the window permanently
+// short and prefetch permanently unreachable.
+//
+// Chunks without both bounds — the first chunk and the open-ended final one —
+// have no measurable width and are skipped. Caller holds the mutex.
+func (t *chunkerOptimistic) recordKeyDensity(chunk *Chunk, actualRows uint64) {
+	if chunk.LowerBound == nil || chunk.UpperBound == nil ||
+		len(chunk.LowerBound.Value) == 0 || len(chunk.UpperBound.Value) == 0 {
+		return
+	}
+	// Range errors on non-numeric keys (a binary PK), where prefetch does not
+	// apply anyway.
+	keys, err := chunk.UpperBound.Value[0].Range(chunk.LowerBound.Value[0])
+	if err != nil {
+		return
+	}
+	t.keyDensity.record(keys, actualRows)
+}
+
 // maybeSwitchToPrefetch is the optimistic chunker's pre-update hook for the
 // shared time-based sizer (dynamicChunkSizer.feedbackTime). When the sizer is
 // already at the max chunk size and still wants to grow while the p90 is only a
-// small fraction of the target time, the auto-increment key space has large
-// gaps — so switch to the prefetch algorithm (which finds boundaries by query)
-// instead of growing the row target further. The composite chunker has no
-// analogous mode. Caller (feedbackTime) holds the chunker's mutex.
-func (t *chunkerOptimistic) maybeSwitchToPrefetch(newTarget uint64, p90 time.Duration) {
-	if t.chunkSize == MaxDynamicRowSize && newTarget > MaxDynamicRowSize && p90*5 < t.ChunkerTarget {
-		t.logger.Warn("dynamic chunking is not working as expected",
-			"target-time", t.ChunkerTarget,
-			"p90-time", p90,
-			"new-target-rows", newTarget,
-			"max-dynamic-row-size", MaxDynamicRowSize,
-		)
-		t.switchToPrefetch()
+// small fraction of the target time, the chunker is not getting what it asked
+// for from a fixed-width chunk — a *necessary* condition for prefetch being
+// useful, but on its own not a sufficient one, so prefetchWouldHelp also
+// requires the key space to measure sparse. The composite chunker has no
+// analogous mode. Caller (feedbackTime) holds the chunker's mutex. Returns true
+// when it switched, so the sizer skips the target it just computed for the mode
+// we are leaving.
+func (t *chunkerOptimistic) maybeSwitchToPrefetch(newTarget uint64, p90 time.Duration) bool {
+	if p90*5 >= t.ChunkerTarget || !t.prefetchWouldHelp(newTarget) {
+		return false
 	}
+	t.switchToPrefetch("target-time", t.ChunkerTarget, "p90-time", p90)
+	return true
 }
 
 // maybeSwitchToPrefetchBytes is the byte-signal twin of maybeSwitchToPrefetch,
@@ -422,26 +477,106 @@ func (t *chunkerOptimistic) maybeSwitchToPrefetch(newTarget uint64, p90 time.Dur
 // the chunk is pinned at the row ceiling but the p90 in-memory size is still
 // under a fifth of the byte budget, which over a large auto-increment gap means
 // chunks keep coming back near-empty. Caller (feedbackBytes) holds the mutex.
-func (t *chunkerOptimistic) maybeSwitchToPrefetchBytes(newTarget uint64, p90Bytes uint64) {
-	if t.chunkSize == MaxDynamicRowSize && newTarget > MaxDynamicRowSize && p90Bytes*5 < t.TargetChunkBytes {
-		t.logger.Warn("dynamic chunking is not working as expected",
-			"target-bytes", t.TargetChunkBytes,
-			"p90-bytes", p90Bytes,
-			"new-target-rows", newTarget,
-			"max-dynamic-row-size", MaxDynamicRowSize,
-		)
-		t.switchToPrefetch()
+func (t *chunkerOptimistic) maybeSwitchToPrefetchBytes(newTarget uint64, p90Bytes uint64) bool {
+	if p90Bytes*5 >= t.TargetChunkBytes || !t.prefetchWouldHelp(newTarget) {
+		return false
 	}
+	t.switchToPrefetch("target-bytes", t.TargetChunkBytes, "p90-bytes", p90Bytes)
+	return true
+}
+
+// prefetchWouldHelp reports whether the signal-independent preconditions for
+// entering prefetch mode hold: the sizer is pinned at the row ceiling and still
+// wants to grow, the key space has actually been measured as sparse, and we
+// have not already tried and been rejected too many times.
+//
+// The density check is the one that matters. Without it the caller's condition
+// ("pinned at the ceiling, and chunks are cheap") is satisfied by every healthy
+// chunk on a dense table — most obviously in the checksum, where a chunk is a
+// server-side CRC sized against a 5s budget, so 100k dense rows come back in
+// well under a fifth of it. That produced an endless entry/exit flap: prefetch
+// was entered, nextChunkByPrefetching found the key space dense and left again,
+// and the chunk size ping-ponged between StartingChunkSize and the ceiling for
+// the whole run. Caller holds the mutex.
+func (t *chunkerOptimistic) prefetchWouldHelp(newTarget uint64) bool {
+	if t.chunkPrefetchingEnabled {
+		// Already prefetching. Re-entering would reset the row offset back to
+		// StartingChunkSize mid-gap, undoing the growth this episode has
+		// already earned — reachable because a prefetch episode's own chunks
+		// feed the sizer and can carry it back up to the ceiling.
+		return false
+	}
+	if t.chunkSize != MaxDynamicRowSize || newTarget <= MaxDynamicRowSize {
+		return false
+	}
+	if t.prefetchRejections >= maxPrefetchRejections {
+		return false
+	}
+	return t.keyDensity.sparse()
 }
 
 // switchToPrefetch flips the optimistic chunker into prefetch mode, where the
 // next boundary is found by query rather than by advancing a fixed row count —
-// the only efficient way to cross a large gap in the key space. Caller holds
-// the mutex.
-func (t *chunkerOptimistic) switchToPrefetch() {
-	t.logger.Warn("switching to prefetch algorithm")
-	t.chunkSize = StartingChunkSize // reset
+// the only efficient way to cross a large gap in the key space. signalAttrs are
+// the log attributes describing whichever budget (time or bytes) raised the
+// alarm. Caller holds the mutex.
+func (t *chunkerOptimistic) switchToPrefetch(signalAttrs ...any) {
+	keys, rows := t.keyDensity.totals()
+	t.logger.Info("large gaps found in the key space; switching to the chunk prefetch algorithm",
+		append([]any{
+			"window-keys", keys,
+			"window-rows", rows,
+			"chunk-size", t.chunkSize,
+		}, signalAttrs...)...)
+	t.prePrefetchChunkSize = t.chunkSize
+	t.prefetchChunks = 0
 	t.chunkPrefetchingEnabled = true
+	t.setChunkSize(StartingChunkSize)
+	t.keyDensity.reset()
+}
+
+// leavePrefetch returns the chunker to fixed-width chunking, having found that
+// the `offset` rows the prefetch query walked span fewer than MaxDynamicRowSize
+// keys — the gap is behind us.
+//
+// The chunk size is restored to what it was when prefetch was entered rather
+// than reset to StartingChunkSize. That reset was the expensive half of the
+// prefetch flap: the sizer grows by at most MaxDynamicStepFactor per feedback
+// window, so climbing StartingChunkSize -> MaxDynamicRowSize costs ~130 chunks,
+// every one of them a fraction of the size the table can sustain. Prefetch is
+// only ever entered from the ceiling, so the restored size is one this table has
+// already been measured to sustain; if the region past the gap cannot, the
+// sizer — and panicShrink ahead of it — brings it down within a window.
+// Caller holds the mutex.
+func (t *chunkerOptimistic) leavePrefetch(minVal, maxVal Datum, keys, offset uint64) {
+	restore := t.prePrefetchChunkSize
+	if restore == 0 {
+		// Prefetch was enabled without going through switchToPrefetch (the test
+		// suite does this). Keep the historical behavior for that case.
+		restore = StartingChunkSize
+	}
+	// An episode abandoned on its very first chunk never crossed a gap: the
+	// entry gate and this test disagreed about the same key space.
+	rejected := t.prefetchChunks <= 1
+	if rejected {
+		t.prefetchRejections++
+	}
+	t.logger.Info("key space is dense again; leaving the chunk prefetch algorithm",
+		"min-val", minVal,
+		"max-val", maxVal,
+		"keys", keys,
+		"rows", offset,
+		"max-dynamic-row-size", MaxDynamicRowSize,
+		"prefetch-chunks", t.prefetchChunks,
+		"chunk-size", restore,
+	)
+	if rejected && t.prefetchRejections >= maxPrefetchRejections {
+		t.logger.Info("prefetching keeps being abandoned on its first chunk; not trying it again for this table",
+			"attempts", t.prefetchRejections)
+	}
+	t.chunkPrefetchingEnabled = false
+	t.setChunkSize(restore)
+	t.keyDensity.reset()
 }
 
 // GetLowWatermark returns the highest known value that has been safely copied,
@@ -477,6 +612,9 @@ func (t *chunkerOptimistic) open() (err error) {
 	t.finalChunkSent = false
 	t.chunkSize = StartingChunkSize
 	t.inflightChunks = 0
+	t.keyDensity.reset()
+	t.prePrefetchChunkSize = 0
+	t.prefetchChunks = 0
 
 	// Initialize progress tracking
 	atomic.StoreUint64(&t.rowsCopied, 0)

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -450,12 +450,46 @@ func TestOptimisticPrefetchChunking(t *testing.T) {
 	require.NoError(t, chunker.Open())
 	require.False(t, chunker.chunkPrefetchingEnabled)
 
+	// Feed back the REAL row count for each chunk, not a placeholder: that is
+	// what the prefetch entry gate reads, so a hardcoded value would make this
+	// test pass without saying anything about a 300B gap. Cost the chunk in
+	// proportion to the rows it really held, the way the checksum's server-side
+	// CRC does.
+	episodes, prefetchChunks, chunks := 0, 0, 0
+	wasPrefetching := false
 	for !chunker.finalChunkSent {
 		chunk, err := chunker.Next()
 		require.NoError(t, err)
-		chunker.Feedback(chunk, 100*time.Millisecond, 1) // way too short.
+		chunks++
+		if wasPrefetching {
+			prefetchChunks++
+		}
+		if chunker.chunkPrefetchingEnabled && !wasPrefetching {
+			episodes++
+		}
+		wasPrefetching = chunker.chunkPrefetchingEnabled
+
+		var rows uint64
+		countQuery := "SELECT COUNT(*) FROM tprefetch WHERE " + chunk.String()
+		require.NoError(t, db.QueryRowContext(t.Context(), countQuery).Scan(&rows))
+		chunker.Feedback(chunk, time.Duration(rows)*8*time.Microsecond, rows)
 	}
 	require.True(t, chunker.chunkPrefetchingEnabled)
+
+	// One prefetch episode per gap in the fixture (300B, 600B, 900B), each
+	// entered off measured emptiness rather than off a cheap chunk.
+	require.Equal(t, 3, episodes)
+	require.Positive(t, prefetchChunks)
+
+	// The gap crossings are real crossings, not entry/exit flaps, so none of
+	// them counted against the rejection backstop.
+	require.Zero(t, chunker.prefetchRejections)
+
+	// And the whole table is covered in far fewer chunks than the flapping
+	// chunker needed: it used to re-ramp from StartingChunkSize after every
+	// episode. Generous bound — the point is the order of magnitude, not a
+	// golden number.
+	require.Less(t, chunks, 300, "prefetch episodes must not each cost a re-ramp to the ceiling")
 }
 
 func TestOptimisticChunkerReset(t *testing.T) {

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -678,3 +678,139 @@ func TestOptimisticChunkerReservedWordTableName(t *testing.T) {
 
 	require.NoError(t, opt.Close())
 }
+
+// denseChunkerForTest returns an optimistic chunker over a synthetic table with
+// a wide, gap-free BIGINT key space, using the time signal and the production
+// chunk time target.
+func denseChunkerForTest(t *testing.T) *chunkerOptimistic {
+	t.Helper()
+	ti := &TableInfo{
+		minValue:          Datum{Val: int64(1), Tp: signedType},
+		maxValue:          Datum{Val: int64(1_000_000_000), Tp: signedType},
+		EstimatedRows:     1_000_000_000,
+		SchemaName:        "test",
+		TableName:         "dense",
+		QuotedTableName:   "`dense`",
+		KeyColumns:        []string{"id"},
+		keyColumnsMySQLTp: []string{"bigint"},
+		keyDatums:         []datumTp{signedType},
+		KeyIsAutoInc:      true,
+		Columns:           []string{"id", "name"},
+	}
+	ti.statisticsLastUpdated = time.Now()
+	chunker := &chunkerOptimistic{
+		Ti:                ti,
+		dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: ChunkerDefaultTarget},
+		watermarkTracker:  watermarkTracker{lowerBoundWatermarkMap: make(map[string]*Chunk)},
+		logger:            slog.Default(),
+	}
+	chunker.SetDynamicChunking(true)
+	require.NoError(t, chunker.Open())
+	return chunker
+}
+
+// TestOptimisticNoPrefetchOnDenseKeySpace is a regression test for the prefetch
+// flap. On a dense table every healthy chunk satisfies the old prefetch-entry
+// condition — the sizer is pinned at MaxDynamicRowSize and still wants to grow
+// while the p90 sits well inside the chunk time target — because a chunk being
+// cheap says nothing about whether the key space has gaps. That is the normal
+// state of a checksum chunk (a server-side CRC against a 5s budget), so the
+// chunker switched to prefetch, immediately discovered the key space was dense,
+// switched back with the chunk size reset to StartingChunkSize, and had to ramp
+// ~130 chunks back to the ceiling — forever.
+func TestOptimisticNoPrefetchOnDenseKeySpace(t *testing.T) {
+	chunker := denseChunkerForTest(t)
+
+	// Walk the table, feeding back what a dense table really reports: the chunk
+	// covered as many rows as it was wide, and it cost time in proportion to
+	// those rows. 8us/row puts a full 100k-row chunk at 800ms, which is inside
+	// a fifth of the 5s target — the shape observed in production, where a
+	// 100k-row checksum chunk lands either side of 1s.
+	for range 200 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		rows := chunk.ChunkSize
+		chunker.Feedback(chunk, time.Duration(rows)*8*time.Microsecond, rows)
+		require.False(t, chunker.chunkPrefetchingEnabled,
+			"must not switch to prefetch on a gap-free key space")
+	}
+
+	// And having found nothing to slow it down, the sizer should be parked at
+	// the ceiling rather than endlessly re-ramping from StartingChunkSize.
+	require.Equal(t, uint64(MaxDynamicRowSize), chunker.chunkSize)
+}
+
+// TestOptimisticPrefetchRestoresChunkSize covers the other half of the prefetch
+// flap: leaving prefetch mode used to reset the chunk size to
+// StartingChunkSize, so even a legitimate gap crossing was paid for with a
+// ~130-chunk ramp back to the ceiling. Prefetch is only ever entered from the
+// ceiling, so that is the size to come back to.
+func TestOptimisticPrefetchRestoresChunkSize(t *testing.T) {
+	db, err := sql.Open("mysql", testutils.DSN())
+	require.NoError(t, err)
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Logf("failed to close db: %v", err)
+		}
+	}()
+
+	testutils.RunSQL(t, `DROP TABLE IF EXISTS tprefetch_dense`)
+	testutils.RunSQL(t, `CREATE TABLE tprefetch_dense (
+		id BIGINT NOT NULL AUTO_INCREMENT,
+		pad VARCHAR(10) NULL,
+		PRIMARY KEY (id)
+	)`)
+	// ~11K rows with no gaps at all, so the prefetch query's OFFSET lands well
+	// inside MaxDynamicRowSize keys and prefetch is abandoned immediately.
+	testutils.RunSQL(t, `INSERT INTO tprefetch_dense (pad) VALUES (NULL)`)
+	for range 3 {
+		testutils.RunSQL(t, `INSERT INTO tprefetch_dense (pad) SELECT NULL FROM tprefetch_dense a JOIN tprefetch_dense b JOIN tprefetch_dense c`)
+	}
+	testutils.RunSQL(t, `INSERT INTO tprefetch_dense (pad) SELECT NULL FROM tprefetch_dense a JOIN tprefetch_dense b LIMIT 10000`)
+
+	t1 := newTableInfo4Test("test", "tprefetch_dense")
+	t1.db = db
+	require.NoError(t, t1.SetInfo(t.Context()))
+	chunker := &chunkerOptimistic{
+		Ti:                t1,
+		dynamicChunkSizer: dynamicChunkSizer{ChunkerTarget: ChunkerDefaultTarget},
+		watermarkTracker:  watermarkTracker{lowerBoundWatermarkMap: make(map[string]*Chunk)},
+		logger:            slog.Default(),
+	}
+	chunker.SetDynamicChunking(true)
+	require.NoError(t, chunker.Open())
+
+	// Enter prefetch the way the sizer does, from the ceiling.
+	chunker.chunkSize = MaxDynamicRowSize
+	chunker.switchToPrefetch()
+	require.True(t, chunker.chunkPrefetchingEnabled)
+	require.Equal(t, uint64(StartingChunkSize), chunker.chunkSize)
+
+	// One prefetch chunk is enough to discover the key space is dense.
+	chunker.chunkPtr = Datum{Val: int64(1), Tp: signedType}
+	chunk, err := chunker.nextChunkByPrefetching()
+	require.NoError(t, err)
+	require.False(t, chunker.chunkPrefetchingEnabled)
+	require.Equal(t, uint64(MaxDynamicRowSize), chunker.chunkSize,
+		"leaving prefetch must restore the pre-prefetch chunk size, not ramp from scratch")
+
+	// The chunk that triggered the exit is labelled with the offset that built
+	// it, not with the size the next chunk will use.
+	require.Equal(t, uint64(StartingChunkSize), chunk.ChunkSize)
+
+	// The episode was abandoned on its first chunk, so it counts as a
+	// rejection, and re-entry is closed until fresh density evidence has
+	// accumulated under the restored chunk size.
+	require.Equal(t, 1, chunker.prefetchRejections)
+	require.False(t, chunker.prefetchWouldHelp(MaxDynamicRowSize+1))
+
+	// After maxPrefetchRejections the chunker stops trying at all, so the log
+	// stays quiet even on a table that sits on the boundary between the entry
+	// gate and prefetch's own exit test.
+	chunker.prefetchRejections = maxPrefetchRejections
+	for range keySpaceDensityWindow {
+		chunker.keyDensity.record(MaxDynamicRowSize, 0) // as sparse as it gets
+	}
+	require.True(t, chunker.keyDensity.sparse())
+	require.False(t, chunker.prefetchWouldHelp(MaxDynamicRowSize+1))
+}

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -485,11 +485,18 @@ func TestOptimisticPrefetchChunking(t *testing.T) {
 	// them counted against the rejection backstop.
 	require.Zero(t, chunker.prefetchRejections)
 
-	// And the whole table is covered in far fewer chunks than the flapping
-	// chunker needed: it used to re-ramp from StartingChunkSize after every
-	// episode. Generous bound — the point is the order of magnitude, not a
-	// golden number.
-	require.Less(t, chunks, 300, "prefetch episodes must not each cost a re-ramp to the ceiling")
+	// And the whole table is covered in fewer chunks than the flapping chunker
+	// needed (430 on this fixture), because an episode no longer ends with a
+	// reset to StartingChunkSize.
+	//
+	// The margin here is deliberately modest. On a gapped table the restore is
+	// the last size proven against real rows, which for this fixture is earned
+	// on the 11k-row dense prefix and so is small — resuming at the ceiling the
+	// *empty* gap chunks bought would cover the table in ~192 chunks but would
+	// hand the buffered copier an unmeasured 100k-row read (see
+	// TestOptimisticPrefetchRestoreIsMeasured). This bound is here to catch a
+	// regression back to per-episode re-ramping, not to pin a golden number.
+	require.Less(t, chunks, 400, "prefetch episodes must not each cost a full re-ramp")
 }
 
 func TestOptimisticChunkerReset(t *testing.T) {
@@ -814,6 +821,19 @@ func TestOptimisticPrefetchRestoresChunkSize(t *testing.T) {
 	chunker.SetDynamicChunking(true)
 	require.NoError(t, chunker.Open())
 
+	// Prove a chunk size against real rows first — only a measured size is
+	// eligible to be restored (see prePrefetchChunkSize).
+	chunker.chunkSize = MaxDynamicRowSize
+	proven := &Chunk{
+		ChunkSize:  MaxDynamicRowSize,
+		Key:        t1.KeyColumns,
+		LowerBound: &Boundary{[]Datum{{Val: int64(1), Tp: signedType}}, true},
+		UpperBound: &Boundary{[]Datum{{Val: int64(1 + MaxDynamicRowSize), Tp: signedType}}, false},
+		Table:      t1,
+	}
+	chunker.Feedback(proven, time.Second, MaxDynamicRowSize)
+	require.Equal(t, uint64(MaxDynamicRowSize), chunker.lastDenseChunkSize)
+
 	// Enter prefetch the way the sizer does, from the ceiling.
 	chunker.chunkSize = MaxDynamicRowSize
 	chunker.switchToPrefetch()
@@ -826,7 +846,7 @@ func TestOptimisticPrefetchRestoresChunkSize(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, chunker.chunkPrefetchingEnabled)
 	require.Equal(t, uint64(MaxDynamicRowSize), chunker.chunkSize,
-		"leaving prefetch must restore the pre-prefetch chunk size, not ramp from scratch")
+		"leaving prefetch must restore the measured chunk size, not ramp from scratch")
 
 	// The chunk that triggered the exit is labelled with the offset that built
 	// it, not with the size the next chunk will use.
@@ -847,4 +867,88 @@ func TestOptimisticPrefetchRestoresChunkSize(t *testing.T) {
 	}
 	require.True(t, chunker.keyDensity.sparse())
 	require.False(t, chunker.prefetchWouldHelp(MaxDynamicRowSize+1))
+}
+
+// TestOptimisticPrefetchRestoreIsMeasured covers the memory bound on the
+// restore. Reaching MaxDynamicRowSize is not evidence the table can sustain
+// 100k-row chunks: over a gap the chunks are empty, and empty chunks are
+// exactly what drive the size to the ceiling (a zero-byte p90 deliberately
+// returns a target above it so prefetch can fire). Restoring the entry-time
+// size would therefore hand the buffered copier a 100k-row read on a table of
+// 16KB rows — ~1.6GB per worker — before any ActualBytes feedback could shrink
+// it. The restore must be a size real rows were measured under.
+func TestOptimisticPrefetchRestoreIsMeasured(t *testing.T) {
+	chunker := denseChunkerForTest(t)
+	chunker.TargetChunkBytes = DefaultTargetChunkBytes // buffered copier: byte signal
+
+	const wideRowBytes = 16 * 1024 // 16KB rows: ~1000 of them fill the budget
+
+	// Phase 1: wide rows. The sizer settles on a row count that fits the byte
+	// budget, and every one of those chunks is validated against real rows.
+	for range 60 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		chunk.SourceRows = chunk.ChunkSize
+		chunk.ActualBytes = chunk.ChunkSize * wideRowBytes
+		chunker.Feedback(chunk, time.Millisecond, chunk.ChunkSize)
+	}
+	measured := chunker.lastDenseChunkSize
+	require.NotZero(t, measured)
+	require.Less(t, measured, uint64(MaxDynamicRowSize),
+		"16KB rows cannot fit the byte budget at the row ceiling")
+
+	// Phase 2: a large empty gap. Zero-byte chunks walk the row target up to the
+	// ceiling and the density window fills with genuine emptiness, so prefetch
+	// legitimately engages.
+	for range 400 {
+		if chunker.chunkPrefetchingEnabled {
+			break
+		}
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		chunk.SourceRows = 0
+		chunk.ActualBytes = 0
+		chunker.Feedback(chunk, time.Microsecond, 0)
+	}
+	// Entry implies the gap carried the row target to the ceiling — that is a
+	// precondition in prefetchWouldHelp — and switchToPrefetch has since reset
+	// the live size to the prefetch offset, so the ceiling is not observable
+	// here. What matters is what the episode will restore.
+	require.True(t, chunker.chunkPrefetchingEnabled, "a real gap must still engage prefetch")
+
+	// It restores the wide-row size measured before the gap, not the ceiling the
+	// empty chunks bought.
+	require.Equal(t, measured, chunker.prePrefetchChunkSize)
+	require.Less(t, chunker.prePrefetchChunkSize, uint64(MaxDynamicRowSize))
+}
+
+// TestOptimisticPrefetchDensityUsesSourceRows covers the other half of the
+// signal's fidelity. On the copy path the row count reaching Feedback is the
+// applier's affected-row count from `INSERT IGNORE`, which does not count a row
+// the binlog applier already wrote to the new table. In an insert-hot tail every
+// row of a chunk can already be present, so affectedRows is 0 on a fully dense
+// chunk — which would read as a gap and enter prefetch on dense data. The
+// producer's own count of rows read takes precedence.
+func TestOptimisticPrefetchDensityUsesSourceRows(t *testing.T) {
+	chunker := denseChunkerForTest(t)
+
+	for range 200 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		// Dense chunk, but the binlog applier got there first: nothing was
+		// newly inserted, so INSERT IGNORE reports zero affected rows.
+		chunk.SourceRows = chunk.ChunkSize
+		chunker.Feedback(chunk, time.Duration(chunk.ChunkSize)*8*time.Microsecond, 0)
+		require.False(t, chunker.chunkPrefetchingEnabled,
+			"rows already written by the binlog applier are not a gap")
+	}
+	require.Equal(t, uint64(MaxDynamicRowSize), chunker.chunkSize)
+
+	// Sanity check the fixture really is the dangerous one: with only the
+	// affected-row count to go on, the same chunks read as pure gap.
+	var affectedOnly keySpaceDensity
+	for range keySpaceDensityWindow {
+		affectedOnly.record(MaxDynamicRowSize, 0)
+	}
+	require.True(t, affectedOnly.sparse())
 }

--- a/pkg/table/dynamic_chunk_sizer.go
+++ b/pkg/table/dynamic_chunk_sizer.go
@@ -83,10 +83,12 @@ func (d *dynamicChunkSizer) panicShrink(logger *slog.Logger, dur time.Duration) 
 // just before the new chunk size is applied — a seam for chunker-specific
 // behavior. The optimistic chunker uses it to switch to prefetch mode (see
 // chunkerOptimistic.maybeSwitchToPrefetch); the composite chunker passes nil.
+// Returning true means the hook has taken ownership of the chunk size and the
+// computed target must not be applied on top of it.
 //
 // Caller must hold the chunker's mutex and have already screened stale/disabled
 // feedback.
-func (d *dynamicChunkSizer) feedbackTime(logger *slog.Logger, dur time.Duration, beforeUpdate func(newTarget uint64, p90 time.Duration)) {
+func (d *dynamicChunkSizer) feedbackTime(logger *slog.Logger, dur time.Duration, beforeUpdate func(newTarget uint64, p90 time.Duration) bool) {
 	// If any chunk takes 5x the target we reduce immediately and don't wait
 	// for more feedback.
 	if dur > d.ChunkerTarget*DynamicPanicFactor {
@@ -96,8 +98,8 @@ func (d *dynamicChunkSizer) feedbackTime(logger *slog.Logger, dur time.Duration,
 	d.chunkTimingInfo = append(d.chunkTimingInfo, dur)
 	if len(d.chunkTimingInfo) > 10 {
 		newTarget, p90 := d.calculateNewTargetChunkSize()
-		if beforeUpdate != nil {
-			beforeUpdate(newTarget, p90)
+		if beforeUpdate != nil && beforeUpdate(newTarget, p90) {
+			return
 		}
 		d.updateChunkerTarget(newTarget)
 	}
@@ -118,9 +120,10 @@ func (d *dynamicChunkSizer) feedbackTime(logger *slog.Logger, dur time.Duration,
 //
 // beforeUpdate, if non-nil, is called with the freshly computed target and the
 // p90 byte size just before the new chunk size is applied — the byte-signal
-// twin of feedbackTime's hook. Caller must hold the chunker's mutex and have
-// already screened stale/disabled feedback.
-func (d *dynamicChunkSizer) feedbackBytes(logger *slog.Logger, bytes uint64, beforeUpdate func(newTarget uint64, p90Bytes uint64)) {
+// twin of feedbackTime's hook, including its true-means-skip-the-update
+// contract. Caller must hold the chunker's mutex and have already screened
+// stale/disabled feedback.
+func (d *dynamicChunkSizer) feedbackBytes(logger *slog.Logger, bytes uint64, beforeUpdate func(newTarget uint64, p90Bytes uint64) bool) {
 	if bytes > d.TargetChunkBytes*DynamicPanicFactor {
 		d.panicShrinkBytes(logger, bytes)
 		return
@@ -128,8 +131,8 @@ func (d *dynamicChunkSizer) feedbackBytes(logger *slog.Logger, bytes uint64, bef
 	d.chunkByteInfo = append(d.chunkByteInfo, bytes)
 	if len(d.chunkByteInfo) > 10 {
 		newTarget, p90 := d.calculateNewTargetChunkBytes()
-		if beforeUpdate != nil {
-			beforeUpdate(newTarget, p90)
+		if beforeUpdate != nil && beforeUpdate(newTarget, p90) {
+			return
 		}
 		d.updateChunkerTarget(newTarget)
 	}
@@ -197,6 +200,25 @@ func (d *dynamicChunkSizer) updateChunkerTarget(newTarget uint64) {
 	}
 	// Reset whichever history feeds the active signal. Clearing both is safe:
 	// the inactive slice is always already empty.
+	d.chunkTimingInfo = []time.Duration{}
+	d.chunkByteInfo = []uint64{}
+}
+
+// setChunkSize applies a chunk size directly — clamped to the dynamic bounds
+// but bypassing the per-step growth cap — and clears the feedback history so
+// the next window measures the size that is now in effect.
+//
+// It exists for the optimistic chunker's prefetch transitions, where the growth
+// cap must not apply because the *meaning* of chunkSize changes across the
+// boundary (a key-space width outside prefetch mode, a row offset inside it).
+// Carrying either the old history or the old growth path across such a
+// transition would be measuring one mode with the other's yardstick. Caller
+// must hold the chunker's mutex.
+func (d *dynamicChunkSizer) setChunkSize(newSize uint64) {
+	d.chunkSize = min(max(newSize, MinDynamicRowSize), MaxDynamicRowSize)
+	if d.chunkSize > MinDynamicRowSize {
+		d.pinnedAtFloor = false
+	}
 	d.chunkTimingInfo = []time.Duration{}
 	d.chunkByteInfo = []uint64{}
 }

--- a/pkg/table/keyspace_density.go
+++ b/pkg/table/keyspace_density.go
@@ -1,0 +1,90 @@
+package table
+
+const (
+	// keySpaceDensityWindow is how many recently-completed chunks the key-space
+	// density estimate covers. It matches the dynamic sizer's own feedback
+	// window (feedbackTime/feedbackBytes recalculate once more than 10 samples
+	// have accumulated) so the density estimate and the p90 that triggers the
+	// prefetch check describe roughly the same stretch of the table. Gaps are a
+	// local property of the key space, so this must be a sliding window and not
+	// a running total for the whole table.
+	keySpaceDensityWindow = 10
+
+	// minKeysPerRowForPrefetch is how sparse the key space must look before the
+	// optimistic chunker will switch to the prefetch algorithm.
+	//
+	// The value is derived from prefetch's own exit test rather than picked:
+	// entering prefetch resets the chunk size to StartingChunkSize, and
+	// nextChunkByPrefetching abandons prefetch as soon as it finds that those
+	// StartingChunkSize rows span fewer than MaxDynamicRowSize keys. So unless
+	// the key space carries at least MaxDynamicRowSize/StartingChunkSize keys
+	// per row, a prefetch episode cannot survive its own first chunk, and
+	// entering it is pure loss. Deriving the entry threshold from the exit test
+	// is what stops the two from disagreeing every chunk.
+	minKeysPerRowForPrefetch = MaxDynamicRowSize / StartingChunkSize
+)
+
+// keySpaceDensity is a sliding window over recently-completed chunks recording,
+// for each, how many keys it spanned and how many rows it actually contained.
+//
+// It exists to answer the question the prefetch algorithm is actually about —
+// "does the key space around here have large gaps?" — with a signal that can
+// answer it. The signal used previously was chunk *cost*: the sizer pinned at
+// MaxDynamicRowSize and still wanting to grow while the p90 sat well inside the
+// chunk budget. But a cheap chunk on a dense table is indistinguishable from a
+// cheap chunk over a gap, and on the checksum path (a server-side CRC sized
+// against ChunkerDefaultTarget) 100k dense rows are routinely cheap — so that
+// condition fired continuously on ordinary dense tables.
+type keySpaceDensity struct {
+	window []chunkDensity
+}
+
+// chunkDensity is one completed chunk's contribution: the width of the key
+// range it covered, and the rows actually found in it.
+type chunkDensity struct {
+	keys uint64
+	rows uint64
+}
+
+// record adds one completed chunk, evicting the oldest sample once the window
+// is full. Caller must hold the chunker's mutex.
+func (k *keySpaceDensity) record(keys, rows uint64) {
+	k.window = append(k.window, chunkDensity{keys: keys, rows: rows})
+	if len(k.window) > keySpaceDensityWindow {
+		k.window = k.window[len(k.window)-keySpaceDensityWindow:]
+	}
+}
+
+// reset discards the window. Used on chunking-mode transitions, where the
+// samples were gathered under a different notion of chunk size, and on
+// Open/Reset. Caller must hold the chunker's mutex.
+func (k *keySpaceDensity) reset() {
+	k.window = nil
+}
+
+// totals returns the summed keys and rows over the window, for logging.
+func (k *keySpaceDensity) totals() (keys, rows uint64) {
+	for _, s := range k.window {
+		keys += s.keys
+		rows += s.rows
+	}
+	return keys, rows
+}
+
+// sparse reports whether the recent key space averaged at least
+// minKeysPerRowForPrefetch keys per row.
+//
+// A short window returns false: the honest answer is "not known yet", and the
+// action it gates (dropping the chunk size to StartingChunkSize and letting the
+// sizer climb back at MaxDynamicStepFactor per window) is far too expensive to
+// take on a guess.
+func (k *keySpaceDensity) sparse() bool {
+	if len(k.window) < keySpaceDensityWindow {
+		return false
+	}
+	keys, rows := k.totals()
+	if rows == 0 {
+		return true // a window entirely inside a gap
+	}
+	return keys/rows >= minKeysPerRowForPrefetch
+}

--- a/pkg/table/keyspace_density_test.go
+++ b/pkg/table/keyspace_density_test.go
@@ -1,0 +1,64 @@
+package table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeySpaceDensitySparse(t *testing.T) {
+	var k keySpaceDensity
+
+	// A short window is never sparse: "not known yet" must not authorize
+	// dropping the chunk size to StartingChunkSize.
+	for range keySpaceDensityWindow - 1 {
+		k.record(MaxDynamicRowSize, 0)
+	}
+	require.False(t, k.sparse())
+	k.record(MaxDynamicRowSize, 0)
+	require.True(t, k.sparse(), "a window entirely inside a gap is sparse")
+
+	// A dense key space — every chunk returned as many rows as it was wide —
+	// is what a healthy table looks like, and must never read as sparse no
+	// matter how long we watch it.
+	k.reset()
+	for range keySpaceDensityWindow * 3 {
+		k.record(MaxDynamicRowSize, MaxDynamicRowSize)
+	}
+	require.False(t, k.sparse())
+
+	// The threshold is prefetch's own exit test: StartingChunkSize rows must
+	// span at least MaxDynamicRowSize keys, i.e. minKeysPerRowForPrefetch keys
+	// per row. Just under it does not qualify.
+	k.reset()
+	for range keySpaceDensityWindow {
+		k.record(MaxDynamicRowSize, MaxDynamicRowSize/minKeysPerRowForPrefetch+1)
+	}
+	require.False(t, k.sparse())
+	k.reset()
+	for range keySpaceDensityWindow {
+		k.record(MaxDynamicRowSize, MaxDynamicRowSize/minKeysPerRowForPrefetch)
+	}
+	require.True(t, k.sparse())
+
+	// The window slides, so a table that gets denser stops reading as sparse
+	// rather than being judged forever on where it started.
+	for range keySpaceDensityWindow {
+		k.record(MaxDynamicRowSize, MaxDynamicRowSize)
+	}
+	require.False(t, k.sparse())
+	require.Len(t, k.window, keySpaceDensityWindow)
+}
+
+func TestKeySpaceDensityTotals(t *testing.T) {
+	var k keySpaceDensity
+	keys, rows := k.totals()
+	require.Zero(t, keys)
+	require.Zero(t, rows)
+
+	k.record(100, 7)
+	k.record(200, 3)
+	keys, rows = k.totals()
+	require.Equal(t, uint64(300), keys)
+	require.Equal(t, uint64(10), rows)
+}


### PR DESCRIPTION
The optimistic chunker flaps in and out of prefetch mode continuously. It is
visible mostly in the checksum, and it is both loud — three `WARN` lines every
few seconds for the length of a run — and slow:

```
08:29:05 [WRN] dynamic chunking is not working as expected
08:29:05 [WRN] switching to prefetch algorithm
08:29:06 [WRN] disabling chunk prefetching
  checksum  35.29% chunk-size=86481  threads=75
  checksum  37.74% chunk-size=100000 threads=76
  checksum  45.24% chunk-size=5062   threads=77
```

Those chunk sizes are the fingerprint. `5062`, `86481` and `100000` are terms 4,
11 and 12 of `1000 * 1.5^n` with uint64 truncation at each step (1000, 1500,
2250, 3375, **5062**, 7593, 11389, 17083, 25624, 38436, 57654, **86481**, →
clamped **100000**) — a chunker repeatedly restarting from `StartingChunkSize`.

## Two bugs

**Entry mis-fires.** `maybeSwitchToPrefetch` read "pinned at `MaxDynamicRowSize`,
sizer still wants to grow, and `p90*5 < ChunkerTarget`" as *"the key space has
large gaps"*. It isn't: it only says the chunk was **cheap**, and a cheap chunk
on a dense table is indistinguishable from a cheap chunk over a gap. On the
checksum path a chunk is a server-side CRC sized against `ChunkerDefaultTarget`
(5s), so the bar is `p90 < 1s` and 100k dense rows clear it routinely — the
condition holds for every healthy chunk. In the run above, ~215M rows/30s across
77 threads puts a 100k chunk right on the 1s line, which is why it flaps rather
than staying stuck.

**Exit is expensive.** `nextChunkByPrefetching` correctly detects the dense key
space and turns prefetch off, but reset the chunk size to `StartingChunkSize`.
The sizer regrows at most `MaxDynamicStepFactor` per 11-chunk feedback window, so
that is ~130 chunks back to the ceiling — and then it fires again.

## Fix

- Gate entry on the signal that actually answers the question: keys-per-row over
  a sliding 10-chunk window, built from the row counts already passed to
  `Feedback` (new `pkg/table/keyspace_density.go`). The threshold is *derived*
  from prefetch's own exit test — `MaxDynamicRowSize/StartingChunkSize`, i.e. 100
  keys/row — rather than picked, so entry and exit cannot disagree by
  construction.
- On exit, restore the chunk size prefetch was entered from. Prefetch is only
  ever entered from the ceiling, so that is a size this table has already been
  measured to sustain; if the region past the gap can't, the sizer and
  `panicShrink` bring it down within a window.
- Backstop: two episodes abandoned on their first chunk retire prefetch for the
  rest of the run.
- The three `WARN` lines become two `INFO` lines per transition, and transitions
  are now rare rather than continuous.

One subtlety: density is recorded **before** `Feedback`'s stale-feedback screen.
With dozens of workers in flight most feedback arrives labelled with a superseded
chunk size and is discarded — but a keys/rows pair is a property of the data, not
of the chunk size that happened to be in effect, so screening those out would
leave the window permanently short and prefetch permanently unreachable.

Also fixes a smaller pre-existing mislabel found on the way: a prefetch chunk was
tagged with the chunk size in effect *after* the exit reset rather than the
`OFFSET` that built it, so its feedback was mis-attributed instead of being
screened as stale.

## Measured

Simulating the reported table — dense 1B-key space, 8us/row so a 100k-row chunk
lands at 800ms:

| | chunks to cover 1B keys | avg chunk size | flaps |
|---|---|---|---|
| before | 36,434 | 27,448 | 254 |
| after | 10,105 | 98,973 | 0 |
| ideal | 10,001 | 100,000 | — |

~3.6x fewer chunks, so ~3.6x fewer round trips for the same work.

## Testing

- `TestOptimisticNoPrefetchOnDenseKeySpace` — regression test for the entry
  mis-fire; fails on `main`.
- `TestOptimisticPrefetchRestoresChunkSize` — regression test for the exit reset,
  the chunk labelling, and the rejection backstop.
- `TestKeySpaceDensitySparse` / `TestKeySpaceDensityTotals` — the window itself,
  including that a short window is never treated as sparse and that it slides.
- `TestOptimisticPrefetchChunking` (existing, sparse table) still enters prefetch
  as intended.
- `pkg/table` (also under `-race`), `pkg/copier`, `pkg/checksum`, `pkg/change`,
  `pkg/migration` green; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
