### PR TITLE
fix(security): resolve code scanning alerts

### DIFF
--- a/.github/workflows/buildandrun-docker.yml
+++ b/.github/workflows/buildandrun-docker.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         with:
           go-version: "1.26.6"
+          cache: false
       - name: Checkout code
         uses: actions/checkout@v7
       - name: golangci-lint

--- a/.github/workflows/mysql-semisync-docker.yml
+++ b/.github/workflows/mysql-semisync-docker.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mysql8-docker.yml
+++ b/.github/workflows/mysql8-docker.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mysql8.0.42-docker.yml
+++ b/.github/workflows/mysql8.0.42-docker.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mysql84-docker.yml
+++ b/.github/workflows/mysql84-docker.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mysql97-docker.yml
+++ b/.github/workflows/mysql97-docker.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/parser-regen.yml
+++ b/.github/workflows/parser-regen.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-go@v7.0.0
         with:
           go-version: "1.26.6"
+          cache: false
       - name: Checkout code
         uses: actions/checkout@v7
       - name: Regenerate parser from grammar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/pkg/dbconn/sqlescape/utils.go
+++ b/pkg/dbconn/sqlescape/utils.go
@@ -26,9 +26,20 @@ import (
 )
 
 func reserveBuffer(buf []byte, appendSize int) []byte {
+	maxInt := int(^uint(0) >> 1)
+	if appendSize < 0 || appendSize > maxInt-len(buf) {
+		panic("sqlescape: buffer size overflow")
+	}
 	newSize := len(buf) + appendSize
 	if cap(buf) < newSize {
-		newBuf := make([]byte, len(buf)*2+appendSize)
+		// Preserve the historical doubling growth strategy when it is safe, but
+		// skip the extra capacity when doubling would overflow int. newSize
+		// itself was checked above.
+		newCapacity := newSize
+		if len(buf) <= maxInt-newSize {
+			newCapacity += len(buf)
+		}
+		newBuf := make([]byte, newCapacity)
 		copy(newBuf, buf)
 		buf = newBuf
 	}

--- a/pkg/dbconn/sqlescape/utils.go
+++ b/pkg/dbconn/sqlescape/utils.go
@@ -49,6 +49,10 @@ func reserveBuffer(buf []byte, appendSize int) []byte {
 // escapeBytesBackslash will escape []byte into the buffer, with backslash.
 func escapeBytesBackslash(buf []byte, v []byte) []byte {
 	pos := len(buf)
+	maxInt := int(^uint(0) >> 1)
+	if len(v) > maxInt/2 {
+		panic("sqlescape: buffer size overflow")
+	}
 	buf = reserveBuffer(buf, len(v)*2)
 
 	for _, c := range v {

--- a/pkg/dbconn/sqlescape/utils_test.go
+++ b/pkg/dbconn/sqlescape/utils_test.go
@@ -16,6 +16,7 @@ package sqlescape
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,13 @@ func TestReserveBuffer(t *testing.T) {
 	require.Len(t, res2, 12)
 	require.Equal(t, 15, cap(res2))
 	require.Equal(t, res1, res2[:3])
+
+	require.PanicsWithValue(t, "sqlescape: buffer size overflow", func() {
+		reserveBuffer(make([]byte, 1), math.MaxInt)
+	})
+	require.PanicsWithValue(t, "sqlescape: buffer size overflow", func() {
+		reserveBuffer(nil, -1)
+	})
 }
 
 func TestEscapeBackslash(t *testing.T) {

--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -91,18 +91,37 @@ func (c *Chunk) String() string {
 }
 
 func (c *Chunk) JSON() string {
-	return fmt.Sprintf(`{"Key":["%s"],"ChunkSize":%d,"LowerBound":%s,"UpperBound":%s}`,
-		strings.Join(c.Key, `","`),
-		c.ChunkSize,
-		c.LowerBound.JSON(),
-		c.UpperBound.JSON(),
-	)
+	out, err := json.Marshal(JSONChunk{
+		Key:        c.Key,
+		ChunkSize:  c.ChunkSize,
+		LowerBound: c.LowerBound.jsonBoundary(),
+		UpperBound: c.UpperBound.jsonBoundary(),
+	})
+	if err != nil {
+		// JSONChunk contains only strings, integers, booleans, and slices, so
+		// encoding it cannot fail. Keep JSON's historical string-only API while
+		// making an impossible future schema regression fail loudly.
+		panic(fmt.Sprintf("could not encode chunk JSON: %v", err))
+	}
+	return string(out)
 }
 
 // JSON encodes a boundary as JSON. The values are represented as strings,
 // to avoid JSON float behavior. See Issue #125
 func (b *Boundary) JSON() string {
-	return fmt.Sprintf(`{"Value": [%s],"Inclusive":%t}`, b.valuesString(), b.Inclusive)
+	out, err := json.Marshal(b.jsonBoundary())
+	if err != nil {
+		panic(fmt.Sprintf("could not encode boundary JSON: %v", err))
+	}
+	return string(out)
+}
+
+func (b *Boundary) jsonBoundary() JSONBoundary {
+	values := make([]string, len(b.Value))
+	for i, value := range b.Value {
+		values[i] = jsonDatumString(value)
+	}
+	return JSONBoundary{Value: values, Inclusive: b.Inclusive}
 }
 
 // comparesTo returns true if the boundaries are the same.
@@ -144,6 +163,18 @@ func (b *Boundary) valuesString() string {
 // control byte like 0x16, or an embedded quote — must be JSON-escaped here, or
 // the checkpoint watermark becomes unparseable and resume fails permanently.
 func jsonQuoteDatum(v Datum) string {
+	s := jsonDatumString(v)
+	// json.Marshal of a (valid-UTF8) string never errors and escapes anything
+	// JSON requires escaped; binary values took the hex branch in
+	// jsonDatumString, so they're ASCII here.
+	out, _ := json.Marshal(s)
+	return string(out)
+}
+
+// jsonDatumString renders a boundary datum as the string value stored in a
+// checkpoint. The enclosing JSON encoder, rather than string interpolation,
+// is responsible for quoting and escaping it.
+func jsonDatumString(v Datum) string {
 	var s string
 	switch {
 	case v.IsNumeric():
@@ -167,11 +198,7 @@ func jsonQuoteDatum(v Datum) string {
 			s = fmt.Sprintf("%v", v.Val)
 		}
 	}
-	// json.Marshal of a (valid-UTF8) string never errors and escapes anything
-	// JSON requires escaped; binary values took the hex branch above so they're
-	// ASCII here.
-	out, _ := json.Marshal(s)
-	return string(out)
+	return s
 }
 
 type JSONChunk struct {

--- a/pkg/table/chunk.go
+++ b/pkg/table/chunk.go
@@ -91,6 +91,16 @@ func (c *Chunk) String() string {
 }
 
 func (c *Chunk) JSON() string {
+	out, err := c.marshalJSON()
+	if err != nil {
+		// Keep the historical string-only API for external callers. Production
+		// checkpoint paths use marshalJSON directly and propagate its error.
+		panic(err)
+	}
+	return out
+}
+
+func (c *Chunk) marshalJSON() (string, error) {
 	out, err := json.Marshal(JSONChunk{
 		Key:        c.Key,
 		ChunkSize:  c.ChunkSize,
@@ -98,12 +108,9 @@ func (c *Chunk) JSON() string {
 		UpperBound: c.UpperBound.jsonBoundary(),
 	})
 	if err != nil {
-		// JSONChunk contains only strings, integers, booleans, and slices, so
-		// encoding it cannot fail. Keep JSON's historical string-only API while
-		// making an impossible future schema regression fail loudly.
-		panic(fmt.Sprintf("could not encode chunk JSON: %v", err))
+		return "", fmt.Errorf("could not encode chunk JSON: %w", err)
 	}
-	return string(out)
+	return string(out), nil
 }
 
 // JSON encodes a boundary as JSON. The values are represented as strings,
@@ -143,8 +150,9 @@ func (b *Boundary) comparesTo(b2 *Boundary) bool {
 	return true
 }
 
-// valuesString renders the boundary values as a comma-separated list of JSON
-// string literals (used inside Boundary.JSON's "Value" array).
+// valuesString renders the boundary values as an injective, comma-separated
+// tuple key for watermarkTracker's out-of-order chunk map. JSON string quoting
+// keeps distinct tuples distinct, including ["a", "b"] versus ["a,b"].
 func (b *Boundary) valuesString() string {
 	vals := make([]string, len(b.Value))
 	for i, v := range b.Value {
@@ -157,11 +165,10 @@ func (b *Boundary) valuesString() string {
 // quoted, properly escaped). Numeric values are quoted to avoid JSON float
 // behavior (#125); binary values are hex-encoded ("0x...", or the empty
 // binary literal for a zero-length value) so they round-trip via
-// datumValFromString. Crucially it uses json.Marshal rather than
-// Datum.String() (which SQL-escapes for WHERE clauses): a string value that is
-// valid in a MySQL string literal but not in JSON — e.g. a VARCHAR PK holding a
-// control byte like 0x16, or an embedded quote — must be JSON-escaped here, or
-// the checkpoint watermark becomes unparseable and resume fails permanently.
+// datumValFromString. Crucially it uses json.Marshal rather than Datum.String()
+// (which SQL-escapes for WHERE clauses), so the tuple representation is
+// injective. Without quoting, distinct boundaries could collide in the
+// watermark map and let one out-of-order chunk overwrite another.
 func jsonQuoteDatum(v Datum) string {
 	s := jsonDatumString(v)
 	// json.Marshal of a (valid-UTF8) string never errors and escapes anything

--- a/pkg/table/chunk_test.go
+++ b/pkg/table/chunk_test.go
@@ -26,19 +26,23 @@ func TestBoundaryJSONControlChar(t *testing.T) {
 }
 
 func TestChunkJSONEscapesKeyNames(t *testing.T) {
+	ti := NewTableInfo(nil, "test", "t1")
+	ti.columnsMySQLTps = map[string]string{"quote\"key": "int", "slash\\key": "int"}
 	chunk := &Chunk{
 		Key:        []string{"quote\"key", "slash\\key"},
 		ChunkSize:  1000,
-		LowerBound: &Boundary{Value: []Datum{{Val: 1, Tp: signedType}, {Val: 2, Tp: signedType}}, Inclusive: true},
-		UpperBound: &Boundary{Value: []Datum{{Val: 3, Tp: signedType}, {Val: 4, Tp: signedType}}, Inclusive: false},
+		LowerBound: &Boundary{Value: []Datum{{Val: int64(1), Tp: signedType}, {Val: int64(2), Tp: signedType}}, Inclusive: true},
+		UpperBound: &Boundary{Value: []Datum{{Val: int64(3), Tp: signedType}, {Val: int64(4), Tp: signedType}}, Inclusive: false},
 	}
 
 	encoded := chunk.JSON()
 	require.True(t, json.Valid([]byte(encoded)), "chunk JSON must be valid: %q", encoded)
 
-	var decoded JSONChunk
-	require.NoError(t, json.Unmarshal([]byte(encoded), &decoded))
-	require.Equal(t, chunk.Key, decoded.Key)
+	restored, err := newChunkFromJSON(ti, encoded)
+	require.NoError(t, err)
+	require.Equal(t, chunk.Key, restored.Key)
+	require.Equal(t, chunk.LowerBound, restored.LowerBound)
+	require.Equal(t, chunk.UpperBound, restored.UpperBound)
 }
 
 // TestBinaryChunkJSONRoundTrip guards against checkpoint corruption for

--- a/pkg/table/chunk_test.go
+++ b/pkg/table/chunk_test.go
@@ -25,6 +25,22 @@ func TestBoundaryJSONControlChar(t *testing.T) {
 	require.Equal(t, []string{"foo\x16bar"}, parsed.Value)
 }
 
+func TestChunkJSONEscapesKeyNames(t *testing.T) {
+	chunk := &Chunk{
+		Key:        []string{"quote\"key", "slash\\key"},
+		ChunkSize:  1000,
+		LowerBound: &Boundary{Value: []Datum{{Val: 1, Tp: signedType}, {Val: 2, Tp: signedType}}, Inclusive: true},
+		UpperBound: &Boundary{Value: []Datum{{Val: 3, Tp: signedType}, {Val: 4, Tp: signedType}}, Inclusive: false},
+	}
+
+	encoded := chunk.JSON()
+	require.True(t, json.Valid([]byte(encoded)), "chunk JSON must be valid: %q", encoded)
+
+	var decoded JSONChunk
+	require.NoError(t, json.Unmarshal([]byte(encoded), &decoded))
+	require.Equal(t, chunk.Key, decoded.Key)
+}
+
 // TestBinaryChunkJSONRoundTrip guards against checkpoint corruption for
 // binary boundary values that are valid UTF-8. The restore path
 // (datumValFromString) unconditionally hex-decodes any binaryType value with

--- a/pkg/table/chunker_composite.go
+++ b/pkg/table/chunker_composite.go
@@ -379,8 +379,12 @@ func (t *chunkerComposite) GetLowWatermark() (string, error) {
 	// into the watermark. This is because progress is determined
 	// based on rowsCopied / estimatedRows (not based on logical
 	// key space).
+	chunkJSON, err := t.watermark.marshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("could not serialize chunk watermark: %w", err)
+	}
 	watermark := compositeWatermark{
-		ChunkJSON:  t.watermark.JSON(),
+		ChunkJSON:  chunkJSON,
 		RowsCopied: atomic.LoadUint64(&t.rowsCopied),
 	}
 	// Serialize to JSON

--- a/pkg/table/chunker_optimistic.go
+++ b/pkg/table/chunker_optimistic.go
@@ -651,7 +651,11 @@ func (t *chunkerOptimistic) GetLowWatermark() (string, error) {
 		return "", ErrWatermarkNotReady
 	}
 
-	return t.watermark.JSON(), nil
+	watermark, err := t.watermark.marshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("could not serialize watermark: %w", err)
+	}
+	return watermark, nil
 }
 
 func (t *chunkerOptimistic) open() (err error) {

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -163,7 +163,7 @@ func datumValFromString(val string, tp datumTp) (any, error) {
 		return strconv.ParseUint(val, 10, 64)
 	case binaryType:
 		// Binary types are hex-encoded ("0x...") in checkpoint JSON via
-		// jsonQuoteDatum, except the empty value, which is serialized as
+		// jsonDatumString, except the empty value, which is serialized as
 		// x'' (there is no zero-digit 0x literal). Decode both back to a
 		// Go string holding the raw bytes: Datum.Val stores binary values
 		// as string, never []byte.


### PR DESCRIPTION
## Summary

Addresses the [open GitHub code-scanning alerts](https://github.com/block/spirit/security/code-scanning).

- Serialize chunk checkpoint data with `encoding/json`, preventing quoted key names or boundary values from producing malformed JSON.
- Propagate checkpoint serialization failures through `GetLowWatermark` instead of panicking in the periodic checkpoint path.
- Reject negative or overflowing SQL escape-buffer growth before allocation.
- Restrict six test workflows to read-only repository permissions.
- Disable `setup-go` caching in three workflows that cross untrusted and privileged execution contexts.
- Add regression coverage for JSON key escaping and allocation overflow.

## Alert disposition

- 13 findings are addressed by this PR: six missing workflow permissions, three cache-poisoning risks, two unsafe JSON-quoting paths, and two allocation-overflow reports.
- Four TLS findings were reviewed separately. `VERIFY_CA` performs explicit x509 chain validation and was marked as a false positive. The `PREFERRED` and `REQUIRED` findings describe intentional, documented MySQL-compatible behavior and were dismissed with rationale.

## Review follow-up

- The quoted-key regression test now round-trips through the real checkpoint resume parser, including both bounds.
- Watermark tuple-key comments now document why JSON quoting must remain injective for out-of-order chunk matching.
- The escape expansion multiplication is checked before it is evaluated; the allocation helper retains its independent overflow backstop.
- Disabling the release cache is the substantive security tradeoff. The lint and parser-regeneration caches were already ineffective because `setup-go` runs before checkout, so those two changes remove warnings at no existing cache-performance cost.

## Testing

```text
golangci-lint run --timeout=2m
go test ./pkg/dbconn/sqlescape ./pkg/table -run 'TestReserveBuffer|TestBoundaryJSONControlChar|TestChunkJSONEscapesKeyNames|TestBinaryChunkJSONRoundTrip|TestBoundary_ValueString|TestChunker.*Watermark' -count=1
git diff --check
```
