### PR TITLE
fix(change): allocate process-local server IDs without collisions

### DIFF
--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -277,6 +277,8 @@ var (
 var serverIDs = sync.OnceValue(func() *serverIDSequence {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
+		// A clock-derived seed lasts for this process: cross-process
+		// separation then depends on differing process start times.
 		return newServerIDSequence(uint32(time.Now().UnixNano()))
 	}
 	return newServerIDSequence(binary.BigEndian.Uint32(b[:]))

--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -270,29 +270,36 @@ var (
 	ErrChangesNotFlushed = errors.New("not all changes flushed")
 )
 
-// serverIDCounter is an atomic counter used to help ensure unique server IDs
-var serverIDCounter atomic.Uint32
-
-// NewServerID generates a unique server ID to avoid conflicts with other binlog readers.
-// Uses crypto/rand combined with an atomic counter to ensure uniqueness even when called
-// concurrently. Returns a value in the range 1001-4294967295 to avoid conflicts with
-// typical MySQL server IDs (0-1000).
-func NewServerID() uint32 {
+// Seed once per process, then allocate consecutive IDs. Mixing a fresh random
+// value with a counter on every call still permits birthday collisions between
+// readers in the same process.
+var serverIDs = func() *serverIDSequence {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// Fallback to nanosecond-based generation if crypto/rand fails (should never happen)
-		rangeSize := int64(^uint32(0) - 1000)
-		return uint32(time.Now().UnixNano()%rangeSize) + 1001
+		return newServerIDSequence(uint32(time.Now().UnixNano()))
 	}
-	// Convert bytes to uint32, mix with counter, and map to valid range
-	randomPart := binary.BigEndian.Uint32(b[:])
-	counterPart := serverIDCounter.Add(1)
+	return newServerIDSequence(binary.BigEndian.Uint32(b[:]))
+}()
 
-	// XOR the random and counter parts for better distribution
-	result := randomPart ^ counterPart
+const serverIDRange = uint64(^uint32(0) - 1000)
 
-	// Map result into the range [1001, max uint32]
-	// Use modulo to constrain to the valid range, then add 1001
-	result = (result % (^uint32(0) - 1000)) + 1001
-	return result
+type serverIDSequence struct {
+	counter atomic.Uint64
+}
+
+func newServerIDSequence(seed uint32) *serverIDSequence {
+	s := &serverIDSequence{}
+	s.counter.Store(uint64(seed) % serverIDRange)
+	return s
+}
+
+func (s *serverIDSequence) next() uint32 {
+	return uint32(s.counter.Add(1)%serverIDRange) + 1001
+}
+
+// NewServerID allocates IDs in [1001, 4294967295], avoiding typical MySQL server
+// IDs. IDs do not repeat within a process until the range is exhausted. The
+// random starting point reduces, but cannot eliminate, cross-process collisions.
+func NewServerID() uint32 {
+	return serverIDs.next()
 }

--- a/pkg/change/repl.go
+++ b/pkg/change/repl.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -270,16 +271,16 @@ var (
 	ErrChangesNotFlushed = errors.New("not all changes flushed")
 )
 
-// Seed once per process, then allocate consecutive IDs. Mixing a fresh random
+// Seed lazily on first use, then allocate consecutive IDs. Mixing a fresh random
 // value with a counter on every call still permits birthday collisions between
 // readers in the same process.
-var serverIDs = func() *serverIDSequence {
+var serverIDs = sync.OnceValue(func() *serverIDSequence {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		return newServerIDSequence(uint32(time.Now().UnixNano()))
 	}
 	return newServerIDSequence(binary.BigEndian.Uint32(b[:]))
-}()
+})
 
 const serverIDRange = uint64(^uint32(0) - 1000)
 
@@ -301,5 +302,5 @@ func (s *serverIDSequence) next() uint32 {
 // IDs. IDs do not repeat within a process until the range is exhausted. The
 // random starting point reduces, but cannot eliminate, cross-process collisions.
 func NewServerID() uint32 {
-	return serverIDs.next()
+	return serverIDs().next()
 }

--- a/pkg/change/repl_test.go
+++ b/pkg/change/repl_test.go
@@ -29,6 +29,20 @@ func TestNewServerIDConcurrent(t *testing.T) {
 		seen[id] = struct{}{}
 	}
 	require.Len(t, seen, workers*perWorker)
+	// A single sequence produces one contiguous block in the circular ID
+	// range. Count its missing successors rather than comparing min/max,
+	// which would flake when the random starting point crosses the wrap.
+	boundaries := 0
+	for id := range seen {
+		successor := id + 1
+		if id == ^uint32(0) {
+			successor = 1001
+		}
+		if _, ok := seen[successor]; !ok {
+			boundaries++
+		}
+	}
+	require.Equal(t, 1, boundaries, "NewServerID must use one process-wide sequence")
 }
 
 func TestServerIDSequenceWrap(t *testing.T) {

--- a/pkg/change/repl_test.go
+++ b/pkg/change/repl_test.go
@@ -7,75 +7,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNewServerIDConcurrent tests that NewServerID generates unique IDs even when called concurrently.
-// This is a regression test for the issue where using time.Now().Unix() as a seed caused collisions
-// when multiple clients were created within the same second. This is *only* an issue for tests,
-// but the serverIDs need to be unique to prevent MySQL disconnecting the sessions.
-//
-// Note: Due to the birthday paradox, when generating 10,000 IDs from a ~4.3B range, there's a small
-// probability (~1.16%) of collision. We allow up to 1 duplicate to make the test less flaky while
-// still catching regressions where the old time-based seed caused frequent collisions.
+// Concurrent allocation must be unique, not merely unlikely to collide.
 func TestNewServerIDConcurrent(t *testing.T) {
-	const numGoroutines = 100
-	const idsPerGoroutine = 100
-	const maxAllowedDuplicates = 1
-
-	// Channel to collect all generated IDs
-	idChan := make(chan uint32, numGoroutines*idsPerGoroutine)
-
-	// Use sync.WaitGroup to ensure all goroutines complete
+	const workers, perWorker = 100, 100
+	ids := make(chan uint32, workers*perWorker)
 	var wg sync.WaitGroup
-	wg.Add(numGoroutines)
-
-	// Start multiple goroutines generating IDs concurrently
-	for range numGoroutines {
-		go func() {
-			defer wg.Done()
-			for range idsPerGoroutine {
-				idChan <- NewServerID()
+	for range workers {
+		wg.Go(func() {
+			for range perWorker {
+				ids <- NewServerID()
 			}
-		}()
+		})
 	}
-
-	// Wait for all goroutines to complete, then close the channel
-	go func() {
-		wg.Wait()
-		close(idChan)
-	}()
-
-	// Collect all IDs and track duplicates
-	ids := make(map[uint32]int) // map ID to count
-	var duplicateCount int
-	var firstDuplicate uint32
-
-	for id := range idChan {
-		// Verify ID is in expected range (at least 1001)
-		require.GreaterOrEqual(t, id, uint32(1001), "ServerID should be >= 1001")
-
-		// Track duplicates - count every occurrence beyond the first
-		ids[id]++
-		if ids[id] > 1 {
-			duplicateCount++
-			if firstDuplicate == 0 {
-				firstDuplicate = id
-			}
-		}
+	wg.Wait()
+	close(ids)
+	seen := make(map[uint32]struct{}, workers*perWorker)
+	for id := range ids {
+		require.GreaterOrEqual(t, id, uint32(1001))
+		_, duplicate := seen[id]
+		require.False(t, duplicate, "duplicate server ID: %d", id)
+		seen[id] = struct{}{}
 	}
+	require.Len(t, seen, workers*perWorker)
+}
 
-	// Log duplicate information if any found
-	if duplicateCount > 0 {
-		t.Logf("Found %d duplicate ID(s). First duplicate: %d", duplicateCount, firstDuplicate)
-	}
-
-	// Allow up to maxAllowedDuplicates to account for birthday paradox
-	require.LessOrEqual(t, duplicateCount, maxAllowedDuplicates,
-		"Should have at most %d duplicate ID(s), but found %d", maxAllowedDuplicates, duplicateCount)
-
-	// Verify we got close to the expected number of unique IDs
-	// With 1 allowed duplicate, we should have at least 9,999 unique IDs
-	minExpectedUnique := numGoroutines*idsPerGoroutine - maxAllowedDuplicates
-	require.GreaterOrEqual(t, len(ids), minExpectedUnique,
-		"Should have at least %d unique IDs", minExpectedUnique)
+func TestServerIDSequenceWrap(t *testing.T) {
+	sequence := newServerIDSequence(uint32(serverIDRange - 3))
+	require.Equal(t, ^uint32(0)-1, sequence.next())
+	require.Equal(t, ^uint32(0), sequence.next())
+	require.Equal(t, uint32(1001), sequence.next())
+	require.Equal(t, uint32(1002), sequence.next())
 }
 
 // TestNewServerIDRange tests that NewServerID always returns values in the expected range.


### PR DESCRIPTION
Repeated random server-ID allocation can collide within one process, disconnect readers, and occasionally fail TestNewServerIDConcurrent even with one duplicate allowed. Lazily seed an atomic sequence on the first NewServerID call so process-local allocations do not repeat until the valid ID range is exhausted; cross-process uniqueness remains probabilistic.

Replace the probabilistic duplicate allowance with strict concurrent uniqueness and wrap-safe circular-contiguity checks and add deterministic coverage of wrapping from the largest allowed ID back to 1001.

Validation: `go test -race ./pkg/change -run 'TestNewServerID|TestServerIDSequence' -count=20`; `golangci-lint run ./pkg/change/...`.
