### PR TITLE
test(testutils): bound artifact cleanup and report failures

### DIFF
--- a/pkg/testutils/table.go
+++ b/pkg/testutils/table.go
@@ -3,14 +3,18 @@ package testutils
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
+
+const testCleanupTimeout = 30 * time.Second
 
 // TestTable manages a test table's lifecycle: creation, cleanup, and
 // provides a DB connection for verification queries after migration.
@@ -49,12 +53,16 @@ func NewTestTable(t *testing.T, name string, createSQL string) *TestTable {
 	t.Cleanup(func() {
 		// Use context.Background() because t.Context() is canceled after
 		// the test finishes, which would cause DROP statements to fail.
-		tt.dropArtifacts(context.Background())
-		utils.CloseAndLog(db)
+		ctx, cancel := context.WithTimeout(context.Background(), testCleanupTimeout)
+		defer cancel()
+		defer utils.CloseAndLog(db)
+		if err := tt.dropArtifacts(ctx); err != nil {
+			t.Errorf("cleaning up test table %q: %v", tt.Name, err)
+		}
 	})
 
 	// Drop any pre-existing table and Spirit artifacts.
-	tt.dropArtifacts(t.Context())
+	require.NoError(t, tt.dropArtifacts(t.Context()), "removing stale artifacts for %q", name)
 
 	// Create the table.
 	_, err = db.ExecContext(t.Context(), createSQL)
@@ -66,22 +74,25 @@ func NewTestTable(t *testing.T, name string, createSQL string) *TestTable {
 // dropArtifacts drops the base table and all Spirit shadow/checkpoint tables.
 // It ignores "identifier name too long" errors for artifact names that exceed
 // MySQL's 64-char limit (e.g., when testing long table names), but propagates
-// other unexpected errors via logging.
-func (tt *TestTable) dropArtifacts(ctx context.Context) {
+// other unexpected errors to the caller. It still attempts the remaining drops.
+func (tt *TestTable) dropArtifacts(ctx context.Context) error {
 	tables := []string{
 		tt.Name,
 		fmt.Sprintf("_%s_new", tt.Name),
 		fmt.Sprintf("_%s_old", tt.Name),
 		fmt.Sprintf("_%s_chkpnt", tt.Name),
 	}
+	var errs []error
 	for _, tbl := range tables {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(append(errs, err)...)
+		}
 		_, err := tt.DB.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", sqlescape.EscapeIdentifier(tbl)))
 		if err != nil && !isIdentifierTooLongError(err) {
-			// Log but don't fail — cleanup is best-effort and the test
-			// may already be finished (e.g., context canceled race).
-			continue
+			errs = append(errs, fmt.Errorf("dropping %q: %w", tbl, err))
 		}
 	}
+	return errors.Join(errs...)
 }
 
 // isIdentifierTooLongError returns true if the error is MySQL's "identifier name

--- a/pkg/testutils/table.go
+++ b/pkg/testutils/table.go
@@ -5,12 +5,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
+	parsermysql "github.com/block/spirit/pkg/parser/mysql"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,12 +51,16 @@ func NewTestTable(t *testing.T, name string, createSQL string) *TestTable {
 	// Register cleanup immediately so the DB is always closed and artifacts
 	// are dropped even if createSQL fails (require.NoError calls FailNow,
 	// but deferred cleanup still runs).
+	cleanupArtifacts := false
 	t.Cleanup(func() {
 		// Use context.Background() because t.Context() is canceled after
 		// the test finishes, which would cause DROP statements to fail.
-		ctx, cancel := context.WithTimeout(context.Background(), testCleanupTimeout)
+		ctx, cancel := newTestCleanupContext()
 		defer cancel()
 		defer utils.CloseAndLog(db)
+		if !cleanupArtifacts {
+			return // Setup already reported the stale-artifact failure.
+		}
 		if err := tt.dropArtifacts(ctx); err != nil {
 			t.Errorf("cleaning up test table %q: %v", tt.Name, err)
 		}
@@ -64,11 +69,17 @@ func NewTestTable(t *testing.T, name string, createSQL string) *TestTable {
 	// Drop any pre-existing table and Spirit artifacts.
 	require.NoError(t, tt.dropArtifacts(t.Context()), "removing stale artifacts for %q", name)
 
+	cleanupArtifacts = true // Clean up even if CREATE fails.
+
 	// Create the table.
 	_, err = db.ExecContext(t.Context(), createSQL)
 	require.NoError(t, err)
 
 	return tt
+}
+
+func newTestCleanupContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), testCleanupTimeout)
 }
 
 // dropArtifacts drops the base table and all Spirit shadow/checkpoint tables.
@@ -90,6 +101,9 @@ func (tt *TestTable) dropArtifacts(ctx context.Context) error {
 		_, err := tt.DB.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", sqlescape.EscapeIdentifier(tbl)))
 		if err != nil && !isIdentifierTooLongError(err) {
 			errs = append(errs, fmt.Errorf("dropping %q: %w", tbl, err))
+			if ctx.Err() != nil {
+				return errors.Join(errs...)
+			}
 		}
 	}
 	return errors.Join(errs...)
@@ -99,7 +113,8 @@ func (tt *TestTable) dropArtifacts(ctx context.Context) error {
 // is too long" error (Error 1059), which happens when artifact table names
 // exceed the 64-character limit.
 func isIdentifierTooLongError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "1059")
+	mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
+	return ok && mysqlErr.Number == parsermysql.ErrTooLongIdent
 }
 
 // SeedRows populates the table by doubling rows until reaching approximately

--- a/pkg/testutils/table_test.go
+++ b/pkg/testutils/table_test.go
@@ -46,7 +46,7 @@ func TestTableCleanupAfterTestContextCancelled(t *testing.T) {
 			_, err := tt.DB.ExecContext(t.Context(), "CREATE TABLE "+name+" (id INT PRIMARY KEY)")
 			require.NoError(t, err)
 		}
-	}) // t.Context is cancelled before NewTestTable's cleanup executes.
+	}) // The subtest's context is cancelled before NewTestTable's cleanup executes.
 	db, err := sql.Open("mysql", DSN())
 	require.NoError(t, err)
 	defer utils.CloseAndLog(db)

--- a/pkg/testutils/table_test.go
+++ b/pkg/testutils/table_test.go
@@ -1,0 +1,59 @@
+package testutils
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropArtifactsRespectsDeadline(t *testing.T) {
+	tt := NewTestTable(t, "cleanup_locked", "CREATE TABLE cleanup_locked (id INT PRIMARY KEY)")
+	trx, err := tt.DB.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = trx.Rollback() }) // release before table cleanup
+	_, err = trx.ExecContext(t.Context(), "SELECT * FROM cleanup_locked")
+	require.NoError(t, err)
+
+	// The transaction holds MDL, so DROP cannot complete until it ends.
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	err = tt.dropArtifacts(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NoError(t, trx.Rollback())
+	require.NoError(t, tt.dropArtifacts(t.Context()))
+}
+
+func TestDropArtifactsReportsErrors(t *testing.T) {
+	db, err := sql.Open("mysql", DSN())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	tt := &TestTable{Name: "cleanup_closed_pool", DB: db}
+	err = tt.dropArtifacts(t.Context())
+	require.ErrorContains(t, err, "database is closed")
+	require.ErrorContains(t, err, "cleanup_closed_pool")
+	require.ErrorContains(t, err, "_cleanup_closed_pool_chkpnt", "attempt every artifact after a non-context error")
+}
+
+func TestTableCleanupAfterTestContextCancelled(t *testing.T) {
+	var tt *TestTable
+	t.Run("create artifacts", func(t *testing.T) {
+		tt = NewTestTable(t, "cleanup_artifacts", "CREATE TABLE cleanup_artifacts (id INT PRIMARY KEY)")
+		for _, name := range []string{"_cleanup_artifacts_new", "_cleanup_artifacts_old", "_cleanup_artifacts_chkpnt"} {
+			_, err := tt.DB.ExecContext(t.Context(), "CREATE TABLE "+name+" (id INT PRIMARY KEY)")
+			require.NoError(t, err)
+		}
+	}) // t.Context is cancelled before NewTestTable's cleanup executes.
+	db, err := sql.Open("mysql", DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM information_schema.tables
+		WHERE table_schema = DATABASE() AND table_name IN
+		('cleanup_artifacts', '_cleanup_artifacts_new', '_cleanup_artifacts_old', '_cleanup_artifacts_chkpnt')`).Scan(&count))
+	require.Zero(t, count)
+	require.Error(t, tt.DB.PingContext(t.Context()), "cleanup must also close the pool")
+}

--- a/pkg/testutils/table_test.go
+++ b/pkg/testutils/table_test.go
@@ -3,10 +3,14 @@ package testutils
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,6 +27,7 @@ func TestDropArtifactsRespectsDeadline(t *testing.T) {
 	defer cancel()
 	err = tt.dropArtifacts(ctx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, strings.Count(err.Error(), context.DeadlineExceeded.Error()), "report the deadline only once")
 	require.NoError(t, trx.Rollback())
 	require.NoError(t, tt.dropArtifacts(t.Context()))
 }
@@ -56,4 +61,38 @@ func TestTableCleanupAfterTestContextCancelled(t *testing.T) {
 		('cleanup_artifacts', '_cleanup_artifacts_new', '_cleanup_artifacts_old', '_cleanup_artifacts_chkpnt')`).Scan(&count))
 	require.Zero(t, count)
 	require.Error(t, tt.DB.PingContext(t.Context()), "cleanup must also close the pool")
+}
+
+func TestIdentifierTooLongError(t *testing.T) {
+	require.True(t, isIdentifierTooLongError(&mysql.MySQLError{Number: 1059}))
+	require.True(t, isIdentifierTooLongError(fmt.Errorf("wrapped: %w", &mysql.MySQLError{Number: 1059})))
+	for _, err := range []error{nil, errors.New("1059"), &mysql.MySQLError{Number: 1062, Message: "Duplicate entry '1059'"}, &mysql.MySQLError{Number: 1406, Message: "Data too long at row 1059"}} {
+		require.False(t, isIdentifierTooLongError(err))
+	}
+}
+
+func TestTableCleanupLongName(t *testing.T) {
+	name := strings.Repeat("a", 60)
+	var tt *TestTable
+	t.Run("long base name", func(t *testing.T) {
+		tt = NewTestTable(t, name, "CREATE TABLE "+name+" (id INT PRIMARY KEY)")
+	})
+	require.Error(t, tt.DB.PingContext(t.Context()))
+	db, err := sql.Open("mysql", DSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?", name).Scan(&count))
+	require.Zero(t, count)
+}
+
+func TestCleanupContextHasThirtySecondDeadline(t *testing.T) {
+	before := time.Now()
+	ctx, cancel := newTestCleanupContext()
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	require.False(t, deadline.Before(before.Add(30*time.Second)))
+	require.False(t, deadline.After(time.Now().Add(30*time.Second)))
+	require.NoError(t, ctx.Err())
 }


### PR DESCRIPTION
Test-table cleanup runs DROP TABLE with an unbounded background context, so a leaked metadata lock can hold cleanup until the package times out. Unexpected DROP errors are also silently discarded despite the helper's documentation promising diagnostics.

Bound cleanup to 30 seconds with a fresh context that survives test-context cancellation. Return and report unexpected artifact-drop errors, fail setup when stale artifacts cannot be removed, and still attempt the remaining drops while the context is live. Preserve the exception for overlong generated artifact names using the typed MySQL error code, and always close the database pool. Skip a duplicate teardown DROP if stale-artifact removal already failed during setup, and report an expired context once. Previously hidden cleanup errors now fail their owning test, so existing leaks may surface as new attributed failures.

Tests cover cancellation against a real metadata lock, reporting errors from a closed pool, removing all artifacts after the subtest's context has been cancelled, long base-table names, exact error-code matching, and the cleanup context's 30-second deadline.

Validation:

- `go test -race ./pkg/testutils -count=5`.
- `go test -race ./pkg/testutils ./pkg/migration ./pkg/move ./pkg/datasync ./pkg/copier ./pkg/applier ./pkg/checksum ./pkg/table -parallel=4 -timeout=5m` against MySQL 8.0.43.
- `golangci-lint run ./pkg/testutils/...`.
