### PR TITLE
test(change): establish reader parking deterministically

### DIFF
--- a/pkg/change/subscription_buffered_concurrency_test.go
+++ b/pkg/change/subscription_buffered_concurrency_test.go
@@ -490,19 +490,11 @@ func TestPeriodicFlushRespondsToParkRequest(t *testing.T) {
 	client.StartPeriodicFlush(t.Context(), time.Hour)
 	defer client.StopPeriodicFlush()
 
-	// Seed one buffered change, then clamp the limit so the next
-	// binlog-driven HasChanged parks.
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", srcTable.QuotedTableName))
-	require.NoError(t, client.BlockWait(t.Context()))
-	sub.Lock()
-	require.Positive(t, sub.sizeBytes, "seed change must be accounted")
-	sub.softLimitBytes = 1
-	sub.Unlock()
-
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'parked')", srcTable.QuotedTableName))
+	requestBinlogPark(t, sub, srcTable)
+	// The flusher may already have released it, so observe the park counter.
 	require.Eventually(t, func() bool {
 		return sub.timesParked.Load() >= 1
-	}, 10*time.Second, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
+	}, parkWaitTimeout, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
 
 	// The park requested a flush; the periodic goroutine must drain the
 	// seed row promptly — not in an hour — which also unparks the reader.
@@ -590,19 +582,11 @@ func TestPeriodicFlushPrioritizesParkedSubscription(t *testing.T) {
 	// B accumulates pending changes first, so it is a candidate to be
 	// drained ahead of A in an unprioritized all-subscription pass.
 	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'b'), (2, 'b'), (3, 'b')", srcB.QuotedTableName))
-	// Seed A with one buffered change, then clamp its limit so the next
-	// binlog-driven event parks the reader on A.
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", srcA.QuotedTableName))
-	require.NoError(t, client.BlockWait(t.Context()))
-	subA.Lock()
-	require.Positive(t, subA.sizeBytes, "seed change must be accounted")
-	subA.softLimitBytes = 1
-	subA.Unlock()
-
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'parked')", srcA.QuotedTableName))
+	requestBinlogPark(t, subA, srcA)
+	// The flusher may already have released it, so observe the park counter.
 	require.Eventually(t, func() bool {
 		return subA.timesParked.Load() >= 1
-	}, 10*time.Second, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
+	}, parkWaitTimeout, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
 
 	// The priority flush drains A; the follow-up pass drains B. Gate on B
 	// specifically rather than on a bare count: the all-subscription pass

--- a/pkg/change/subscription_buffered_test.go
+++ b/pkg/change/subscription_buffered_test.go
@@ -1560,21 +1560,7 @@ func TestProcessRowsEventDoesNotDeadlockOnPark(t *testing.T) {
 
 	sub := getBufferedMap(t, client, srcTable.SchemaName+"."+srcTable.TableName)
 
-	// Seed a row so sizeBytes > 0, then drop the soft limit. Any
-	// further HasChanged from the binlog reader will park.
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", srcTable.QuotedTableName))
-	require.NoError(t, client.BlockWait(t.Context()))
-	sub.Lock()
-	sub.softLimitBytes = 1
-	sub.Unlock()
-
-	// Trigger a second INSERT. The binlog reader will pick this up
-	// asynchronously, route it through processRowsEvent, call
-	// sub.HasChanged — which must park on the soft limit.
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'parked')", srcTable.QuotedTableName))
-	require.Eventually(t, func() bool {
-		return sub.timesParked.Load() >= 1
-	}, 5*time.Second, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
+	parkBinlogReader(t, client, sub, srcTable)
 
 	// While HasChanged is parked from inside processRowsEvent,
 	// client.Flush must still make progress. With the lock-release
@@ -1595,6 +1581,29 @@ func TestProcessRowsEventDoesNotDeadlockOnPark(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(t.Context(),
 		fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable.QuotedTableName)).Scan(&count))
 	require.Equal(t, 2, count)
+}
+
+// parkBinlogReader arranges both rows in a single statement/event: admitting
+// the first reaches the one-change cap, so the second must park. There is no
+// seed/catch-up/reconfigure window and no dependence on row-image byte sizing.
+// These clients have no periodic flusher: only the test's Flush or Close may
+// release the park. Keep real binlog delivery in the lifecycle regression.
+func parkBinlogReader(t *testing.T, client *binlogClient, sub *bufferedMap, src *table.TableInfo) {
+	t.Helper()
+	client.periodicFlushLock.Lock()
+	flushing := client.periodicFlushCancel != nil
+	client.periodicFlushLock.Unlock()
+	require.False(t, flushing, "a background flusher could release the test's park")
+	sub.Lock()
+	sub.softLimitBytes = 0
+	sub.softLimitChanges = 1
+	sub.Unlock()
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed'), (2, 'parked')", src.QuotedTableName))
+	require.Eventually(t, func() bool {
+		sub.Lock()
+		defer sub.Unlock()
+		return sub.parked && sub.lengthLocked() == 1
+	}, DefaultTimeout, 10*time.Millisecond, "binlog reader must be held at the second row")
 }
 
 // TestBufferedMapCloseUnblocksParkedHasChanged pins the invariant that
@@ -1680,20 +1689,7 @@ func TestClientCloseUnblocksParkedHasChanged(t *testing.T) {
 		client.Close()
 	})
 
-	// Seed one row so sizeBytes > 0, then crank the soft limit down.
-	// Any further binlog-driven HasChanged will park.
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", srcTable.QuotedTableName))
-	require.NoError(t, client.BlockWait(t.Context()))
-	sub.Lock()
-	sub.softLimitBytes = 1
-	sub.Unlock()
-
-	// Trigger a second INSERT; the binlog reader will pick it up and
-	// park inside processRowsEvent → HasChanged.
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'parked')", srcTable.QuotedTableName))
-	require.Eventually(t, func() bool {
-		return sub.timesParked.Load() >= 1
-	}, 5*time.Second, 10*time.Millisecond, "binlog-driven HasChanged should park on soft limit")
+	parkBinlogReader(t, client, sub, srcTable)
 
 	// Close must return within a bounded time. Without the wake, it
 	// would block on streamWG.Wait() forever because readStream is

--- a/pkg/change/subscription_buffered_test.go
+++ b/pkg/change/subscription_buffered_test.go
@@ -1583,27 +1583,38 @@ func TestProcessRowsEventDoesNotDeadlockOnPark(t *testing.T) {
 	require.Equal(t, 2, count)
 }
 
-// parkBinlogReader arranges both rows in a single statement/event: admitting
-// the first reaches the one-change cap, so the second must park. There is no
-// seed/catch-up/reconfigure window and no dependence on row-image byte sizing.
-// These clients have no periodic flusher: only the test's Flush or Close may
-// release the park. Keep real binlog delivery in the lifecycle regression.
+// Real binlog delivery may be delayed on contended CI runners. Keep this test
+// budget independent of production BlockWait tuning.
+const parkWaitTimeout = 30 * time.Second
+
+// requestBinlogPark starts with an empty subscription and inserts two distinct
+// keys in one statement. The first fills the one-change cap; the second must
+// park (an overwrite of the first key would bypass the cap). This also works
+// if MySQL splits the statement across multiple row events.
+func requestBinlogPark(t *testing.T, sub *bufferedMap, src *table.TableInfo) {
+	t.Helper()
+	sub.Lock()
+	sub.softLimitBytes = 0
+	sub.softLimitChanges = 1
+	sub.Unlock()
+	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed'), (2, 'parked')", src.QuotedTableName))
+}
+
+// parkBinlogReader requires the caller to keep periodic flushing stopped until
+// it deliberately releases the park via Flush or Close. The entry guard catches
+// an already-running flusher; it does not prevent later starts.
 func parkBinlogReader(t *testing.T, client *binlogClient, sub *bufferedMap, src *table.TableInfo) {
 	t.Helper()
 	client.periodicFlushLock.Lock()
 	flushing := client.periodicFlushCancel != nil
 	client.periodicFlushLock.Unlock()
 	require.False(t, flushing, "a background flusher could release the test's park")
-	sub.Lock()
-	sub.softLimitBytes = 0
-	sub.softLimitChanges = 1
-	sub.Unlock()
-	testutils.RunSQL(t, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed'), (2, 'parked')", src.QuotedTableName))
+	requestBinlogPark(t, sub, src)
 	require.Eventually(t, func() bool {
 		sub.Lock()
 		defer sub.Unlock()
 		return sub.parked && sub.lengthLocked() == 1
-	}, DefaultTimeout, 10*time.Millisecond, "binlog reader must be held at the second row")
+	}, parkWaitTimeout, 10*time.Millisecond, "binlog reader must be held at the second row")
 }
 
 // TestBufferedMapCloseUnblocksParkedHasChanged pins the invariant that


### PR DESCRIPTION
Four binlog-driven parking tests used a seed INSERT, a catch-up wait, and a later limit change. Share a single-statement arrangement across all four: set a one-change cap, then insert two distinct keys. The first fills the buffer and the second parks the actual binlog reader, even if MySQL splits the statement across row events.

Flush/Close lifecycle tests require the reader to be currently parked and require callers to keep periodic flushing stopped until release. The periodic-flush tests instead observe the monotonic park counter, since releasing that park is their intended behavior. Use a dedicated 30-second test budget for real binlog delivery, independent of production BlockWait tuning.

Fixes #1163. Also covers the companion test formerly tracked in #858 and both periodic-flush park-request tests.

Validation: all four integration tests passed 30 repetitions under the race detector against MySQL 8.0.43; golangci-lint reports 0 issues. No production behavior changes.
