### PR TITLE
move/check: export TargetSchemaDiff

### DIFF
--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -1072,7 +1072,7 @@ func (r *Runner) createTargetTables(ctx context.Context) error {
 // the target alone would not make the copy correct.
 //
 // The comparison is deliberately exact, unlike move's source->target check
-// (move/check.targetSchemaDiff), which forgives a target that drops the
+// (move/check.TargetSchemaDiff), which forgives a target that drops the
 // source's column-level AUTO_INCREMENT or is stricter about NULL. Neither
 // relaxation transfers, because the two gates guard different states:
 //

--- a/pkg/move/check/resume_state.go
+++ b/pkg/move/check/resume_state.go
@@ -72,7 +72,7 @@ func resumeStateCheck(ctx context.Context, r Resources, logger *slog.Logger) err
 			// names-only comparison let a target with the same columns but a
 			// different type/charset/collation pass resume validation; on a
 			// resume whose checksum watermark already covers the affected chunk,
-			// that mismatch would never be re-verified. targetSchemaDiff compares
+			// that mismatch would never be re-verified. TargetSchemaDiff compares
 			// types, charset, collation, indexes and constraints while ignoring
 			// AUTO_INCREMENT counters and other instance-specific noise. It is
 			// the same comparison target_state ran before the copy, so a move
@@ -85,7 +85,7 @@ func resumeStateCheck(ctx context.Context, r Resources, logger *slog.Logger) err
 			if err != nil {
 				return fmt.Errorf("failed to read target %d schema for table '%s': %w", i, sourceTable.TableName, err)
 			}
-			diff, err := targetSchemaDiff(sourceTable.TableName, sourceCreate, targetCreate)
+			diff, err := TargetSchemaDiff(sourceTable.TableName, sourceCreate, targetCreate)
 			if err != nil {
 				return fmt.Errorf("failed to compare schema for table '%s' on target %d: %w", sourceTable.TableName, i, err)
 			}

--- a/pkg/move/check/schema_compare.go
+++ b/pkg/move/check/schema_compare.go
@@ -39,30 +39,47 @@ func showCreateTable(ctx context.Context, db *sql.DB, schema, table string) (str
 //
 // This is the comparison for two schemas that must be IDENTICAL — today
 // sources[0] against every other source (source_schema_consistency). Use
-// targetSchemaDiff for a source→target comparison, which additionally forgives
+// TargetSchemaDiff for a source→target comparison, which additionally forgives
 // a target that is deliberately stricter.
 func schemaDiff(table, wantCreate, gotCreate string) (string, error) {
 	return statement.DiffCreateTables(table, wantCreate, gotCreate, moveDiffOptions())
 }
 
-// targetSchemaDiff compares a move's SOURCE table against a pre-created TARGET
-// table, and is the comparison the source→target checks use (target_state,
-// resume_state). It is schemaDiff plus one further relaxation, in one
-// direction only: a target column may be NOT NULL where the source permits
-// NULL.
+// TargetSchemaDiff compares a move's SOURCE table against a pre-created TARGET
+// table and returns a runnable ALTER TABLE statement describing how they differ,
+// or an empty string if the move will accept the target as it stands. It is the
+// comparison the source→target checks use (target_state, resume_state).
 //
-// That is what statement.IgnoreNotNullRelaxation does: it lets the schema being
-// validated be stricter than its reference. Here the target is the validated
-// schema, so it must be passed as DiffCreateTables' "got" and the source as
-// "want" — the other way round would forgive the opposite, dangerous direction,
-// which is why the option and the argument order stay together in this one
-// function.
+// Two divergences are tolerated, and only these two. Both are a target that is
+// deliberately stricter or leaner than the unsharded source it moves from, so
+// that a declaratively-managed target does not have to mirror artifacts of its
+// source:
 //
-// A sharded target needs this. A Vitess primary vindex cannot map NULL to a
-// keyspace id, so the target declares its shard key NOT NULL — while the source
-// may still permit NULL because the ALTER to tighten it was never affordable on
-// a multi-terabyte unsharded table. Refusing that move forced operators to
-// choose between a correct target schema and being able to move into it at all.
+//   - the source's column-level AUTO_INCREMENT may be absent on the target,
+//     whose ids come from elsewhere (e.g. a Vitess sequence);
+//   - a column the source declares nullable may be NOT NULL on the target — a
+//     shard key, typically, which cannot be NULL in a sharded keyspace.
+//
+// Anything else is a difference, the reverse of either included: a target looser
+// than its source fails, as does any change to types, charset, collation,
+// indexes or constraints. See statement.DiffCreateTables for the
+// canonicalization rules underneath.
+//
+// It is exported because "which divergences does a move tolerate" must have
+// exactly one definition. A caller that wants to know in advance whether a move
+// will accept a given target — strata's `keyspace move-tables` previews it
+// before the operator confirms anything — would otherwise reassemble the option
+// set by hand, and drift in either direction is a bug: the caller blocks a move
+// that would have succeeded, or promises one that fails here in pre-flight.
+// Adding to or removing from the tolerated set is therefore a change in public
+// behaviour, not an internal one.
+//
+// The nullability tolerance exists because refusing it forced a choice. A
+// Vitess primary vindex cannot map NULL to a keyspace id, so a sharded target
+// must declare its shard key NOT NULL — while the source may still permit NULL
+// because the ALTER to tighten it was never affordable on a multi-terabyte
+// unsharded table. Without this, an operator had to pick between a correct
+// target schema and being able to move into it at all.
 //
 // The relaxation cannot mask a NULL that actually exists. On a sharded target
 // the row never reaches an INSERT: the applier hashes the shard key first and a
@@ -81,7 +98,17 @@ func schemaDiff(table, wantCreate, gotCreate string) (string, error) {
 // it again before the run gives up. Callers that want the failure in seconds
 // rather than hours should probe the tightened columns for NULLs before
 // starting the copy.
-func targetSchemaDiff(table, sourceCreate, targetCreate string) (string, error) {
+//
+// One note for maintainers: what is exported is this function and not the
+// options it builds, deliberately. The nullability tolerance is directional —
+// statement.IgnoreNotNullRelaxation lets the schema being *validated* be
+// stricter than its *reference*, and here the target is the validated schema, so
+// it must reach DiffCreateTables as "got" with the source as "want". Handing a
+// caller the options would hand them that trap: passed the other way round they
+// forgive the opposite, dangerous direction, silently and with no diff to show
+// for it. The parameter names below are what prevents that, which is why the
+// option and the argument order never leave this function.
+func TargetSchemaDiff(table, sourceCreate, targetCreate string) (string, error) {
 	diffOpts := moveDiffOptions()
 	diffOpts.IgnoreNotNullRelaxation = true
 	return statement.DiffCreateTables(table, sourceCreate, targetCreate, diffOpts)

--- a/pkg/move/check/schema_compare_test.go
+++ b/pkg/move/check/schema_compare_test.go
@@ -33,7 +33,7 @@ func TestSchemaDiffIgnoresColumnAutoIncrement(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diff, "a column-level AUTO_INCREMENT difference must not be reported as a schema mismatch")
 
-	diff, err = targetSchemaDiff("corder", source, target)
+	diff, err = TargetSchemaDiff("corder", source, target)
 	require.NoError(t, err)
 	require.Empty(t, diff, "the source→target comparison must ignore column AUTO_INCREMENT too")
 }
@@ -56,7 +56,7 @@ func TestTargetSchemaDiffIgnoresNotNullOnTarget(t *testing.T) {
 		"  PRIMARY KEY (`order_id`)\n" +
 		") ENGINE=InnoDB"
 
-	diff, err := targetSchemaDiff("corder", source, target)
+	diff, err := TargetSchemaDiff("corder", source, target)
 	require.NoError(t, err)
 	require.Empty(t, diff, "a target that tightens a nullable source column must not be reported as a mismatch")
 }
@@ -77,7 +77,7 @@ func TestTargetSchemaDiffRejectsNullableTarget(t *testing.T) {
 		"  PRIMARY KEY (`order_id`)\n" +
 		") ENGINE=InnoDB"
 
-	diff, err := targetSchemaDiff("corder", source, target)
+	diff, err := TargetSchemaDiff("corder", source, target)
 	require.NoError(t, err)
 	require.NotEmpty(t, diff, "a target that drops a NOT NULL the source had must still be reported")
 	require.Contains(t, diff, "customer_id", "the reported diff should name the mismatched column")
@@ -124,10 +124,129 @@ func TestTargetSchemaDiffNarrowNotNullRelaxation(t *testing.T) {
 		"  PRIMARY KEY (`order_id`)\n" +
 		") ENGINE=InnoDB"
 
-	diff, err := targetSchemaDiff("corder", source, target)
+	diff, err := TargetSchemaDiff("corder", source, target)
 	require.NoError(t, err)
 	require.NotEmpty(t, diff, "a type change on a tightened column must still be reported")
 	require.Contains(t, diff, "customer_id", "the reported diff should name the mismatched column")
+}
+
+// TestTargetSchemaDiffPublicContract pins what TargetSchemaDiff promises now
+// that it is exported: an empty diff means "the move will accept this target",
+// and the tolerated set is exactly two divergences. External callers preview a
+// move by calling this and testing the result against "" — strata's
+// `keyspace move-tables` does, before the operator confirms — so a tolerance
+// added or removed here changes their verdict too, and a case moving between
+// these two lists is a deliberate public behaviour change, not a refactor.
+func TestTargetSchemaDiffPublicContract(t *testing.T) {
+	const source = "CREATE TABLE `corder` (\n" +
+		"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+		"  `customer_id` bigint DEFAULT NULL,\n" +
+		"  `sku` varchar(128) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`order_id`),\n" +
+		"  KEY `idx_customer_id` (`customer_id`)\n" +
+		") ENGINE=InnoDB"
+
+	tests := []struct {
+		name     string
+		target   string
+		accepted bool
+	}{
+		{
+			name:     "identical",
+			target:   source,
+			accepted: true,
+		},
+		{
+			name: "target drops column AUTO_INCREMENT",
+			target: "CREATE TABLE `corder` (\n" +
+				"  `order_id` bigint NOT NULL,\n" +
+				"  `customer_id` bigint DEFAULT NULL,\n" +
+				"  `sku` varchar(128) DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`order_id`),\n" +
+				"  KEY `idx_customer_id` (`customer_id`)\n" +
+				") ENGINE=InnoDB",
+			accepted: true,
+		},
+		{
+			name: "target tightens a nullable column",
+			target: "CREATE TABLE `corder` (\n" +
+				"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+				"  `customer_id` bigint NOT NULL,\n" +
+				"  `sku` varchar(128) DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`order_id`),\n" +
+				"  KEY `idx_customer_id` (`customer_id`)\n" +
+				") ENGINE=InnoDB",
+			accepted: true,
+		},
+		{
+			// The move this whole relaxation exists for: a sharded target
+			// takes its ids from a sequence and its shard key cannot be NULL.
+			name: "target does both at once",
+			target: "CREATE TABLE `corder` (\n" +
+				"  `order_id` bigint NOT NULL,\n" +
+				"  `customer_id` bigint NOT NULL,\n" +
+				"  `sku` varchar(128) DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`order_id`),\n" +
+				"  KEY `idx_customer_id` (`customer_id`)\n" +
+				") ENGINE=InnoDB",
+			accepted: true,
+		},
+		{
+			name: "target changes a column type",
+			target: "CREATE TABLE `corder` (\n" +
+				"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+				"  `customer_id` bigint DEFAULT NULL,\n" +
+				"  `sku` varbinary(128) DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`order_id`),\n" +
+				"  KEY `idx_customer_id` (`customer_id`)\n" +
+				") ENGINE=InnoDB",
+			accepted: false,
+		},
+		{
+			name: "target drops a column",
+			target: "CREATE TABLE `corder` (\n" +
+				"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+				"  `customer_id` bigint DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`order_id`),\n" +
+				"  KEY `idx_customer_id` (`customer_id`)\n" +
+				") ENGINE=InnoDB",
+			accepted: false,
+		},
+		{
+			name: "target adds a column",
+			target: "CREATE TABLE `corder` (\n" +
+				"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+				"  `customer_id` bigint DEFAULT NULL,\n" +
+				"  `sku` varchar(128) DEFAULT NULL,\n" +
+				"  `note` varchar(64) DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`order_id`),\n" +
+				"  KEY `idx_customer_id` (`customer_id`)\n" +
+				") ENGINE=InnoDB",
+			accepted: false,
+		},
+		{
+			name: "target drops an index",
+			target: "CREATE TABLE `corder` (\n" +
+				"  `order_id` bigint NOT NULL AUTO_INCREMENT,\n" +
+				"  `customer_id` bigint DEFAULT NULL,\n" +
+				"  `sku` varchar(128) DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`order_id`)\n" +
+				") ENGINE=InnoDB",
+			accepted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff, err := TargetSchemaDiff("corder", source, tt.target)
+			require.NoError(t, err)
+			if tt.accepted {
+				require.Empty(t, diff, "the move must accept this target")
+			} else {
+				require.NotEmpty(t, diff, "the move must reject this target")
+			}
+		})
+	}
 }
 
 // TestSchemaDiffDetectsRealMismatch ensures the AUTO_INCREMENT relaxation is

--- a/pkg/move/check/target_state.go
+++ b/pkg/move/check/target_state.go
@@ -100,7 +100,7 @@ func validateExistingTargetTable(ctx context.Context, target applier.Target, tab
 	// source utf8mb4_bin vs target utf8mb4_0900_ai_ci): REPLACE/INSERT IGNORE
 	// would then collapse rows that differ only by case, and the mismatch would
 	// surface only much later at checksum time (or never, on a resume whose
-	// watermark already covers the affected chunk). targetSchemaDiff compares
+	// watermark already covers the affected chunk). TargetSchemaDiff compares
 	// column types, charset, collation, indexes and constraints while ignoring
 	// instance-specific noise like AUTO_INCREMENT counters, and forgiving the
 	// ways a sharded target is deliberately stricter than its unsharded source
@@ -113,7 +113,7 @@ func validateExistingTargetTable(ctx context.Context, target applier.Target, tab
 	if err != nil {
 		return fmt.Errorf("failed to read target %d schema for table '%s': %w", targetIndex, tableName, err)
 	}
-	diff, err := targetSchemaDiff(tableName, sourceCreate, targetCreate)
+	diff, err := TargetSchemaDiff(tableName, sourceCreate, targetCreate)
 	if err != nil {
 		return fmt.Errorf("failed to compare schema for table '%s' on target %d: %w", tableName, targetIndex, err)
 	}

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -38,7 +38,7 @@ type DiffOptions struct {
 	// gaining or losing NOT NULL is a real change.
 	//
 	// It is enabled by the move-tables target checks (see
-	// move/check.targetSchemaDiff), where the reference is the move's SOURCE and
+	// move/check.TargetSchemaDiff), where the reference is the move's SOURCE and
 	// the validated schema is its physical TARGET. What that permits is a target
 	// column declared NOT NULL where the source still permits NULL — an
 	// unsharded source moving into a sharded target whose shard key must be

--- a/pkg/statement/diff_test.go
+++ b/pkg/statement/diff_test.go
@@ -1795,7 +1795,7 @@ func TestDiff_DiffOptions(t *testing.T) {
 // the move SOURCE, the validated schema is the physical TARGET, and the rule
 // being asserted is that a target may be *stricter* than its source (NOT NULL
 // where the source permits NULL) but never looser. See
-// move/check.targetSchemaDiff.
+// move/check.TargetSchemaDiff.
 func TestDiff_IgnoreNotNullRelaxation(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Why

Since #1186, "which divergences does a move tolerate" has two definitions.

`move/check.targetSchemaDiff` is one. The other is in strata, which reassembles the same option set by hand so its `keyspace move-tables` can tell an operator whether a move will be accepted **before** they confirm it, rather than an hour into the copy. That only works while the two agree:

- strata drifts stricter → it blocks a move spirit would have run happily;
- strata drifts looser → it promises a move that then dies in spirit's pre-flight, after the operator has already said yes.

Neither failure is visible from either side, and the set is now two flags rather than one, so this is a good moment to stop having two copies of it.

## What

Export the function the checks already use — `check.TargetSchemaDiff` — and state in its doc that the tolerated set is public behaviour, not an internal detail.

**Exported as a function, not as the options it builds.** That is the substantive design point rather than a style preference. The nullability tolerance is directional: `statement.IgnoreNotNullRelaxation` lets the schema being *validated* be stricter than its *reference*, and the target is the validated one, so it has to reach `DiffCreateTables` as `got` with the source as `want`. Handing a caller the options hands them that trap — passed the other way round they forgive the opposite, dangerous direction, silently and with no diff to show for it. (This orientation has already misled a reader once, on #1186.) The parameter names `sourceCreate, targetCreate` are what prevents it, so the option and the argument order stay together inside the one function.

Two doc changes came with it:

- the exported doc no longer says "it is `schemaDiff` plus one relaxation" — a godoc reader cannot follow a reference to an unexported function — and enumerates both tolerated divergences itself;
- `TestTargetSchemaDiffPublicContract` pins the contract external callers actually depend on: an empty diff means "the move will accept this target", and the tolerated set is exactly those two. Eight cases across accept and reject, so a case moving between the lists is a deliberate behaviour change rather than a refactor.

`schemaDiff` (the source↔source comparison, which must stay exact) deliberately stays unexported — nothing outside needs it, and it is the one that must *not* forgive a tightening.

## Not in scope

No behaviour change. Internal callers are unchanged apart from the identifier.

## Testing

`go test ./pkg/move/check/ ./pkg/statement/` and `golangci-lint run ./pkg/move/... ./pkg/statement/... ./pkg/datasync/...` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)