### PR TITLE
fix(fmt): preserve literals when stripping table counters

### DIFF
--- a/pkg/fmt/fmt.go
+++ b/pkg/fmt/fmt.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/block/spirit/pkg/parser/ast"
@@ -124,41 +123,41 @@ func formatFile(ctx context.Context, db *sql.DB, path string) (bool, error) {
 }
 
 // parseAndPrepare parses the SQL, validates it is exactly one CREATE TABLE
-// statement, and returns the table name and the SQL to execute. If the
+// statement, and returns the table name, SQL to execute, and whether MySQL's
+// instance-specific AUTO_INCREMENT counter must be reset after creation. If the
 // statement includes a database qualifier (e.g., CREATE TABLE mydb.mytable),
 // it is stripped so the table is created in the connected working database.
 // This also prevents SQL injection since only parsed CREATE TABLE statements
 // are accepted.
-func parseAndPrepare(createSQL string) (tableName string, execSQL string, err error) {
+func parseAndPrepare(createSQL string) (tableName string, execSQL string, resetAutoIncrement bool, err error) {
 	ct, err := statement.ParseCreateTable(createSQL)
 	if err != nil {
-		return "", "", fmt.Errorf("not a valid CREATE TABLE statement: %w", err)
+		return "", "", false, fmt.Errorf("not a valid CREATE TABLE statement: %w", err)
 	}
 
 	tableName = ct.TableName
+	for _, opt := range ct.Raw.Options {
+		if opt.Tp == ast.TableOptionAutoIncrement {
+			resetAutoIncrement = true
+			break
+		}
+	}
 
-	// Remove only the instance-specific table counter. Matching SQL text also
-	// matches defaults, comments and quoted identifiers, changing the schema.
-	optionCount := len(ct.Raw.Options)
-	ct.Raw.Options = slices.DeleteFunc(ct.Raw.Options, func(opt *ast.TableOption) bool {
-		return opt.Tp == ast.TableOptionAutoIncrement
-	})
-
-	// Restore only when stripping a schema qualifier or table counter;
-	// otherwise preserve the original SQL for MySQL to canonicalize.
-	if ct.Raw.Table.Schema.L != "" || len(ct.Raw.Options) != optionCount {
+	// Restore only when stripping a schema qualifier. In the common case the
+	// exact input is sent to MySQL, including every literal and table option.
+	if ct.Raw.Table.Schema.L != "" {
 		ct.Raw.Table.Schema = ast.CIStr{}
 		var sb strings.Builder
 		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
 		if err := ct.Raw.Restore(rCtx); err != nil {
-			return "", "", fmt.Errorf("failed to restore CREATE TABLE: %w", err)
+			return "", "", false, fmt.Errorf("failed to restore CREATE TABLE: %w", err)
 		}
 		execSQL = sb.String()
 	} else {
 		execSQL = createSQL
 	}
 
-	return tableName, execSQL, nil
+	return tableName, execSQL, resetAutoIncrement, nil
 }
 
 // canonicalize takes a CREATE TABLE statement, applies it to MySQL, reads it
@@ -170,7 +169,7 @@ func parseAndPrepare(createSQL string) (tableName string, execSQL string, err er
 // Any database qualifier is stripped. This prevents SQL injection since only
 // valid CREATE TABLE statements are executed against the MySQL server.
 func canonicalize(ctx context.Context, db *sql.DB, createStmt string) (string, error) {
-	tableName, execSQL, err := parseAndPrepare(createStmt)
+	tableName, execSQL, resetAutoIncrement, err := parseAndPrepare(createStmt)
 	if err != nil {
 		return "", err
 	}
@@ -186,6 +185,14 @@ func canonicalize(ctx context.Context, db *sql.DB, createStmt string) (string, e
 	if _, err := db.ExecContext(ctx, execSQL); err != nil {
 		return "", fmt.Errorf("failed to create table: %w", err)
 	}
+	// Keep all table options and literals intact while applying the input. An
+	// empty table reports no instance-specific counter after resetting it to
+	// the initial value, so SHOW CREATE produces the desired canonical schema.
+	if resetAutoIncrement {
+		if _, err := db.ExecContext(ctx, sqlescape.MustEscapeSQL("ALTER TABLE %n AUTO_INCREMENT = 1", tableName)); err != nil {
+			return "", fmt.Errorf("failed to reset AUTO_INCREMENT counter: %w", err)
+		}
+	}
 
 	// Read back the canonical form via SHOW CREATE TABLE.
 	var tbl, canonical string
@@ -198,8 +205,7 @@ func canonicalize(ctx context.Context, db *sql.DB, createStmt string) (string, e
 		return "", fmt.Errorf("failed to drop table: %w", err)
 	}
 
-	// The table counter was removed before CREATE, so SHOW CREATE needs no
-	// textual substitutions. Ensure a trailing newline.
+	// Ensure a trailing newline.
 	canonical = strings.TrimRight(canonical, "\n") + "\n"
 	return canonical, nil
 }

--- a/pkg/fmt/fmt.go
+++ b/pkg/fmt/fmt.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/block/spirit/pkg/parser/ast"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
 	"github.com/block/spirit/pkg/statement"
-	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 )
 
@@ -137,10 +137,16 @@ func parseAndPrepare(createSQL string) (tableName string, execSQL string, err er
 
 	tableName = ct.TableName
 
-	// If there's a schema qualifier, strip it by clearing the schema on the
-	// AST and restoring to SQL. Otherwise use the original SQL directly to
-	// avoid any formatting changes from the parser's Restore.
-	if ct.Raw.Table.Schema.L != "" {
+	// Remove only the instance-specific table counter. Matching SQL text also
+	// matches defaults, comments and quoted identifiers, changing the schema.
+	optionCount := len(ct.Raw.Options)
+	ct.Raw.Options = slices.DeleteFunc(ct.Raw.Options, func(opt *ast.TableOption) bool {
+		return opt.Tp == ast.TableOptionAutoIncrement
+	})
+
+	// Restore only when stripping a schema qualifier or table counter;
+	// otherwise preserve the original SQL for MySQL to canonicalize.
+	if ct.Raw.Table.Schema.L != "" || len(ct.Raw.Options) != optionCount {
 		ct.Raw.Table.Schema = ast.CIStr{}
 		var sb strings.Builder
 		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
@@ -192,9 +198,8 @@ func canonicalize(ctx context.Context, db *sql.DB, createStmt string) (string, e
 		return "", fmt.Errorf("failed to drop table: %w", err)
 	}
 
-	// Strip AUTO_INCREMENT since it's instance-specific.
-	// Ensure trailing newline.
-	canonical = table.StripAutoIncrement(canonical)
+	// The table counter was removed before CREATE, so SHOW CREATE needs no
+	// textual substitutions. Ensure a trailing newline.
 	canonical = strings.TrimRight(canonical, "\n") + "\n"
 	return canonical, nil
 }

--- a/pkg/fmt/fmt_test.go
+++ b/pkg/fmt/fmt_test.go
@@ -31,6 +31,7 @@ func TestParseAndPrepare(t *testing.T) {
 		wantTable     string
 		wantErr       bool
 		wantSchemaStr bool // if true, execSQL should differ from input (schema stripped)
+		wantReset     bool
 	}{
 		{
 			name:      "simple",
@@ -60,6 +61,19 @@ func TestParseAndPrepare(t *testing.T) {
 			wantSchemaStr: true,
 		},
 		{
+			name:      "unqualified counter preserves input",
+			input:     "CREATE TABLE `counter` (`id` bigint AUTO_INCREMENT PRIMARY KEY, `note` varchar(255) DEFAULT 'AUTO_INCREMENT=42') ENGINE=InnoDB AUTO_INCREMENT=123 COMMENT='keep AUTO_INCREMENT=999'",
+			wantTable: "counter",
+			wantReset: true,
+		},
+		{
+			name:          "qualified counter strips only schema",
+			input:         "CREATE TABLE `mydb`.`counter` (`id` bigint AUTO_INCREMENT PRIMARY KEY, `note` varchar(255) DEFAULT 'AUTO_INCREMENT=42') ENGINE=InnoDB AUTO_INCREMENT=123 COMMENT='keep AUTO_INCREMENT=999'",
+			wantTable:     "counter",
+			wantSchemaStr: true,
+			wantReset:     true,
+		},
+		{
 			name:    "not create table",
 			input:   "ALTER TABLE users ADD COLUMN x INT",
 			wantErr: true,
@@ -78,13 +92,14 @@ func TestParseAndPrepare(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tableName, execSQL, err := parseAndPrepare(tc.input)
+			tableName, execSQL, resetAutoIncrement, err := parseAndPrepare(tc.input)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.wantTable, tableName)
+			require.Equal(t, tc.wantReset, resetAutoIncrement)
 			if tc.wantSchemaStr {
 				// Schema should be stripped from execSQL
 				require.NotContains(t, execSQL, "mydb")
@@ -92,6 +107,10 @@ func TestParseAndPrepare(t *testing.T) {
 			} else {
 				// Without schema qualifier, original SQL is used as-is
 				require.Equal(t, tc.input, execSQL)
+			}
+			if tc.wantReset {
+				require.Contains(t, execSQL, "AUTO_INCREMENT=42")
+				require.Contains(t, execSQL, "AUTO_INCREMENT=999")
 			}
 		})
 	}

--- a/pkg/fmt/fmt_test.go
+++ b/pkg/fmt/fmt_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/block/spirit/pkg/testutils"
@@ -356,4 +357,46 @@ func writeTestFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644)
 	require.NoError(t, err)
+}
+
+// Formatting must not change SQL literals or identifiers that happen to look
+// like a table counter, even when the statement also contains a real counter.
+func TestFormatFile_PreservesAutoIncrementLiterals(t *testing.T) {
+	for _, option := range []string{"", " AUTO_INCREMENT=98765"} {
+		t.Run(option, func(t *testing.T) {
+			db := testDB(t)
+			input := "CREATE TABLE `fmt_AUTO_INCREMENT=123` (" +
+				"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+				"val VARCHAR(100) DEFAULT 'AUTO_INCREMENT=123' COMMENT 'keep AUTO_INCREMENT = 456', " +
+				"`AUTO_INCREMENT=789` INT DEFAULT 1" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" + option + " COMMENT='keep auto_increment=321'"
+			dir := t.TempDir()
+			path := filepath.Join(dir, "schema.sql")
+			writeTestFile(t, dir, "schema.sql", input)
+			_, err := formatFile(t.Context(), db, path)
+			require.NoError(t, err)
+			content, err := os.ReadFile(path)
+			require.NoError(t, err)
+			canonical := string(content)
+			for _, preserved := range []string{"`fmt_AUTO_INCREMENT=123`", "DEFAULT 'AUTO_INCREMENT=123'", "COMMENT 'keep AUTO_INCREMENT = 456'", "`AUTO_INCREMENT=789`", "COMMENT='keep auto_increment=321'"} {
+				require.Contains(t, canonical, preserved)
+			}
+			require.NotContains(t, canonical, "98765")
+			tt := testutils.NewTestTable(t, "fmt_AUTO_INCREMENT=123", canonical)
+			_, err = tt.DB.ExecContext(t.Context(), "INSERT INTO `fmt_AUTO_INCREMENT=123` () VALUES ()")
+			require.NoError(t, err)
+			var id int
+			var val string
+			require.NoError(t, tt.DB.QueryRowContext(t.Context(), "SELECT id, val FROM `fmt_AUTO_INCREMENT=123`").Scan(&id, &val))
+			require.Equal(t, 1, id)
+			require.Equal(t, "AUTO_INCREMENT=123", val)
+			changed, err := formatFile(t.Context(), db, path)
+			require.NoError(t, err)
+			after, readErr := os.ReadFile(path)
+			require.NoError(t, readErr)
+			require.Equal(t, canonical, string(after))
+			require.False(t, changed)
+			require.True(t, strings.HasSuffix(canonical, "\n"))
+		})
+	}
 }

--- a/pkg/fmt/fmt_test.go
+++ b/pkg/fmt/fmt_test.go
@@ -362,14 +362,21 @@ func writeTestFile(t *testing.T, dir, name, content string) {
 // Formatting must not change SQL literals or identifiers that happen to look
 // like a table counter, even when the statement also contains a real counter.
 func TestFormatFile_PreservesAutoIncrementLiterals(t *testing.T) {
-	for _, option := range []string{"", " AUTO_INCREMENT=98765"} {
-		t.Run(option, func(t *testing.T) {
+	tests := []struct {
+		name   string
+		option string
+	}{
+		{name: "without table counter"},
+		{name: "with table counter", option: " AUTO_INCREMENT=98765"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			db := testDB(t)
 			input := "CREATE TABLE `fmt_AUTO_INCREMENT=123` (" +
 				"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
 				"val VARCHAR(100) DEFAULT 'AUTO_INCREMENT=123' COMMENT 'keep AUTO_INCREMENT = 456', " +
 				"`AUTO_INCREMENT=789` INT DEFAULT 1" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" + option + " COMMENT='keep auto_increment=321'"
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" + tt.option + " COMMENT='keep auto_increment=321'"
 			dir := t.TempDir()
 			path := filepath.Join(dir, "schema.sql")
 			writeTestFile(t, dir, "schema.sql", input)

--- a/pkg/table/table_schema.go
+++ b/pkg/table/table_schema.go
@@ -5,9 +5,13 @@ import (
 	"database/sql"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/block/spirit/pkg/dbconn/sqlescape"
+	"github.com/block/spirit/pkg/parser"
+	"github.com/block/spirit/pkg/parser/ast"
+	"github.com/block/spirit/pkg/parser/format"
 )
 
 // TableSchema represents a table's name and its raw CREATE TABLE DDL statement.
@@ -42,9 +46,6 @@ const (
 // <name>_archive_YYYY, <name>_archive_YYYY_MM, or <name>_archive_YYYY_MM_DD.
 var archiveTableRegexp = regexp.MustCompile(`^.*_archive_[0-9]{4}(_[0-9]{2}(_[0-9]{2})?)?$`)
 
-// autoIncrementRegexp matches the AUTO_INCREMENT table option in CREATE TABLE output.
-var autoIncrementRegexp = regexp.MustCompile(`(?i)\s*AUTO_INCREMENT\s*=?\s*[0-9]+`)
-
 // IsArchiveTable returns true if the table name matches the archive naming
 // convention: <name>_archive_YYYY, <name>_archive_YYYY_MM, or
 // <name>_archive_YYYY_MM_DD.
@@ -56,7 +57,26 @@ func IsArchiveTable(name string) bool {
 // CREATE TABLE statement. This is useful when comparing schemas to avoid
 // spurious diffs caused by differing auto-increment counters.
 func StripAutoIncrement(stmt string) string {
-	return autoIncrementRegexp.ReplaceAllString(stmt, "")
+	node, err := parser.New().ParseOneStmt(stmt, "", "")
+	if err != nil {
+		return stmt
+	}
+	create, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return stmt
+	}
+	originalCount := len(create.Options)
+	create.Options = slices.DeleteFunc(create.Options, func(opt *ast.TableOption) bool {
+		return opt.Tp == ast.TableOptionAutoIncrement
+	})
+	if len(create.Options) == originalCount {
+		return stmt
+	}
+	var restored strings.Builder
+	if err := create.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &restored)); err != nil {
+		return stmt
+	}
+	return restored.String()
 }
 
 // LoadSchemaFromDB retrieves all table schemas from the database using the

--- a/pkg/table/table_schema_test.go
+++ b/pkg/table/table_schema_test.go
@@ -141,6 +141,15 @@ func TestLoadSchemaFromDB_StripAutoIncrement(t *testing.T) {
 	require.Contains(t, tables[0].Schema, "AUTO_INCREMENT")
 }
 
+func TestStripAutoIncrementPreservesLiterals(t *testing.T) {
+	stmt := "CREATE TABLE `counter` (`id` bigint AUTO_INCREMENT PRIMARY KEY, `value` varchar(255) DEFAULT 'AUTO_INCREMENT=42') ENGINE=InnoDB AUTO_INCREMENT=123 COMMENT='keep AUTO_INCREMENT=999'"
+	got := StripAutoIncrement(stmt)
+	require.NotContains(t, got, "AUTO_INCREMENT=123")
+	require.Contains(t, got, "AUTO_INCREMENT=42")
+	require.Contains(t, got, "AUTO_INCREMENT=999")
+	require.Contains(t, got, "`id` BIGINT AUTO_INCREMENT")
+}
+
 func TestLoadSchemaFromDB_CombinedFilters(t *testing.T) {
 	dbName, _ := testutils.CreateUniqueTestDatabase(t)
 	testutils.RunSQLInDatabase(t, dbName, `CREATE TABLE users (


### PR DESCRIPTION
Fixes #1208.

`spirit fmt` could turn `DEFAULT 'AUTO_INCREMENT=123'` into `DEFAULT ''` because counter removal matched text throughout the statement.

For the common unqualified CREATE statement, the formatter now sends the original SQL to MySQL byte-for-byte, resets the empty table's counter with `ALTER TABLE ... AUTO_INCREMENT = 1`, and then reads canonical `SHOW CREATE TABLE` output. Only a schema-qualified table needs AST restoration to redirect it into the temporary database.

The exported `table.StripAutoIncrement` helper remains available for Strata, Gap, and Schemabot callers, but now removes the table option through the SQL parser instead of a regex. Defaults, comments, quoted identifiers, and column AUTO_INCREMENT attributes remain intact.

Validation against MySQL 8.0.43:

- `go test ./pkg/fmt ./pkg/table`
- Regressions for counters embedded in defaults and comments, qualified tables, formatting idempotence, and executable output.
- `golangci-lint run`: clean.
