### PR TITLE
change: report reader and buffer state on catch-up timeout

### DIFF
--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1450,7 +1450,7 @@ func (c *binlogClient) BlockWait(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-timer.C:
-			return fmt.Errorf("timed out waiting to catch up to source position: %v, current position is: %v", targetPos, c.getBufferedPos())
+			return fmt.Errorf("timed out waiting to catch up to source position: %v, current position is: %v, started at: %v; %s", targetPos, c.getBufferedPos(), bufferedPos, catchUpDiagnostics(c.subs.Snapshot()))
 		default:
 			currPos := c.getBufferedPos()
 			if stalls.observe(prevPos, currPos) {

--- a/pkg/change/binlog.go
+++ b/pkg/change/binlog.go
@@ -1423,6 +1423,12 @@ func (c *binlogClient) runPeriodicFlush(ctx context.Context, interval time.Durat
 // The default timeout is 10 seconds, after which an error will be returned.
 // Satisfies Source interface.
 func (c *binlogClient) BlockWait(ctx context.Context) error {
+	return c.blockWait(ctx, DefaultTimeout)
+}
+
+// blockWait accepts a budget so timeout diagnostics can be exercised without a
+// thirty-second test or mutation of shared configuration.
+func (c *binlogClient) blockWait(ctx context.Context, timeout time.Duration) error {
 	targetPos, err := c.getCurrentBinlogPosition(ctx)
 	if err != nil {
 		return err
@@ -1440,7 +1446,7 @@ func (c *binlogClient) BlockWait(ctx context.Context) error {
 		logCatchUp = c.logger.Info
 	}
 	logCatchUp("waiting to catch up to source position", "target_position", targetPos, "current_position", bufferedPos)
-	timer := time.NewTimer(DefaultTimeout)
+	timer := time.NewTimer(timeout)
 	defer timer.Stop() // Ensure timer is always stopped to prevent goroutine leak
 
 	prevPos := c.getBufferedPos()

--- a/pkg/change/catchup_diagnostics.go
+++ b/pkg/change/catchup_diagnostics.go
@@ -23,7 +23,7 @@ func catchUpDiagnostics(subs []Subscription) string {
 			continue
 		}
 		out = append(out, fmt.Sprintf("subscription[%d]: pending=%d flushing=%d bytes=%d parked=%t parks=%d drain-budget-hit=%t",
-			i, sub.lengthLocked(), sub.flushingCount, sub.sizeBytes, sub.parked, parks, sub.lastDrainHitBudget.Load()))
+			i, len(sub.changes)+len(sub.queue), sub.flushingCount, sub.sizeBytes, sub.parked, parks, sub.lastDrainHitBudget.Load()))
 		sub.Unlock()
 	}
 	if len(out) == 0 {

--- a/pkg/change/catchup_diagnostics.go
+++ b/pkg/change/catchup_diagnostics.go
@@ -13,17 +13,16 @@ func catchUpDiagnostics(subs []Subscription) string {
 	var out []string
 	for i, subscription := range subs {
 		sub, ok := subscription.(*bufferedMap)
-		if !ok {
+		if !ok || sub == nil {
 			out = append(out, fmt.Sprintf("subscription[%d]=unavailable", i))
 			continue
 		}
-		parks := sub.timesParked.Load()
 		if !sub.TryLock() {
-			out = append(out, fmt.Sprintf("subscription[%d]=busy parks=%d", i, parks))
+			out = append(out, fmt.Sprintf("subscription[%d]=busy parks=%d drain-budget-hit=%t", i, sub.timesParked.Load(), sub.LastDrainHitBudget()))
 			continue
 		}
 		out = append(out, fmt.Sprintf("subscription[%d]: pending=%d flushing=%d bytes=%d parked=%t parks=%d drain-budget-hit=%t",
-			i, len(sub.changes)+len(sub.queue), sub.flushingCount, sub.sizeBytes, sub.parked, parks, sub.lastDrainHitBudget.Load()))
+			i, len(sub.changes)+len(sub.queue), sub.flushingCount, sub.sizeBytes, sub.parked, sub.timesParked.Load(), sub.LastDrainHitBudget()))
 		sub.Unlock()
 	}
 	if len(out) == 0 {

--- a/pkg/change/catchup_diagnostics.go
+++ b/pkg/change/catchup_diagnostics.go
@@ -1,0 +1,33 @@
+package change
+
+import (
+	"fmt"
+	"strings"
+)
+
+// catchUpDiagnostics is best effort: reporting a timeout must never wait for a
+// subscription mutex held by the flush whose progress we are investigating.
+// Unknown subscription implementations are explicitly counted, not treated as
+// empty. The fields are an observation, not a diagnosis of the timeout's cause.
+func catchUpDiagnostics(subs []Subscription) string {
+	var out []string
+	for i, subscription := range subs {
+		sub, ok := subscription.(*bufferedMap)
+		if !ok {
+			out = append(out, fmt.Sprintf("subscription[%d]=unavailable", i))
+			continue
+		}
+		parks := sub.timesParked.Load()
+		if !sub.TryLock() {
+			out = append(out, fmt.Sprintf("subscription[%d]=busy parks=%d", i, parks))
+			continue
+		}
+		out = append(out, fmt.Sprintf("subscription[%d]: pending=%d flushing=%d bytes=%d parked=%t parks=%d drain-budget-hit=%t",
+			i, sub.lengthLocked(), sub.flushingCount, sub.sizeBytes, sub.parked, parks, sub.lastDrainHitBudget.Load()))
+		sub.Unlock()
+	}
+	if len(out) == 0 {
+		return "no subscriptions"
+	}
+	return strings.Join(out, "; ")
+}

--- a/pkg/change/catchup_diagnostics_test.go
+++ b/pkg/change/catchup_diagnostics_test.go
@@ -1,9 +1,14 @@
 package change
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/testutils"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,20 +21,23 @@ func TestCatchUpDiagnostics(t *testing.T) {
 	got := catchUpDiagnostics([]Subscription{sub})
 	require.Contains(t, got, "pending=1 flushing=0")
 	require.Contains(t, got, "parked=true parks=2 drain-budget-hit=true")
-	require.NotContains(t, got, "bytes=0")
+	require.Contains(t, got, fmt.Sprintf("bytes=%d", sub.sizeBytes))
+	require.Positive(t, sub.sizeBytes)
 	require.Equal(t, "no subscriptions", catchUpDiagnostics(nil))
 	require.Equal(t, "subscription[0]=unavailable", catchUpDiagnostics([]Subscription{nil}))
+	require.Equal(t, "subscription[0]=unavailable", catchUpDiagnostics([]Subscription{(*bufferedMap)(nil)}))
 }
 
 func TestCatchUpDiagnosticsDoesNotBlockBehindFlush(t *testing.T) {
 	sub := newBareBufferedMap(1024)
+	sub.lastDrainHitBudget.Store(true)
 	sub.Lock()
 	defer sub.Unlock()
 	done := make(chan string, 1)
 	go func() { done <- catchUpDiagnostics([]Subscription{sub}) }()
 	select {
 	case got := <-done:
-		require.Equal(t, "subscription[0]=busy parks=0", got)
+		require.Equal(t, "subscription[0]=busy parks=0 drain-budget-hit=true", got)
 	case <-time.After(time.Second):
 		t.Fatal("timeout diagnostics blocked behind subscription lock")
 	}
@@ -46,4 +54,47 @@ func TestCatchUpDiagnosticsSeparatesPendingFromFlushing(t *testing.T) {
 	sub.changes = nil
 	sub.queue = nil
 	require.Contains(t, catchUpDiagnostics([]Subscription{sub}), "pending=0 flushing=3")
+}
+
+// Use a real server for target coordinates, but leave the reader stopped so the
+// timeout is deterministic. Both clients must include subscription diagnostics.
+func TestBlockWaitTimeoutDiagnostics(t *testing.T) {
+	for _, mode := range []string{"binlog", "gtid"} {
+		t.Run(mode, func(t *testing.T) {
+			if mode == "gtid" {
+				skipUnlessGTIDEnabled(t)
+			}
+			tt := testutils.NewTestTable(t, "catchup_timeout", "CREATE TABLE catchup_timeout (id INT PRIMARY KEY)")
+			sub := newBareBufferedMap(1024)
+			sub.HasChanged([]any{int32(1)}, []any{int32(1), "seed"}, false)
+			subs := newSubscriptionRegistry()
+			require.True(t, subs.Add("catchup_timeout", sub))
+			var wait func(context.Context, time.Duration) error
+			var initial string
+			if mode == "binlog" {
+				client := &binlogClient{db: tt.DB, logger: slog.Default(), subs: subs}
+				position, err := client.getCurrentBinlogPosition(t.Context())
+				require.NoError(t, err)
+				client.bufferedPos = position // blockWait rotates to a later real file.
+				initial = fmt.Sprint(client.getBufferedPos())
+				wait = client.blockWait
+			} else {
+				empty, err := mysql.ParseMysqlGTIDSet("")
+				require.NoError(t, err)
+				client := &gtidClient{db: tt.DB, logger: slog.Default(), subs: subs, bufferedGTID: empty}
+				target, err := client.getCurrentGTIDSet(t.Context())
+				require.NoError(t, err)
+				require.False(t, target.IsEmpty(), "CREATE TABLE must advance the source GTID")
+				initial = empty.String()
+				wait = client.blockWait
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			err := wait(ctx, 20*time.Millisecond)
+			require.ErrorContains(t, err, "timed out waiting to catch up to source")
+			require.ErrorContains(t, err, "current")
+			require.ErrorContains(t, err, "started at: "+initial+";")
+			require.ErrorContains(t, err, catchUpDiagnostics([]Subscription{sub}))
+		})
+	}
 }

--- a/pkg/change/catchup_diagnostics_test.go
+++ b/pkg/change/catchup_diagnostics_test.go
@@ -1,0 +1,36 @@
+package change
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatchUpDiagnostics(t *testing.T) {
+	sub := newBareBufferedMap(1024)
+	sub.HasChanged([]any{int32(1)}, []any{int32(1), "seed"}, false)
+	sub.parked = true
+	sub.timesParked.Store(2)
+	sub.lastDrainHitBudget.Store(true)
+	got := catchUpDiagnostics([]Subscription{sub})
+	require.Contains(t, got, "pending=1 flushing=0")
+	require.Contains(t, got, "parked=true parks=2 drain-budget-hit=true")
+	require.NotContains(t, got, "bytes=0")
+	require.Equal(t, "no subscriptions", catchUpDiagnostics(nil))
+	require.Equal(t, "subscription[0]=unavailable", catchUpDiagnostics([]Subscription{nil}))
+}
+
+func TestCatchUpDiagnosticsDoesNotBlockBehindFlush(t *testing.T) {
+	sub := newBareBufferedMap(1024)
+	sub.Lock()
+	defer sub.Unlock()
+	done := make(chan string, 1)
+	go func() { done <- catchUpDiagnostics([]Subscription{sub}) }()
+	select {
+	case got := <-done:
+		require.Equal(t, "subscription[0]=busy parks=0", got)
+	case <-time.After(time.Second):
+		t.Fatal("timeout diagnostics blocked behind subscription lock")
+	}
+}

--- a/pkg/change/catchup_diagnostics_test.go
+++ b/pkg/change/catchup_diagnostics_test.go
@@ -34,3 +34,16 @@ func TestCatchUpDiagnosticsDoesNotBlockBehindFlush(t *testing.T) {
 		t.Fatal("timeout diagnostics blocked behind subscription lock")
 	}
 }
+
+// A flush swaps entries out of the active stores. Pending and flushing must
+// describe disjoint work so summing them does not double-count that snapshot.
+func TestCatchUpDiagnosticsSeparatesPendingFromFlushing(t *testing.T) {
+	sub := newBareBufferedMap(1024)
+	sub.HasChanged([]any{int32(1)}, []any{int32(1), "seed"}, false)
+	sub.queue = append(sub.queue, queuedChange{})
+	sub.flushingCount = 3
+	require.Contains(t, catchUpDiagnostics([]Subscription{sub}), "pending=2 flushing=3")
+	sub.changes = nil
+	sub.queue = nil
+	require.Contains(t, catchUpDiagnostics([]Subscription{sub}), "pending=0 flushing=3")
+}

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -1383,7 +1383,7 @@ func (c *gtidClient) BlockWait(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-timer.C:
-			return fmt.Errorf("timed out waiting to catch up to source GTID: %s, current: %s", targetGTID.String(), c.getBufferedGTID().String())
+			return fmt.Errorf("timed out waiting to catch up to source GTID: %s, current: %s, started at: %s; %s", targetGTID.String(), c.getBufferedGTID().String(), bufferedGTID.String(), catchUpDiagnostics(c.subs.Snapshot()))
 		default:
 			if c.getBufferedGTID().Contain(targetGTID) {
 				return nil

--- a/pkg/change/gtid.go
+++ b/pkg/change/gtid.go
@@ -1363,6 +1363,12 @@ func (c *gtidClient) runPeriodicFlush(ctx context.Context, interval time.Duratio
 // BlockWait satisfies Source. Reads the source's @@GLOBAL.gtid_executed
 // and waits until our buffered set is a superset of it.
 func (c *gtidClient) BlockWait(ctx context.Context) error {
+	return c.blockWait(ctx, DefaultTimeout)
+}
+
+// blockWait accepts a budget so timeout diagnostics can be exercised without a
+// thirty-second test or mutation of shared configuration.
+func (c *gtidClient) blockWait(ctx context.Context, timeout time.Duration) error {
 	targetGTID, err := c.getCurrentGTIDSet(ctx)
 	if err != nil {
 		return err
@@ -1375,7 +1381,7 @@ func (c *gtidClient) BlockWait(ctx context.Context) error {
 		logCatchUp = c.logger.Info
 	}
 	logCatchUp("waiting to catch up to source GTID", "target", targetGTID.String(), "current", bufferedGTID.String())
-	timer := time.NewTimer(DefaultTimeout)
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
 	for {


### PR DESCRIPTION
Catch-up timeouts currently report only target and current coordinates. Add the starting coordinate and a best-effort subscription snapshot to both file-position and GTID timeout errors: active pending changes, in-flight flush count, bytes, current/cumulative parking, and whether the previous drain exhausted its dispatch budget.

TryLock keeps reporting from waiting on a subscription mutex. Busy subscriptions still report the lock-free park count and drain-budget flag through its accessor. Successful snapshots read the parking pair under the acquired lock; unknown or typed-nil subscriptions are reported as unavailable.

Related to #628 and #837. This adds diagnostic coverage and does not claim to fix either intermittent CI failure.

Validation on MySQL 8.0.43: diagnostic tests and both real-server timeout paths passed ten repetitions under -race. Tests assert exact nonzero bytes, nonblocking busy output, typed nil, separate pending/in-flight work, and each client's timeout wiring and starting coordinate. The full change package passed under -race; golangci-lint reports 0 issues.
