### PR TITLE
migrate: reject an ambiguous DROP CONSTRAINT rather than dropping the CHECK

### DIFF
--- a/pkg/migration/change.go
+++ b/pkg/migration/change.go
@@ -116,7 +116,18 @@ func (c *tableChange) newTableAlter(ctx context.Context) (string, error) {
 	if len(c.stmt.CheckConstraintsReferenced()) == 0 {
 		return c.stmt.TrimAlter(), nil
 	}
-	renames, err := c.checkConstraintRenames(ctx)
+	source, err := tableDefinition(ctx, c.runner.db, c.table.TableName)
+	if err != nil {
+		return "", err
+	}
+	if err := rejectAmbiguousConstraintDrop(c.stmt, source, c.table.TableName); err != nil {
+		return "", err
+	}
+	newTable, err := tableDefinition(ctx, c.runner.db, c.newTable.TableName)
+	if err != nil {
+		return "", err
+	}
+	renames, err := c.checkConstraintRenames(source, newTable)
 	if err != nil {
 		return "", err
 	}
@@ -137,6 +148,52 @@ func (c *tableChange) newTableAlter(ctx context.Context) (string, error) {
 	return alter, nil
 }
 
+// rejectAmbiguousConstraintDrop refuses an ALTER whose DROP CONSTRAINT names a
+// constraint MySQL itself would not resolve, before newTableAlter retargets it
+// at the check constraint of that name and quietly makes the migration mean
+// something the statement does not.
+//
+// A table may hold the same symbol in more than one constraint namespace -
+// UNIQUE KEY `dup` alongside CONSTRAINT `dup` CHECK (..) is legal - and MySQL
+// rejects a DROP CONSTRAINT that cannot tell them apart: "Table has multiple
+// constraints with the name 'dup'" (error 3939).
+//
+// Spirit does not inherit that rejection. The direct-DDL attempt does get
+// error 3939 back from the user's table, but a direct-DDL failure is the
+// ordinary signal to use the copy algorithm instead, so it is discarded. The
+// copy then applies the ALTER to the _new table, where CREATE TABLE .. LIKE
+// has renamed the check constraint (see newTableAlter) and left only one `dup`
+// behind: the clause resolves there and drops the check constraint while
+// keeping the unique key - a table the user never asked for, reported as
+// success.
+//
+// The foreign key namespace is not consulted: spirit refuses a table with
+// foreign keys long before this point.
+func rejectAmbiguousConstraintDrop(stmt *statement.AbstractStatement, def *statement.CreateTable, tableName string) error {
+	for _, name := range stmt.GenericConstraintDrops() {
+		var owners []string
+		for _, constraint := range def.GetConstraints() {
+			if constraint.Type == "CHECK" && strings.EqualFold(constraint.Name, name) {
+				owners = append(owners, "CHECK constraint")
+			}
+		}
+		for _, index := range def.GetIndexes() {
+			// MySQL resolves DROP CONSTRAINT against unique and primary keys
+			// only, so a non-unique index of the same name is not a clash.
+			// GetIndexes names the primary key "PRIMARY", which is the symbol
+			// MySQL matches it under.
+			if (index.Type == "UNIQUE" || index.Type == "PRIMARY KEY") && strings.EqualFold(index.Name, name) {
+				owners = append(owners, index.Type)
+			}
+		}
+		if len(owners) > 1 {
+			return fmt.Errorf("table %s has multiple constraints named %s (%s), so DROP CONSTRAINT %s is ambiguous and MySQL rejects it: name the one you mean with a constraint specific clause such as DROP CHECK or DROP KEY",
+				tableName, name, strings.Join(owners, ", "), name)
+		}
+	}
+	return nil
+}
+
 // checkConstraintRenames maps each check constraint name on the table being
 // altered (lower-cased, because MySQL matches these names case-insensitively)
 // to the name the same constraint has on the _new table.
@@ -149,15 +206,9 @@ func (c *tableChange) newTableAlter(ctx context.Context) (string, error) {
 // back in numeric order. Their expressions and enforcement are compared
 // afterwards to confirm the pairing, rather than trusting the ordering and
 // retargeting a DROP CHECK at some other constraint.
-func (c *tableChange) checkConstraintRenames(ctx context.Context) (map[string]string, error) {
-	source, err := checkConstraints(ctx, c.runner.db, c.table.TableName)
-	if err != nil {
-		return nil, err
-	}
-	newTable, err := checkConstraints(ctx, c.runner.db, c.newTable.TableName)
-	if err != nil {
-		return nil, err
-	}
+func (c *tableChange) checkConstraintRenames(sourceDef, newTableDef *statement.CreateTable) (map[string]string, error) {
+	source := checkConstraints(sourceDef)
+	newTable := checkConstraints(newTableDef)
 	if len(source) != len(newTable) {
 		return nil, fmt.Errorf("table %s has %d CHECK constraint(s) but its copy %s has %d",
 			c.table.TableName, len(source), c.newTable.TableName, len(newTable))
@@ -204,9 +255,8 @@ func sortByGeneratedNumber(constraints statement.Constraints, tableName string) 
 	return nil
 }
 
-// checkConstraints returns the table's CHECK constraints as SHOW CREATE TABLE
-// lists them, which is sorted by name.
-func checkConstraints(ctx context.Context, db *sql.DB, tableName string) (statement.Constraints, error) {
+// tableDefinition returns the table's SHOW CREATE TABLE, parsed.
+func tableDefinition(ctx context.Context, db *sql.DB, tableName string) (*statement.CreateTable, error) {
 	var name, createTable string
 	if err := db.QueryRowContext(ctx,
 		sqlescape.MustEscapeSQL("SHOW CREATE TABLE %n", tableName)).Scan(&name, &createTable); err != nil {
@@ -220,13 +270,19 @@ func checkConstraints(ctx context.Context, db *sql.DB, tableName string) (statem
 	if err != nil {
 		return nil, fmt.Errorf("could not parse the definition of table %s: %w", tableName, err)
 	}
+	return createStmt, nil
+}
+
+// checkConstraints returns the table's CHECK constraints as SHOW CREATE TABLE
+// lists them, which is sorted by name.
+func checkConstraints(def *statement.CreateTable) statement.Constraints {
 	var constraints statement.Constraints
-	for _, constraint := range createStmt.GetConstraints() {
+	for _, constraint := range def.GetConstraints() {
 		if constraint.Type == "CHECK" {
 			constraints = append(constraints, constraint)
 		}
 	}
-	return constraints, nil
+	return constraints
 }
 
 // checkConstraintsMatch reports whether two CHECK constraints are the same

--- a/pkg/migration/check_constraint_test.go
+++ b/pkg/migration/check_constraint_test.go
@@ -596,6 +596,95 @@ func TestCheckConstraintDropAmongIdenticalExpressions(t *testing.T) {
 	require.NoError(t, err, "the dropped CHECK constraint should no longer be enforced")
 }
 
+// TestDropConstraintAmbiguousWithUniqueKey covers a DROP CONSTRAINT whose name
+// is held by both a CHECK constraint and a unique key. MySQL refuses to guess
+// which one is meant (error 3939), and Spirit must refuse too: it applies the
+// ALTER to the _new table, where CREATE TABLE .. LIKE has renamed the check
+// constraint, so the name is no longer ambiguous there and the copy would drop
+// the check constraint, keep the unique key, and report success.
+func TestDropConstraintAmbiguousWithUniqueKey(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "chk_ambig", `CREATE TABLE chk_ambig (
+		id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+		name VARCHAR(32) NOT NULL,
+		val INT NOT NULL,
+		CONSTRAINT dup UNIQUE (name),
+		CONSTRAINT dup CHECK (val > 0)
+	)`)
+	testutils.RunSQL(t, `INSERT INTO chk_ambig (name, val) VALUES ('a', 1), ('b', 2)`)
+
+	// MySQL rejects this statement outright, so run it to confirm the premise
+	// rather than assuming it.
+	_, err := tt.DB.ExecContext(t.Context(), "ALTER TABLE chk_ambig DROP CONSTRAINT dup")
+	require.ErrorContains(t, err, "multiple constraints with the name")
+
+	m := NewTestRunner(t, "chk_ambig", "DROP CONSTRAINT dup")
+	err = m.Run(t.Context())
+	require.ErrorContains(t, err, "ambiguous")
+	require.NoError(t, m.Close())
+
+	// Neither constraint was dropped.
+	require.Equal(t, map[string]bool{"dup": true}, tableCheckConstraints(t, tt.DB, "chk_ambig"))
+	_, err = tt.DB.ExecContext(t.Context(), "INSERT INTO chk_ambig (name, val) VALUES ('c', -1)")
+	require.Error(t, err, "the CHECK constraint should still be enforced")
+	_, err = tt.DB.ExecContext(t.Context(), "INSERT INTO chk_ambig (name, val) VALUES ('a', 1)")
+	require.Error(t, err, "the unique key should still be enforced")
+
+	// DROP CHECK says which one is meant, so it is not ambiguous and goes ahead.
+	m = NewTestRunner(t, "chk_ambig", "DROP CHECK dup, ENGINE=InnoDB")
+	require.NoError(t, m.Run(t.Context()))
+	require.NoError(t, m.Close())
+	require.Empty(t, tableCheckConstraints(t, tt.DB, "chk_ambig"))
+	_, err = tt.DB.ExecContext(t.Context(), "INSERT INTO chk_ambig (name, val) VALUES ('c', -1)")
+	require.NoError(t, err, "the CHECK constraint should have been dropped")
+}
+
+// TestDropConstraintAmbiguousWithPrimaryKey is the same clash against the
+// primary key, which MySQL matches under the symbol PRIMARY even though
+// SHOW CREATE TABLE prints no name for it.
+func TestDropConstraintAmbiguousWithPrimaryKey(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "chk_ambig_pk", `CREATE TABLE chk_ambig_pk (
+		id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+		val INT NOT NULL,
+		CONSTRAINT `+"`PRIMARY`"+` CHECK (val > 0)
+	)`)
+	testutils.RunSQL(t, "INSERT INTO chk_ambig_pk (val) VALUES (1), (2)")
+
+	m := NewTestRunner(t, "chk_ambig_pk", "DROP CONSTRAINT `PRIMARY`")
+	require.ErrorContains(t, m.Run(t.Context()), "ambiguous")
+	require.NoError(t, m.Close())
+
+	require.Equal(t, map[string]bool{"PRIMARY": true}, tableCheckConstraints(t, tt.DB, "chk_ambig_pk"))
+}
+
+// TestDropConstraintResolvesToUniqueKey pins the case the ambiguity check must
+// not fire on: the name is held by a unique key only, so it is unambiguous even
+// though the table has check constraints for the rewriting to consider.
+func TestDropConstraintResolvesToUniqueKey(t *testing.T) {
+	t.Parallel()
+	tt := testutils.NewTestTable(t, "chk_uq_only", `CREATE TABLE chk_uq_only (
+		id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+		name VARCHAR(32) NOT NULL,
+		val INT NOT NULL,
+		CONSTRAINT uq_chk_uq_only_name UNIQUE (name),
+		CONSTRAINT chk_uq_only_valpos CHECK (val > 0)
+	)`)
+	testutils.RunSQL(t, `INSERT INTO chk_uq_only (name, val) VALUES ('a', 1), ('b', 2)`)
+
+	m := NewTestRunner(t, "chk_uq_only", "DROP CONSTRAINT uq_chk_uq_only_name")
+	require.NoError(t, m.Run(t.Context()))
+	require.NoError(t, m.Close())
+
+	// The unique key is gone and the check constraint - renamed by the copy, as
+	// every copied check constraint is - is still enforced.
+	_, err := tt.DB.ExecContext(t.Context(), "INSERT INTO chk_uq_only (name, val) VALUES ('a', 1)")
+	require.NoError(t, err, "the unique key should have been dropped")
+	require.Len(t, tableCheckConstraints(t, tt.DB, "chk_uq_only"), 1)
+	_, err = tt.DB.ExecContext(t.Context(), "INSERT INTO chk_uq_only (name, val) VALUES ('c', -1)")
+	require.Error(t, err, "the CHECK constraint should still be enforced")
+}
+
 // tableCheckConstraints returns the table's CHECK constraints as a map of name to
 // whether the constraint is enforced.
 func tableCheckConstraints(t *testing.T, db *sql.DB, tableName string) map[string]bool {

--- a/pkg/statement/check_constraints_test.go
+++ b/pkg/statement/check_constraints_test.go
@@ -30,6 +30,30 @@ func TestCheckConstraintsReferenced(t *testing.T) {
 	}
 }
 
+func TestGenericConstraintDrops(t *testing.T) {
+	tests := []struct {
+		statement string
+		expected  []string
+	}{
+		// Only DROP CONSTRAINT leaves the constraint type unsaid.
+		{"ALTER TABLE t1 DROP CONSTRAINT dup", []string{"dup"}},
+		{"ALTER TABLE t1 DROP CONSTRAINT a, DROP CONSTRAINT b", []string{"a", "b"}},
+		{"ALTER TABLE t1 DROP CONSTRAINT dup, ENGINE=InnoDB", []string{"dup"}},
+		// These say which kind they mean, so MySQL resolves them in one
+		// namespace and they can never be ambiguous.
+		{"ALTER TABLE t1 DROP CHECK dup", nil},
+		{"ALTER TABLE t1 ALTER CHECK dup NOT ENFORCED", nil},
+		{"ALTER TABLE t1 DROP FOREIGN KEY dup", nil},
+		{"ALTER TABLE t1 DROP KEY dup", nil},
+		{"ALTER TABLE t1 ADD CONSTRAINT dup CHECK (a > 0)", nil},
+		{"CREATE TABLE t1 (a INT)", nil},
+	}
+	for _, test := range tests {
+		stmts := MustNew(test.statement)
+		assert.Equal(t, test.expected, stmts[0].GenericConstraintDrops(), test.statement)
+	}
+}
+
 func TestAlterWithRenamedCheckConstraints(t *testing.T) {
 	// Names as they are on the table the ALTER will actually be applied to,
 	// keyed by the name on the table the user named.

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -472,6 +472,31 @@ func (a *AbstractStatement) CheckConstraintsReferenced() []string {
 	return names
 }
 
+// GenericConstraintDrops returns the names in this ALTER's DROP CONSTRAINT
+// clauses - the subset of CheckConstraintsReferenced that does not say which
+// kind of constraint it means. DROP CHECK and ALTER CHECK do say, so they are
+// not returned.
+//
+// MySQL resolves such a name against the table's CHECK, FOREIGN KEY, UNIQUE and
+// PRIMARY KEY constraints, which are separate namespaces, and refuses the ALTER
+// when more than one of them holds it: "Table has multiple constraints with the
+// name 'x'. Please use constraint specific 'DROP' clause" (error 3939). A caller
+// that resolves the name itself has to reproduce that rather than pick one.
+func (a *AbstractStatement) GenericConstraintDrops() []string {
+	alterStmt, ok := a.AsAlterTable()
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, spec := range alterStmt.Specs {
+		if spec.Tp == ast.AlterTableDropConstraint &&
+			spec.Constraint != nil && spec.Constraint.Name != "" {
+			names = append(names, spec.Constraint.Name)
+		}
+	}
+	return names
+}
+
 // AlterWithRenamedCheckConstraints returns this ALTER's clauses with its check
 // constraint symbols rewritten for a table other than the one the user named:
 // the copy algorithm's _new table, which holds the same check constraints under


### PR DESCRIPTION
Fixes #1192.

## The bug

A table can legally hold the same symbol in more than one constraint namespace — `UNIQUE KEY dup` alongside `CONSTRAINT dup CHECK (..)` — and MySQL refuses to guess which one a `DROP CONSTRAINT` means:

```
mysql> ALTER TABLE t DROP CONSTRAINT same;
ERROR 3939 (HY000): Table has multiple constraints with the name 'same'.
Please use constraint specific 'DROP' clause.
```

Spirit ran it and reported success, having dropped the CHECK constraint and kept the unique key. Three things line up:

1. `attemptInstantDDL` does run the statement on the user's table, and does get error 3939 — but a direct-DDL failure is the ordinary signal to fall through to the copy algorithm, so `Runner.Run` discards it. It cannot tell this apart from "not INSTANT-able".
2. `CREATE TABLE .. LIKE` renames the check constraint on `_t_new` (#418), so only one `same` is left there.
3. `newTableAlter` (#1181) retargets the `DROP CONSTRAINT` at that renamed check constraint. On `_t_new` the name resolves, MySQL accepts it, and cutover installs a table the statement never described.

Full repro in #1192.

## The change

`newTableAlter` now refuses a `DROP CONSTRAINT` whose name the source table holds in more than one namespace, and names the clause that disambiguates it:

```
spirit: error: table t has multiple constraints named same (CHECK constraint, UNIQUE),
so DROP CONSTRAINT same is ambiguous and MySQL rejects it: name the one you mean with
a constraint specific clause such as DROP CHECK or DROP KEY
```

* `statement.GenericConstraintDrops` returns the names carried by `DROP CONSTRAINT` clauses only — the subset of `CheckConstraintsReferenced` that does not say which kind of constraint it means. `DROP CHECK` and `ALTER CHECK` do say, so they can never be ambiguous and are excluded.
* `rejectAmbiguousConstraintDrop` matches each of those names, case-insensitively as MySQL does, against the source table's CHECK constraints and its unique and primary keys. `GetIndexes` reports the primary key as `PRIMARY`, which is the symbol MySQL matches it under. A non-unique index of the same name is deliberately not a clash: `DROP CONSTRAINT` does not resolve against one (verified — MySQL drops the CHECK constraint without complaint). The foreign key namespace is unreachable: `hasforeignkeys` refuses an FK-bearing table first, which I confirmed.
* `checkConstraints` was reading `SHOW CREATE TABLE` itself; it now takes an already-parsed definition, and `tableDefinition` does the read. Same two round trips as before, with the source definition shared between the ambiguity check and the rename pairing.

I did consider the smaller fix of not swallowing error 3939 in `attemptMySQLDDL`. It relies on classifying error codes out of a path whose whole purpose is to fail, gives the user MySQL's message with no indication of which of their statements it came from, and would not cover a case where the direct-DDL attempt is skipped. The explicit check is self-describing and testable without a live failure.

## Testing

Both new migration tests were confirmed to fail on pre-fix behaviour by deleting the guard call and re-running — `An error is expected but got nil` for each — and the third passes either way, which is the point of it.

* `pkg/migration/TestDropConstraintAmbiguousWithUniqueKey` — runs the ALTER through MySQL first to pin the premise (error 3939), then asserts spirit refuses it, that neither constraint was dropped, and that `DROP CHECK dup, ENGINE=InnoDB` still goes through.
* `pkg/migration/TestDropConstraintAmbiguousWithPrimaryKey` — the same clash against the primary key, which `SHOW CREATE TABLE` prints no name for.
* `pkg/migration/TestDropConstraintResolvesToUniqueKey` — the case the check must not fire on: the name is held by a unique key only, on a table that does have check constraints. Copy path, unique key dropped, check constraint still enforced.
* `pkg/statement/TestGenericConstraintDrops` — which clause types contribute a name.

Green locally against MySQL 8.0.43: `pkg/statement/...`, `pkg/lint/...`, and `pkg/migration/ -run 'CheckConstraint|DropConstraint'`. `golangci-lint run ./...` reports `0 issues.`

## Scope

This rejects the ambiguous statement rather than making it work. Resolving it faithfully would mean deciding which namespace the user meant, which is exactly what MySQL declines to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)