### PR TITLE
refactor(datasync): require a change stream

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -66,7 +66,6 @@ source privileges depend on the change feed:
 - [write-threads](#write-threads)
 - [flush-interval](#flush-interval)
 - [defer-secondary-indexes](#defer-secondary-indexes)
-- [copy-only](#copy-only)
 - [force](#force)
 
 ### source-dsn
@@ -125,11 +124,10 @@ the replication-latency vs. batching trade-off.
 
 When set to `true`, the target tables are created **without their regular
 secondary indexes**, and the indexes are added back in a single `ALTER` per
-table once the initial copy has completed (before the continuous phase begins,
-or before the post-copy checksum in `--copy-only` mode). Bulk-loading an
-index-free table is faster and lighter on temporary space; only regular
-secondary indexes are deferred — `PRIMARY`, `UNIQUE`, `FULLTEXT` and `SPATIAL`
-indexes are kept on the initial `CREATE`. This mirrors
+table once the initial copy has completed, before the continuous phase begins.
+Bulk-loading an index-free table is faster and lighter on temporary space; only
+regular secondary indexes are deferred — `PRIMARY`, `UNIQUE`, `FULLTEXT` and
+`SPATIAL` indexes are kept on the initial `CREATE`. This mirrors
 [`move --defer-secondary-indexes`](move.md#defer-secondary-indexes).
 
 Use it only when the target is **not yet serving reads**: the tables briefly
@@ -139,18 +137,6 @@ representative). Adding the indexes also needs enough temporary space on the
 target to build them. The restore is resume-safe and idempotent — a re-run
 (even without the flag) detects any indexes still missing on the target and
 adds them, so an interrupted run finishes the job on the next start.
-
-### copy-only
-
-- Type: Boolean
-- Default value: `false`
-
-Run only the initial copy and then exit — no change capture, no continuous
-replication. Use it for a one-shot snapshot, or when the source cannot provide
-a change feed (e.g. a managed Vitess without binlog/VStream access, or a
-replica lacking the `REPLICATION` privileges the binlog client needs). A
-checkpoint is still written, so a re-run resumes the copy (or no-ops if it had
-already completed) rather than starting over.
 
 ### force
 
@@ -186,5 +172,4 @@ Sync-specific notes:
 - **Resume keeps the checkpoint's scheme.** A file+offset checkpoint resumes
   on the file+offset client even after GTIDs are enabled on the source, and a
   GTID checkpoint fails with a clear error if the source no longer has GTIDs
-  enabled. A [`--copy-only`](#copy-only) checkpoint records no stream
-  position, so a later full sync picks its scheme fresh from the server.
+  enabled.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -57,6 +57,10 @@ source privileges depend on the change feed:
   the source does not have GTIDs enabled (the file+offset reader issues
   `FLUSH BINARY LOGS`)
 
+A source that cannot grant the built-in feed privileges must use a
+programmatically injected `change.Source`; the CLI no longer has a mode that
+runs without a change stream.
+
 ## Configuration
 
 - [source-dsn](#source-dsn)
@@ -173,3 +177,8 @@ Sync-specific notes:
   on the file+offset client even after GTIDs are enabled on the source, and a
   GTID checkpoint fails with a clear error if the source no longer has GTIDs
   enabled.
+- **Legacy copy-only checkpoints have no stream position.** When upgrading a
+  target with one of these checkpoints, Sync warns and starts the change stream
+  at the current source head. Changes made after the old checkpoint are not
+  replayed immediately; the continuous checksum finds and repairs that gap as
+  it walks the target.

--- a/pkg/change/README.md
+++ b/pkg/change/README.md
@@ -269,7 +269,6 @@ This is the same mechanism as [issue #746](https://github.com/block/spirit/issue
 |---|---|---|
 | `migrate`, `move` | Mandatory pre-cutover checksum with `FixDifferences=true` | Repaired before cutover. Cost: `differencesFound > 0`, a chunk recopy, and a "checksum found differences" signal that looks alarming |
 | `sync` (continuous) | Continuous checksum + `MySQLRecopier`, *lazy* | Real exposure: the target can serve a missing/stale/phantom row from copy time until a later checksum pass covers that chunk |
-| `sync --copy-only` | n/a | Not applicable — the discard is never enabled (`SetWatermarkOptimization` is skipped) |
 | Library consumers of pkg/copier + pkg/change with no checksum | None | Silent data loss |
 
 This is the same reliance already accepted knowingly for collation-imprecise key comparisons ([issue #479](https://github.com/block/spirit/issues/479), "checksum will fix any discrepancies") — except the visibility window affects every key type, not just collated strings.

--- a/pkg/checksum/continuous.go
+++ b/pkg/checksum/continuous.go
@@ -163,15 +163,15 @@ type ContinuousCheckerConfig struct {
 	Recopier Recopier
 
 	// DivergenceIsFatal selects the policy for a confirmed stable divergence,
-	// making explicit the replication-backed vs. copy-only distinction rather
-	// than inferring it from Recopier presence:
+	// making explicit whether the caller should abort or heal rather than
+	// inferring it from Recopier presence:
 	//   - true  (migration's cutover gate): the target is kept in sync by
 	//     replication, so a confirmed difference means something is genuinely
 	//     wrong. Run returns ErrPermanentDivergence and the caller aborts. No
 	//     Recopier is configured.
-	//   - false (datasync, especially --copy-only): the checker's job is to find
-	//     and re-copy diverged rows, so a confirmed difference is repaired via
-	//     Recopier and the run continues.
+	//   - false (datasync): the checker's job is to find and re-copy diverged
+	//     rows, so a confirmed difference is repaired via Recopier and the run
+	//     continues.
 	// When false, a Recopier must be set; without one a divergence is treated as
 	// fatal anyway (there is nothing to heal with).
 	DivergenceIsFatal bool
@@ -898,8 +898,8 @@ func (c *ContinuousChecker) executeWork(ctx context.Context, item *workItem) *wo
 	// FlushUnderTableLock reconciles exactly that lag moments later. Draining
 	// here performs the same reconciliation before we judge, so only a mismatch
 	// that survives a full drain (with the source still unchanged) is treated as
-	// real. The feed is advisory and may be nil (e.g. copy-only sync has no
-	// feed); with nothing to drain, the mismatch is taken at face value.
+	// real. The feed is advisory and may be nil for library callers; with
+	// nothing to drain, the mismatch is taken at face value.
 	if c.feed != nil {
 		if flushErr := c.feed.Flush(ctx); flushErr != nil {
 			res.err = fmt.Errorf("drain change feed before divergence verdict for chunk %s: %w", item.chunk.String(), flushErr)

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -193,17 +193,15 @@ func (r *Runner) runCopy(ctx context.Context) error {
 		if err := r.copier.Run(ctx); err != nil {
 			return fmt.Errorf("copy failed: %w", err)
 		}
-		if !r.sync.CopyOnly {
-			if !r.resuming.Load() {
-				if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
-					return err
-				}
+		if !r.resuming.Load() {
+			if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+				return err
 			}
-			// Drain the copy-phase backlog so every change observed so far is
-			// applied before steady-state streaming.
-			if err := r.replClient.Flush(ctx); err != nil {
-				return fmt.Errorf("failed to flush after copy: %w", err)
-			}
+		}
+		// Drain the copy-phase backlog so every change observed so far is
+		// applied before steady-state streaming.
+		if err := r.replClient.Flush(ctx); err != nil {
+			return fmt.Errorf("failed to flush after copy: %w", err)
 		}
 		return nil
 	})
@@ -324,7 +322,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// — and finishes immediately if the copy had already completed. The applier
 	// copies with INSERT IGNORE, so re-copying the chunks straddling the
 	// watermark is idempotent.
-	if !r.sync.CopyOnly && !r.resuming.Load() {
+	if !r.resuming.Load() {
 		// Watermark optimization ON during a fresh continuous copy: change
 		// events for keys the copier has not reached yet (above the watermark)
 		// are discarded, because the copier will copy those rows directly.
@@ -358,103 +356,19 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	// The initial copy is done. Restore any secondary indexes deferred during
-	// table creation now, before the target is consumed (continuous sync) or
-	// the post-copy checksum walks it (copy-only). Always called — it is a
-	// no-op when nothing was deferred and resume-safe; see
-	// restoreSecondaryIndexes.
+	// table creation now, before the target is consumed by continuous sync.
+	// Always called — it is a no-op when nothing was deferred and resume-safe;
+	// see restoreSecondaryIndexes.
 	if err := r.status.Do(status.RestoreSecondaryIndexes, func() error {
 		return r.restoreSecondaryIndexes(ctx)
 	}); err != nil {
 		return fmt.Errorf("failed to restore secondary indexes: %w", err)
 	}
 
-	// Copy-only past this point: no change capture is configured, but the
-	// post-copy continuous checksum is independent of replication and still
-	// has a job — verify the copy and, if a Recopier is configured, lazily
-	// re-copy diverged rows. Write an intermediate checkpoint marking the
-	// copy as complete (so a crash during the checksum resumes to a copy
-	// no-op instead of re-copying), then block on the checker until ctx is
-	// cancelled.
-	if r.sync.CopyOnly {
-		if err := r.dumpCheckpoint(ctx); err != nil {
-			r.logger.Warn("post-copy checkpoint write failed", "error", err)
-		}
-		r.logger.Info("Copy complete; entering continuous checksum (CopyOnly mode)")
-		return r.status.Do(status.ApplyChangeset, func() error {
-			return r.runCopyOnlyChecksum(ctx)
-		})
-	}
-
 	r.logger.Info("Copy complete; entering continuous sync")
 	return r.status.Do(status.ApplyChangeset, func() error {
 		return r.runContinuous(ctx)
 	})
-}
-
-// runCopyOnlyChecksum runs the post-copy continuous checksum without a
-// change feed. With CopyOnly there's no replication to drive, but the
-// checker still verifies source vs. target convergence (and, with a
-// Recopier configured, lazily re-copies diverged rows). Blocks until ctx
-// is cancelled or the checker hits a permanent failure, then writes a
-// final checkpoint.
-//
-// This is structurally a stripped-down runContinuous: same checker
-// lifecycle and shutdown contract, no replClient calls. The caller brackets
-// it in the ApplyChangeset state.
-func (r *Runner) runCopyOnlyChecksum(ctx context.Context) error {
-	checksumCtx, cancelChecksum := context.WithCancel(ctx)
-	defer cancelChecksum()
-	checksumDone := make(chan struct{})
-	var checksumErr error
-	go func() {
-		defer close(checksumDone)
-		checksumErr = r.runContinuousChecksum(checksumCtx)
-	}()
-
-	r.logger.Info("Continuous checksum running; will run until cancelled")
-
-	select {
-	case <-ctx.Done():
-		// Normal cancellation.
-	case <-checksumDone:
-		// Checker exited on its own — only happens on a real failure
-		// (clean runs return only on ctx-cancel). Trigger the parent ctx
-		// cancellation so the shutdown path proceeds.
-		if checksumErr != nil && ctx.Err() == nil {
-			r.logger.Error("continuous checksum failed; stopping sync", "error", checksumErr)
-			r.progMu.RLock()
-			cancelParent := r.cancelFunc
-			r.progMu.RUnlock()
-			if cancelParent != nil {
-				cancelParent()
-			}
-		}
-	}
-
-	// Ensure the checksum goroutine is fully shut down before we write the
-	// final checkpoint so its in-flight queries don't race the checkpoint.
-	cancelChecksum()
-	<-checksumDone
-
-	r.logger.Info("Copy-only sync stopping; writing final checkpoint")
-	cpCtx, cancelCp := context.WithTimeout(context.WithoutCancel(ctx), shutdownCheckpointTimeout)
-	defer cancelCp()
-	if err := r.dumpCheckpoint(cpCtx); err != nil {
-		r.logger.Warn("Final checkpoint write failed", "error", err)
-	}
-	r.logger.Info("Copy-only sync stopped", "total_time", r.status.TotalElapsed().Round(time.Second).String())
-
-	// A recorded fatal (e.g. a checkpoint-write failure that status.WatchTask
-	// cancelled us for) must surface rather than be masked by the clean
-	// ctx-cancel return below.
-	if ferr := r.fatal(); ferr != nil {
-		return ferr
-	}
-	// A real checksum failure outranks a clean nil — surface it.
-	if checksumErr != nil && !errors.Is(checksumErr, context.Canceled) {
-		return fmt.Errorf("continuous checksum failed: %w", checksumErr)
-	}
-	return nil
 }
 
 // runContinuous creates/maintains the target checkpoint and blocks until
@@ -574,8 +488,7 @@ func (r *Runner) runContinuousChecksum(ctx context.Context) error {
 	// Stop closes chunkletBuffer), which leaves any later Apply call
 	// panicking with "send on closed channel". Start is idempotent and
 	// reinitializes the channels on a previously-stopped applier, so
-	// calling it here is the cheapest way to keep the recopier path
-	// working in both fresh and CopyOnly continuous-sync modes.
+	// calling it here is the cheapest way to keep the recopier path working.
 	//
 	// We pass context.WithoutCancel(ctx) to Start so the applier's
 	// worker context is *not* tied to the parent: the recopier uses
@@ -610,9 +523,8 @@ func (r *Runner) runContinuousChecksum(ctx context.Context) error {
 			MinPassInterval: checksum.ContinuousMinPassInterval,
 			Recopier:        recopier,
 			Logger:          r.logger,
-			// Sync verifies a target it keeps converging (and under --copy-only
-			// expects to find diverged rows), so a confirmed divergence is
-			// repaired by the Recopier, not fatal.
+			// Sync verifies a target it keeps converging, so a confirmed
+			// divergence is repaired by the Recopier, not fatal.
 			DivergenceIsFatal: false,
 		},
 	)
@@ -743,28 +655,26 @@ func (r *Runner) setup(ctx context.Context) error {
 		return err
 	}
 
-	// Wire the change source (continuous mode only): injected (e.g. VStream),
+	// Wire the change source: injected (e.g. VStream),
 	// or a built-in MySQL client constructed from the source DSN. The built-in
 	// client's coordinate scheme (GTID vs binlog file+position) is selected
 	// automatically: a resumed sync stays in the scheme its checkpointed
 	// position was written in, and a fresh one uses GTIDs whenever the source
 	// has them enabled. Sync replicates a whole schema, so the DDL filter is
-	// by schema only. Copy-only sync constructs no change source.
-	if !r.sync.CopyOnly {
-		if r.sync.Source != nil {
-			r.setReplClient(r.sync.Source)
-		} else {
-			replConfig := change.NewClientDefaultConfig()
-			replConfig.Logger = r.logger
-			replConfig.CancelFunc = r.fatalError
-			replConfig.DDLFilterSchema = r.source.config.DBName
-			replConfig.DBConfig = r.sourceDBConfig
-			client, err := change.NewAutoClient(ctx, r.source.db, r.source.config.Addr, r.source.config.User, r.source.config.Passwd, r.applier, replConfig, pos)
-			if err != nil {
-				return err
-			}
-			r.setReplClient(client)
+	// by schema only.
+	if r.sync.Source != nil {
+		r.setReplClient(r.sync.Source)
+	} else {
+		replConfig := change.NewClientDefaultConfig()
+		replConfig.Logger = r.logger
+		replConfig.CancelFunc = r.fatalError
+		replConfig.DDLFilterSchema = r.source.config.DBName
+		replConfig.DBConfig = r.sourceDBConfig
+		client, err := change.NewAutoClient(ctx, r.source.db, r.source.config.Addr, r.source.config.User, r.source.config.Passwd, r.applier, replConfig, pos)
+		if err != nil {
+			return err
 		}
+		r.setReplClient(client)
 	}
 
 	// If a checkpoint exists on the target, resume: open the copier chunker at
@@ -1189,19 +1099,17 @@ func (r *Runner) buildChunkers() ([]table.Chunker, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !r.sync.CopyOnly {
-			if err := r.replClient.AddSubscription(tbl, nil, cc); err != nil {
-				return nil, err
-			}
+		if err := r.replClient.AddSubscription(tbl, nil, cc); err != nil {
+			return nil, err
 		}
 		chunkers = append(chunkers, cc)
 	}
 	return chunkers, nil
 }
 
-// buildCopyPipeline builds the per-table chunkers (and, for continuous sync,
-// their change-feed subscriptions), assembles the multi-chunker, and
-// constructs the buffered copier. The caller opens the chunker afterwards —
+// buildCopyPipeline builds the per-table chunkers and change-feed subscriptions,
+// assembles the multi-chunker, and constructs the buffered copier. The caller
+// opens the chunker afterwards —
 // Open() for a fresh sync, OpenAtWatermark() for a resume.
 func (r *Runner) buildCopyPipeline() error {
 	chunkers, err := r.buildChunkers()
@@ -1225,7 +1133,7 @@ func (r *Runner) buildCopyPipeline() error {
 }
 
 // startFresh creates the target tables, builds the copy pipeline, opens the
-// chunker from the beginning, starts the change feed (continuous only), and
+// chunker from the beginning, starts the change feed, and
 // creates the checkpoint table so copy progress can be recorded from the
 // start of the copy.
 func (r *Runner) startFresh(ctx context.Context) error {
@@ -1238,29 +1146,26 @@ func (r *Runner) startFresh(ctx context.Context) error {
 	if err := r.copyChunker.Open(); err != nil {
 		return err
 	}
-	// Copy-only sync has no change feed to start.
-	if !r.sync.CopyOnly {
-		// The change-feed reader must outlive ctx. On a clean shutdown ctx is
-		// cancelled first, and only then does the drain path (runContinuous)
-		// issue its final Flush. That Flush relies on the reader goroutine to
-		// keep advancing the buffered binlog position so BlockWait can converge;
-		// if the reader were tied to ctx it would already be dead, the buffered
-		// position would be frozen, and the final flush would spin (re-flushing
-		// binary logs) until it burned its entire shutdownFlushTimeout budget.
-		// Tie the reader's lifetime to Close() instead — Close() cancels its own
-		// derived context — by handing it a cancellation-detached ctx here.
-		if err := r.replClient.Start(context.WithoutCancel(ctx)); err != nil {
-			return fmt.Errorf("failed to start change source: %w", err)
-		}
+	// The change-feed reader must outlive ctx. On a clean shutdown ctx is
+	// cancelled first, and only then does the drain path (runContinuous)
+	// issue its final Flush. That Flush relies on the reader goroutine to
+	// keep advancing the buffered binlog position so BlockWait can converge;
+	// if the reader were tied to ctx it would already be dead, the buffered
+	// position would be frozen, and the final flush would spin (re-flushing
+	// binary logs) until it burned its entire shutdownFlushTimeout budget.
+	// Tie the reader's lifetime to Close() instead — Close() cancels its own
+	// derived context — by handing it a cancellation-detached ctx here.
+	if err := r.replClient.Start(context.WithoutCancel(ctx)); err != nil {
+		return fmt.Errorf("failed to start change source: %w", err)
 	}
 	return r.checkpointTbl().Create(ctx)
 }
 
 // startResume rebuilds the copy pipeline and opens the chunker at the
 // checkpointed watermark, so the copier continues a partial copy (or finishes
-// immediately if the copy had completed). For continuous sync it also disables
-// the watermark optimization (every change applies) and opens the feed at the
-// saved position. The target tables already exist (createTargetTables is
+// immediately if the copy had completed). It also disables the watermark
+// optimization (every change applies) and opens the feed at the saved position.
+// The target tables already exist (createTargetTables is
 // idempotent, skipping them) and the target-empty check is skipped.
 func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
 	if err := r.createTargetTables(ctx); err != nil {
@@ -1283,22 +1188,20 @@ func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
 			return err
 		}
 	}
-	if !r.sync.CopyOnly {
-		if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
-			return err
+	if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
+		return err
+	}
+	// The reader must outlive ctx so the drain-time final Flush can
+	// converge; see the matching comment in startFresh. Close() stops it.
+	streamCtx := context.WithoutCancel(ctx)
+	if pos != "" {
+		if err := r.replClient.StartFromPosition(streamCtx, pos); err != nil {
+			return fmt.Errorf("failed to resume change source from position %q: %w", pos, err)
 		}
-		// The reader must outlive ctx so the drain-time final Flush can
-		// converge; see the matching comment in startFresh. Close() stops it.
-		streamCtx := context.WithoutCancel(ctx)
-		if pos != "" {
-			if err := r.replClient.StartFromPosition(streamCtx, pos); err != nil {
-				return fmt.Errorf("failed to resume change source from position %q: %w", pos, err)
-			}
-		} else if err := r.replClient.Start(streamCtx); err != nil {
-			// No saved position (prior attempt failed before checkpointing):
-			// start the feed fresh; changes apply with the optimization off.
-			return fmt.Errorf("failed to start change source: %w", err)
-		}
+	} else if err := r.replClient.Start(streamCtx); err != nil {
+		// No saved position (prior attempt failed before checkpointing):
+		// start the feed fresh; changes apply with the optimization off.
+		return fmt.Errorf("failed to start change source: %w", err)
 	}
 	return r.checkpointTbl().Create(ctx)
 }
@@ -1390,10 +1293,7 @@ func (r *Runner) readCheckpoint(ctx context.Context) (watermark, pos string, ok 
 // periodic checkpoint loop. The checkpoint loop runs for the whole run (copy
 // and continuous), so a restart at any point resumes from the last checkpoint.
 func (r *Runner) startBackgroundRoutines(ctx context.Context) {
-	// Copy-only sync has no change feed, so no periodic flush.
-	if !r.sync.CopyOnly {
-		r.replClient.StartPeriodicFlush(ctx, r.sync.FlushInterval)
-	}
+	r.replClient.StartPeriodicFlush(ctx, r.sync.FlushInterval)
 	// Share the status + checkpoint loop with the migration and move runners
 	// (status.WatchTask); *Runner satisfies status.Task via Progress / Status /
 	// DumpCheckpoint / Cancel. Unlike the previous bespoke loop, a checkpoint

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -1188,6 +1188,18 @@ func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
 			return err
 		}
 	}
+	if err := r.startResumeChangeSource(ctx, watermark, pos); err != nil {
+		return err
+	}
+	return r.checkpointTbl().Create(ctx)
+}
+
+// startResumeChangeSource disables copy-time filtering and opens the change
+// source at the checkpointed position. A checkpoint can have copy progress but
+// no stream position (notably legacy copy-only checkpoints); those must start
+// at the current head, leaving the continuous checksum to repair changes made
+// since the checkpoint.
+func (r *Runner) startResumeChangeSource(ctx context.Context, watermark, pos string) error {
 	if err := r.replClient.SetWatermarkOptimization(ctx, false); err != nil {
 		return err
 	}
@@ -1198,12 +1210,19 @@ func (r *Runner) startResume(ctx context.Context, watermark, pos string) error {
 		if err := r.replClient.StartFromPosition(streamCtx, pos); err != nil {
 			return fmt.Errorf("failed to resume change source from position %q: %w", pos, err)
 		}
-	} else if err := r.replClient.Start(streamCtx); err != nil {
-		// No saved position (prior attempt failed before checkpointing):
-		// start the feed fresh; changes apply with the optimization off.
+		return nil
+	}
+
+	if watermark != "" {
+		r.logger.Warn("checkpoint has copy progress but no change-stream position; starting the stream at the current source head, so the target may be stale until the continuous checksum repairs changes made since the checkpoint",
+			"watermark", watermark)
+	} else {
+		r.logger.Info("checkpoint has no copy watermark or change-stream position; starting the stream at the current source head")
+	}
+	if err := r.replClient.Start(streamCtx); err != nil {
 		return fmt.Errorf("failed to start change source: %w", err)
 	}
-	return r.checkpointTbl().Create(ctx)
+	return nil
 }
 
 // checkpointTbl returns a handle to datasync's checkpoint table on the target.

--- a/pkg/datasync/sync.go
+++ b/pkg/datasync/sync.go
@@ -65,16 +65,6 @@ type Sync struct {
 	// same as `move --defer-secondary-indexes`.
 	DeferSecondaryIndexes bool `name:"defer-secondary-indexes" help:"Create target tables without secondary indexes, then add them after the initial copy." default:"false"`
 
-	// CopyOnly performs only the initial copy and then returns — no change
-	// capture and no continuous replication, so no change.Source is
-	// constructed or required. Useful for a one-shot snapshot, or when the
-	// source cannot provide a change feed (e.g. a managed Vitess without
-	// binlog/VStream access, or a replica lacking the REPLICATION privileges
-	// the built-in binlog client needs). A final checkpoint is still written,
-	// so a later run resumes the copy from there (or no-ops if it had already
-	// completed) rather than starting over.
-	CopyOnly bool `name:"copy-only" help:"Only run the initial copy, then exit (no continuous change capture)." default:"false"`
-
 	// Force, when set, makes the runner drop and recreate the target database
 	// at startup *unless* a resumable checkpoint exists — i.e. it only nukes
 	// the target when the copy could not have resumed anyway. A resumable

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -1,8 +1,10 @@
 package datasync
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"log/slog"
 	"reflect"
 	"strconv"
 	"sync"
@@ -899,6 +901,15 @@ func TestSyncVerifyExistingTargetTableRequiresExactSchema(t *testing.T) {
 			target: "CREATE TABLE t1 (id BIGINT PRIMARY KEY, customer_id BIGINT DEFAULT NULL)",
 		},
 		{
+			// This is the state after applying the ALTER named by a prior
+			// schema-divergence error. Pin that the reconciled target passes the
+			// gate even though replaying the historical DDL prevents the old
+			// end-to-end test from continuing in always-streaming mode.
+			name:   "target reconciled with suggested ALTER",
+			source: "CREATE TABLE t1 (id BIGINT PRIMARY KEY, customer_id BIGINT DEFAULT NULL, added VARCHAR(64) NOT NULL DEFAULT 'x')",
+			target: "CREATE TABLE t1 (id BIGINT PRIMARY KEY, customer_id BIGINT DEFAULT NULL, added VARCHAR(64) NOT NULL DEFAULT 'x')",
+		},
+		{
 			// Accepted by move — a sharded target's shard key cannot be NULL —
 			// and rejected here.
 			name:     "target stricter about NULL",
@@ -987,7 +998,38 @@ func TestSyncResumeSourceSchemaChanged(t *testing.T) {
 
 	// The unchanged table must not be implicated in the failure.
 	require.NotContains(t, runErr.Error(), "t2")
+}
 
+type resumeSource struct {
+	change.Source
+	started               bool
+	watermarkOptimization bool
+}
+
+func (s *resumeSource) SetWatermarkOptimization(_ context.Context, enabled bool) error {
+	s.watermarkOptimization = enabled
+	return nil
+}
+
+func (s *resumeSource) Start(context.Context) error {
+	s.started = true
+	return nil
+}
+
+func TestStartResumeChangeSourceWarnsWhenCopyProgressHasNoStreamPosition(t *testing.T) {
+	var logs bytes.Buffer
+	source := &resumeSource{watermarkOptimization: true}
+	r := &Runner{
+		replClient: source,
+		logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	require.NoError(t, r.startResumeChangeSource(t.Context(), "finished-watermark", ""))
+	require.True(t, source.started)
+	require.False(t, source.watermarkOptimization)
+	require.Contains(t, logs.String(), "checkpoint has copy progress but no change-stream position")
+	require.Contains(t, logs.String(), "target may be stale until the continuous checksum repairs changes")
+	require.Contains(t, logs.String(), "watermark=finished-watermark")
 }
 
 // TestSyncTargetSchemaVerifyIgnoresDeferredIndexes guards the resume-time schema

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -208,77 +208,6 @@ func TestSyncInitialCopy(t *testing.T) {
 	require.Equal(t, "two", v)
 }
 
-// TestSyncCopyOnly verifies the CopyOnly path: initial copy runs (no
-// change source constructed, so no REPLICATION/RELOAD privileges
-// required), then the continuous checksum keeps running until the
-// context is cancelled. FirstCleanPass is signalled once the checker
-// observes source == target; that gates the cancel. A clean ctx-cancel
-// returns nil and the snapshot remains on the target.
-func TestSyncCopyOnly(t *testing.T) {
-	cfg, err := mysql.ParseDSN(testutils.DSN())
-	require.NoError(t, err)
-	src := cfg.Clone()
-	src.DBName = "sync_copyonly_src"
-	dest := cfg.Clone()
-	dest.DBName = "sync_copyonly_dest"
-	sourceDSN := src.FormatDSN()
-	targetDSN := dest.FormatDSN()
-
-	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_copyonly_src`)
-	testutils.RunSQL(t, `CREATE DATABASE sync_copyonly_src`)
-	testutils.RunSQL(t, `CREATE TABLE sync_copyonly_src.t1 (id INT PRIMARY KEY, val VARCHAR(255))`)
-	testutils.RunSQL(t, `INSERT INTO sync_copyonly_src.t1 VALUES (1,'one'),(2,'two'),(3,'three')`)
-	testutils.RunSQL(t, `DROP DATABASE IF EXISTS sync_copyonly_dest`)
-
-	s := &Sync{
-		SourceDSN:    sourceDSN,
-		TargetDSN:    targetDSN,
-		Threads:      2,
-		WriteThreads: 2,
-		CopyOnly:     true,
-	}
-	runner, err := NewRunner(s)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	runDone := make(chan error, 1)
-	go func() { runDone <- runner.Run(ctx) }()
-
-	// Wait for the checker to publish a first clean pass — that's the
-	// signal that source and target are known consistent. With a quiescent
-	// source this should happen well within the test deadline.
-	select {
-	case <-runner.FirstCleanPass():
-	case err := <-runDone:
-		t.Fatalf("Run returned before FirstCleanPass: %v", err)
-	case <-ctx.Done():
-		t.Fatalf("timed out waiting for FirstCleanPass: %v", ctx.Err())
-	}
-
-	// Run is still going after the clean pass — it's supposed to block
-	// until cancelled. Cancel now and expect a clean nil return.
-	cancel()
-	select {
-	case err := <-runDone:
-		require.NoError(t, err)
-	case <-time.After(30 * time.Second):
-		t.Fatal("Run did not return after ctx cancellation")
-	}
-	require.NoError(t, runner.Close())
-
-	// Snapshot landed on target with the right values.
-	tgt, err := sql.Open("mysql", targetDSN)
-	require.NoError(t, err)
-	defer utils.CloseAndLog(tgt)
-	var n int
-	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM t1").Scan(&n))
-	require.Equal(t, 3, n)
-	var v string
-	require.NoError(t, tgt.QueryRowContext(context.Background(), "SELECT val FROM t1 WHERE id = 2").Scan(&v))
-	require.Equal(t, "two", v)
-}
-
 // TestRunnerStatusTask exercises the status.Task surface (Progress, Status,
 // DumpCheckpoint, Cancel) concurrently with Run, validating both the values
 // reported and the locking around the progress fields (run with -race).
@@ -1059,21 +988,6 @@ func TestSyncResumeSourceSchemaChanged(t *testing.T) {
 	// The unchanged table must not be implicated in the failure.
 	require.NotContains(t, runErr.Error(), "t2")
 
-	// Reconciling the target unblocks the resume. (The rows copied under the old
-	// schema carry the column default rather than the source's values, which is
-	// why spirit refuses to perform this repair itself — see
-	// verifyExistingTargetTable.) Resume in copy-only mode: a continuous resume
-	// opens the change feed at the checkpointed position, which predates the
-	// ALTER, so the source's DDL guard would cancel the run before the copy
-	// finishes — that guard is exactly what leaves the resumable checkpoint this
-	// test starts from, and it is not what's under test here.
-	testutils.RunSQL(t, `ALTER TABLE sync_ddl_drift_dest.t1 ADD COLUMN added VARCHAR(64) NOT NULL DEFAULT 'x'`)
-	reconciled := newSync()
-	reconciled.CopyOnly = true
-	r3, err := NewRunner(reconciled)
-	require.NoError(t, err)
-	require.NoError(t, runUntilCopied(t, r3))
-	require.NoError(t, r3.Close())
 }
 
 // TestSyncTargetSchemaVerifyIgnoresDeferredIndexes guards the resume-time schema


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you are offering a new feature or fixing anything, we would like to know beforehand in Issues,
> and potentially we will be able to point development in a particular direction.
> Further notes in https://github.com/block/spirit/blob/main/.github/CONTRIBUTING.md

## Summary

- remove the `--copy-only` CLI flag and `Sync.CopyOnly` configuration
- make datasync always construct, subscribe to, start, flush, and resume a change stream
- remove the duplicate copy-only checksum path and its integration coverage
- warn when a resume checkpoint has copy progress but no stream position, and document how the continuous checksum repairs the resulting legacy-checkpoint gap

Sources that cannot grant the built-in MySQL replication privileges now need a programmatically injected `change.Source`; the CLI no longer supports a no-stream snapshot mode.

The old end-to-end schema-reconciliation tail intentionally cannot be retained: it used copy-only mode to avoid replaying the historical source DDL. The strict schema gate still has explicit coverage that a target matching the suggested reconciliation ALTER is accepted.

## Testing

- `go test ./...`
- `golangci-lint run`
- `go run ./cmd/spirit sync --help`