### PR TITLE
move: accept a target that is stricter about NULL than its source

### DIFF
--- a/docs/move.md
+++ b/docs/move.md
@@ -139,7 +139,9 @@ A table that already exists on the target is used as-is, provided it is empty an
 
 The reverse of either — a target looser than its source — is still a mismatch and fails pre-flight, as does any other difference (column types, charset, collation, indexes, constraints). The error reports the `ALTER` that would reconcile the target.
 
-A `NOT NULL` target column does not make Move filter or rewrite source rows. If the source data does contain a NULL there, the move fails — at row-hashing time for a sharded target, otherwise at the checksum — rather than silently substituting a value. Confirm the column holds no NULLs before starting a large copy.
+A `NOT NULL` target column does not make Move filter or rewrite source rows. If the source data does contain a NULL there, the move fails rather than silently substituting a value — at row-hashing time for a sharded target, otherwise at the checksum.
+
+Failing at the checksum is correct but slow. The copy writes with `INSERT IGNORE`, which stores the type's implicit default instead of erroring, so the NULL is only detected once the [initial checksum](#two-checksum-model) compares the rows; that checksum repairs and retries up to three times, and every attempt re-copies the chunk, re-coerces the same NULL and finds it again before the run gives up. On a table large enough to be worth moving this way, that is hours of copying and verifying to learn something a single `SELECT 1 FROM <table> WHERE <column> IS NULL LIMIT 1` answers up front. Confirm the column holds no NULLs before starting the copy.
 
 ### threads
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -132,6 +132,15 @@ The in-memory byte budget the buffered copier sizes each copy chunk against. Mov
 
 A Go MySQL DSN for the target database. Tables will be created here automatically from the source schema.
 
+A table that already exists on the target is used as-is, provided it is empty and its schema matches the source. "Matches" permits the target to be *stricter* in two specific ways, so a declaratively-managed target does not have to mirror artifacts of its unsharded source:
+
+- the source's column-level `AUTO_INCREMENT` may be absent on the target (its ids come from elsewhere, e.g. a Vitess sequence);
+- a column the source declares nullable may be `NOT NULL` on the target — for example a shard key, which cannot be NULL in a sharded keyspace.
+
+The reverse of either — a target looser than its source — is still a mismatch and fails pre-flight, as does any other difference (column types, charset, collation, indexes, constraints). The error reports the `ALTER` that would reconcile the target.
+
+A `NOT NULL` target column does not make Move filter or rewrite source rows. If the source data does contain a NULL there, the move fails — at row-hashing time for a sharded target, otherwise at the checksum — rather than silently substituting a value. Confirm the column holds no NULLs before starting a large copy.
+
 ### threads
 
 - Type: Integer

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -1071,6 +1071,29 @@ func (r *Runner) createTargetTables(ctx context.Context) error {
 // would carry column defaults rather than the source's values, so an ALTER on
 // the target alone would not make the copy correct.
 //
+// The comparison is deliberately exact, unlike move's source->target check
+// (move/check.targetSchemaDiff), which forgives a target that drops the
+// source's column-level AUTO_INCREMENT or is stricter about NULL. Neither
+// relaxation transfers, because the two gates guard different states:
+//
+//   - move requires a pre-existing target table to be EMPTY (target_state
+//     rejects one holding any row), so only rows not yet copied are at stake
+//     and its unconditional pre-cutover checksum vets every one of them. This
+//     gate fires on a target that may already be half-copied by an earlier
+//     attempt — the resumable-checkpoint case above — where a divergence can
+//     mean the rows already on the target are wrong, and no schema relaxation
+//     can establish otherwise.
+//   - move's relaxations exist for a sharded Vitess target: ids from a
+//     sequence, and a shard key that cannot be NULL because a primary vindex
+//     has no keyspace id for one. Sync has a single unsharded target and no
+//     cutover, so neither reason arises here.
+//
+// The strictness is therefore a decision, not an oversight: sync copies into a
+// target shaped exactly like its source or it does not copy at all. Revisit it
+// here on its own merits rather than by reaching for move's options — the two
+// paths agreeing about a target should be on purpose, and so should their
+// disagreeing. TestSyncVerifyExistingTargetTableRequiresExactSchema pins it.
+//
 // Regular secondary indexes are excluded from the comparison on both sides.
 // With DeferSecondaryIndexes the target is deliberately created without them,
 // and an attempt that died mid-copy leaves it that way; restoreSecondaryIndexes

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -947,6 +947,61 @@ func TestSyncValidate(t *testing.T) {
 	}
 }
 
+// TestSyncVerifyExistingTargetTableRequiresExactSchema pins sync's deliberate
+// divergence from move: move's source->target check forgives a target that
+// drops the source's column-level AUTO_INCREMENT or is stricter about NULL,
+// because it has already established the target is empty and vets the copy with
+// an unconditional pre-cutover checksum. Sync's gate fires on a target that may
+// be half-copied from an earlier attempt, so it requires an exact match — see
+// verifyExistingTargetTable for the full reasoning. If this is ever relaxed, it
+// should be because someone decided to, not because move's options got reused.
+func TestSyncVerifyExistingTargetTableRequiresExactSchema(t *testing.T) {
+	r := &Runner{target: applier.Target{Config: &mysql.Config{DBName: "sync_dest"}}}
+
+	tests := []struct {
+		name     string
+		source   string
+		target   string
+		wantDiff string // empty means the target must be accepted
+	}{
+		{
+			name:   "identical",
+			source: "CREATE TABLE t1 (id BIGINT PRIMARY KEY, customer_id BIGINT DEFAULT NULL)",
+			target: "CREATE TABLE t1 (id BIGINT PRIMARY KEY, customer_id BIGINT DEFAULT NULL)",
+		},
+		{
+			// Accepted by move — a sharded target's shard key cannot be NULL —
+			// and rejected here.
+			name:     "target stricter about NULL",
+			source:   "CREATE TABLE t1 (id BIGINT PRIMARY KEY, customer_id BIGINT DEFAULT NULL)",
+			target:   "CREATE TABLE t1 (id BIGINT PRIMARY KEY, customer_id BIGINT NOT NULL)",
+			wantDiff: "MODIFY COLUMN `customer_id`",
+		},
+		{
+			// Also accepted by move — a sharded target takes its ids from a
+			// Vitess sequence — and rejected here.
+			name:     "target drops column AUTO_INCREMENT",
+			source:   "CREATE TABLE t1 (id BIGINT PRIMARY KEY AUTO_INCREMENT, val VARCHAR(64) DEFAULT NULL)",
+			target:   "CREATE TABLE t1 (id BIGINT PRIMARY KEY, val VARCHAR(64) DEFAULT NULL)",
+			wantDiff: "MODIFY COLUMN `id`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := r.verifyExistingTargetTable("t1", tt.source, tt.target)
+			if tt.wantDiff == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "schema has diverged from the source")
+			require.Contains(t, err.Error(), tt.wantDiff,
+				"the error must carry the ALTER that reconciles the target")
+		})
+	}
+}
+
 // TestSyncResumeSourceSchemaChanged covers issue #1165: a source DDL that lands
 // between attempts must not be silently copied past. The target table exists
 // from the first run, so createTargetTables does not recreate it; without a

--- a/pkg/move/check/resume_state.go
+++ b/pkg/move/check/resume_state.go
@@ -72,9 +72,11 @@ func resumeStateCheck(ctx context.Context, r Resources, logger *slog.Logger) err
 			// names-only comparison let a target with the same columns but a
 			// different type/charset/collation pass resume validation; on a
 			// resume whose checksum watermark already covers the affected chunk,
-			// that mismatch would never be re-verified. schemaDiff compares
+			// that mismatch would never be re-verified. targetSchemaDiff compares
 			// types, charset, collation, indexes and constraints while ignoring
-			// AUTO_INCREMENT counters and other instance-specific noise.
+			// AUTO_INCREMENT counters and other instance-specific noise. It is
+			// the same comparison target_state ran before the copy, so a move
+			// that was allowed to start does not fail on resume.
 			sourceCreate, err := showCreateTable(ctx, sourceTable.DB(), sourceTable.SchemaName, sourceTable.TableName)
 			if err != nil {
 				return fmt.Errorf("failed to read source schema for table '%s': %w", sourceTable.TableName, err)
@@ -83,7 +85,7 @@ func resumeStateCheck(ctx context.Context, r Resources, logger *slog.Logger) err
 			if err != nil {
 				return fmt.Errorf("failed to read target %d schema for table '%s': %w", i, sourceTable.TableName, err)
 			}
-			diff, err := schemaDiff(sourceTable.TableName, sourceCreate, targetCreate)
+			diff, err := targetSchemaDiff(sourceTable.TableName, sourceCreate, targetCreate)
 			if err != nil {
 				return fmt.Errorf("failed to compare schema for table '%s' on target %d: %w", sourceTable.TableName, i, err)
 			}

--- a/pkg/move/check/schema_compare.go
+++ b/pkg/move/check/schema_compare.go
@@ -36,8 +36,55 @@ func showCreateTable(ctx context.Context, db *sql.DB, schema, table string) (str
 //
 // "want" is treated as the source-of-truth (e.g. sources[0] or the move source);
 // "got" is the schema being validated (another source, or a pre-created target).
+//
+// This is the comparison for two schemas that must be IDENTICAL — today
+// sources[0] against every other source (source_schema_consistency). Use
+// targetSchemaDiff for a source→target comparison, which additionally forgives
+// a target that is deliberately stricter.
 func schemaDiff(table, wantCreate, gotCreate string) (string, error) {
+	return statement.DiffCreateTables(table, wantCreate, gotCreate, moveDiffOptions())
+}
+
+// targetSchemaDiff compares a move's SOURCE table against a pre-created TARGET
+// table, and is the comparison the source→target checks use (target_state,
+// resume_state). It is schemaDiff plus one further relaxation, in one
+// direction only: a target column may be NOT NULL where the source permits
+// NULL.
+//
+// That is what statement.IgnoreNotNullRelaxation does: it lets the schema being
+// validated be stricter than its reference. Here the target is the validated
+// schema, so it must be passed as DiffCreateTables' "got" and the source as
+// "want" — the other way round would forgive the opposite, dangerous direction,
+// which is why the option and the argument order stay together in this one
+// function.
+//
+// A sharded target needs this. A Vitess primary vindex cannot map NULL to a
+// keyspace id, so the target declares its shard key NOT NULL — while the source
+// may still permit NULL because the ALTER to tighten it was never affordable on
+// a multi-terabyte unsharded table. Refusing that move forced operators to
+// choose between a correct target schema and being able to move into it at all.
+//
+// The relaxation cannot mask a NULL that actually exists. On a sharded target
+// the row never reaches an INSERT: the applier hashes the shard key first and a
+// NULL fails there. For any other tightened column the copy runs under
+// spirit's session sql_mode (NO_AUTO_VALUE_ON_ZERO, i.e. non-strict), where a
+// batched INSERT coerces the NULL to the type's implicit default instead of
+// erroring — and the checksum then reports the mismatch, because
+// ColumnMapping.ChecksumExprs compares an explicit ISNULL() digit per column.
+// So the outcome is a failed move, never a silently altered value; callers that
+// want the failure sooner should probe the tightened columns for NULLs before
+// starting the copy.
+func targetSchemaDiff(table, sourceCreate, targetCreate string) (string, error) {
+	diffOpts := moveDiffOptions()
+	diffOpts.IgnoreNotNullRelaxation = true
+	return statement.DiffCreateTables(table, sourceCreate, targetCreate, diffOpts)
+}
+
+// moveDiffOptions returns the diff options every move-tables schema comparison
+// starts from: the package defaults plus move's column-level AUTO_INCREMENT
+// relaxation (see schemaDiff).
+func moveDiffOptions() *statement.DiffOptions {
 	diffOpts := statement.NewDiffOptions()
 	diffOpts.IgnoreColumnAutoIncrement = true
-	return statement.DiffCreateTables(table, wantCreate, gotCreate, diffOpts)
+	return diffOpts
 }

--- a/pkg/move/check/schema_compare.go
+++ b/pkg/move/check/schema_compare.go
@@ -66,13 +66,20 @@ func schemaDiff(table, wantCreate, gotCreate string) (string, error) {
 //
 // The relaxation cannot mask a NULL that actually exists. On a sharded target
 // the row never reaches an INSERT: the applier hashes the shard key first and a
-// NULL fails there. For any other tightened column the copy runs under
-// spirit's session sql_mode (NO_AUTO_VALUE_ON_ZERO, i.e. non-strict), where a
-// batched INSERT coerces the NULL to the type's implicit default instead of
-// erroring — and the checksum then reports the mismatch, because
-// ColumnMapping.ChecksumExprs compares an explicit ISNULL() digit per column.
-// So the outcome is a failed move, never a silently altered value; callers that
-// want the failure sooner should probe the tightened columns for NULLs before
+// NULL fails there. For any other tightened column, both copy paths write with
+// INSERT IGNORE (the copier's INSERT IGNORE ... SELECT, the applier's
+// INSERT IGNORE ... VALUES), and IGNORE downgrades the would-be
+// ER_BAD_NULL_ERROR to a warning and stores the type's implicit default
+// instead — regardless of row count, so this does not depend on batching. The
+// checksum then reports the mismatch, because ColumnMapping.ChecksumExprs
+// compares an explicit ISNULL() digit per column, which differs even for a
+// VARCHAR NOT NULL whose implicit default is the empty string.
+//
+// So the outcome is a failed move, never a silently altered value — but it is
+// an expensive failure: the initial checker runs with FixDifferences and three
+// retries, so each attempt re-copies the chunk, re-coerces the NULL, and finds
+// it again before the run gives up. Callers that want the failure in seconds
+// rather than hours should probe the tightened columns for NULLs before
 // starting the copy.
 func targetSchemaDiff(table, sourceCreate, targetCreate string) (string, error) {
 	diffOpts := moveDiffOptions()

--- a/pkg/move/check/schema_compare_test.go
+++ b/pkg/move/check/schema_compare_test.go
@@ -7,13 +7,16 @@ import (
 )
 
 // TestSchemaDiffIgnoresColumnAutoIncrement locks in the behavior that the
-// move-tables schema comparison treats a column-level AUTO_INCREMENT
+// move-tables schema comparisons treat a column-level AUTO_INCREMENT
 // difference as equivalent. This is the unsharded-source → sharded-target
 // case: the source carries AUTO_INCREMENT on its primary key, while the
 // sharded target intentionally drops it in favor of a Vitess sequence. That
 // difference does not affect copy correctness and must not block the move
 // (target_state / resume_state checks), which previously reported a spurious
 // "schema does not match source" mismatch.
+//
+// The relaxation lives in the shared base options, so it holds for both the
+// source↔source and the source→target comparison.
 func TestSchemaDiffIgnoresColumnAutoIncrement(t *testing.T) {
 	source := "CREATE TABLE `corder` (\n" +
 		"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
@@ -29,6 +32,102 @@ func TestSchemaDiffIgnoresColumnAutoIncrement(t *testing.T) {
 	diff, err := schemaDiff("corder", source, target)
 	require.NoError(t, err)
 	require.Empty(t, diff, "a column-level AUTO_INCREMENT difference must not be reported as a schema mismatch")
+
+	diff, err = targetSchemaDiff("corder", source, target)
+	require.NoError(t, err)
+	require.Empty(t, diff, "the source→target comparison must ignore column AUTO_INCREMENT too")
+}
+
+// TestTargetSchemaDiffIgnoresNotNullOnTarget covers the other way a sharded
+// target is deliberately stricter than its unsharded source: the shard key is
+// NOT NULL on the target because a Vitess primary vindex cannot map NULL to a
+// keyspace id, while the source still permits NULL because the ALTER to
+// tighten it was never affordable on a multi-terabyte table. The move must be
+// allowed to proceed into that target.
+func TestTargetSchemaDiffIgnoresNotNullOnTarget(t *testing.T) {
+	source := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+		"  `customer_id` bigint DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+	target := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` bigint NOT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+
+	diff, err := targetSchemaDiff("corder", source, target)
+	require.NoError(t, err)
+	require.Empty(t, diff, "a target that tightens a nullable source column must not be reported as a mismatch")
+}
+
+// TestTargetSchemaDiffRejectsNullableTarget pins the direction. Forgiving a
+// stricter target must not become forgiving a weaker one: a target that lost a
+// NOT NULL the source had can accept rows the source never could, and that is
+// a real mismatch the check has to keep reporting.
+func TestTargetSchemaDiffRejectsNullableTarget(t *testing.T) {
+	source := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` bigint NOT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+	target := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` bigint DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+
+	diff, err := targetSchemaDiff("corder", source, target)
+	require.NoError(t, err)
+	require.NotEmpty(t, diff, "a target that drops a NOT NULL the source had must still be reported")
+	require.Contains(t, diff, "customer_id", "the reported diff should name the mismatched column")
+}
+
+// TestSchemaDiffRejectsNullabilityBetweenSources keeps the nullability
+// relaxation out of the source↔source comparison. Sources of one move must be
+// identical — tolerating a tightening there would make the verdict depend on
+// which source happened to sort first, and would let genuine drift between
+// shards pass as expected divergence.
+func TestSchemaDiffRejectsNullabilityBetweenSources(t *testing.T) {
+	nullable := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` bigint DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+	notNull := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` bigint NOT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+
+	diff, err := schemaDiff("corder", nullable, notNull)
+	require.NoError(t, err)
+	require.NotEmpty(t, diff, "nullability drift between sources must be reported")
+
+	diff, err = schemaDiff("corder", notNull, nullable)
+	require.NoError(t, err)
+	require.NotEmpty(t, diff, "nullability drift between sources must be reported in either order")
+}
+
+// TestTargetSchemaDiffNarrowNotNullRelaxation ensures the nullability
+// relaxation cannot smuggle anything else past the check: a tightened column
+// that also changes type is still a mismatch.
+func TestTargetSchemaDiffNarrowNotNullRelaxation(t *testing.T) {
+	source := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` bigint DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+	target := "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL,\n" +
+		"  `customer_id` int NOT NULL,\n" +
+		"  PRIMARY KEY (`order_id`)\n" +
+		") ENGINE=InnoDB"
+
+	diff, err := targetSchemaDiff("corder", source, target)
+	require.NoError(t, err)
+	require.NotEmpty(t, diff, "a type change on a tightened column must still be reported")
+	require.Contains(t, diff, "customer_id", "the reported diff should name the mismatched column")
 }
 
 // TestSchemaDiffDetectsRealMismatch ensures the AUTO_INCREMENT relaxation is

--- a/pkg/move/check/target_state.go
+++ b/pkg/move/check/target_state.go
@@ -100,9 +100,11 @@ func validateExistingTargetTable(ctx context.Context, target applier.Target, tab
 	// source utf8mb4_bin vs target utf8mb4_0900_ai_ci): REPLACE/INSERT IGNORE
 	// would then collapse rows that differ only by case, and the mismatch would
 	// surface only much later at checksum time (or never, on a resume whose
-	// watermark already covers the affected chunk). schemaDiff compares column
-	// types, charset, collation, indexes and constraints while ignoring
-	// instance-specific noise like AUTO_INCREMENT counters.
+	// watermark already covers the affected chunk). targetSchemaDiff compares
+	// column types, charset, collation, indexes and constraints while ignoring
+	// instance-specific noise like AUTO_INCREMENT counters, and forgiving the
+	// ways a sharded target is deliberately stricter than its unsharded source
+	// (no column-level AUTO_INCREMENT, a NOT NULL shard key).
 	sourceCreate, err := showCreateTable(ctx, sourceTable.DB(), sourceTable.SchemaName, sourceTable.TableName)
 	if err != nil {
 		return fmt.Errorf("failed to read source schema for table '%s': %w", tableName, err)
@@ -111,7 +113,7 @@ func validateExistingTargetTable(ctx context.Context, target applier.Target, tab
 	if err != nil {
 		return fmt.Errorf("failed to read target %d schema for table '%s': %w", targetIndex, tableName, err)
 	}
-	diff, err := schemaDiff(tableName, sourceCreate, targetCreate)
+	diff, err := targetSchemaDiff(tableName, sourceCreate, targetCreate)
 	if err != nil {
 		return fmt.Errorf("failed to compare schema for table '%s' on target %d: %w", tableName, targetIndex, err)
 	}

--- a/pkg/move/check/target_state_test.go
+++ b/pkg/move/check/target_state_test.go
@@ -204,3 +204,84 @@ func TestTargetStateCheckSchemaTypesAndCollation(t *testing.T) {
 		require.Contains(t, err.Error(), "name")
 	})
 }
+
+// TestTargetStateCheckNotNullShardKey covers the deliberately-stricter target:
+// a sharded target declares its shard key NOT NULL (a Vitess primary vindex
+// cannot map NULL to a keyspace id) while the unsharded source still permits
+// NULL, because the ALTER to tighten it was never affordable on a
+// multi-terabyte table. Pre-flight must accept that target, and must still
+// reject the opposite direction.
+//
+// This runs against real SHOW CREATE TABLE output on purpose: MySQL renders a
+// nullable column as `DEFAULT NULL`, so the comparison has to recognize the
+// rendered default as "no default" on the nullable side alone — a unit test on
+// hand-written DDL can miss that.
+func TestTargetStateCheckNotNullShardKey(t *testing.T) {
+	srcName, srcDB := createW3DDatabase(t)
+	tgtName, tgtDB := createW3DDatabase(t)
+	targetConfig := &mysql.Config{DBName: tgtName}
+
+	// The source's shard key is nullable and carries AUTO_INCREMENT on its PK:
+	// the two ways a sharded target legitimately diverges from it.
+	_, err := srcDB.ExecContext(t.Context(),
+		fmt.Sprintf("CREATE TABLE %s.corder (order_id BIGINT NOT NULL AUTO_INCREMENT, customer_id BIGINT, PRIMARY KEY (order_id))", srcName))
+	require.NoError(t, err)
+	sourceTable := table.NewTableInfo(srcDB, srcName, "corder")
+	require.NoError(t, sourceTable.SetInfo(t.Context()))
+
+	newResources := func() Resources {
+		return Resources{
+			Sources:      []SourceResource{{DB: srcDB, Config: &mysql.Config{DBName: srcName}}},
+			Targets:      []applier.Target{{DB: tgtDB, Config: targetConfig}},
+			SourceTables: []*table.TableInfo{sourceTable},
+		}
+	}
+
+	t.Run("stricter target passes", func(t *testing.T) {
+		_, err := tgtDB.ExecContext(t.Context(),
+			fmt.Sprintf("CREATE TABLE %s.corder (order_id BIGINT NOT NULL, customer_id BIGINT NOT NULL, PRIMARY KEY (order_id))", tgtName))
+		require.NoError(t, err)
+		defer func() { _, _ = tgtDB.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s.corder", tgtName)) }()
+		require.NoError(t, targetStateCheck(t.Context(), newResources(), slog.Default()),
+			"a target that tightens a nullable shard key must not block the move")
+	})
+
+	t.Run("stricter target with a real type change still fails", func(t *testing.T) {
+		_, err := tgtDB.ExecContext(t.Context(),
+			fmt.Sprintf("CREATE TABLE %s.corder (order_id BIGINT NOT NULL, customer_id INT NOT NULL, PRIMARY KEY (order_id))", tgtName))
+		require.NoError(t, err)
+		defer func() { _, _ = tgtDB.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s.corder", tgtName)) }()
+		err = targetStateCheck(t.Context(), newResources(), slog.Default())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "schema does not match")
+		require.Contains(t, err.Error(), "customer_id")
+	})
+}
+
+// TestTargetStateCheckRejectsNullableTargetColumn pins the direction of the
+// nullability relaxation from the other side: a target that permits NULL where
+// the SOURCE is NOT NULL can accept rows the source never could, so it stays a
+// pre-flight failure.
+func TestTargetStateCheckRejectsNullableTargetColumn(t *testing.T) {
+	srcName, srcDB := createW3DDatabase(t)
+	tgtName, tgtDB := createW3DDatabase(t)
+
+	_, err := srcDB.ExecContext(t.Context(),
+		fmt.Sprintf("CREATE TABLE %s.corder (order_id BIGINT NOT NULL, customer_id BIGINT NOT NULL, PRIMARY KEY (order_id))", srcName))
+	require.NoError(t, err)
+	sourceTable := table.NewTableInfo(srcDB, srcName, "corder")
+	require.NoError(t, sourceTable.SetInfo(t.Context()))
+
+	_, err = tgtDB.ExecContext(t.Context(),
+		fmt.Sprintf("CREATE TABLE %s.corder (order_id BIGINT NOT NULL, customer_id BIGINT, PRIMARY KEY (order_id))", tgtName))
+	require.NoError(t, err)
+
+	err = targetStateCheck(t.Context(), Resources{
+		Sources:      []SourceResource{{DB: srcDB, Config: &mysql.Config{DBName: srcName}}},
+		Targets:      []applier.Target{{DB: tgtDB, Config: &mysql.Config{DBName: tgtName}}},
+		SourceTables: []*table.TableInfo{sourceTable},
+	}, slog.Default())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema does not match")
+	require.Contains(t, err.Error(), "customer_id")
+}

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -27,6 +27,38 @@ type DiffOptions struct {
 	// affect copy correctness and must not block the move.
 	IgnoreColumnAutoIncrement bool
 
+	// IgnoreNotNullRelaxation lets the schema being validated be STRICTER than
+	// its reference on nullability, and only stricter: a validated column
+	// declared NOT NULL where the reference permits NULL is accepted, while one
+	// that permits NULL where the reference is NOT NULL remains a real
+	// difference. The option therefore can never quietly accept a schema that
+	// lost a NOT NULL the reference had.
+	//
+	// Default: false (via NewDiffOptions) — for general schema diffing a column
+	// gaining or losing NOT NULL is a real change.
+	//
+	// It is enabled by the move-tables target checks (see
+	// move/check.targetSchemaDiff), where the reference is the move's SOURCE and
+	// the validated schema is its physical TARGET. What that permits is a target
+	// column declared NOT NULL where the source still permits NULL — an
+	// unsharded source moving into a sharded target whose shard key must be
+	// NOT NULL, because a Vitess primary vindex cannot map NULL to a keyspace
+	// id.
+	//
+	// In terms of Diff's own arguments the reference is the parameter and the
+	// validated schema is the receiver, because DiffCreateTables diffs
+	// got->want. Stating the direction that way inverts it, which is why the
+	// wording above and TestDiff_IgnoreNotNullRelaxation both name the two
+	// schemas by role instead.
+	//
+	// That is safe for a move because nullability is metadata, not row bytes:
+	// the copy and the checksum compare values, and every column's NULL-ness is
+	// compared explicitly (see ColumnMapping.ChecksumExprs, which emits an
+	// ISNULL() digit per column). A tightened column whose source data holds no
+	// NULLs is therefore identical on both sides, and one that does hold a NULL
+	// is reported as a mismatch rather than hidden by this option.
+	IgnoreNotNullRelaxation bool
+
 	// IgnoreEngine skips diffing the ENGINE table option.
 	// Default: true (via NewDiffOptions).
 	IgnoreEngine bool
@@ -52,6 +84,7 @@ func NewDiffOptions() *DiffOptions {
 	return &DiffOptions{
 		IgnoreAutoIncrement:       true,
 		IgnoreColumnAutoIncrement: false,
+		IgnoreNotNullRelaxation:   false,
 		IgnoreEngine:              true,
 		IgnoreCharsetCollation:    false,
 		IgnorePartitioning:        false,
@@ -684,8 +717,22 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	if !ptrEqual(a.Zerofill, b.Zerofill) {
 		return false
 	}
+	// A nullability difference is normally a real change. With
+	// IgnoreNotNullRelaxation it is forgiven in exactly one direction: `a` is
+	// NOT NULL and `b` permits NULL, so the only thing the MODIFY would do is
+	// weaken the column (the same NOT NULL -> NULL relaxation diffColumns
+	// already suppresses for a dropped primary key). The opposite direction —
+	// a difference the MODIFY would need to *tighten* — stays a real change.
+	//
+	// `a` belongs to the receiver and `b` to the diffed-to table, which for a
+	// DiffCreateTables caller means `a` is the schema under validation and `b`
+	// the reference: this forgives a validated schema that is stricter, which
+	// is the direction the option documents.
 	if a.Nullable != b.Nullable {
-		return false
+		forgivenRelaxation := opts.IgnoreNotNullRelaxation && !a.Nullable && b.Nullable
+		if !forgivenRelaxation {
+			return false
+		}
 	}
 	// Normalize default values for nullable columns:
 	// For nullable columns, nil and the NULL *keyword* are semantically
@@ -693,15 +740,22 @@ func (ct *CreateTable) columnsEqualWithContext(a, b *Column, target *CreateTable
 	// `VARCHAR(255) DEFAULT NULL`. A quoted string literal 'NULL'
 	// (DefaultIsString) is NOT the keyword and must not collapse — it is a
 	// real default that differs from no-default.
+	//
+	// Each side is normalized on its OWN nullability. Until
+	// IgnoreNotNullRelaxation existed the two were always equal here (the check
+	// above returned early otherwise), so this is the same normalization as
+	// before for every other comparison. It matters for a forgiven relaxation:
+	// there the nullable side renders `DEFAULT NULL` while the NOT NULL side
+	// carries no default, and gating on one side's nullability alone would
+	// report that as a default difference — reintroducing the very MODIFY the
+	// option exists to suppress.
 	sourceDefault := a.Default
 	targetDefault := b.Default
-	if a.Nullable {
-		if sourceDefault != nil && *sourceDefault == "NULL" && !a.DefaultIsString {
-			sourceDefault = nil
-		}
-		if targetDefault != nil && *targetDefault == "NULL" && !b.DefaultIsString {
-			targetDefault = nil
-		}
+	if a.Nullable && sourceDefault != nil && *sourceDefault == "NULL" && !a.DefaultIsString {
+		sourceDefault = nil
+	}
+	if b.Nullable && targetDefault != nil && *targetDefault == "NULL" && !b.DefaultIsString {
+		targetDefault = nil
 	}
 	if !ptrEqual(sourceDefault, targetDefault) {
 		return false

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -254,6 +254,11 @@ func (ct *CreateTable) diffColumns(target *CreateTable, opts *DiffOptions) []str
 			// belonged to (a PK column is NOT NULL; once the PK is gone the
 			// target can declare it NULL). The PK drop itself is emitted by
 			// diffIndexes.
+			//
+			// This is the same predicate IgnoreNotNullRelaxation applies in
+			// columnsEqualWithContext, gated on PK membership rather than on
+			// the option — so with that option on, this case is subsumed.
+			// Change one and check the other.
 			lower := strings.ToLower(targetCol.Name)
 			pkDroppedNullabilityChange := sourcePKColumns[lower] && !targetPKColumns[lower] &&
 				!sourceCol.Nullable && targetCol.Nullable

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -1643,6 +1643,21 @@ func TestDiff_DiffOptions(t *testing.T) {
 			expected: "ALTER TABLE `t1` MODIFY COLUMN `b` varchar(100) NULL",
 		},
 
+		// IgnoreNotNullRelaxation is covered by
+		// TestDiff_IgnoreNotNullRelaxation instead of here. It is the one
+		// directional option, and this table's "source"/"target" fields are
+		// Diff's receiver and parameter — the opposite order to the reference
+		// and validated schemas every consumer passes to DiffCreateTables — so
+		// stating its direction in these names would read backwards. The
+		// dedicated test asserts it in the orientation consumers see.
+		{
+			name:     "DefaultDetectsNullability",
+			source:   "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NOT NULL)",
+			target:   "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NULL)",
+			opts:     nil, // nil uses NewDiffOptions(): IgnoreNotNullRelaxation=false
+			expected: "ALTER TABLE `t1` MODIFY COLUMN `customer_id` bigint NULL",
+		},
+
 		// IgnoreCharsetCollation
 		{
 			name:     "IgnoreCharsetCollation_Charset",
@@ -1764,6 +1779,114 @@ func TestDiff_DiffOptions(t *testing.T) {
 				require.Len(t, stmts, 1)
 				require.Equal(t, tt.expected, stmts[0].Statement)
 			}
+		})
+	}
+}
+
+// TestDiff_IgnoreNotNullRelaxation covers the one directional DiffOption, and
+// deliberately drives it through DiffCreateTables rather than Diff, because
+// only that orientation reads the way consumers use it.
+//
+// Diff compares got->want (DiffCreateTables calls got.Diff(want, opts)), so the
+// receiver is the schema being validated and the parameter is the reference it
+// is validated against. Naming a direction in terms of Diff's own arguments
+// therefore inverts it. Here "reference" and "validated" are named for their
+// roles, and move-tables' use of them is spelled out per case: the reference is
+// the move SOURCE, the validated schema is the physical TARGET, and the rule
+// being asserted is that a target may be *stricter* than its source (NOT NULL
+// where the source permits NULL) but never looser. See
+// move/check.targetSchemaDiff.
+func TestDiff_IgnoreNotNullRelaxation(t *testing.T) {
+	tests := []struct {
+		name string
+		// reference is the source of truth — the move's SOURCE table.
+		reference string
+		// validated is the schema checked against it — the move's TARGET.
+		validated string
+		relax     bool
+		// expected is the ALTER that would turn validated into reference,
+		// i.e. what a consumer reports as a mismatch. Empty means the two are
+		// equivalent and the check passes.
+		expected string
+	}{
+		{
+			// Without the option a stricter target is a mismatch, which is why
+			// the option has to exist for a sharded move at all.
+			name:      "DefaultRejectsStricterTarget",
+			reference: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NULL)",
+			validated: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NOT NULL)",
+			relax:     false,
+			expected:  "ALTER TABLE `t1` MODIFY COLUMN `customer_id` bigint NULL",
+		},
+		{
+			// The move-tables case: the source column still permits NULL, the
+			// sharded target declares NOT NULL because a primary vindex cannot
+			// map NULL to a keyspace id. Accepted.
+			name:      "StricterTargetAccepted",
+			reference: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NULL)",
+			validated: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NOT NULL)",
+			relax:     true,
+			expected:  "",
+		},
+		{
+			// Same case in the form SHOW CREATE TABLE actually reports a
+			// nullable column, which is what the move checks feed in: the
+			// rendered `DEFAULT NULL` must not read as a default difference
+			// against the NOT NULL side's absent default.
+			name:      "StricterTargetAccepted_SourceRendersDefaultNull",
+			reference: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT DEFAULT NULL)",
+			validated: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NOT NULL)",
+			relax:     true,
+			expected:  "",
+		},
+		{
+			// The direction that matters for safety: a target that LOST a
+			// NOT NULL its source had is still a mismatch, so the option can
+			// never quietly accept a looser target.
+			name:      "LooserTargetStillRejected",
+			reference: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NOT NULL)",
+			validated: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NULL)",
+			relax:     true,
+			expected:  "ALTER TABLE `t1` MODIFY COLUMN `customer_id` bigint NOT NULL",
+		},
+		{
+			// Forgiving one column's nullability does not stop the diff
+			// reporting a different column's change.
+			name:      "OtherColumnChangesStillDetected",
+			reference: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NULL, b INT)",
+			validated: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NOT NULL, b VARCHAR(100))",
+			relax:     true,
+			expected:  "ALTER TABLE `t1` MODIFY COLUMN `b` int NULL",
+		},
+		{
+			// The relaxation is scoped to nullability alone: a column that also
+			// changes type is still reported, so the option cannot smuggle a
+			// type change past a consumer's check.
+			name:      "TypeChangeStillDetected",
+			reference: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NULL)",
+			validated: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id INT NOT NULL)",
+			relax:     true,
+			expected:  "ALTER TABLE `t1` MODIFY COLUMN `customer_id` bigint NULL",
+		},
+		{
+			// Only the bare NULL keyword collapses to "no default", so a real
+			// default the target lacks is still reported.
+			name:      "ExplicitDefaultStillDetected",
+			reference: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NULL DEFAULT '0')",
+			validated: "CREATE TABLE t1 (id INT PRIMARY KEY, customer_id BIGINT NOT NULL)",
+			relax:     true,
+			expected:  "ALTER TABLE `t1` MODIFY COLUMN `customer_id` bigint NULL DEFAULT '0'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewDiffOptions()
+			opts.IgnoreNotNullRelaxation = tt.relax
+
+			diff, err := DiffCreateTables("t1", tt.reference, tt.validated, opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, diff)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

A pre-created target table has to match the move source exactly, with one existing exception: the column-level `AUTO_INCREMENT` attribute, which a sharded target legitimately drops in favor of a Vitess sequence.

The shard key needs the same treatment for the opposite attribute. A Vitess primary vindex cannot map NULL to a keyspace id, so a sharded target declares its shard key `NOT NULL` — while the source may still permit NULL, because the `ALTER` to tighten it was never affordable on a multi-terabyte unsharded table. Pre-flight refused that pairing:

```
table 'corder' exists on target 0 (dest) but schema does not match source;
reconcile the target to the source with: ALTER TABLE `corder`
MODIFY COLUMN `customer_id` bigint NULL DEFAULT NULL
```

That leaves an operator choosing between a correct target schema and being able to move into it at all.

## Change

`statement.DiffOptions.IgnoreNotNullRelaxation` skips a nullability difference in exactly one direction: when the emitted `MODIFY COLUMN` would only **weaken** the constraint. A difference the `MODIFY` would have to tighten stays a real change, so the option can never quietly accept a schema that lost a `NOT NULL` the reference had. Default false; general schema diffing is unchanged.

Tightening is safe for a move because nullability is metadata, not row bytes. The copy and the checksum compare values, and every column's NULL-ness is compared explicitly — `ColumnMapping.ChecksumExprs` emits an `ISNULL()` digit per column — so a tightened column whose source holds no NULLs is identical on both sides, and one that *does* hold a NULL is reported rather than hidden.

### Two supporting changes

**Split the comparison in two.** `schemaDiff` kept its strict semantics and now serves only source↔source (`source_schema_consistency`); the new `targetSchemaDiff` sets the option and serves the source→target checks (`target_state` and `resume_state`, so a move allowed to start does not fail on resume). Sources of one move must be identical — tolerating a tightening there would make the verdict depend on which source sorted first.

**Normalize each side's `DEFAULT NULL` on its own nullability.** The normalization was gated on one side's, which was equivalent while unequal nullability returned early. But a forgiven relaxation compares a nullable side rendering `DEFAULT NULL` against a `NOT NULL` side carrying no default, and reported that as a *default* difference — reintroducing the very `MODIFY` the option suppresses. Verified load-bearing: reverting just that hunk fails the new integration test with `MODIFY COLUMN customer_id bigint NULL DEFAULT NULL`.

## On the naming

The option is named in the differ's own vocabulary rather than after the move's target, because `DiffCreateTables` diffs `got->want`: inside `pkg/statement` the move's *target* is the receiver and the parameter literally named `target` is the move's *source*. A flag called `IgnoreNotNullOnTarget` would read backwards in the file that implements it. The move's "target" vocabulary lives in the consumer, `targetSchemaDiff`, where it is correct — and its doc comment pins the orientation so the arguments cannot be swapped without forgiving the dangerous direction.

## What this does NOT do

It does not create the constraint. A target table that does not exist yet is still created from the source's `SHOW CREATE TABLE` verbatim, so an absent target yields a nullable column and no error — the constraint has to come from whoever authors the target schema.

It also does not filter or rewrite rows. If the source data does contain a NULL in a tightened column, the move fails rather than substituting a value: at row-hashing time for a sharded target (the applier hashes the shard key before any INSERT), otherwise at the checksum, since the copy runs under spirit's non-strict session `sql_mode` where a batched INSERT would coerce the NULL to the type's implicit default. The outcome is a failed move, never a silently altered value — but the checksum is a late place to learn it, so a caller wanting a fast failure should probe the tightened columns for NULLs before starting the copy. `docs/move.md` says so.

## Tests

- `pkg/statement`: 7 cases on `TestDiff_DiffOptions` covering both directions, the `DEFAULT NULL` rendering, and that a type change or an explicit default on a forgiven column is still reported.
- `pkg/move/check`: unit coverage that `targetSchemaDiff` forgives a stricter target while `schemaDiff` still rejects nullability drift between sources in either order, plus three integration tests against real `SHOW CREATE TABLE` output — which is where the rendered `DEFAULT NULL` bites, and a hand-written-DDL unit test misses it.
- The directional guards fail without the change, so they are not tautologies.
- `./pkg/statement/... ./pkg/move/... ./pkg/migration/... ./pkg/table/...` pass; `golangci-lint` clean.

Filed without a prior issue against the template's suggestion — happy to open one if you'd like the discussion there. The consumer is strata's `keyspace move-tables`, which will pin this and then surface the accepted divergences in its own pre-move preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
