### PR TITLE
dbconn: carry the warning code on a fatal unsafe warning

### DIFF
--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -3,6 +3,7 @@ package copier
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -182,6 +183,14 @@ func TestCopierNullToNotNullConversion(t *testing.T) {
 	require.NoError(t, err)
 	err = copier.Run(t.Context())
 	require.ErrorContains(t, err, "unsafe warning")
+
+	// The warning carries the code that says which condition stopped the copy,
+	// so a caller can tell "a row held NULL in a NOT NULL column" from any
+	// other warning the same branch classifies as fatal.
+	warning, ok := errors.AsType[*dbconn.UnsafeWarningError](err)
+	require.True(t, ok, "copy error does not carry the warning: %v", err)
+	require.Equal(t, uint16(1048), warning.Warning.Number)
+
 	require.Equal(t, 0, db.Stats().InUse) // no connections in use.
 }
 

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -129,6 +129,27 @@ func IsConnectionLossError(err error) bool {
 	}
 }
 
+// UnsafeWarningError reports a warning that MySQL raised on a statement Spirit
+// executed without error, and that Spirit treats as fatal. Statements such as
+// INSERT IGNORE succeed while discarding rows, so the warning is the only
+// signal that the copy would silently lose data.
+//
+// It unwraps to the underlying *mysql.MySQLError, so callers can classify the
+// warning by its code with errors.As or errors.AsType rather than by matching
+// on the message. The code matters because the same fatal branch covers
+// unrelated conditions — a NOT NULL column with no default (1364), a duplicate
+// on a unique key (1062), a value too long for its column (1406) — which a
+// caller may want to report or act on differently.
+type UnsafeWarningError struct {
+	Warning *mysql.MySQLError
+}
+
+func (e *UnsafeWarningError) Error() string {
+	return fmt.Sprintf("unsafe warning %d: %s", e.Warning.Number, e.Warning.Message)
+}
+
+func (e *UnsafeWarningError) Unwrap() error { return e.Warning }
+
 // canRetryError looks at the MySQL error and decides if it is considered
 // a permanent failure or not. For simplicity a "retryable" error means
 // rollback the transaction and start the transaction again.
@@ -274,7 +295,10 @@ func RetryableTransaction(ctx context.Context, db *sql.DB, dupKeyHandling DupKey
 						return
 					default:
 						isFatal = true
-						err = fmt.Errorf("unsafe warning: %s", message)
+						err = &UnsafeWarningError{Warning: &mysql.MySQLError{
+							Number:  uint16(code),
+							Message: message,
+						}}
 						return
 					}
 				}

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -144,11 +144,25 @@ type UnsafeWarningError struct {
 	Warning *mysql.MySQLError
 }
 
+// Error reports the warning and its code. The type is exported, so a caller can
+// hold one without a warning; Error stays callable on that value because the
+// places an error's text is read — logs, %v, a failing test — are the last
+// places a panic is affordable.
 func (e *UnsafeWarningError) Error() string {
+	if e.Warning == nil {
+		return "unsafe warning"
+	}
 	return fmt.Sprintf("unsafe warning %d: %s", e.Warning.Number, e.Warning.Message)
 }
 
-func (e *UnsafeWarningError) Unwrap() error { return e.Warning }
+// Unwrap returns the underlying warning, or nil when the error carries none.
+// A nil return ends the chain, which is what errors.Is and errors.As expect.
+func (e *UnsafeWarningError) Unwrap() error {
+	if e.Warning == nil {
+		return nil
+	}
+	return e.Warning
+}
 
 // canRetryError looks at the MySQL error and decides if it is considered
 // a permanent failure or not. For simplicity a "retryable" error means

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -522,3 +522,43 @@ func TestRangeOptimizerRefusal(t *testing.T) {
 	_, err = RetryableTransaction(t.Context(), db, IgnoreDupKeyWarnings, config, query)
 	require.ErrorContains(t, err, "range_optimizer_max_mem_size")
 }
+
+// An unsafe warning reads as one sentence naming its code, and stays
+// classifiable by that code through errors.As.
+func TestUnsafeWarningError(t *testing.T) {
+	err := &UnsafeWarningError{Warning: &mysql.MySQLError{
+		Number:  1364,
+		Message: "Field 'name' doesn't have a default value",
+	}}
+
+	assert.Equal(t, "unsafe warning 1364: Field 'name' doesn't have a default value", err.Error())
+
+	wrapped := fmt.Errorf("failed to execute upsert: %w", err)
+	warning, ok := errors.AsType[*mysql.MySQLError](wrapped)
+	require.True(t, ok, "the warning code is not recoverable from the error chain")
+	assert.Equal(t, uint16(1364), warning.Number)
+}
+
+// A warning MySQL raises on a statement that itself returned no error still
+// stops the transaction, and carries the code that says why.
+func TestRetryableTransactionUnsafeWarningCarriesCode(t *testing.T) {
+	config := NewDBConfig()
+	db, err := New(testutils.DSN(), config)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	require.NoError(t, Exec(t.Context(), db, "DROP TABLE IF EXISTS test.unsafewarn1"))
+	require.NoError(t, Exec(t.Context(), db,
+		"CREATE TABLE test.unsafewarn1 (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a))"))
+
+	// INSERT IGNORE succeeds while discarding the row, so the warning is the
+	// only signal that the write did not land as asked.
+	_, err = RetryableTransaction(t.Context(), db, IgnoreDupKeyWarnings, config,
+		"INSERT IGNORE INTO test.unsafewarn1 (a, b) VALUES (1, NULL)")
+	require.Error(t, err)
+
+	warning, ok := errors.AsType[*UnsafeWarningError](err)
+	require.True(t, ok, "transaction error does not carry the warning: %v", err)
+	assert.Equal(t, uint16(1048), warning.Warning.Number)
+	assert.Contains(t, err.Error(), "unsafe warning 1048:")
+}

--- a/pkg/dbconn/dbconn_test.go
+++ b/pkg/dbconn/dbconn_test.go
@@ -539,6 +539,19 @@ func TestUnsafeWarningError(t *testing.T) {
 	assert.Equal(t, uint16(1364), warning.Number)
 }
 
+// The type is exported, so a caller can hold one carrying no warning. Reading
+// its text or unwrapping it must not panic, and the empty chain must not
+// present a typed nil as a non-nil error.
+func TestUnsafeWarningErrorWithoutWarning(t *testing.T) {
+	err := &UnsafeWarningError{}
+
+	assert.Equal(t, "unsafe warning", err.Error())
+	require.NoError(t, errors.Unwrap(err))
+
+	_, ok := errors.AsType[*mysql.MySQLError](err)
+	assert.False(t, ok, "an absent warning must not match as a MySQL error")
+}
+
 // A warning MySQL raises on a statement that itself returned no error still
 // stops the transaction, and carries the code that says why.
 func TestRetryableTransactionUnsafeWarningCarriesCode(t *testing.T) {


### PR DESCRIPTION
## Why this matters

`SHOW WARNINGS` returns level, code and message. The fatal branch in `RetryableTransaction` scanned all three, then built its error from the message alone:

```go
err = fmt.Errorf("unsafe warning: %s", message)
```

That branch is a catch-all. It fires for a NOT NULL column with no default (1364), a duplicate on a unique key (1062), a value too long for its column (1406), and anything else MySQL warns about on a statement that itself returned no error. Those mean very different things to a caller, but the code that distinguishes them was in scope and discarded, leaving only a message to match on.

It matters because these warnings are how a copy reports that it would silently lose data — `INSERT IGNORE` succeeds while discarding the row, so the warning is the only signal.

## What it does

Adds `UnsafeWarningError`, which carries the `*mysql.MySQLError` and unwraps to it, so the code is recoverable with `errors.As` / `errors.AsType`:

```
RetryableTransaction
  └─ SHOW WARNINGS → level, code, message
       └─ UnsafeWarningError{Warning: &mysql.MySQLError{Number: code, Message: message}}
            └─ Unwrap() → *mysql.MySQLError    (errors.As finds it)
```

The rendered text gains the code and keeps the prefix:

```
before:  unsafe warning: Column 'c' cannot be null
after:   unsafe warning 1048: Column 'c' cannot be null
```

**Retry behavior is unchanged.** `canRetryError` is only consulted on the `ExecContext` error, before warnings are inspected; the warning branch sets `isFatal` directly and returns. The new unwrap is unreachable from either retry classifier.

**Existing assertions still pass.** Both call sites use `ErrorContains(err, "unsafe warning")`, and the prefix is untouched.

Verified against MySQL 8.0.45: `pkg/dbconn`, `pkg/copier`, `pkg/applier`, `pkg/change` all green, lint clean. The copier test now asserts the recovered code is 1048 rather than just that the copy failed.