### PR TITLE
move: name the real backstop for a NULL in a tightened column

### DIFF
--- a/docs/move.md
+++ b/docs/move.md
@@ -139,9 +139,9 @@ A table that already exists on the target is used as-is, provided it is empty an
 
 The reverse of either — a target looser than its source — is still a mismatch and fails pre-flight, as does any other difference (column types, charset, collation, indexes, constraints). The error reports the `ALTER` that would reconcile the target.
 
-A `NOT NULL` target column does not make Move filter or rewrite source rows. If the source data does contain a NULL there, the move fails rather than silently substituting a value — at row-hashing time for a sharded target, otherwise at the checksum.
+A `NOT NULL` target column does not make Move filter or rewrite source rows. If the source data does contain a NULL there, the move fails rather than silently substituting a value — at row-hashing time for a sharded target, and otherwise on the copy batch carrying the row: MySQL coerces the NULL to the column's implicit default and raises a warning, and Move fails on warnings it does not explicitly tolerate, precisely because on an `INSERT IGNORE` the warning is the only evidence a row was not stored as read.
 
-Failing at the checksum is correct but slow. The copy writes with `INSERT IGNORE`, which stores the type's implicit default instead of erroring, so the NULL is only detected once the [initial checksum](#two-checksum-model) compares the rows; that checksum repairs and retries up to three times, and every attempt re-copies the chunk, re-coerces the same NULL and finds it again before the run gives up. On a table large enough to be worth moving this way, that is hours of copying and verifying to learn something a single `SELECT 1 FROM <table> WHERE <column> IS NULL LIMIT 1` answers up front. Confirm the column holds no NULLs before starting the copy.
+The failure is therefore immediate, but it still arrives later than it needs to: not until the copy reaches the chunk holding that row, which on a table large enough to be worth moving this way is hours, and reported as a MySQL warning code against a batch rather than as "this column has NULLs". A single `SELECT 1 FROM <table> WHERE <column> IS NULL LIMIT 1` per tightened column answers it up front. Confirm the column holds no NULLs before starting the copy.
 
 ### threads
 

--- a/pkg/move/check/schema_compare.go
+++ b/pkg/move/check/schema_compare.go
@@ -83,21 +83,22 @@ func schemaDiff(table, wantCreate, gotCreate string) (string, error) {
 //
 // The relaxation cannot mask a NULL that actually exists. On a sharded target
 // the row never reaches an INSERT: the applier hashes the shard key first and a
-// NULL fails there. For any other tightened column, both copy paths write with
-// INSERT IGNORE (the copier's INSERT IGNORE ... SELECT, the applier's
-// INSERT IGNORE ... VALUES), and IGNORE downgrades the would-be
-// ER_BAD_NULL_ERROR to a warning and stores the type's implicit default
-// instead — regardless of row count, so this does not depend on batching. The
-// checksum then reports the mismatch, because ColumnMapping.ChecksumExprs
-// compares an explicit ISNULL() digit per column, which differs even for a
-// VARCHAR NOT NULL whose implicit default is the empty string.
+// NULL fails there. For any other tightened column MySQL does coerce it —
+// Spirit runs a non-strict sql_mode (conn.go sets NO_AUTO_VALUE_ON_ZERO alone)
+// and its copy writes are INSERT IGNORE, so the would-be ER_BAD_NULL_ERROR
+// becomes a warning and the implicit default is stored — but the write does not
+// survive that. RetryableTransaction reads SHOW WARNINGS after every statement
+// and fails on any warning it does not explicitly tolerate, which is what
+// dbconn.UnsafeWarningError is for: on an IGNORE statement the warning is the
+// only evidence the copy lost data. The row's batch takes the whole run down
+// with it, and because the error is fatal it is not retried.
 //
-// So the outcome is a failed move, never a silently altered value — but it is
-// an expensive failure: the initial checker runs with FixDifferences and three
-// retries, so each attempt re-copies the chunk, re-coerces the NULL, and finds
-// it again before the run gives up. Callers that want the failure in seconds
-// rather than hours should probe the tightened columns for NULLs before
-// starting the copy.
+// So the outcome is a failed move, never a silently altered value, and the
+// failure is immediate rather than deferred to the checksum. It is still worth
+// probing the tightened columns for NULLs before starting the copy: unchecked,
+// the run dies whenever the copier reaches the chunk holding that row — hours,
+// on a table large enough to want this relaxation — and reports a raw warning
+// code against a batch rather than naming the column.
 //
 // One note for maintainers: what is exported is this function and not the
 // options it builds, deliberately. The nullability tolerance is directional —

--- a/pkg/statement/diff.go
+++ b/pkg/statement/diff.go
@@ -55,8 +55,10 @@ type DiffOptions struct {
 	// the copy and the checksum compare values, and every column's NULL-ness is
 	// compared explicitly (see ColumnMapping.ChecksumExprs, which emits an
 	// ISNULL() digit per column). A tightened column whose source data holds no
-	// NULLs is therefore identical on both sides, and one that does hold a NULL
-	// is reported as a mismatch rather than hidden by this option.
+	// NULLs is therefore identical on both sides, and this option hides nothing
+	// about the rows themselves. One that does hold a NULL fails the move
+	// instead of being accepted, and fails before the checksum ever runs — see
+	// move/check.TargetSchemaDiff for where and why.
 	IgnoreNotNullRelaxation bool
 
 	// IgnoreEngine skips diffing the ENGINE table option.


### PR DESCRIPTION
## Why

#1186 documented the wrong mechanism, and I repeated it in that PR's review thread when justifying the tolerance. It said a NULL coerced into a tightened target column is caught by the initial checksum, and called it "an expensive failure" costing three `FixDifferences` repair-and-retry rounds.

Neither part holds.

`RetryableTransaction` reads `SHOW WARNINGS` after **every** statement and fails on any warning it does not explicitly tolerate (`pkg/dbconn/dbconn.go`). `dbconn.UnsafeWarningError` exists for exactly this case — its own doc says that on a statement like `INSERT IGNORE`, the warning is the only signal the copy would silently lose data. Every write goes through that path: the legacy `INSERT IGNORE ... SELECT` copier was removed in #908, so the only copier streams through the applier, and both `InsertRows` and `UpsertRows`/`REPLACE INTO` call `RetryableTransaction`. `sql_mode` is `NO_AUTO_VALUE_ON_ZERO` alone, so MySQL does coerce the NULL and raise 1048 rather than erroring — and that warning is then fatal, and fatal errors skip the retry loop.

So the run dies on the batch carrying the row, immediately. The tolerance is safer than #1186 described, and the checksum never gets a say.

## What changes

Doc-only, three places:

- `TargetSchemaDiff`'s comment — replaces the checksum/`ChecksumExprs` explanation with the warning-inspection one, and keeps the up-front-probe advice while correcting *why* it is worth doing. The reason is no longer "the failure is deferred" but "otherwise it waits until the copier reaches that chunk — hours on a table large enough to want this relaxation — and surfaces as a warning code against a batch instead of naming the column".
- `docs/move.md` — same correction for operators.
- `IgnoreNotNullRelaxation`'s comment — it pointed at `ColumnMapping.ChecksumExprs` as the thing that catches a real NULL. The `ISNULL()`-digit argument stays, because it is still exactly why the option cannot hide anything about the *rows*; what goes is the implication that the checksum is the backstop.

No behaviour change, no test change — the tests assert the diff verdict, which is unaffected.

## Testing

`go test ./pkg/move/check/ ./pkg/statement/` and `golangci-lint run ./pkg/move/... ./pkg/statement/...` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)