### PR TITLE
fix(dbconn): wait for killed session cleanup before retrying DDL

### DIFF
--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -380,12 +380,12 @@ func ForceExec(ctx context.Context, db *sql.DB, tables []*table.TableInfo, dbCon
 	}
 	return forceExec(ctx, db, dbConfig, logger, stmt, func(ctx context.Context, connID int) ([]int, error) {
 		return killLockingTransactions(ctx, db, tables, dbConfig, logger, []int{connID})
-	})
+	}, waitForKilledTransactions)
 }
 
-// forceExec receives the kill operation so tests can hold a real MySQL blocker
-// past the acknowledgement and verify the post-kill cleanup ordering.
-func forceExec(ctx context.Context, db *sql.DB, dbConfig *DBConfig, logger *slog.Logger, stmt string, kill func(context.Context, int) ([]int, error)) error {
+// forceExec receives the kill and cleanup operations so tests can control their
+// failures while exercising the statement and retry against real MySQL.
+func forceExec(ctx context.Context, db *sql.DB, dbConfig *DBConfig, logger *slog.Logger, stmt string, kill func(context.Context, int) ([]int, error), waitForCleanup func(context.Context, *sql.DB, []int) error) error {
 	trx, connId, err := BeginStandardTrx(ctx, db, nil)
 	if err != nil {
 		return err
@@ -426,16 +426,20 @@ func forceExec(ctx context.Context, db *sql.DB, dbConfig *DBConfig, logger *slog
 	// are now being used for subsequent operations.
 	wg.Wait()
 	if shouldRetryForceExecAfterKill(err, killTimerFired.Load()) {
+		// These operations use other connections. Their errors must not enter
+		// the statement's error tree: callers use it to detect ambiguous DDL.
 		if killErr != nil {
-			return errors.Join(err, fmt.Errorf("force-kill failed: %w", killErr))
+			logger.Warn("force-kill failed; retrying statement anyway", "error", killErr)
 		}
-		// MySQL KILL is asynchronous. Give only the sessions already signalled a
-		// bounded cleanup window before spending the retry's lock_wait_timeout.
-		cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		cleanupErr := waitForKilledTransactions(cleanupCtx, db, killed)
-		cancel()
-		if cleanupErr != nil {
-			return errors.Join(err, cleanupErr)
+		// MySQL KILL is asynchronous. Wait only for sessions already signalled.
+		if len(killed) > 0 {
+			logger.Debug("waiting for killed sessions to exit", "pids", killed)
+			cleanupCtx, cancel := context.WithTimeout(ctx, forceKillCleanupTimeout)
+			cleanupErr := waitForCleanup(cleanupCtx, db, killed)
+			cancel()
+			if cleanupErr != nil {
+				logger.Warn("killed-session cleanup failed; retrying statement anyway", "pids", killed, "error", cleanupErr)
+			}
 		}
 		logger.Warn("retrying statement after lock wait timeout because force-kill timer fired", "error", err)
 		_, err = trx.ExecContext(ctx, stmt)

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -378,6 +378,14 @@ func ForceExec(ctx context.Context, db *sql.DB, tables []*table.TableInfo, dbCon
 	if err != nil {
 		return err
 	}
+	return forceExec(ctx, db, dbConfig, logger, stmt, func(ctx context.Context, connID int) ([]int, error) {
+		return killLockingTransactions(ctx, db, tables, dbConfig, logger, []int{connID})
+	})
+}
+
+// forceExec receives the kill operation so tests can hold a real MySQL blocker
+// past the acknowledgement and verify the post-kill cleanup ordering.
+func forceExec(ctx context.Context, db *sql.DB, dbConfig *DBConfig, logger *slog.Logger, stmt string, kill func(context.Context, int) ([]int, error)) error {
 	trx, connId, err := BeginStandardTrx(ctx, db, nil)
 	if err != nil {
 		return err
@@ -399,14 +407,13 @@ func ForceExec(ctx context.Context, db *sql.DB, tables []*table.TableInfo, dbCon
 	duration := forceKillGracePeriod(dbConfig.LockWaitTimeout)
 	var wg sync.WaitGroup
 	var killTimerFired atomic.Bool
+	var killed []int
+	var killErr error
 	wg.Add(1)
 	timer := time.AfterFunc(duration, func() {
 		defer wg.Done()
 		killTimerFired.Store(true)
-		err := KillLockingTransactions(ctx, db, tables, dbConfig, logger, []int{connId})
-		if err != nil {
-			return // just return, we can't do much more here
-		}
+		killed, killErr = kill(ctx, connId)
 	})
 	_, err = trx.ExecContext(ctx, stmt)
 	if timer.Stop() {
@@ -419,6 +426,20 @@ func ForceExec(ctx context.Context, db *sql.DB, tables []*table.TableInfo, dbCon
 	// are now being used for subsequent operations.
 	wg.Wait()
 	if shouldRetryForceExecAfterKill(err, killTimerFired.Load()) {
+		if killErr != nil {
+			return errors.Join(err, fmt.Errorf("force-kill failed: %w", killErr))
+		}
+		if len(killed) == 0 {
+			return err
+		}
+		// MySQL KILL is asynchronous. Give only the sessions already signalled a
+		// bounded cleanup window before spending the retry's lock_wait_timeout.
+		cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		cleanupErr := waitForKilledTransactions(cleanupCtx, db, killed)
+		cancel()
+		if cleanupErr != nil {
+			return errors.Join(err, cleanupErr)
+		}
 		logger.Warn("retrying statement after lock wait timeout because force-kill timer fired", "error", err)
 		_, err = trx.ExecContext(ctx, stmt)
 	}

--- a/pkg/dbconn/dbconn.go
+++ b/pkg/dbconn/dbconn.go
@@ -429,9 +429,6 @@ func forceExec(ctx context.Context, db *sql.DB, dbConfig *DBConfig, logger *slog
 		if killErr != nil {
 			return errors.Join(err, fmt.Errorf("force-kill failed: %w", killErr))
 		}
-		if len(killed) == 0 {
-			return err
-		}
 		// MySQL KILL is asynchronous. Give only the sessions already signalled a
 		// bounded cleanup window before spending the retry's lock_wait_timeout.
 		cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/pkg/dbconn/forceexec_cleanup_test.go
+++ b/pkg/dbconn/forceexec_cleanup_test.go
@@ -1,0 +1,97 @@
+package dbconn
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForceExecWaitsForKilledSessionCleanup(t *testing.T) {
+	tt := testutils.NewTestTable(t, "forceexec_delayed_cleanup", "CREATE TABLE forceexec_delayed_cleanup (id INT PRIMARY KEY)")
+	config := NewDBConfig()
+	config.LockWaitTimeout = 1
+	db, err := New(testutils.DSN(), config)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	blockerDB, err := New(testutils.DSN(), NewDBConfig())
+	require.NoError(t, err)
+	blockerDB.SetMaxIdleConns(0) // Rollback also closes the physical session.
+	t.Cleanup(func() { _ = blockerDB.Close() })
+	blocker, pid, err := BeginStandardTrx(t.Context(), blockerDB, nil)
+	require.NoError(t, err)
+	// Simulate the interval between KILL's acknowledgement and server cleanup,
+	// using a real MDL-holding transaction. Release later than the old retry's
+	// one-second budget; cancellation also releases it on an assertion failure.
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	var workers sync.WaitGroup
+	t.Cleanup(func() { cancel(); workers.Wait(); _ = blocker.Rollback() })
+	_, err = blocker.ExecContext(ctx, "SELECT * FROM forceexec_delayed_cleanup")
+	require.NoError(t, err)
+	calls := 0
+	err = forceExec(ctx, db, config, slog.Default(),
+		"ALTER TABLE forceexec_delayed_cleanup ADD COLUMN c INT, ALGORITHM=INSTANT",
+		func(context.Context, int) ([]int, error) {
+			calls++
+			workers.Go(func() {
+				timer := time.NewTimer(1500 * time.Millisecond)
+				defer timer.Stop()
+				select {
+				case <-ctx.Done():
+				case <-timer.C:
+				}
+				_ = blocker.Rollback()
+			})
+			return []int{pid}, nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "must not kill a fresh set of blockers on retry")
+	var column string
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(), "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'forceexec_delayed_cleanup' AND column_name = 'c'").Scan(&column))
+	require.Equal(t, "c", column)
+}
+
+func TestWaitForKilledTransactionsHonorsCancellation(t *testing.T) {
+	db, err := New(testutils.DSN(), NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	blocker, pid, err := BeginStandardTrx(t.Context(), db, nil)
+	require.NoError(t, err)
+	defer func() { _ = blocker.Rollback() }()
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, waitForKilledTransactions(ctx, db, []int{pid}), context.DeadlineExceeded)
+	var alive int
+	require.NoError(t, blocker.QueryRowContext(t.Context(), "SELECT 1").Scan(&alive))
+	require.Equal(t, 1, alive, "waiting must never kill a session")
+	// Already-gone sessions and the empty set do not wait on unrelated sessions.
+	require.NoError(t, waitForKilledTransactions(t.Context(), db, nil))
+	require.NoError(t, waitForKilledTransactions(t.Context(), db, []int{-1}))
+}
+
+func TestForceExecReportsKillFailure(t *testing.T) {
+	tt := testutils.NewTestTable(t, "forceexec_kill_failure", "CREATE TABLE forceexec_kill_failure (id INT PRIMARY KEY)")
+	config := NewDBConfig()
+	config.LockWaitTimeout = 1
+	db, err := New(testutils.DSN(), config)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	blocker, _, err := BeginStandardTrx(t.Context(), tt.DB, nil)
+	require.NoError(t, err)
+	defer func() { _ = blocker.Rollback() }()
+	_, err = blocker.ExecContext(t.Context(), "SELECT * FROM forceexec_kill_failure")
+	require.NoError(t, err)
+	want := fmt.Errorf("kill permission denied")
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	err = forceExec(ctx, db, config, slog.Default(),
+		"ALTER TABLE forceexec_kill_failure ADD COLUMN c INT, ALGORITHM=INSTANT",
+		func(context.Context, int) ([]int, error) { return nil, want })
+	require.ErrorIs(t, err, want)
+}

--- a/pkg/dbconn/forceexec_cleanup_test.go
+++ b/pkg/dbconn/forceexec_cleanup_test.go
@@ -95,3 +95,43 @@ func TestForceExecReportsKillFailure(t *testing.T) {
 		func(context.Context, int) ([]int, error) { return nil, want })
 	require.ErrorIs(t, err, want)
 }
+
+// A blocker can disappear without being killed. Preserve ForceExec's existing
+// single retry in that case; the empty PID set only makes cleanup waiting a no-op.
+func TestForceExecRetriesWhenBlockerExitsWithoutKill(t *testing.T) {
+	tt := testutils.NewTestTable(t, "forceexec_no_kill", "CREATE TABLE forceexec_no_kill (id INT PRIMARY KEY)")
+	config := NewDBConfig()
+	config.LockWaitTimeout = 1
+	db, err := New(testutils.DSN(), config)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	blocker, _, err := BeginStandardTrx(t.Context(), tt.DB, nil)
+	require.NoError(t, err)
+	defer func() { _ = blocker.Rollback() }()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	_, err = blocker.ExecContext(ctx, "SELECT * FROM forceexec_no_kill")
+	require.NoError(t, err)
+	calls := 0
+	err = forceExec(ctx, db, config, slog.Default(),
+		"ALTER TABLE forceexec_no_kill ADD COLUMN c INT, ALGORITHM=INSTANT",
+		func(ctx context.Context, _ int) ([]int, error) {
+			calls++
+			// The timer fires at 900ms. Hold the blocker beyond the first
+			// statement's one-second timeout, then let it exit voluntarily.
+			timer := time.NewTimer(250 * time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+			return nil, blocker.Rollback()
+		})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	var count int
+	require.NoError(t, tt.DB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'forceexec_no_kill' AND column_name = 'c'").Scan(&count))
+	require.Equal(t, 1, count)
+}

--- a/pkg/dbconn/forceexec_cleanup_test.go
+++ b/pkg/dbconn/forceexec_cleanup_test.go
@@ -1,8 +1,10 @@
 package dbconn
 
 import (
+	"bytes"
 	"context"
-	"fmt"
+	"database/sql"
+	"io"
 	"log/slog"
 	"sync"
 	"testing"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +52,7 @@ func TestForceExecWaitsForKilledSessionCleanup(t *testing.T) {
 				_ = blocker.Rollback()
 			})
 			return []int{pid}, nil
-		})
+		}, waitForKilledTransactions)
 	require.NoError(t, err)
 	require.Equal(t, 1, calls, "must not kill a fresh set of blockers on retry")
 	var column string
@@ -75,25 +78,69 @@ func TestWaitForKilledTransactionsHonorsCancellation(t *testing.T) {
 	require.NoError(t, waitForKilledTransactions(t.Context(), db, []int{-1}))
 }
 
-func TestForceExecReportsKillFailure(t *testing.T) {
-	tt := testutils.NewTestTable(t, "forceexec_kill_failure", "CREATE TABLE forceexec_kill_failure (id INT PRIMARY KEY)")
-	config := NewDBConfig()
-	config.LockWaitTimeout = 1
-	db, err := New(testutils.DSN(), config)
-	require.NoError(t, err)
-	defer utils.CloseAndLog(db)
-	blocker, _, err := BeginStandardTrx(t.Context(), tt.DB, nil)
-	require.NoError(t, err)
-	defer func() { _ = blocker.Rollback() }()
-	_, err = blocker.ExecContext(t.Context(), "SELECT * FROM forceexec_kill_failure")
-	require.NoError(t, err)
-	want := fmt.Errorf("kill permission denied")
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-	err = forceExec(ctx, db, config, slog.Default(),
-		"ALTER TABLE forceexec_kill_failure ADD COLUMN c INT, ALGORITHM=INSTANT",
-		func(context.Context, int) ([]int, error) { return nil, want })
-	require.ErrorIs(t, err, want)
+// An ancillary connection failure cannot make a definite DDL timeout ambiguous.
+func TestForceExecAncillaryFailuresPreserveRetry(t *testing.T) {
+	for _, stage := range []string{"kill", "cleanup"} {
+		for _, release := range []bool{false, true} {
+			t.Run(stage+map[bool]string{false: "/blocked", true: "/released"}[release], func(t *testing.T) {
+				tt := testutils.NewTestTable(t, "forceexec_ancillary_failure", "CREATE TABLE forceexec_ancillary_failure (id INT PRIMARY KEY)")
+				config := NewDBConfig()
+				config.LockWaitTimeout = 1
+				db, err := New(testutils.DSN(), config)
+				require.NoError(t, err)
+				defer utils.CloseAndLog(db)
+				blocker, pid, err := BeginStandardTrx(t.Context(), tt.DB, nil)
+				require.NoError(t, err)
+				defer func() { _ = blocker.Rollback() }()
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				defer cancel()
+				_, err = blocker.ExecContext(ctx, "SELECT * FROM forceexec_ancillary_failure")
+				require.NoError(t, err)
+				var logs bytes.Buffer
+				logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+				killCalls, cleanupCalls := 0, 0
+				fail := func() error {
+					// Keep the first attempt blocked beyond its one-second lock budget.
+					timer := time.NewTimer(250 * time.Millisecond)
+					defer timer.Stop()
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-timer.C:
+					}
+					if release {
+						_ = blocker.Rollback()
+					}
+					return io.EOF
+				}
+				err = forceExec(ctx, db, config, logger,
+					"ALTER TABLE forceexec_ancillary_failure ADD COLUMN c INT, ALGORITHM=INSTANT",
+					func(context.Context, int) ([]int, error) {
+						killCalls++
+						if stage == "kill" {
+							return nil, fail()
+						}
+						return []int{pid}, nil
+					}, func(context.Context, *sql.DB, []int) error { cleanupCalls++; return fail() })
+				require.Equal(t, 1, killCalls)
+				if stage == "cleanup" {
+					require.Equal(t, 1, cleanupCalls)
+					require.Contains(t, logs.String(), "waiting for killed sessions")
+				}
+				require.Contains(t, logs.String(), "retrying statement anyway")
+				require.Contains(t, logs.String(), "EOF")
+				if release {
+					require.NoError(t, err)
+				} else {
+					var ddlErr *mysql.MySQLError
+					require.ErrorAs(t, err, &ddlErr)
+					require.EqualValues(t, 1205, ddlErr.Number)
+					require.False(t, IsConnectionLossError(err))
+					require.NotErrorIs(t, err, io.EOF)
+				}
+			})
+		}
+	}
 }
 
 // A blocker can disappear without being killed. Preserve ForceExec's existing
@@ -127,7 +174,7 @@ func TestForceExecRetriesWhenBlockerExitsWithoutKill(t *testing.T) {
 			case <-timer.C:
 			}
 			return nil, blocker.Rollback()
-		})
+		}, waitForKilledTransactions)
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 	var count int

--- a/pkg/dbconn/kill.go
+++ b/pkg/dbconn/kill.go
@@ -127,10 +127,17 @@ type LockDetail struct {
 }
 
 func KillLockingTransactions(ctx context.Context, db *sql.DB, tables []*table.TableInfo, config *DBConfig, logger *slog.Logger, ignorePIDs []int) error {
+	_, err := killLockingTransactions(ctx, db, tables, config, logger, ignorePIDs)
+	return err
+}
+
+// killLockingTransactions also returns the successfully signalled sessions.
+// KILL acknowledges the request before rollback and lock release complete.
+func killLockingTransactions(ctx context.Context, db *sql.DB, tables []*table.TableInfo, config *DBConfig, logger *slog.Logger, ignorePIDs []int) ([]int, error) {
 	// First, check if there are explicit table locks that would prevent us from acquiring the metadata lock.
 	locks, err := GetTableLocks(ctx, db, tables, logger, ignorePIDs)
 	if err != nil {
-		return fmt.Errorf("failed to get table locks: %w", err)
+		return nil, fmt.Errorf("failed to get table locks: %w", err)
 	}
 	if len(locks) > 0 {
 		// If we find any table locks, we cannot proceed with the metadata lock.
@@ -145,25 +152,28 @@ func KillLockingTransactions(ctx context.Context, db *sql.DB, tables []*table.Ta
 				"objectName", lock.ObjectName,
 			)
 		}
-		return ErrTableLockFound
+		return nil, ErrTableLockFound
 	}
 	pids, err := GetLockingTransactions(ctx, db, tables, config, logger, ignorePIDs)
 	if err != nil {
-		return fmt.Errorf("failed to get locking transactions: %w", err)
+		return nil, fmt.Errorf("failed to get locking transactions: %w", err)
 	}
 	// Now we can kill these transactions
 	var errs []error
+	var killed []int
 	for _, pid := range pids {
 		logger.Warn("killing locking transaction", "pid", pid)
 		err = KillTransaction(ctx, db, pid)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to kill transaction %d: %w", pid, err))
+		} else {
+			killed = append(killed, pid)
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("errors occurred while killing locking transactions: %w", errors.Join(errs...))
+		return nil, fmt.Errorf("errors occurred while killing locking transactions: %w", errors.Join(errs...))
 	}
-	return nil
+	return killed, nil
 }
 
 // GetLockingTransactions queries the performance schema to find locking transactions
@@ -416,4 +426,31 @@ func sliceToInList[S ~[]E, E any](items S) (inList string, inParams []any) {
 		}
 	}
 	return builder.String(), inParams
+}
+
+// waitForKilledTransactions waits only for the sessions we already signalled.
+// Do not discover or kill new blockers here: the retry must not broaden the
+// original kill decision. The caller supplies a bounded context.
+func waitForKilledTransactions(ctx context.Context, db *sql.DB, pids []int) error {
+	if len(pids) == 0 {
+		return nil
+	}
+	inList, params := sliceToInList(pids)
+	query := "SELECT COUNT(*) FROM performance_schema.threads WHERE processlist_id IN (" + inList + ")"
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var remaining int
+		if err := db.QueryRowContext(ctx, query, params...).Scan(&remaining); err != nil {
+			return fmt.Errorf("waiting for killed sessions %v to exit: %w", pids, err)
+		}
+		if remaining == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for killed sessions %v to exit: %w", pids, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }

--- a/pkg/dbconn/kill.go
+++ b/pkg/dbconn/kill.go
@@ -44,6 +44,10 @@ func forceKillGracePeriod(lockWaitTimeout int) time.Duration {
 	return time.Duration(seconds * float64(time.Second))
 }
 
+// Rollback can outlast lock acquisition, so this budget is independent of
+// LockWaitTimeout. It adds at most 30 seconds before the single statement retry.
+const forceKillCleanupTimeout = 30 * time.Second
+
 const (
 	// TableLockQuery is used to find tables that are locked by a LOCK TABLES command.
 	// It's not really possible to find out how long the lock has been held, so we don't consider
@@ -437,8 +441,9 @@ func waitForKilledTransactions(ctx context.Context, db *sql.DB, pids []int) erro
 	}
 	inList, params := sliceToInList(pids)
 	query := "SELECT COUNT(*) FROM performance_schema.threads WHERE processlist_id IN (" + inList + ")"
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
+	interval := 10 * time.Millisecond
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
 	for {
 		var remaining int
 		if err := db.QueryRowContext(ctx, query, params...).Scan(&remaining); err != nil {
@@ -450,7 +455,9 @@ func waitForKilledTransactions(ctx context.Context, db *sql.DB, pids []int) erro
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("waiting for killed sessions %v to exit: %w", pids, ctx.Err())
-		case <-ticker.C:
+		case <-timer.C:
 		}
+		interval = min(interval*2, 100*time.Millisecond)
+		timer.Reset(interval)
 	}
 }


### PR DESCRIPTION
MySQL acknowledges KILL before session rollback and lock release finish. ForceExec's immediate retry can spend its entire lock_wait_timeout waiting for that cleanup, reproducing #1161.

Record the sessions successfully signalled by the existing kill operation. Before the existing single retry, wait for those sessions to disappear from performance_schema.threads, with caller cancellation and a named 30-second cleanup ceiling independent of LockWaitTimeout. Polling backs off from 10ms to 100ms. No new blockers are discovered or killed, and the explicit-table-lock and transaction-weight exclusions remain.

Kill and cleanup failures are logged, then the original single retry proceeds. Only the statement's result is returned, so a failure on an ancillary connection cannot make a definite DDL timeout appear ownership-ambiguous. An empty killed-session set also retains the retry.

Fixes #1161's delayed-killed-session cleanup scenario. New blockers can still legitimately cause the retry to fail.

Validation on MySQL 8.0.43: all ForceExec and cleanup-wait tests passed three repetitions under -race; golangci-lint reports 0 issues. Regression cases cover delayed cleanup, cancellation, already-gone sessions, voluntary blocker exit, and kill/cleanup connection failures with both successful and failed retries. Failed retries are checked against the actual IsConnectionLossError classifier.
