### PR TITLE
test(change): make BlockWait stall assertions deterministic

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1435,8 +1435,7 @@ func (c *binlogClient) BlockWait(ctx context.Context) error {
 	defer timer.Stop() // Ensure timer is always stopped to prevent goroutine leak
 
 	prevPos := c.getBufferedPos()
-	first := true
-	stallCount := 0
+	stalls := blockWaitStalls{}
 	for {
 		select {
 		case <-ctx.Done():
@@ -1445,25 +1444,14 @@ func (c *binlogClient) BlockWait(ctx context.Context) error {
 			return fmt.Errorf("timed out waiting to catch up to source position: %v, current position is: %v", targetPos, c.getBufferedPos())
 		default:
 			currPos := c.getBufferedPos()
-			if currPos.Compare(prevPos) <= 0 && !first {
-				// Position hasn't advanced. Only flush after multiple consecutive
-				// stalls to avoid unnecessary flushes when the binlog syncer is
-				// just slightly behind (e.g., under CI load). getCurrentBinlogPosition
-				// already flushes once at the start, so a brief stall is expected.
-				stallCount++
-				if stallCount >= blockWaitStallThreshold {
-					c.logger.Debug("buffered position has not advanced, flushing binary logs")
-					if err := dbconn.Exec(ctx, c.db, "FLUSH BINARY LOGS"); err != nil {
-						return err // it could be context cancelled, return it
-					}
-					c.flushedBinlogs.Add(1)
-					stallCount = 0
+			if stalls.observe(currPos.Compare(prevPos) > 0) {
+				c.logger.Debug("buffered position has not advanced, flushing binary logs")
+				if err := dbconn.Exec(ctx, c.db, "FLUSH BINARY LOGS"); err != nil {
+					return err
 				}
-			} else {
-				stallCount = 0
+				c.flushedBinlogs.Add(1)
 			}
 			prevPos = currPos
-			first = false
 
 			if c.getBufferedPos().Compare(targetPos) >= 0 {
 				return nil // we are up to date!

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -152,7 +152,7 @@ type binlogClient struct {
 	// parks), so requests never queue behind each other.
 	flushRequests chan Subscription
 
-	flushedBinlogs atomic.Int64 // for testing binlog flushing frequency
+	flushedBinlogs atomic.Int64 // stall-triggered rotations reported as FeedStats.ForcedRotations
 }
 
 // NewBinlogClient constructs the binlog-backed change.Source. The
@@ -1444,7 +1444,7 @@ func (c *binlogClient) BlockWait(ctx context.Context) error {
 			return fmt.Errorf("timed out waiting to catch up to source position: %v, current position is: %v", targetPos, c.getBufferedPos())
 		default:
 			currPos := c.getBufferedPos()
-			if stalls.observe(currPos.Compare(prevPos) > 0) {
+			if stalls.observe(prevPos, currPos) {
 				c.logger.Debug("buffered position has not advanced, flushing binary logs")
 				if err := dbconn.Exec(ctx, c.db, "FLUSH BINARY LOGS"); err != nil {
 					return err

--- a/pkg/change/binlog_test.go
+++ b/pkg/change/binlog_test.go
@@ -583,29 +583,11 @@ func TestBlockWait(t *testing.T) {
 	require.NoError(t, client.Start(t.Context()))
 	defer client.Close()
 
-	// We test that BlockWait does not flush the binlog if the buffered position is advancing by
-	// 1. kicking off a go-routine that inserts into an unrelated table
-	// 2. verifying that flushedBinlogs is still 0 at the end of BlockWait
-	ctx, cancel := context.WithCancel(t.Context())
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		i := 1
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				_, _ = db.ExecContext(ctx, fmt.Sprintf("INSERT INTO blockwaitt3 (a, b, c) VALUES (%d, %d, %d)", i, i, i))
-				i++
-			}
-		}
-	})
-	time.Sleep(3 * time.Second) // should be enough for BlockWait to block for 1 iteration before catching up, but not guaranteed
-	client.flushedBinlogs.Store(0)
+	// Unrelated-table events must not prevent the reader catching up. Whether
+	// a real reader briefly stalls is scheduler-dependent; the exact rotation
+	// policy is covered by TestBlockWaitStalls using controlled progress.
+	testutils.RunSQL(t, "INSERT INTO blockwaitt3 (a, b, c) VALUES (1, 1, 1)")
 	require.NoError(t, client.BlockWait(t.Context()))
-	cancel()
-	wg.Wait() // ensure goroutine exits before test completes
-	require.Equal(t, int64(0), client.flushedBinlogs.Load())
 
 	// Insert into t1.
 	testutils.RunSQL(t, "INSERT INTO blockwaitt1 (a, b, c) VALUES (1, 2, 3)")

--- a/pkg/change/blockwait.go
+++ b/pkg/change/blockwait.go
@@ -1,0 +1,24 @@
+package change
+
+// blockWaitStalls decides when the file-position reader needs a rotation to
+// nudge it forward. The first observation establishes a baseline; progress
+// resets the consecutive-stall count. Keep this independent of wall time so
+// tests can exercise the policy without assuming how CI schedules the reader.
+type blockWaitStalls struct {
+	observed    bool
+	consecutive int
+}
+
+func (s *blockWaitStalls) observe(advanced bool) bool {
+	if !s.observed || advanced {
+		s.observed = true
+		s.consecutive = 0
+		return false
+	}
+	s.consecutive++
+	if s.consecutive < blockWaitStallThreshold {
+		return false
+	}
+	s.consecutive = 0
+	return true
+}

--- a/pkg/change/blockwait.go
+++ b/pkg/change/blockwait.go
@@ -1,16 +1,20 @@
 package change
 
+import "github.com/go-mysql-org/go-mysql/mysql"
+
 // blockWaitStalls decides when the file-position reader needs a rotation to
 // nudge it forward. The first observation establishes a baseline; progress
-// resets the consecutive-stall count. Keep this independent of wall time so
-// tests can exercise the policy without assuming how CI schedules the reader.
+// resets the consecutive-stall count. getCurrentBinlogPosition rotates the log
+// before sampling, so a brief initial stall while the reader opens it is normal.
+// Keep this independent of wall time so tests can exercise the policy without
+// assuming how CI schedules the reader.
 type blockWaitStalls struct {
 	observed    bool
 	consecutive int
 }
 
-func (s *blockWaitStalls) observe(advanced bool) bool {
-	if !s.observed || advanced {
+func (s *blockWaitStalls) observe(prev, curr mysql.Position) bool {
+	if !s.observed || curr.Compare(prev) > 0 {
 		s.observed = true
 		s.consecutive = 0
 		return false

--- a/pkg/change/blockwait_test.go
+++ b/pkg/change/blockwait_test.go
@@ -3,34 +3,60 @@ package change
 import (
 	"testing"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBlockWaitStalls(t *testing.T) {
+	before := mysql.Position{Name: "binlog.000001", Pos: 4}
+	after := mysql.Position{Name: "binlog.000001", Pos: 8}
 	t.Run("advancing reader never rotates", func(t *testing.T) {
 		var stalls blockWaitStalls
 		for range 100 {
-			require.False(t, stalls.observe(true))
+			require.False(t, stalls.observe(before, after))
 		}
 	})
 	t.Run("interrupted stalls do not accumulate", func(t *testing.T) {
 		var stalls blockWaitStalls
-		require.False(t, stalls.observe(false), "first observation is only a baseline")
+		require.False(t, stalls.observe(before, before), "first observation is only a baseline")
 		for range 10 {
 			for range blockWaitStallThreshold - 1 {
-				require.False(t, stalls.observe(false))
+				require.False(t, stalls.observe(before, before))
 			}
-			require.False(t, stalls.observe(true), "progress resets the stall count")
+			require.False(t, stalls.observe(before, after), "progress resets the stall count")
 		}
 	})
 	t.Run("sustained stalls rotate at the threshold", func(t *testing.T) {
 		var stalls blockWaitStalls
-		require.False(t, stalls.observe(false))
+		require.False(t, stalls.observe(before, before))
 		for range 3 {
 			for range blockWaitStallThreshold - 1 {
-				require.False(t, stalls.observe(false))
+				require.False(t, stalls.observe(before, before))
 			}
-			require.True(t, stalls.observe(false))
+			require.True(t, stalls.observe(before, before))
 		}
 	})
+}
+
+func TestBlockWaitPositionOrdering(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		prev, curr mysql.Position
+		advances   bool
+	}{
+		{"offset advances", mysql.Position{Name: "binlog.000001", Pos: 4}, mysql.Position{Name: "binlog.000001", Pos: 8}, true},
+		{"unchanged", mysql.Position{Name: "binlog.000001", Pos: 8}, mysql.Position{Name: "binlog.000001", Pos: 8}, false},
+		{"offset regresses", mysql.Position{Name: "binlog.000001", Pos: 8}, mysql.Position{Name: "binlog.000001", Pos: 4}, false},
+		{"file rollover", mysql.Position{Name: "binlog.000001", Pos: 999}, mysql.Position{Name: "binlog.000002", Pos: 4}, true},
+		{"file regresses", mysql.Position{Name: "binlog.000002", Pos: 4}, mysql.Position{Name: "binlog.000001", Pos: 999}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stalls blockWaitStalls
+			require.False(t, stalls.observe(tc.prev, tc.prev))
+			for range blockWaitStallThreshold - 1 {
+				require.False(t, stalls.observe(tc.prev, tc.prev))
+			}
+			require.Equal(t, !tc.advances, stalls.observe(tc.prev, tc.curr))
+		})
+	}
 }

--- a/pkg/change/blockwait_test.go
+++ b/pkg/change/blockwait_test.go
@@ -1,0 +1,36 @@
+package change
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockWaitStalls(t *testing.T) {
+	t.Run("advancing reader never rotates", func(t *testing.T) {
+		var stalls blockWaitStalls
+		for range 100 {
+			require.False(t, stalls.observe(true))
+		}
+	})
+	t.Run("interrupted stalls do not accumulate", func(t *testing.T) {
+		var stalls blockWaitStalls
+		require.False(t, stalls.observe(false), "first observation is only a baseline")
+		for range 10 {
+			for range blockWaitStallThreshold - 1 {
+				require.False(t, stalls.observe(false))
+			}
+			require.False(t, stalls.observe(true), "progress resets the stall count")
+		}
+	})
+	t.Run("sustained stalls rotate at the threshold", func(t *testing.T) {
+		var stalls blockWaitStalls
+		require.False(t, stalls.observe(false))
+		for range 3 {
+			for range blockWaitStallThreshold - 1 {
+				require.False(t, stalls.observe(false))
+			}
+			require.True(t, stalls.observe(false))
+		}
+	})
+}


### PR DESCRIPTION
TestBlockWait requires zero binlog rotations while an unrelated writer is active, but a legitimately stalled reader can trigger a rotation under CI scheduling pressure. Extract the existing consecutive-stall policy and test it with controlled MySQL positions, including offset regression and file rollover: advancing readers never rotate, progress resets the stall count, and sustained stalls rotate at the existing threshold.

Keep real MySQL catch-up coverage for unrelated-table events and remove the scheduling-dependent rotation assertion, background writer, and three-second sleep. Production stall thresholds and behavior are unchanged.

Fixes #1162.

Validation: `go test -race ./pkg/change -run '^TestBlockWait' -count=10`; `golangci-lint run ./pkg/change/...`.
