### PR TITLE
Don't record a sparse chunk as a measured chunk size

### DIFF
--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -85,6 +85,18 @@ var _ MappedChunker = &chunkerOptimistic{}
 // See chunkerOptimistic.prefetchRejections.
 const maxPrefetchRejections = 2
 
+// minChunkFullnessDivisor is how full a fixed-width chunk must come back before
+// its size counts as measured and becomes eligible for prefetch to restore: at
+// least one row per this many keys of width, i.e. half full.
+//
+// Half rather than full because real tables have small gaps throughout, and
+// requiring every key to hold a row would mean nothing is ever recorded and
+// leaving prefetch would always fall back to the StartingChunkSize ramp. Half
+// bounds the cost a restored size can understate by 2x, which the sizer's own
+// feedback absorbs in one window and which sits well inside panicShrink's 5x
+// threshold. See chunkerOptimistic.lastDenseChunkSize.
+const minChunkFullnessDivisor = 2
+
 // nextChunkByPrefetching uses prefetching instead of feedback to determine the chunk size.
 // It is used when the chunker detects that there are very large gaps in the sequence.
 // When this mode is enabled, the chunkSize is "reset" to 1000 rows, so we know that
@@ -484,7 +496,17 @@ func (t *chunkerOptimistic) recordKeyDensity(chunk *Chunk, actualRows uint64) {
 	// chunk (next() builds those as chunkPtr..chunkPtr+chunkSize) and excludes a
 	// prefetch chunk, whose ChunkSize is a row offset while its width is the gap
 	// it crossed — restoring a prefetch offset would defeat the whole point.
-	if rows > 0 && keys == chunk.ChunkSize {
+	//
+	// The chunk also has to have come back reasonably *full*, not merely
+	// non-empty. A chunk holding a handful of rows across its whole width
+	// measures the cost of those few rows, not of a full chunk of that size —
+	// and thinly-populated chunks are exactly what carry the sizer to the
+	// ceiling to begin with, so accepting them would validate the ceiling from
+	// the very evidence that makes prefetch fire. That is the case
+	// prePrefetchChunkSize exists to exclude, and `rows > 0` does not exclude
+	// it: over a gap that is sparse rather than empty, one row per chunk is
+	// enough to "prove" a 100k-row chunk that no full chunk was ever read at.
+	if rows*minChunkFullnessDivisor >= chunk.ChunkSize && keys == chunk.ChunkSize {
 		t.lastDenseChunkSize = chunk.ChunkSize
 	}
 }

--- a/pkg/table/chunker_optimistic_test.go
+++ b/pkg/table/chunker_optimistic_test.go
@@ -922,6 +922,64 @@ func TestOptimisticPrefetchRestoreIsMeasured(t *testing.T) {
 	require.Less(t, chunker.prePrefetchChunkSize, uint64(MaxDynamicRowSize))
 }
 
+// TestOptimisticPrefetchRestoreIgnoresSparseChunks is the same memory bound as
+// TestOptimisticPrefetchRestoreIsMeasured over the gap that is sparse rather
+// than empty — the case a `rows > 0` test for "was this size measured?" lets
+// through.
+//
+// A chunk holding a handful of rows across its whole width measures the cost of
+// those few rows, not of a full chunk of that size. And thinly-populated chunks
+// are precisely what carry the sizer to the ceiling, so accepting them records
+// the ceiling as measured from the very evidence that makes prefetch fire: one
+// row per chunk is enough to "prove" a 100k-row chunk no full chunk was ever
+// read at. The restore then hands the buffered copier the ~1.6GB read that
+// prePrefetchChunkSize exists to prevent.
+func TestOptimisticPrefetchRestoreIgnoresSparseChunks(t *testing.T) {
+	chunker := denseChunkerForTest(t)
+	chunker.TargetChunkBytes = DefaultTargetChunkBytes // buffered copier: byte signal
+
+	const wideRowBytes = 16 * 1024 // 16KB rows: ~1000 of them fill the budget
+
+	// Phase 1: full chunks of wide rows, as in the empty-gap case.
+	for range 60 {
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		chunk.SourceRows = chunk.ChunkSize
+		chunk.ActualBytes = chunk.ChunkSize * wideRowBytes
+		chunker.Feedback(chunk, time.Millisecond, chunk.ChunkSize)
+	}
+	measured := chunker.lastDenseChunkSize
+	require.NotZero(t, measured)
+	require.Less(t, measured, uint64(MaxDynamicRowSize))
+
+	// Phase 2: a sparse gap. Every chunk carries a few real rows no matter how
+	// wide it gets, so it stays far enough under the byte budget to keep the
+	// sizer growing and to pass the entry gate, while the density window sees
+	// well over minKeysPerRowForPrefetch keys per row.
+	const sparseRows = 150
+	require.Less(t, uint64(sparseRows*wideRowBytes)*5, uint64(DefaultTargetChunkBytes),
+		"a sparse chunk has to stay under the prefetch entry gate")
+	for range 400 {
+		if chunker.chunkPrefetchingEnabled {
+			break
+		}
+		chunk, err := chunker.Next()
+		require.NoError(t, err)
+		chunk.SourceRows = sparseRows
+		chunk.ActualBytes = sparseRows * wideRowBytes
+		chunker.Feedback(chunk, time.Millisecond, sparseRows)
+	}
+	require.True(t, chunker.chunkPrefetchingEnabled, "a sparse gap must still engage prefetch")
+
+	// The sparse chunks are not evidence of anything the copier can afford, so
+	// the restore is still the size phase 1 measured.
+	require.Equal(t, measured, chunker.prePrefetchChunkSize,
+		"a chunk that came back nearly empty must not count as a measured size")
+	require.LessOrEqual(t, chunker.prePrefetchChunkSize*wideRowBytes,
+		uint64(DefaultTargetChunkBytes),
+		"the restored size must fit the byte budget it was measured against")
+}
+
 // TestOptimisticPrefetchDensityUsesSourceRows covers the other half of the
 // signal's fidelity. On the copy path the row count reaching Feedback is the
 // applier's affected-row count from `INSERT IGNORE`, which does not count a row


### PR DESCRIPTION
## Problem

`prePrefetchChunkSize` (#1184) exists so that leaving a prefetch episode restores a chunk size that real rows were once read at, rather than the `MaxDynamicRowSize` ceiling the gap itself bought. `recordKeyDensity` decides what qualifies as "measured", and the test was `rows > 0`:

```go
if rows > 0 && keys == chunk.ChunkSize {
    t.lastDenseChunkSize = chunk.ChunkSize
}
```

Over a gap that is **sparse rather than empty**, that is not the same question. A chunk holding a handful of rows across its whole width measures the cost of those few rows, not of a full chunk of that size — and thinly-populated chunks are exactly what carry the sizer to the ceiling, so accepting them records the ceiling as "measured" from the very evidence that makes prefetch fire. One row per chunk is enough to "prove" a 100k-row chunk that no full chunk was ever read at.

`TestOptimisticPrefetchRestoreIsMeasured` covers the *empty* gap, where `lastDenseChunkSize` correctly stays at the pre-gap size. The sparse gap was uncovered.

## Why it matters

The chunker that gets `TargetChunkBytes` is the copy chunker — `runner.go`:

```go
copyChunkerCfg.TargetChunkBytes = r.migration.TargetChunkSize
// This applies to the copy chunker only: the checksum runs server-side CRC and keeps the time signal.
```

So this is the buffered copier's path, and `readChunkData` appends every row into `rowDataList` with no in-read byte cap. With 16KB rows against the 16MiB default budget the restore is 100,000 rows — ~1.5GB, fully materialized before any `ActualBytes` feedback exists to shrink it. `panicShrinkBytes` (5 × 16MiB) only reacts after that chunk has already been read, and with several read workers per migration.

The checksum chunker is unaffected: it keeps the time signal and its CRC is server-side, so no rows reach the client.

## Reproducer

The new test is a byte-signal chunker, 16KB rows: phase 1 is 60 full chunks, phase 2 is a gap where every chunk carries 150 real rows however wide it gets — under the entry gate (2.34MiB × 5 < 16MiB) and well over `minKeysPerRowForPrefetch`, so prefetch legitimately engages. Before this change:

```
phase 1: chunkSize=1024 lastDenseChunkSize=1024
phase 2: prefetching=true lastDenseChunkSize=100000 prePrefetchChunkSize=100000
```

Phase 1 measures honestly; phase 2 overwrites it with the ceiling.

## Fix

Require the chunk to have come back at least half full before its size counts:

```go
if rows*minChunkFullnessDivisor >= chunk.ChunkSize && keys == chunk.ChunkSize {
```

Half rather than full because real tables have small gaps throughout, and demanding every key hold a row would record nothing — making every prefetch exit fall back to the `StartingChunkSize` ramp. Half bounds what a restored size can understate by 2x, which the sizer's own feedback absorbs in one window and which sits well inside `panicShrink`'s 5x threshold.

After: `prePrefetchChunkSize=1024`, i.e. 16MiB against a 16MiB budget — the size the pre-gap chunks were actually measured at — while prefetch still engages.

For the record, a density-based gate (`keys/rows < minKeysPerRowForPrefetch`) is *not* sufficient: at intermediate ramp widths 11664/150 = 77.7 still passes, and the restore only comes down to 11,664 rows / 182MiB. Fullness is the property that matters here, not density.

## Testing

New `TestOptimisticPrefetchRestoreIgnoresSparseChunks` fails on `main` (`expected 1024, actual 100000`) and passes with the change. `./pkg/table/`, `./pkg/copier/` and `./pkg/checksum/` all pass.