### PR TITLE
test(migration): join sentinel runners on every exit path

### DIFF
--- a/pkg/migration/check_constraint_test.go
+++ b/pkg/migration/check_constraint_test.go
@@ -141,7 +141,7 @@ func TestCheckConstraintWithDML(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		if !waitForCopyRows(t.Context(), m) {
+		if !waitForCopyRows(t, t.Context(), m) {
 			return
 		}
 		for i := range 100 {

--- a/pkg/migration/checksum_invalidation_test.go
+++ b/pkg/migration/checksum_invalidation_test.go
@@ -274,16 +274,9 @@ func TestContinuousChecksumDivergenceClearsCheckpointWatermark(t *testing.T) {
 		WithThreads(1),
 		WithDeferCutOver(),
 		WithRespectSentinel())
-	defer utils.CloseAndLog(m)
+	running := startTestRun(t, m.Run, m.Close)
 
-	var runErr error
-	runDone := make(chan struct{})
-	go func() {
-		defer close(runDone)
-		runErr = m.Run(t.Context())
-	}()
-
-	waitForStatus(t, m, status.WaitingOnSentinelTable)
+	waitForStatus(t, m, status.WaitingOnSentinelTable, running)
 
 	// The test-suite checkpoint dumper runs every 100ms (see TestMain).
 	// Wait until a checkpoint row carrying the end-of-initial-checksum
@@ -304,11 +297,7 @@ func TestContinuousChecksumDivergenceClearsCheckpointWatermark(t *testing.T) {
 	// allowing cutover.
 	testutils.RunSQL(t, fmt.Sprintf("UPDATE `%s` SET val = 'corrupted' WHERE id = 1", utils.NewTableName(tableName)))
 
-	select {
-	case <-runDone:
-	case <-time.After(2 * time.Minute):
-		t.Fatal("timed out waiting for the continuous checksum to abort the migration")
-	}
+	runErr := running.wait(t)
 	require.Error(t, runErr)
 	require.ErrorContains(t, runErr, "continuous checksum")
 

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -1023,10 +1023,7 @@ func TestDeferCutOverE2E(t *testing.T) {
 		WithDeferCutOver(),
 		WithRespectSentinel())
 
-	c := make(chan error)
-	go func() {
-		c <- m.Run(t.Context())
-	}()
+	running := startTestRun(t, m.Run, m.Close)
 
 	// Wait until the sentinel table exists.
 	db, err := dbconn.New(testutils.DSNForDatabase(dbName), dbconn.NewDBConfig())
@@ -1044,7 +1041,7 @@ func TestDeferCutOverE2E(t *testing.T) {
 	// Drop the sentinel table — migration should complete.
 	testutils.RunSQLInDatabase(t, dbName, "DROP TABLE "+sentinel.TableName)
 
-	err = <-c
+	err = running.wait(t)
 	require.NoError(t, err)
 
 	// Old table should be dropped (SkipDropAfterCutover is false).
@@ -1053,7 +1050,6 @@ func TestDeferCutOverE2E(t *testing.T) {
 		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
 		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, m.changes[0].oldTableName())).Scan(&tableCount))
 	require.Equal(t, 0, tableCount)
-	require.NoError(t, m.Close())
 }
 
 // TestDeferCutOverE2EBinlogAdvance tests that during the sentinel wait phase,
@@ -1073,16 +1069,13 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 		WithDeferCutOver(),
 		WithRespectSentinel())
 
-	c := make(chan error)
-	go func() {
-		c <- m.Run(t.Context())
-	}()
+	running := startTestRun(t, m.Run, m.Close)
 
 	db, err := dbconn.New(testutils.DSNForDatabase(dbName), dbconn.NewDBConfig())
 	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
-	waitForStatus(t, m, status.WaitingOnSentinelTable)
+	waitForStatus(t, m, status.WaitingOnSentinelTable, running)
 
 	// Verify the source position advances while waiting. Position() is an
 	// opaque string and the binlogClient's internal setBufferedPos enforces
@@ -1099,7 +1092,7 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 
 	testutils.RunSQLInDatabase(t, dbName, "DROP TABLE "+sentinel.TableName)
 
-	err = <-c
+	err = running.wait(t)
 	require.NoError(t, err)
 
 	var tableCount int
@@ -1107,7 +1100,6 @@ func TestDeferCutOverE2EBinlogAdvance(t *testing.T) {
 		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
 		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='%s'`, m.changes[0].oldTableName())).Scan(&tableCount))
 	require.Equal(t, 0, tableCount)
-	require.NoError(t, m.Close())
 }
 
 // TestSentinelCreateNeverObservedAbsent verifies that createSentinelTable is

--- a/pkg/migration/cutover_test.go
+++ b/pkg/migration/cutover_test.go
@@ -987,15 +987,9 @@ func TestDeferCutOver(t *testing.T) {
 		WithDeferCutOver(),
 		WithRespectSentinel())
 
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		err := m.Run(t.Context())
-		require.Error(t, err)
-		require.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
-	})
-
-	waitForStatus(t, m, status.WaitingOnSentinelTable)
-	wg.Wait()
+	running := startTestRun(t, m.Run, m.Close)
+	waitForStatus(t, m, status.WaitingOnSentinelTable, running)
+	require.ErrorContains(t, running.wait(t), "timed out waiting for sentinel table to be dropped")
 
 	newName := fmt.Sprintf("_%s_new", tableName)
 	var tableCount int
@@ -1186,11 +1180,8 @@ func TestDeferCutOverTwoMigrationsSharedSentinel(t *testing.T) {
 		WithDBName(dbName),
 		WithDeferCutOver(),
 		WithRespectSentinel())
-	cA := make(chan error)
-	go func() {
-		cA <- mA.Run(t.Context())
-	}()
-	waitForStatus(t, mA, status.WaitingOnSentinelTable)
+	runningA := startTestRun(t, mA.Run, mA.Close)
+	waitForStatus(t, mA, status.WaitingOnSentinelTable, runningA)
 
 	// Migration B starts fresh in the same schema while A is blocked on the
 	// sentinel, and re-creates the shared sentinel during its setup.
@@ -1198,11 +1189,8 @@ func TestDeferCutOverTwoMigrationsSharedSentinel(t *testing.T) {
 		WithDBName(dbName),
 		WithDeferCutOver(),
 		WithRespectSentinel())
-	cB := make(chan error)
-	go func() {
-		cB <- mB.Run(t.Context())
-	}()
-	waitForStatus(t, mB, status.WaitingOnSentinelTable)
+	runningB := startTestRun(t, mB.Run, mB.Close)
+	waitForStatus(t, mB, status.WaitingOnSentinelTable, runningB)
 
 	// Give A several sentinel poll intervals to (incorrectly) notice any
 	// sentinel gap left by B's setup. It must still be waiting: the operator
@@ -1214,10 +1202,8 @@ func TestDeferCutOverTwoMigrationsSharedSentinel(t *testing.T) {
 	// Operator approves: drop the shared sentinel once; both migrations
 	// proceed to cutover.
 	testutils.RunSQLInDatabase(t, dbName, "DROP TABLE "+sentinel.TableName)
-	require.NoError(t, <-cA)
-	require.NoError(t, <-cB)
-	require.NoError(t, mA.Close())
-	require.NoError(t, mB.Close())
+	require.NoError(t, runningA.wait(t))
+	require.NoError(t, runningB.wait(t))
 }
 
 // TestMultiTableMigrationBlockedPerSchema verifies that only one atomic
@@ -1240,9 +1226,8 @@ func TestMultiTableMigrationBlockedPerSchema(t *testing.T) {
 	stmtA := "ALTER TABLE mt_lock_a1 ENGINE=InnoDB; ALTER TABLE mt_lock_a2 ENGINE=InnoDB"
 	mA := NewTestRunnerFromStatement(t, stmtA, WithDBName(dbName), WithDeferCutOver(), WithRespectSentinel())
 	require.Len(t, mA.changes, 2)
-	cA := make(chan error, 1) // buffered: mA's goroutine never blocks on send if an assertion fails first
-	go func() { cA <- mA.Run(t.Context()) }()
-	waitForStatus(t, mA, status.WaitingOnSentinelTable)
+	runningA := startTestRun(t, mA.Run, mA.Close)
+	waitForStatus(t, mA, status.WaitingOnSentinelTable, runningA)
 
 	// A second atomic multi-table migration in the same schema must be blocked
 	// fast, with an error that names the cause.
@@ -1256,6 +1241,5 @@ func TestMultiTableMigrationBlockedPerSchema(t *testing.T) {
 
 	// Operator approves A; it finishes and releases the schema lock.
 	testutils.RunSQLInDatabase(t, dbName, "DROP TABLE "+sentinel.TableName)
-	require.NoError(t, <-cA)
-	require.NoError(t, mA.Close())
+	require.NoError(t, runningA.wait(t))
 }

--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -201,7 +201,7 @@ func TestEnumReorder(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		for i := range 50 {
@@ -248,7 +248,7 @@ func TestSetReorder(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		for i := range 50 {
@@ -314,7 +314,7 @@ func TestEnumDrop(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		// Concurrent DML uses only retained values; binlog ordinals for
@@ -407,7 +407,7 @@ func TestEnumToVarchar(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		for i := 1; i <= 100; i++ {
@@ -474,7 +474,7 @@ func TestSetToVarchar(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		for i := 1; i <= 50; i++ {
@@ -532,7 +532,7 @@ func TestEnumToSet(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		for i := 1; i <= 100; i++ {
@@ -596,14 +596,9 @@ func TestBufferedMigrationFailsGracefullyWithMinimalRBR(t *testing.T) {
 		WithTestThrottler())
 
 	// Run the migration in a goroutine so we can inject minimal-RBR writes.
-	var migrationErr error
-	migrationDone := make(chan struct{})
-	go func() {
-		defer close(migrationDone)
-		migrationErr = m.Run(ctx)
-	}()
+	running := startTestRun(t, m.Run, m.Close)
 
-	waitForStatus(t, m, status.CopyRows)
+	waitForStatus(t, m, status.CopyRows, running)
 
 	// Continuously write using the minimal-RBR session during the copy phase.
 	var writerWg sync.WaitGroup
@@ -618,10 +613,9 @@ func TestBufferedMigrationFailsGracefullyWithMinimalRBR(t *testing.T) {
 		}
 	})
 
-	<-migrationDone
+	migrationErr := running.wait(t)
 	cancel()
 	writerWg.Wait()
-	require.NoError(t, m.Close())
 
 	require.Error(t, migrationErr)
 }
@@ -708,7 +702,7 @@ func TestAlterPKIntToBigIntWithDML(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		if !waitForCopyRows(t.Context(), m) {
+		if !waitForCopyRows(t, t.Context(), m) {
 			return
 		}
 		for i := range 100 {
@@ -773,7 +767,7 @@ func TestAlterPKIntToBigIntWithDMLAndAdditionalColumnChange(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		if !waitForCopyRows(t.Context(), m) {
+		if !waitForCopyRows(t, t.Context(), m) {
 			return
 		}
 		for i := range 50 {
@@ -881,7 +875,7 @@ func TestBinaryToVarbinaryConcurrentDML(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		for range 50 {
@@ -1062,7 +1056,7 @@ func runBitDMLTest(t *testing.T, tableName, colName, colDef string, values []uin
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		// UPDATE the marker rows mid-migration. Each update produces a
@@ -1322,7 +1316,7 @@ func TestVectorConcurrentDML(t *testing.T) {
 	dmlDone := make(chan struct{})
 	go func() {
 		defer close(dmlDone)
-		if !waitForCopyRows(ctx, m) {
+		if !waitForCopyRows(t, ctx, m) {
 			return
 		}
 		// The DELETE happens once, up front, so the row is gone from the

--- a/pkg/migration/e2e_test.go
+++ b/pkg/migration/e2e_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/block/spirit/pkg/dbconn"
@@ -339,19 +338,10 @@ func TestPreventConcurrentRuns(t *testing.T) {
 		WithDBName(dbName),
 		WithDeferCutOver(),
 		WithRespectSentinel())
-	defer utils.CloseAndLog(m)
-
-	wg := sync.WaitGroup{}
-	wg.Go(func() {
-		err := m.Run(t.Context())
-		require.Error(t, err)
-		if !errors.Is(err, context.Canceled) {
-			require.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
-		}
-	})
+	running := startTestRun(t, m.Run, m.Close)
 
 	// Wait until m has reached the sentinel wait phase before starting m2.
-	waitForStatus(t, m, status.WaitingOnSentinelTable)
+	waitForStatus(t, m, status.WaitingOnSentinelTable, running)
 
 	m2 := NewTestRunner(t, tableName, "ENGINE=InnoDB",
 		WithDBName(dbName),
@@ -361,8 +351,12 @@ func TestPreventConcurrentRuns(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "could not acquire advisory lock")
 
-	m.Cancel()
-	wg.Wait()
+	running.cancel()
+	err = running.wait(t)
+	require.Error(t, err)
+	if !errors.Is(err, context.Canceled) {
+		require.ErrorContains(t, err, "timed out waiting for sentinel table to be dropped")
+	}
 }
 
 // TestMigrationCancelledFromTableModification tests that a migration detects
@@ -379,20 +373,14 @@ func TestMigrationCancelledFromTableModification(t *testing.T) {
 	m := NewTestRunnerFromStatement(t, "ALTER TABLE t1modification ENGINE=InnoDB",
 		WithThreads(1))
 
-	wg := sync.WaitGroup{}
-	var gErr error
-	wg.Go(func() {
-		gErr = m.Run(t.Context())
-	})
+	running := startTestRun(t, m.Run, m.Close)
 
-	waitForStatus(t, m, status.CopyRows)
+	waitForStatus(t, m, status.CopyRows, running)
 
 	// Apply instant DDL — migration should detect this and cancel itself.
 	testutils.RunSQL(t, "ALTER TABLE t1modification ADD col3 INT")
 
-	wg.Wait()
-	require.Error(t, gErr)
-	require.NoError(t, m.Close())
+	require.Error(t, running.wait(t))
 }
 
 // TestReservedWordPKMigration is a regression test for issue #828.

--- a/pkg/migration/helpers_test.go
+++ b/pkg/migration/helpers_test.go
@@ -109,7 +109,9 @@ func startTestRun(t *testing.T, run func(context.Context) error, closeRunner fun
 		select {
 		case <-running.done:
 			// Close only after Run has stopped touching the runner's fields.
-			require.NoError(t, closeRunner())
+			if err := closeRunner(); err != nil {
+				t.Errorf("closing test runner: %v", err)
+			}
 		case <-time.After(30 * time.Second):
 			t.Error("runner did not stop during cleanup")
 		}

--- a/pkg/migration/helpers_test.go
+++ b/pkg/migration/helpers_test.go
@@ -38,13 +38,6 @@ func mkIniFile(t *testing.T, content string) string {
 	return tmpFile.Name()
 }
 
-// stringerFunc adapts a func() string to fmt.Stringer so that message
-// arguments to require.Eventually can be evaluated lazily, at the moment the
-// failure message is formatted, rather than eagerly when Eventually is called.
-type stringerFunc func() string
-
-func (f stringerFunc) String() string { return f() }
-
 // waitForStatus polls until the runner reaches the target status or times out.
 // The timeout is generous because the runner must finish the copy and
 // checksum phases before it reaches the later states (e.g.
@@ -54,17 +47,96 @@ func (f stringerFunc) String() string { return f() }
 // binlog catch-up plus 30s acquiring the table lock, and the runner retries
 // the checksum up to 3 times, so the budget must cover at least two full
 // attempts.
-func waitForStatus(t *testing.T, m *Runner, target status.State) {
+func waitForStatus(t *testing.T, m *Runner, target status.State, runs ...*testRun) {
 	t.Helper()
-	// The status is read lazily via a Stringer: fmt args are evaluated when
-	// the failure message is formatted (at timeout), so the message reports
-	// the status the runner was actually stuck in, not the status when the
-	// wait began.
-	lastStatus := stringerFunc(func() string { return m.status.Get().String() })
-	require.Eventually(t, func() bool {
-		return m.status.Get() >= target
-	}, 3*time.Minute, 10*time.Millisecond,
-		"timeout waiting for status >= %s, last status: %s", target, lastStatus)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+	var run *testRun
+	if len(runs) > 0 {
+		run = runs[0]
+	}
+	require.NoError(t, awaitTestStatus(ctx, m, target, run))
+}
+
+func awaitTestStatus(ctx context.Context, m *Runner, target status.State, run *testRun) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	var done <-chan struct{}
+	if run != nil {
+		done = run.done
+	}
+	for {
+		// Run may fail without ever publishing a later state. Its completion is
+		// authoritative, and closing done publishes its error to this goroutine.
+		select {
+		case <-done:
+			return fmt.Errorf("runner exited before waiting for %s completed: %w", target, run.result())
+		default:
+		}
+		current := m.status.Get()
+		if current >= status.Close {
+			return fmt.Errorf("runner entered terminal state %s while waiting for %s", current, target)
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if current >= target {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for %s (last state %s): %w", target, m.status.Get(), ctx.Err())
+		case <-done:
+		case <-ticker.C:
+		}
+	}
+}
+
+// testRun owns a runner until Run has exited and Close has finished. Cleanup is
+// installed before launch, so FailNow anywhere in the test cannot strand a
+// result send or race table cleanup against the runner.
+type testRun struct {
+	done chan struct{}
+	err  error // published by closing done
+}
+
+func startTestRun(t *testing.T, run func(context.Context) error, closeRunner func() error) *testRun {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	running := &testRun{done: make(chan struct{})}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-running.done:
+			// Close only after Run has stopped touching the runner's fields.
+			require.NoError(t, closeRunner())
+		case <-time.After(30 * time.Second):
+			t.Error("runner did not stop during cleanup")
+		}
+	})
+	go func() {
+		running.err = run(ctx)
+		close(running.done)
+	}()
+	return running
+}
+
+func (r *testRun) result() error {
+	if r.err != nil {
+		return r.err
+	}
+	return fmt.Errorf("runner completed")
+}
+
+func (r *testRun) wait(t *testing.T) error {
+	t.Helper()
+	select {
+	case <-r.done:
+		return r.err
+	case <-time.After(3 * time.Minute):
+		t.Fatal("runner did not complete")
+		return nil
+	}
 }
 
 // waitForCopyRows blocks until the runner reaches the CopyRows state (returning
@@ -79,7 +151,11 @@ func waitForCopyRows(ctx context.Context, m *Runner) bool {
 	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
 	for {
-		if m.status.Get() >= status.CopyRows {
+		current := m.status.Get()
+		if ctx.Err() != nil || current >= status.Close {
+			return false
+		}
+		if current >= status.CopyRows {
 			return true
 		}
 		select {

--- a/pkg/migration/helpers_test.go
+++ b/pkg/migration/helpers_test.go
@@ -47,14 +47,11 @@ func mkIniFile(t *testing.T, content string) string {
 // binlog catch-up plus 30s acquiring the table lock, and the runner retries
 // the checksum up to 3 times, so the budget must cover at least two full
 // attempts.
-func waitForStatus(t *testing.T, m *Runner, target status.State, runs ...*testRun) {
+func waitForStatus(t *testing.T, m *Runner, target status.State, run *testRun) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
-	var run *testRun
-	if len(runs) > 0 {
-		run = runs[0]
-	}
+	require.NotNil(t, run)
 	require.NoError(t, awaitTestStatus(ctx, m, target, run))
 }
 
@@ -77,9 +74,6 @@ func awaitTestStatus(ctx context.Context, m *Runner, target status.State, run *t
 		if current >= status.Close {
 			return fmt.Errorf("runner entered terminal state %s while waiting for %s", current, target)
 		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
 		if current >= target {
 			return nil
 		}
@@ -96,14 +90,15 @@ func awaitTestStatus(ctx context.Context, m *Runner, target status.State, run *t
 // installed before launch, so FailNow anywhere in the test cannot strand a
 // result send or race table cleanup against the runner.
 type testRun struct {
-	done chan struct{}
-	err  error // published by closing done
+	cancel context.CancelFunc
+	done   chan struct{}
+	err    error // published by closing done
 }
 
 func startTestRun(t *testing.T, run func(context.Context) error, closeRunner func() error) *testRun {
 	t.Helper()
 	ctx, cancel := context.WithCancel(t.Context())
-	running := &testRun{done: make(chan struct{})}
+	running := &testRun{done: make(chan struct{}), cancel: cancel}
 	t.Cleanup(func() {
 		cancel()
 		select {
@@ -149,12 +144,18 @@ func (r *testRun) wait(t *testing.T) error {
 // copy phase may never begin. It avoids testify so it is safe to call off the
 // test goroutine (require would call runtime.Goexit — testifylint go-require);
 // callers should return when it reports false.
-func waitForCopyRows(ctx context.Context, m *Runner) bool {
+func waitForCopyRows(t *testing.T, ctx context.Context, m *Runner) bool {
+	t.Helper()
 	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
 	for {
 		current := m.status.Get()
-		if ctx.Err() != nil || current >= status.Close {
+		if err := ctx.Err(); err != nil {
+			t.Logf("load generator skipped: context ended before observing CopyRows (state %s): %v", current, err)
+			return false
+		}
+		if current >= status.Close {
+			t.Logf("load generator skipped: runner reached terminal state %s before CopyRows was observed", current)
 			return false
 		}
 		if current >= status.CopyRows {
@@ -162,6 +163,7 @@ func waitForCopyRows(ctx context.Context, m *Runner) bool {
 		}
 		select {
 		case <-ctx.Done():
+			t.Logf("load generator skipped: context ended before observing CopyRows (state %s): %v", m.status.Get(), ctx.Err())
 			return false
 		case <-ticker.C:
 		}

--- a/pkg/migration/resume_test.go
+++ b/pkg/migration/resume_test.go
@@ -389,21 +389,16 @@ func TestCheckpointResumeDuringChecksum(t *testing.T) {
 	// When we see that we are waiting on the sentinel table,
 	// we then manually start the first bits of checksum, and then close()
 	// We should be able to resume from the checkpoint into the checksum state.
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	c := make(chan error, 1)
-	go func() {
-		c <- r.Run(ctx)
-	}()
+	running := startTestRun(t, r.Run, r.Close)
 	// Wait for the migration to block on the sentinel table.
-	waitForStatus(t, r, status.WaitingOnSentinelTable)
+	waitForStatus(t, r, status.WaitingOnSentinelTable, running)
 
 	require.NoError(t, r.checksum(t.Context()))       // run the checksum, the original Run is blocked on sentinel.
 	require.NoError(t, r.DumpCheckpoint(t.Context())) // dump a checkpoint with the watermark.
 	// Cancel + wait for Run to fully return before Close. See
 	// TestChangeIntToBigIntPKResumeFromChkPt for the rationale.
-	cancel()              // unblocks the goroutine that was waiting on sentinel.
-	require.Error(t, <-c) // context cancelled
+	running.cancel()                  // unblocks the goroutine that was waiting on sentinel.
+	require.Error(t, running.wait(t)) // context cancelled
 	require.NoError(t, r.Close())
 
 	// drop the sentinel table.

--- a/pkg/migration/test_lifecycle_test.go
+++ b/pkg/migration/test_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/block/spirit/pkg/status"
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,7 @@ func TestAwaitTestStatusRejectsTerminalStates(t *testing.T) {
 			m := &Runner{}
 			m.status.Set(state)
 			require.ErrorContains(t, awaitTestStatus(t.Context(), m, status.CopyRows, nil), "terminal state")
-			require.False(t, waitForCopyRows(t.Context(), m))
+			require.False(t, waitForCopyRows(t, t.Context(), m))
 		})
 	}
 }
@@ -42,9 +43,15 @@ func TestAwaitTestStatusRejectsTerminalStates(t *testing.T) {
 func TestAwaitTestStatusReportsRunnerError(t *testing.T) {
 	want := errors.New("setup failed")
 	running := startTestRun(t, func(context.Context) error { return want }, func() error { return nil })
-	<-running.done
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	select {
+	case <-running.done:
+	case <-ctx.Done():
+		t.Fatal("runner did not complete")
+	}
 	m := &Runner{}
-	require.ErrorIs(t, awaitTestStatus(t.Context(), m, status.WaitingOnSentinelTable, running), want)
+	require.ErrorIs(t, awaitTestStatus(ctx, m, status.WaitingOnSentinelTable, running), want)
 }
 
 func TestAwaitTestStatusAcceptsProgress(t *testing.T) {
@@ -53,6 +60,15 @@ func TestAwaitTestStatusAcceptsProgress(t *testing.T) {
 	require.NoError(t, awaitTestStatus(t.Context(), m, status.CopyRows, nil))
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	require.ErrorIs(t, awaitTestStatus(ctx, m, status.CopyRows, nil), context.Canceled)
-	require.False(t, waitForCopyRows(ctx, m))
+	require.NoError(t, awaitTestStatus(ctx, m, status.CopyRows, nil))
+	require.ErrorIs(t, awaitTestStatus(ctx, &Runner{}, status.CopyRows, nil), context.Canceled)
+	require.False(t, waitForCopyRows(t, ctx, m))
+}
+
+func TestAwaitTestStatusReportsCleanCompletion(t *testing.T) {
+	running := startTestRun(t, func(context.Context) error { return nil }, func() error { return nil })
+	require.NoError(t, running.wait(t))
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.ErrorContains(t, awaitTestStatus(ctx, &Runner{}, status.CopyRows, running), "runner completed")
 }

--- a/pkg/migration/test_lifecycle_test.go
+++ b/pkg/migration/test_lifecycle_test.go
@@ -1,0 +1,58 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/block/spirit/pkg/status"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestRunCleanupWithoutReceivingResult(t *testing.T) {
+	var exited, closed atomic.Bool
+	t.Run("returns before runner", func(t *testing.T) {
+		startTestRun(t, func(ctx context.Context) error {
+			<-ctx.Done()
+			exited.Store(true)
+			return ctx.Err()
+		}, func() error {
+			require.True(t, exited.Load(), "Close must run after Run returns")
+			closed.Store(true)
+			return nil
+		})
+		// Deliberately never receive a result, as on an early assertion failure.
+	})
+	require.True(t, exited.Load())
+	require.True(t, closed.Load())
+}
+
+func TestAwaitTestStatusRejectsTerminalStates(t *testing.T) {
+	for _, state := range []status.State{status.Close, status.ErrCleanup} {
+		t.Run(state.String(), func(t *testing.T) {
+			m := &Runner{}
+			m.status.Set(state)
+			require.ErrorContains(t, awaitTestStatus(t.Context(), m, status.CopyRows, nil), "terminal state")
+			require.False(t, waitForCopyRows(t.Context(), m))
+		})
+	}
+}
+
+func TestAwaitTestStatusReportsRunnerError(t *testing.T) {
+	want := errors.New("setup failed")
+	running := startTestRun(t, func(context.Context) error { return want }, func() error { return nil })
+	<-running.done
+	m := &Runner{}
+	require.ErrorIs(t, awaitTestStatus(t.Context(), m, status.WaitingOnSentinelTable, running), want)
+}
+
+func TestAwaitTestStatusAcceptsProgress(t *testing.T) {
+	m := &Runner{}
+	m.status.Set(status.Checksum)
+	require.NoError(t, awaitTestStatus(t.Context(), m, status.CopyRows, nil))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, awaitTestStatus(ctx, m, status.CopyRows, nil), context.Canceled)
+	require.False(t, waitForCopyRows(ctx, m))
+}


### PR DESCRIPTION
Background migration tests can leave Run blocked on an unbuffered result send or skip Close after an assertion failure. Start every runner used by waitForStatus through a helper that registers cancellation, joining, and Close before launch, and publishes completion without a blocking send. This covers sentinel, shared-schema, concurrent-run, DDL-cancellation, minimal-RBR, checksum-divergence, and checkpoint-resume tests. Runner assertions execute on the test goroutine; cleanup reports Close failures with t.Errorf.

Make the runner-completion handle mandatory for status waits, reject terminal states, and report the original runner error or clean early exit. An already-reached nonterminal target succeeds even when the wait context has expired. Load generators log whether cancellation or a terminal state prevented them from observing CopyRows. Regression tests cover cleanup without receiving a result, terminal-state rejection, satisfied/cancelled waits, and both error and clean runner completion, with bounded waits.

Related to #628 and #946. This fixes failure-path cleanup and diagnostics; it does not claim to eliminate the original binlog catch-up or checksum timeout described in those issues.

Validation: full race-enabled migration suite against MySQL 8.0.43; checkpoint-resume and helper tests repeated three times with the singleversion tag; golangci-lint reports 0 issues. The existing 48-hour sentinel-timeout test remains skipped.
