### PR TITLE
fix(throttler): cancel and join background monitors on Close

### DIFF
--- a/pkg/throttler/aurora_commitlatency.go
+++ b/pkg/throttler/aurora_commitlatency.go
@@ -111,14 +111,16 @@ func NewCommitLatencyThrottler(db *sql.DB, threshold time.Duration, logger *slog
 }
 
 func (c *CommitLatency) Open(ctx context.Context) error {
+	if err := c.poller.checkOpen(); err != nil {
+		return err
+	}
 	// Take an initial sample so the first delta computed by the background
 	// loop is meaningful; otherwise we'd flap "throttled" on the very first
 	// post-open chunk based on whatever the cumulative average happened to be.
 	if err := c.UpdateLag(ctx); err != nil {
 		return err
 	}
-	c.poller.start(ctx, c.run)
-	return nil
+	return c.poller.start(ctx, c.run)
 }
 
 func (c *CommitLatency) run(ctx context.Context) {

--- a/pkg/throttler/aurora_commitlatency.go
+++ b/pkg/throttler/aurora_commitlatency.go
@@ -72,7 +72,7 @@ type CommitLatency struct {
 	logger    *slog.Logger
 
 	isThrottled atomic.Bool
-	isClosed    atomic.Bool
+	poller      monitorLoop
 
 	// Previous sample, guarded by sampleMu. commits and latency must move
 	// together to compute a meaningful delta, so a single mutex is simpler
@@ -117,7 +117,7 @@ func (c *CommitLatency) Open(ctx context.Context) error {
 	if err := c.UpdateLag(ctx); err != nil {
 		return err
 	}
-	go c.run(ctx)
+	c.poller.start(ctx, c.run)
 	return nil
 }
 
@@ -129,9 +129,6 @@ func (c *CommitLatency) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if c.isClosed.Load() {
-				return
-			}
 			if err := c.UpdateLag(ctx); err != nil {
 				if isShutdownError(ctx, err) {
 					return // teardown cancelled the in-flight sample; not a monitoring failure
@@ -144,7 +141,7 @@ func (c *CommitLatency) run(ctx context.Context) {
 }
 
 func (c *CommitLatency) Close() error {
-	c.isClosed.Store(true)
+	c.poller.close()
 	return nil
 }
 

--- a/pkg/throttler/aurora_threads.go
+++ b/pkg/throttler/aurora_threads.go
@@ -294,6 +294,9 @@ func newAuroraThreadsThrottler(db *sql.DB, mode threadsMode, logger *slog.Logger
 }
 
 func (a *AuroraThreads) Open(ctx context.Context) error {
+	if err := a.poller.checkOpen(); err != nil {
+		return err
+	}
 	vCPUs, err := AuroraVCPUs(ctx, a.db)
 	if err != nil {
 		return err
@@ -304,8 +307,7 @@ func (a *AuroraThreads) Open(ctx context.Context) error {
 	if err := a.UpdateLag(ctx); err != nil {
 		return err
 	}
-	a.poller.start(ctx, a.run)
-	return nil
+	return a.poller.start(ctx, a.run)
 }
 
 func (a *AuroraThreads) run(ctx context.Context) {

--- a/pkg/throttler/aurora_threads.go
+++ b/pkg/throttler/aurora_threads.go
@@ -256,7 +256,7 @@ type AuroraThreads struct {
 	vCPUs int64
 
 	isThrottled atomic.Bool
-	isClosed    atomic.Bool
+	poller      monitorLoop
 
 	// lastSample holds the most recent observation for logging and the raw
 	// hard-stop comparison.
@@ -304,7 +304,7 @@ func (a *AuroraThreads) Open(ctx context.Context) error {
 	if err := a.UpdateLag(ctx); err != nil {
 		return err
 	}
-	go a.run(ctx)
+	a.poller.start(ctx, a.run)
 	return nil
 }
 
@@ -316,9 +316,6 @@ func (a *AuroraThreads) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if a.isClosed.Load() {
-				return
-			}
 			if err := a.UpdateLag(ctx); err != nil {
 				if isShutdownError(ctx, err) {
 					return // teardown cancelled the in-flight sample; not a monitoring failure
@@ -331,7 +328,7 @@ func (a *AuroraThreads) run(ctx context.Context) {
 }
 
 func (a *AuroraThreads) Close() error {
-	a.isClosed.Store(true)
+	a.poller.close()
 	return nil
 }
 

--- a/pkg/throttler/monitor.go
+++ b/pkg/throttler/monitor.go
@@ -2,8 +2,11 @@ package throttler
 
 import (
 	"context"
+	"errors"
 	"sync"
 )
+
+var errMonitorClosed = errors.New("cannot open a closed throttler")
 
 // monitorLoop owns one background monitor. Closing it interrupts in-flight
 // queries and joins the loop before the caller closes its database pool.
@@ -14,11 +17,14 @@ type monitorLoop struct {
 	done   chan struct{}
 }
 
-func (m *monitorLoop) start(ctx context.Context, run func(context.Context)) {
+func (m *monitorLoop) start(ctx context.Context, run func(context.Context)) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.closed || m.done != nil {
-		return
+	if m.closed {
+		return errMonitorClosed
+	}
+	if m.done != nil {
+		return nil
 	}
 	ctx, m.cancel = context.WithCancel(ctx)
 	m.done = make(chan struct{})
@@ -26,6 +32,7 @@ func (m *monitorLoop) start(ctx context.Context, run func(context.Context)) {
 		defer close(m.done)
 		run(ctx)
 	}()
+	return nil
 }
 
 func (m *monitorLoop) close() {
@@ -37,4 +44,15 @@ func (m *monitorLoop) close() {
 		cancel()
 		<-done
 	}
+}
+
+// Check before initial sampling too, so reopening fails without touching pools
+// that the owner may already have closed. start rechecks after sampling.
+func (m *monitorLoop) checkOpen() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return errMonitorClosed
+	}
+	return nil
 }

--- a/pkg/throttler/monitor.go
+++ b/pkg/throttler/monitor.go
@@ -1,0 +1,40 @@
+package throttler
+
+import (
+	"context"
+	"sync"
+)
+
+// monitorLoop owns one background monitor. Closing it interrupts in-flight
+// queries and joins the loop before the caller closes its database pool.
+type monitorLoop struct {
+	mu     sync.Mutex
+	closed bool
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func (m *monitorLoop) start(ctx context.Context, run func(context.Context)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed || m.done != nil {
+		return
+	}
+	ctx, m.cancel = context.WithCancel(ctx)
+	m.done = make(chan struct{})
+	go func() {
+		defer close(m.done)
+		run(ctx)
+	}()
+}
+
+func (m *monitorLoop) close() {
+	m.mu.Lock()
+	m.closed = true
+	cancel, done := m.cancel, m.done
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		<-done
+	}
+}

--- a/pkg/throttler/monitor_test.go
+++ b/pkg/throttler/monitor_test.go
@@ -3,6 +3,7 @@ package throttler
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,11 +34,11 @@ func TestMonitorCloseCancelsAndJoins(t *testing.T) {
 				tc.loop.close()
 				<-closed
 			})
-			tc.loop.start(ctx, func(ctx context.Context) {
+			require.NoError(t, tc.loop.start(ctx, func(ctx context.Context) {
 				<-ctx.Done()
 				close(cancelled)
 				<-release
-			})
+			}))
 			go func() {
 				defer close(closed)
 				_ = tc.throttler.Close()
@@ -66,13 +67,13 @@ func TestMonitorCloseCancelsAndJoins(t *testing.T) {
 func TestMonitorCloseBeforeStart(t *testing.T) {
 	var loop monitorLoop
 	loop.close()
-	loop.start(t.Context(), func(context.Context) { t.Error("closed monitor started") })
+	require.ErrorIs(t, loop.start(t.Context(), func(context.Context) { t.Error("closed monitor started") }), errMonitorClosed)
 	require.Nil(t, loop.done)
 }
 
 func TestMonitorConcurrentClose(t *testing.T) {
 	var loop monitorLoop
-	loop.start(t.Context(), func(ctx context.Context) { <-ctx.Done() })
+	require.NoError(t, loop.start(t.Context(), func(ctx context.Context) { <-ctx.Done() }))
 	var wg sync.WaitGroup
 	for range 10 {
 		wg.Go(loop.close)
@@ -83,4 +84,38 @@ func TestMonitorConcurrentClose(t *testing.T) {
 	default:
 		t.Fatal("Close returned before monitor exited")
 	}
+}
+
+func TestClosedThrottlerCannotReopen(t *testing.T) {
+	for _, throttler := range []Throttler{&Replica{}, &AuroraThreads{}, &CommitLatency{}} {
+		require.NoError(t, throttler.Close())
+		require.ErrorIs(t, throttler.Open(t.Context()), errMonitorClosed)
+	}
+}
+
+func TestMonitorStartIsIdempotent(t *testing.T) {
+	var loop monitorLoop
+	var calls atomic.Int32
+	started := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	defer loop.close()
+	require.NoError(t, loop.start(ctx, func(ctx context.Context) {
+		calls.Add(1)
+		close(started)
+		<-ctx.Done()
+	}))
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("monitor did not start")
+	}
+	originalDone := loop.done
+	require.NoError(t, loop.start(ctx, func(ctx context.Context) {
+		calls.Add(1)
+		<-ctx.Done()
+	}))
+	require.Equal(t, originalDone, loop.done, "a repeated start must keep the original monitor")
+	loop.close()
+	require.Equal(t, int32(1), calls.Load())
 }

--- a/pkg/throttler/monitor_test.go
+++ b/pkg/throttler/monitor_test.go
@@ -1,0 +1,86 @@
+package throttler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitorCloseCancelsAndJoins(t *testing.T) {
+	// Drive the same lifecycle through each public Close method. Hold the
+	// monitor after cancellation to prove Close waits for query teardown.
+	replica := &Replica{}
+	threads := &AuroraThreads{}
+	latency := &CommitLatency{}
+	for _, tc := range []struct {
+		name      string
+		loop      *monitorLoop
+		throttler Throttler
+	}{
+		{"replica", &replica.poller, replica},
+		{"threads", &threads.poller, threads},
+		{"latency", &latency.poller, latency},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cancelled, release, closed := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(func() {
+				cancel()
+				close(release)
+				tc.loop.close()
+				<-closed
+			})
+			tc.loop.start(ctx, func(ctx context.Context) {
+				<-ctx.Done()
+				close(cancelled)
+				<-release
+			})
+			go func() {
+				defer close(closed)
+				_ = tc.throttler.Close()
+			}()
+			select {
+			case <-cancelled:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Close did not cancel the monitor")
+			}
+			select {
+			case <-closed:
+				t.Fatal("Close returned before the monitor exited")
+			default:
+			}
+			release <- struct{}{}
+			select {
+			case <-closed:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Close did not join the monitor")
+			}
+			require.NoError(t, tc.throttler.Close())
+		})
+	}
+}
+
+func TestMonitorCloseBeforeStart(t *testing.T) {
+	var loop monitorLoop
+	loop.close()
+	loop.start(t.Context(), func(context.Context) { t.Error("closed monitor started") })
+	require.Nil(t, loop.done)
+}
+
+func TestMonitorConcurrentClose(t *testing.T) {
+	var loop monitorLoop
+	loop.start(t.Context(), func(ctx context.Context) { <-ctx.Done() })
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(loop.close)
+	}
+	wg.Wait()
+	select {
+	case <-loop.done:
+	default:
+		t.Fatal("Close returned before monitor exited")
+	}
+}

--- a/pkg/throttler/replica.go
+++ b/pkg/throttler/replica.go
@@ -30,7 +30,7 @@ type Replica struct {
 	lagTolerance   time.Duration
 	currentLagInMs atomic.Int64
 	logger         *slog.Logger
-	isClosed       atomic.Bool
+	poller         monitorLoop
 
 	// stale guards against the cached lag freezing at a healthy value when
 	// polling fails persistently: IsThrottled() fails closed while the
@@ -74,32 +74,31 @@ func (l *Replica) Open(ctx context.Context) error {
 	if err := l.UpdateLag(ctx); err != nil {
 		return err
 	}
-	go func() {
-		ticker := time.NewTicker(loopInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				if l.isClosed.Load() {
-					return
-				}
-				if err := l.UpdateLag(ctx); err != nil {
-					if isShutdownError(ctx, err) {
-						return // teardown cancelled the in-flight poll; not a monitoring failure
-					}
-					l.logger.Error("error polling replica lag; keeping the last reading (throttling fails closed if polling stays stale)",
-						"error", err)
-				}
-			}
-		}
-	}()
+	l.poller.start(ctx, l.run)
 	return nil
 }
 
+func (l *Replica) run(ctx context.Context) {
+	ticker := time.NewTicker(loopInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := l.UpdateLag(ctx); err != nil {
+				if isShutdownError(ctx, err) {
+					return // teardown cancelled the in-flight poll; not a monitoring failure
+				}
+				l.logger.Error("error polling replica lag; keeping the last reading (throttling fails closed if polling stays stale)",
+					"error", err)
+			}
+		}
+	}
+}
+
 func (l *Replica) Close() error {
-	l.isClosed.Store(true)
+	l.poller.close()
 	return nil
 }
 

--- a/pkg/throttler/replica.go
+++ b/pkg/throttler/replica.go
@@ -71,11 +71,13 @@ var _ ReasonedThrottler = &Replica{}
 // We only check the replica every 5 seconds, and typically allow up to 120s
 // of replica lag, which is a lot.
 func (l *Replica) Open(ctx context.Context) error {
+	if err := l.poller.checkOpen(); err != nil {
+		return err
+	}
 	if err := l.UpdateLag(ctx); err != nil {
 		return err
 	}
-	l.poller.start(ctx, l.run)
-	return nil
+	return l.poller.start(ctx, l.run)
 }
 
 func (l *Replica) run(ctx context.Context) {

--- a/pkg/throttler/throttler_test.go
+++ b/pkg/throttler/throttler_test.go
@@ -30,7 +30,6 @@ func TestThrottlerInterface(t *testing.T) {
 	defer utils.CloseAndLog(db)
 
 	//	NewReplicationThrottler will attach either MySQL 8.0 or MySQL 5.7 throttler
-	loopInterval = 1 * time.Millisecond
 	throttler, err := NewReplicationThrottler(db, 60*time.Second, slog.Default())
 	require.NoError(t, err)
 	require.NoError(t, throttler.Open(t.Context()))
@@ -45,7 +44,6 @@ func TestThrottlerInterface(t *testing.T) {
 
 	require.NoError(t, throttler.Close())
 
-	time.Sleep(50 * time.Millisecond) // give it time to shutdown.
 }
 
 func TestNoopThrottler(t *testing.T) {


### PR DESCRIPTION
Replica and Aurora throttler Close methods only set a flag, leaving polling goroutines and in-flight queries alive after shutdown returns. Introduce a shared monitor lifecycle that cancels and joins the poller before callers close its database pool. Use it for replica lag, Aurora threads, and commit-latency monitoring. This makes Runner.Close wait for in-flight monitoring before closing its Aurora and replica pools. Open on a closed throttler now returns an error before sampling.

Tests hold a monitor open after cancellation to verify that each public Close waits for completion, and cover concurrent Close, Close-before-start, reopen rejection, and idempotent repeated start. Remove the replica test's shutdown sleep and global polling-interval mutation.

Validation: `go test -race ./pkg/throttler -count=5`; `golangci-lint run ./pkg/throttler/...`. Aurora sampling itself still requires Aurora; lifecycle tests run without it.
