### PR TITLE
test: preserve embedded TLS trust bundle across certificate validation

### DIFF
--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -244,8 +244,9 @@ func TestValidCertificateBundle(t *testing.T) {
 	// parse certificate bundle
 	var block *pem.Block
 	foundCertificates := false
+	remaining := rdsGlobalBundle
 	for {
-		block, rdsGlobalBundle = pem.Decode(rdsGlobalBundle)
+		block, remaining = pem.Decode(remaining)
 		if block == nil {
 			break
 		}


### PR DESCRIPTION
TestValidCertificateBundle assigns pem.Decode's remainder back into the embedded rdsGlobalBundle. This empties shared production TLS input for later consumers in the same test process, including NewTLSConfig and GetEmbeddedRDSBundle. RDS TLS initialization can consequently depend on test order; repeated test runs also fail with “No certificates found in bundle”.

Walk a local slice instead. pem.Decode does not mutate its input bytes, so a local slice header preserves the global bundle without copying it. Existing certificate parsing and nonempty assertions remain.

Discovered while repeating dbconn tests for #1161; independent of the force-kill fix.

Validation: the certificate test passed 20 repetitions under -race. The reviewer independently verified preserved CA subjects and embedded bundle length after the test. golangci-lint reports 0 issues.
