### PR TITLE
fix(change): join periodic flushing during Close

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1115,6 +1115,10 @@ func (c *binlogClient) Close() {
 
 	// Wait for the readStream goroutine to exit cleanly. This prevents
 	// goroutine leaks detected by goleak in tests.
+	// Quiesce writes as well as the reader before callers tear down pools.
+	// The periodic loop has its own context and is not joined by streamWG.
+	c.StopPeriodicFlush()
+
 	c.streamWG.Wait()
 
 	// streamWG.Wait has returned, so readStream has exited and c.syncer
@@ -1347,7 +1351,7 @@ func (c *binlogClient) StopPeriodicFlush() {
 // Satisfies Source interface.
 func (c *binlogClient) StartPeriodicFlush(ctx context.Context, interval time.Duration) {
 	c.periodicFlushLock.Lock()
-	if c.periodicFlushCancel != nil {
+	if c.isClosed.Load() || c.periodicFlushCancel != nil {
 		c.periodicFlushLock.Unlock()
 		return
 	}

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1115,8 +1115,8 @@ func (c *binlogClient) Close() {
 
 	// Wait for the readStream goroutine to exit cleanly. This prevents
 	// goroutine leaks detected by goleak in tests.
-	// Quiesce writes as well as the reader before callers tear down pools.
-	// The periodic loop has its own context and is not joined by streamWG.
+	// Join the independently cancellable writer too. Both background loops
+	// must finish before Close returns; neither join depends on the other.
 	c.StopPeriodicFlush()
 
 	c.streamWG.Wait()
@@ -1347,11 +1347,16 @@ func (c *binlogClient) StopPeriodicFlush() {
 // StopPeriodicFlush is guaranteed to observe the registration. Callers
 // MUST NOT prefix with `go` — the loop is spawned internally.
 //
-// Calling Start while a flush is already running is a no-op.
+// Calling Start while a flush is already running or after Close is a no-op.
 // Satisfies Source interface.
 func (c *binlogClient) StartPeriodicFlush(ctx context.Context, interval time.Duration) {
 	c.periodicFlushLock.Lock()
-	if c.isClosed.Load() || c.periodicFlushCancel != nil {
+	if c.isClosed.Load() {
+		c.periodicFlushLock.Unlock()
+		c.logger.Debug("ignoring periodic flush start on a closed client")
+		return
+	}
+	if c.periodicFlushCancel != nil {
 		c.periodicFlushLock.Unlock()
 		return
 	}

--- a/pkg/change/close_test.go
+++ b/pkg/change/close_test.go
@@ -1,0 +1,94 @@
+package change
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/stretchr/testify/require"
+)
+
+// Hold the flush after it observes cancellation so the test distinguishes
+// cancelling the worker from actually joining it.
+type closingSubscription struct {
+	stubSubscription
+	entered   chan struct{}
+	cancelled chan struct{}
+	release   chan struct{}
+}
+
+func (s *closingSubscription) Flush(ctx context.Context, _ bool, _ []*dbconn.TableLock) (bool, error) {
+	close(s.entered)
+	<-ctx.Done()
+	close(s.cancelled)
+	<-s.release
+	return false, ctx.Err()
+}
+
+func TestCloseJoinsPeriodicFlush(t *testing.T) {
+	for _, name := range []string{"binlog", "gtid"} {
+		t.Run(name, func(t *testing.T) {
+			var client Source
+			var requests chan Subscription
+			var flushDone func() chan struct{}
+			if name == "binlog" {
+				c := NewBinlogClient(nil, "", "", "", nil, NewClientDefaultConfig()).(*binlogClient)
+				client, requests = c, c.flushRequests
+				flushDone = func() chan struct{} { return c.periodicFlushDone }
+			} else {
+				c := NewGTIDClient(nil, "", "", "", nil, NewClientDefaultConfig()).(*gtidClient)
+				client, requests = c, c.flushRequests
+				flushDone = func() chan struct{} { return c.periodicFlushDone }
+			}
+			sub := &closingSubscription{
+				entered: make(chan struct{}), cancelled: make(chan struct{}), release: make(chan struct{}),
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			closed := make(chan struct{})
+			t.Cleanup(func() {
+				cancel()
+				close(sub.release)
+				client.StopPeriodicFlush()
+				select {
+				case <-closed:
+				case <-time.After(5 * time.Second):
+					t.Error("Close did not finish during cleanup")
+				}
+			})
+			client.StartPeriodicFlush(ctx, time.Hour)
+			done := flushDone()
+			requests <- sub
+			<-sub.entered
+			go func() {
+				client.Close()
+				close(closed)
+			}()
+			select {
+			case <-sub.cancelled:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Close did not cancel the in-flight flush")
+			}
+			select {
+			case <-closed:
+				t.Fatal("Close returned before the in-flight flush finished")
+			default:
+			}
+			// Unblock without closing: cleanup owns the channel close.
+			sub.release <- struct{}{}
+			select {
+			case <-closed:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Close did not join the completed flush")
+			}
+			select {
+			case <-done:
+			default:
+				t.Fatal("periodic flush is still running after Close")
+			}
+			client.Close() // idempotent
+			client.StartPeriodicFlush(ctx, time.Hour)
+			require.Nil(t, flushDone(), "a closed client must not restart flushing")
+		})
+	}
+}

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -1106,6 +1106,10 @@ func (c *gtidClient) Close() {
 		sub.Close()
 	}
 
+	// Quiesce writes as well as the reader before callers tear down pools.
+	// The periodic loop has its own context and is not joined by streamWG.
+	c.StopPeriodicFlush()
+
 	c.streamWG.Wait()
 
 	if c.syncer != nil {
@@ -1298,7 +1302,7 @@ func (c *gtidClient) StopPeriodicFlush() {
 // StartPeriodicFlush satisfies Source.
 func (c *gtidClient) StartPeriodicFlush(ctx context.Context, interval time.Duration) {
 	c.periodicFlushLock.Lock()
-	if c.periodicFlushCancel != nil {
+	if c.isClosed.Load() || c.periodicFlushCancel != nil {
 		c.periodicFlushLock.Unlock()
 		return
 	}

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -1106,8 +1106,8 @@ func (c *gtidClient) Close() {
 		sub.Close()
 	}
 
-	// Quiesce writes as well as the reader before callers tear down pools.
-	// The periodic loop has its own context and is not joined by streamWG.
+	// Join the independently cancellable writer too. Both background loops
+	// must finish before Close returns; neither join depends on the other.
 	c.StopPeriodicFlush()
 
 	c.streamWG.Wait()
@@ -1299,10 +1299,15 @@ func (c *gtidClient) StopPeriodicFlush() {
 	<-done
 }
 
-// StartPeriodicFlush satisfies Source.
+// StartPeriodicFlush satisfies Source. Calls after Close are ignored.
 func (c *gtidClient) StartPeriodicFlush(ctx context.Context, interval time.Duration) {
 	c.periodicFlushLock.Lock()
-	if c.isClosed.Load() || c.periodicFlushCancel != nil {
+	if c.isClosed.Load() {
+		c.periodicFlushLock.Unlock()
+		c.logger.Debug("ignoring periodic flush start on a closed client")
+		return
+	}
+	if c.periodicFlushCancel != nil {
 		c.periodicFlushLock.Unlock()
 		return
 	}

--- a/pkg/change/source.go
+++ b/pkg/change/source.go
@@ -151,7 +151,7 @@ type Source interface {
 	// StartPeriodicFlush spawns a background goroutine that flushes the
 	// changeset at the given interval. Used by the migrator to advance
 	// the safe-flushed position. Calling Start while a periodic flush
-	// is already running is a no-op.
+	// is already running or after Close has been called is a no-op.
 	StartPeriodicFlush(ctx context.Context, interval time.Duration)
 
 	// StopPeriodicFlush stops the goroutine started by
@@ -179,6 +179,8 @@ type Source interface {
 	// rename that fails ambiguously is retried via Flush and BlockWait.
 	Stop()
 
-	// Close releases all resources. Safe to call more than once.
+	// Close releases all resources, cancelling and joining the reader and any
+	// periodic flush loop. Subsequent StartPeriodicFlush calls are no-ops.
+	// Safe to call more than once.
 	Close()
 }


### PR DESCRIPTION
Both change-feed implementations leave periodic flushing alive when Close returns, despite the Source contract requiring all resources to be released. Cancel and join periodic flushing during Close, after waking parked subscriptions, and prevent a closed client from restarting the periodic loop. Document this lifecycle contract on Source and both implementations, and log ignored starts on closed clients.

The regression test holds an in-flight flush after it observes cancellation, proving Close waits for completion rather than merely sending cancellation. It covers both file-position and GTID clients, repeated Close, and attempts to restart flushing after Close. This fixes the shared implementation used by migration, move, and datasync; no runner-specific lifecycle fork is needed.

Validation:

- Race-enabled shutdown and parked-reader tests, five repetitions.
- `go test -race ./pkg/change ./pkg/migration ./pkg/move ./pkg/datasync -parallel=4 -timeout=5m` against MySQL 8.0.43.
- `golangci-lint run ./pkg/change/...`.
