### PR TITLE
fix(move): preserve target writes committed during the traffic switch

### DIFF
--- a/pkg/move/cutover.go
+++ b/pkg/move/cutover.go
@@ -61,15 +61,22 @@ type CutOver struct {
 	// invoked again.
 	cutoverFuncSucceeded bool
 
-	// postSwitch, when set, runs once under the source locks after the traffic
-	// switch (cutoverFunc) succeeds and before the sources are renamed out of
-	// the way. The reverse-window move uses it to capture each target's binlog
-	// position and persist that the move has entered its reverse window, while
-	// the sources are quiescent (writes switched away, replication flushed) so
-	// the captured positions cleanly bound the post-cutover writes. Like
-	// cutoverFunc it must run at most once; postSwitchDone guards that.
+	// preSwitch runs under the source locks after the final flush and before
+	// traffic can reach the target. Reverse moves capture their start positions
+	// here so writes committed during the switch are included. It runs again
+	// on a safe retry, after that attempt's final flush.
+	preSwitch func(ctx context.Context) error
+
+	// postSwitch persists the captured positions after the switch succeeds,
+	// before the source rename. It must run at most once.
 	postSwitch     func(ctx context.Context) error
 	postSwitchDone bool
+}
+
+// SetPreSwitch registers a hook after the final source flush and before the
+// traffic switch, under the source locks. See CutOver.preSwitch.
+func (c *CutOver) SetPreSwitch(fn func(ctx context.Context) error) {
+	c.preSwitch = fn
 }
 
 // SetPostSwitch registers a hook to run once under the source locks, after the
@@ -260,6 +267,12 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 		}
 	}
 
+	if c.preSwitch != nil {
+		if err := c.preSwitch(ctx); err != nil {
+			return fmt.Errorf("reverse-window pre-switch hook failed: %w", err)
+		}
+	}
+
 	// Run the caller-owned traffic switch at most once. Result-bearing callers
 	// retain durable-mutation and ambiguity evidence even when they return an
 	// error; the legacy callback is conservatively ambiguous on any error.
@@ -268,7 +281,7 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 	}
 
 	// Reverse-window hook: after the traffic switch and before retiring the
-	// sources, capture the reverse-feed start positions and record that the
+	// sources, persist the captured reverse-feed positions and record that the
 	// move has entered its reverse window. Runs once, under the source locks,
 	// while the sources are quiescent. If it fails the cutover fails: the
 	// routing switch has already succeeded, so (like a rename failure past that
@@ -305,7 +318,7 @@ func (c *CutOver) algorithmCutover(ctx context.Context) error {
 			// rather than after the deferred unlock, where the first straggler
 			// write races us. A reverse window is unaffected: its feeds are
 			// separate clients (ReverseFeed) reading the targets, and its start
-			// positions were captured by postSwitch above. See change.Source's
+			// positions were captured by preSwitch above. See change.Source's
 			// Stop.
 			c.stopSourceFeeds()
 			return nil

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -56,8 +56,8 @@ func targetCurrentPosition(ctx context.Context, r *Runner, tgt *applier.Target) 
 }
 
 // captureReverseWindow runs under the source locks after the final forward
-// flush, BEFORE switching traffic. These positions include every target write
-// committed once the traffic switch begins, even before the callback returns.
+// flush, before switching traffic. They are the reverse feeds' start points,
+// so writes committed during the switch are included when those feeds start.
 // On a safe cutover retry they are recaptured after the new final flush.
 func captureReverseWindow(ctx context.Context, r *Runner) error {
 	positions := make(map[string]string, len(r.targets))

--- a/pkg/move/reversewindow.go
+++ b/pkg/move/reversewindow.go
@@ -55,11 +55,10 @@ func targetCurrentPosition(ctx context.Context, r *Runner, tgt *applier.Target) 
 	return src.CurrentPosition(ctx)
 }
 
-// captureReverseWindow runs as the cutover postSwitch hook (under the source
-// lock, after the traffic switch, before the source rename). It records each
-// target's current position — the reverse feeds' start points — and persists
-// that the move has entered its reverse window. The background checkpoint
-// dumper has already been stopped, so this write is authoritative.
+// captureReverseWindow runs under the source locks after the final forward
+// flush, BEFORE switching traffic. These positions include every target write
+// committed once the traffic switch begins, even before the callback returns.
+// On a safe cutover retry they are recaptured after the new final flush.
 func captureReverseWindow(ctx context.Context, r *Runner) error {
 	positions := make(map[string]string, len(r.targets))
 	for i := range r.targets {
@@ -70,9 +69,15 @@ func captureReverseWindow(ctx context.Context, r *Runner) error {
 		positions[targetKey(r.targets[i])] = pos
 	}
 	r.reversePositions = positions
-	r.cutoverAt = time.Now()
+	return nil
+}
 
-	posJSON, err := json.Marshal(positions)
+// persistReverseWindow runs after the traffic switch and before retiring the
+// source. The background checkpoint dumper is already stopped, so this write
+// is authoritative. The window duration starts when the switch completes.
+func persistReverseWindow(ctx context.Context, r *Runner) error {
+	r.cutoverAt = time.Now()
+	posJSON, err := json.Marshal(r.reversePositions)
 	if err != nil {
 		return fmt.Errorf("marshal reverse positions: %w", err)
 	}

--- a/pkg/move/reversewindow_test.go
+++ b/pkg/move/reversewindow_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -729,4 +730,69 @@ func TestFinalizeReverseFailsClosedWhenOwnershipCannotBePersisted(t *testing.T) 
 
 	require.ErrorIs(t, w.finalizeReverse(t.Context()), persistErr)
 	require.False(t, cleanupCalled)
+}
+
+// Traffic can reach the target before the switch callback returns. Those
+// commits must be included in the reverse feed's captured starting position.
+func TestMoveReverseWindowSwitchWrites(t *testing.T) {
+	shortenReverseWindowPolling(t)
+	for _, resultCallback := range []bool{false, true} {
+		t.Run(fmt.Sprintf("result_%t", resultCallback), func(t *testing.T) {
+			srcName, srcDB := testutils.CreateUniqueTestDatabase(t)
+			dstName, dstDB := testutils.CreateUniqueTestDatabase(t)
+			testutils.RunSQLInDatabase(t, srcName, "CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(255))")
+			testutils.RunSQLInDatabase(t, srcName, "INSERT INTO t1 VALUES (1,'one'),(2,'two')")
+			r, err := NewRunner(&Move{
+				SourceDSN: testutils.DSNForDatabase(srcName),
+				TargetDSN: testutils.DSNForDatabase(dstName),
+				Threads:   1, WriteThreads: 1, ReverseWindow: 30 * time.Second,
+			})
+			require.NoError(t, err)
+			defer utils.CloseAndLog(r)
+			switchTraffic := func(ctx context.Context) error {
+				for _, stmt := range []string{
+					"INSERT INTO t1 VALUES (99,'during switch')",
+					"UPDATE t1 SET val='updated during switch' WHERE id=1",
+					"DELETE FROM t1 WHERE id=2",
+					"CREATE TABLE " + revertMarkerName + " (id INT)",
+				} {
+					if _, err := dstDB.ExecContext(ctx, stmt); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+			if resultCallback {
+				r.SetCutoverWithResult(func(ctx context.Context) (CutoverResult, error) {
+					return CutoverResult{DurableMutation: true}, switchTraffic(ctx)
+				})
+			} else {
+				r.SetCutover(switchTraffic)
+			}
+			var reverted bool
+			r.SetReverseCutover(func(ctx context.Context) error {
+				// The source must already contain every commit when traffic returns.
+				var inserted, updated string
+				var deleted int
+				if err := srcDB.QueryRowContext(ctx, "SELECT val FROM t1 WHERE id=99").Scan(&inserted); err != nil {
+					return err
+				}
+				if err := srcDB.QueryRowContext(ctx, "SELECT val FROM t1 WHERE id=1").Scan(&updated); err != nil {
+					return err
+				}
+				if err := srcDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM t1 WHERE id=2").Scan(&deleted); err != nil {
+					return err
+				}
+				if inserted != "during switch" || updated != "updated during switch" || deleted != 0 {
+					return fmt.Errorf("lost target writes at reverse switch: inserted=%q updated=%q deleted=%d", inserted, updated, deleted)
+				}
+				reverted = true
+				return nil
+			})
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			require.NoError(t, r.Run(ctx))
+			require.True(t, reverted)
+		})
+	}
 }

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -1324,10 +1324,10 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 			cutover.SetCutoverWithResult(r.runForwardCutoverCallback)
 		}
 		if r.move.ReverseWindow > 0 {
-			// Under the cutover lock, right after the traffic switch, capture the
-			// reverse-feed start positions and record that the move has entered its
-			// reverse window (see captureReverseWindow). The source rename still runs.
-			cutover.SetPostSwitch(func(ctx context.Context) error { return captureReverseWindow(ctx, r) })
+			// Capture before the switch can accept target writes, then persist
+			// the captured positions once the traffic switch succeeds.
+			cutover.SetPreSwitch(func(ctx context.Context) error { return captureReverseWindow(ctx, r) })
+			cutover.SetPostSwitch(func(ctx context.Context) error { return persistReverseWindow(ctx, r) })
 		}
 		// Pre-cutover: refuse to switch traffic if a revert has been requested (a
 		// marker appeared on targets[0] during the copy). Cutting over only to

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -148,11 +148,10 @@ type Runner struct {
 	// immediately after a Run goroutine returns.
 	durableMutation   atomic.Bool
 	terminalOwnership atomic.Uint32
-	// reversePositions holds each target's binlog position captured at cutover
-	// (keyed by targetKey) — the start points for the reverse feeds. cutoverAt
-	// is when the forward cutover completed (the reverse-window deadline is
-	// measured from it). Both are set by the cutover postSwitch hook when
-	// move.ReverseWindow > 0.
+	// reversePositions holds each target's binlog position captured by the
+	// pre-switch hook (keyed by targetKey) — the start points for the reverse
+	// feeds. cutoverAt is set by the post-switch hook when the forward cutover
+	// completes, and the reverse-window deadline is measured from it.
 	reversePositions map[string]string
 	cutoverAt        time.Time
 


### PR DESCRIPTION
Fixes #1207.

A target write committed while the forward traffic-switch callback was running fell before the reverse feed's starting position. Rollback could therefore succeed with that committed write missing from the restored source.

Capture every target's reverse-feed position under the source locks, after the final forward flush and before invoking the traffic switch. Persist those captured positions after the switch succeeds, keeping the reverse-window timer tied to switch completion.

The MySQL integration regression commits an insert, update, and delete inside each callback API form, then verifies all three changes are present before traffic switches back. Reverse-window and cutover tests pass with `-race`; `golangci-lint run` is clean.
