### PR TITLE
test(move): bound VARCHAR-PK writers before cutover

### DIFF
--- a/pkg/move/helpers_test.go
+++ b/pkg/move/helpers_test.go
@@ -1,0 +1,62 @@
+package move
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/status"
+	"github.com/stretchr/testify/require"
+)
+
+// Give setup/copy/checksum its own budget, independent of subsequent writes
+// and cutover. Like migration's status wait, allow three minutes for checksum
+// catch-up and lock retries on slow CI servers.
+func waitForMoveStatus(t *testing.T, runner *Runner, target status.State, done <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+	require.NoError(t, awaitMoveStatus(ctx, runner, target, done))
+}
+
+func awaitMoveStatus(ctx context.Context, runner *Runner, target status.State, done <-chan error) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-done:
+			return fmt.Errorf("move exited while waiting for %s: %w", target, err)
+		default:
+		}
+		current := runner.status.Get()
+		if current >= status.Close {
+			return fmt.Errorf("move entered terminal state %s while waiting for %s", current, target)
+		}
+		if current >= target {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for %s (last state %s): %w", target, runner.status.Get(), ctx.Err())
+		case err := <-done:
+			return fmt.Errorf("move exited while waiting for %s: %w", target, err)
+		case <-ticker.C:
+		}
+	}
+}
+
+func TestAwaitMoveStatus(t *testing.T) {
+	runner := &Runner{}
+	runner.status.Set(status.CutOver)
+	require.NoError(t, awaitMoveStatus(t.Context(), runner, status.WaitingOnSentinelTable, nil))
+	runner.status.Set(status.Close)
+	require.ErrorContains(t, awaitMoveStatus(t.Context(), runner, status.WaitingOnSentinelTable, nil), "terminal state")
+	runner.status.Set(status.Initial)
+	done := make(chan error, 1)
+	done <- fmt.Errorf("copy failed")
+	require.ErrorContains(t, awaitMoveStatus(t.Context(), runner, status.WaitingOnSentinelTable, done), "copy failed")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, awaitMoveStatus(ctx, runner, status.WaitingOnSentinelTable, nil), context.Canceled)
+}

--- a/pkg/move/move_sharded_test.go
+++ b/pkg/move/move_sharded_test.go
@@ -410,17 +410,7 @@ func TestShardedMoveVindexUpdateFails(t *testing.T) {
 
 	// Wait until the move blocks on the sentinel: the copy and the initial
 	// checksum are done and the repl client is streaming.
-	deadline := time.Now().Add(2 * time.Minute)
-	for runner.status.Get() != status.WaitingOnSentinelTable {
-		select {
-		case err := <-errCh:
-			t.Fatalf("move finished before reaching the sentinel wait: %v", err)
-		case <-time.After(50 * time.Millisecond):
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for the move to reach the sentinel wait")
-		}
-	}
+	waitForMoveStatus(t, runner, status.WaitingOnSentinelTable, errCh)
 
 	// Change the vindex value of a row. The change feed must treat this as
 	// fatal and cancel the move.

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -745,16 +745,13 @@ func TestConcurrentMoveDoesNotWipeTarget(t *testing.T) {
 	require.Zero(t, artifacts, "a concurrent run must not create a checkpoint table before acquiring the lock")
 }
 
-// TestMoveWithVarcharPK verifies a move on a table with a non-memory-comparable
-// primary key (VARCHAR with a CI collation) — the case from issue #607. The
-// move runs under concurrent writes to exercise the binlog replay path.
-//
-// For non-memory-comparable PKs the bufferedMap subscription uses LWW map
-// dedup during the copy phase and FIFO queue post-copy. The queue replays
-// binlog events in their original order, which is required for collation-
-// sensitive PKs because the map's hash equality ("A" ≠ "a") does not match
-// MySQL's row identity ("A" = "a" under a CI collation). The post-cutover
-// checksum keeps the optimization honest by repairing any divergence.
+// TestMoveWithVarcharPK verifies FIFO replay after copying a table with a
+// non-memory-comparable VARCHAR primary key (issue #607). Concurrent writes
+// run while the sentinel holds cutover, after the switch from LWW map dedup
+// to FIFO. This test does not exercise concurrent writes during map-mode copy;
+// the move checksum is the correctness gate for divergence in that phase.
+// FIFO preserves event order when Go key equality differs from MySQL's CI
+// collation ("A" and "a" identify the same row in MySQL).
 func TestMoveWithVarcharPK(t *testing.T) {
 	srcDB := "source_varcharpk"
 	dstDB := "dest_varcharpk"
@@ -791,7 +788,7 @@ func TestMoveWithVarcharPK(t *testing.T) {
 	// Hold cutover at the sentinel so the finite workload definitely runs
 	// after copy, when VARCHAR primary keys use FIFO replay. The old writers
 	// ran until move.Run returned, so a slow reader could chase them forever.
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	runner, err := NewRunner(&Move{
 		SourceDSN:    sourceDSN,
@@ -802,6 +799,7 @@ func TestMoveWithVarcharPK(t *testing.T) {
 	})
 	require.NoError(t, err)
 	done := make(chan struct{})
+	errCh := make(chan error, 1)
 	var runErr error
 	var wg sync.WaitGroup
 	t.Cleanup(func() {
@@ -816,23 +814,17 @@ func TestMoveWithVarcharPK(t *testing.T) {
 			t.Error("move runner did not stop during cleanup")
 		}
 	})
-	go func() { runErr = runner.Run(ctx); close(done) }()
+	go func() { runErr = runner.Run(ctx); errCh <- runErr; close(done) }()
 
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-	for runner.status.Get() != status.WaitingOnSentinelTable {
-		select {
-		case <-done:
-			t.Fatalf("move exited before sentinel wait: %v", runErr)
-		case <-ctx.Done():
-			t.Fatalf("waiting for sentinel (state %s): %v", runner.status.Get(), ctx.Err())
-		case <-ticker.C:
-		}
-	}
+	waitForMoveStatus(t, runner, status.WaitingOnSentinelTable, errCh)
 
 	var writeCount, errorCount atomic.Int64
 	// Four finite writers keep concurrent FIFO apply coverage while guaranteeing
-	// a quiet source for the final drain. Pacing keeps their binlog load bounded.
+	// a quiet source for the final drain (#834). Unbounded writers can produce
+	// binlog faster than a slow CI reader drains it, preventing catch-up forever.
+	// The finite count guarantees convergence; pacing also limits peak pressure.
+	writeCtx, cancelWrites := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancelWrites()
 	const writers, iterations = 4, 25
 	for range writers {
 		wg.Go(func() {
@@ -840,11 +832,11 @@ func TestMoveWithVarcharPK(t *testing.T) {
 			defer pace.Stop()
 			for range iterations {
 				select {
-				case <-ctx.Done():
+				case <-writeCtx.Done():
 					return
 				case <-pace.C:
 				}
-				if err := varcharPKWriteOne(ctx, sourceDB, srcDB); err != nil {
+				if err := varcharPKWriteOne(writeCtx, sourceDB, srcDB); err != nil {
 					errorCount.Add(1)
 				} else {
 					writeCount.Add(1)
@@ -855,12 +847,14 @@ func TestMoveWithVarcharPK(t *testing.T) {
 	wg.Wait()
 	require.Equal(t, int64(0), errorCount.Load())
 	require.Equal(t, int64(writers*iterations), writeCount.Load(), "the test must execute its concurrent write workload")
+	drainCtx, cancelDrain := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancelDrain()
 	testutils.RunSQL(t, "DROP TABLE "+dstDB+"."+sentinel.TableName)
 	select {
 	case <-done:
 		require.NoError(t, runErr, "move on VARCHAR PK table must succeed (issue #607)")
-	case <-ctx.Done():
-		t.Fatalf("move did not finish after finite writes (state %s): %v", runner.status.Get(), ctx.Err())
+	case <-drainCtx.Done():
+		t.Fatalf("move did not finish within the final drain budget (state %s): %v", runner.status.Get(), drainCtx.Err())
 	}
 
 	// Source/target row counts must match. The internal checksum step inside

--- a/pkg/move/runner_test.go
+++ b/pkg/move/runner_test.go
@@ -777,9 +777,8 @@ func TestMoveWithVarcharPK(t *testing.T) {
 		updated_at DATETIME NOT NULL
 	) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`)
 
-	// Seed enough rows that the copier runs for long enough to interleave
-	// with the concurrent writers. Use UUIDs for PK values to keep them
-	// well-distributed.
+	// Seed existing rows for the initial copy. The concurrent write workload
+	// runs later, once the sentinel holds the move in FIFO replay mode.
 	for range 50 {
 		testutils.RunSQL(t, `INSERT INTO `+srcDB+`.items (id, val, updated_at)
 			VALUES (UUID(), HEX(RANDOM_BYTES(20)), NOW())`)
@@ -789,58 +788,83 @@ func TestMoveWithVarcharPK(t *testing.T) {
 	require.NoError(t, err)
 	defer utils.CloseAndLog(sourceDB)
 
-	ctx, cancel := context.WithCancel(t.Context())
+	// Hold cutover at the sentinel so the finite workload definitely runs
+	// after copy, when VARCHAR primary keys use FIFO replay. The old writers
+	// ran until move.Run returned, so a slow reader could chase them forever.
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
-
+	runner, err := NewRunner(&Move{
+		SourceDSN:    sourceDSN,
+		TargetDSN:    targetDSN,
+		Threads:      2,
+		WriteThreads: 2,
+		DeferCutOver: true,
+	})
+	require.NoError(t, err)
+	done := make(chan struct{})
+	var runErr error
 	var wg sync.WaitGroup
-	var writeCount, errorCount atomic.Int64
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+		select {
+		case <-done:
+			if err := runner.Close(); err != nil {
+				t.Errorf("closing move runner: %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Error("move runner did not stop during cleanup")
+		}
+	})
+	go func() { runErr = runner.Run(ctx); close(done) }()
 
-	// 4 writers doing INSERT / UPDATE / DELETE on VARCHAR PKs while the
-	// move runs. The FIFO queue must replay these in binlog order to land
-	// on the correct end state on the target.
-	//
-	// A short delay between iterations rate-limits the writers to ~400 ops/sec
-	// total. Without this, an uncapped tight loop generates binlog faster than
-	// the reader can drain it on slow CI runners — the source position
-	// outruns the buffered position indefinitely and Flush()'s BlockWait loop
-	// never converges below binlogTrivialThreshold, eventually tripping the
-	// 10-minute test timeout (issue #834).
-	for range 4 {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for runner.status.Get() != status.WaitingOnSentinelTable {
+		select {
+		case <-done:
+			t.Fatalf("move exited before sentinel wait: %v", runErr)
+		case <-ctx.Done():
+			t.Fatalf("waiting for sentinel (state %s): %v", runner.status.Get(), ctx.Err())
+		case <-ticker.C:
+		}
+	}
+
+	var writeCount, errorCount atomic.Int64
+	// Four finite writers keep concurrent FIFO apply coverage while guaranteeing
+	// a quiet source for the final drain. Pacing keeps their binlog load bounded.
+	const writers, iterations = 4, 25
+	for range writers {
 		wg.Go(func() {
-			for {
+			pace := time.NewTicker(10 * time.Millisecond)
+			defer pace.Stop()
+			for range iterations {
 				select {
 				case <-ctx.Done():
 					return
-				default:
+				case <-pace.C:
 				}
 				if err := varcharPKWriteOne(ctx, sourceDB, srcDB); err != nil {
 					errorCount.Add(1)
 				} else {
 					writeCount.Add(1)
 				}
-				time.Sleep(10 * time.Millisecond)
 			}
 		})
 	}
-	time.Sleep(100 * time.Millisecond)
-
-	move := &Move{
-		SourceDSN:    sourceDSN,
-		TargetDSN:    targetDSN,
-		Threads:      2,
-		WriteThreads: 2,
-		DeferCutOver: false,
-	}
-	err = move.Run()
-	cancel()
 	wg.Wait()
-
-	t.Logf("%d successful writes, %d errors during move",
-		writeCount.Load(), errorCount.Load())
-	require.NoError(t, err, "move on VARCHAR PK table must succeed (issue #607)")
+	require.Equal(t, int64(0), errorCount.Load())
+	require.Equal(t, int64(writers*iterations), writeCount.Load(), "the test must execute its concurrent write workload")
+	testutils.RunSQL(t, "DROP TABLE "+dstDB+"."+sentinel.TableName)
+	select {
+	case <-done:
+		require.NoError(t, runErr, "move on VARCHAR PK table must succeed (issue #607)")
+	case <-ctx.Done():
+		t.Fatalf("move did not finish after finite writes (state %s): %v", runner.status.Get(), ctx.Err())
+	}
 
 	// Source/target row counts must match. The internal checksum step inside
-	// move.Run() already proves content equivalence; this is a belt-and-braces
+	// runner.Run() already proves content equivalence; this is a belt-and-braces
 	// check on top of that.
 	var sourceCount, targetCount int
 	require.NoError(t, sourceDB.QueryRowContext(t.Context(),

--- a/pkg/move/sentinel_test.go
+++ b/pkg/move/sentinel_test.go
@@ -68,17 +68,7 @@ func TestMoveSentinelDropReleasesCutover(t *testing.T) {
 	go func() { errCh <- runner.Run(context.Background()) }()
 
 	// Wait until the move is blocked on the sentinel.
-	deadline := time.Now().Add(60 * time.Second)
-	for runner.status.Get() != status.WaitingOnSentinelTable {
-		select {
-		case err := <-errCh:
-			t.Fatalf("move finished before reaching the sentinel wait: %v", err)
-		case <-time.After(50 * time.Millisecond):
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for the move to reach the sentinel wait")
-		}
-	}
+	waitForMoveStatus(t, runner, status.WaitingOnSentinelTable, errCh)
 
 	// Drop the sentinel on targets[0] to release the cutover.
 	testutils.RunSQL(t, "DROP TABLE sentrel_dst."+sentinel.TableName)


### PR DESCRIPTION
TestMoveWithVarcharPK stops its writers only after the move returns. Even paced writers can keep a slow reader chasing a changing source indefinitely, so completion and writer shutdown depend on each other.

Use a finite workload while holding cutover at the sentinel. After copy switches VARCHAR primary keys to FIFO replay, four writers execute 25 paced write cycles each. Require all 100 cycles to succeed, stop writing, then drop the sentinel and verify cutover/data agreement. The test explicitly covers post-copy FIFO replay; concurrent map-mode copy is outside its coverage.

Setup/copy/checksum, writes, and final drain each receive their own three-minute budget. The runner is cancelled, joined and closed during cleanup. Consolidate all three move sentinel waits into a helper that detects early exit and terminal states and accepts reaching or passing the requested state. Retain the #834 explanation for finite writers and pacing.

Fixes #834's unbounded VARCHAR test-workload scenario.

Validation on MySQL 8.0.43: the VARCHAR workload, shared-wait regressions, sentinel-drop test, and sharded vindex-failure test passed three repetitions under -race. The full move package passed under -race; golangci-lint reports 0 issues.
