### PR TITLE
test(throttler): decouple live query from replica lag

### DIFF
--- a/pkg/throttler/replica_test.go
+++ b/pkg/throttler/replica_test.go
@@ -92,6 +92,28 @@ func TestReplica_BlockWaitFailsClosedOnStaleSignal(t *testing.T) {
 	require.Less(t, elapsed, 500*time.Millisecond)
 }
 
+func TestReplica_BlockWaitReturnsWhenLagRecovers(t *testing.T) {
+	// Use a short blockWaitInterval so the test doesn't have to wait a full
+	// second per loop iteration. Save and restore.
+	prev := blockWaitInterval
+	blockWaitInterval = 10 * time.Millisecond
+	t.Cleanup(func() { blockWaitInterval = prev })
+
+	l := newTestReplica(t, 60*time.Second)
+	l.applyLag(60_000) // exactly at the tolerance, so BlockWait must hold
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		l.applyLag(59_999)
+	}()
+
+	start := time.Now()
+	l.BlockWait(t.Context())
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(t, elapsed, 20*time.Millisecond, "BlockWait must block while lag is over budget")
+	require.Less(t, elapsed, 500*time.Millisecond)
+}
+
 func TestReplica_UpdateLagWrapsCause(t *testing.T) {
 	// sql.Open is lazy and does not connect. A pre-canceled context makes
 	// QueryRowContext fail deterministically with context.Canceled before any

--- a/pkg/throttler/replica_test.go
+++ b/pkg/throttler/replica_test.go
@@ -13,12 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	replicaBlockWaitTestInterval = 10 * time.Millisecond
+	replicaBlockWaitRecoverAfter = 3 * replicaBlockWaitTestInterval
+	replicaBlockWaitMinDuration  = 2 * replicaBlockWaitTestInterval
+	replicaBlockWaitMaxDuration  = 50 * replicaBlockWaitTestInterval
+)
+
 func newTestReplica(t *testing.T, tolerance time.Duration) *Replica {
 	t.Helper()
 	return &Replica{
 		lagTolerance: tolerance,
 		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
+}
+
+func useReplicaBlockWaitTestInterval(t *testing.T) {
+	t.Helper()
+	prev := blockWaitInterval
+	blockWaitInterval = replicaBlockWaitTestInterval
+	t.Cleanup(func() { blockWaitInterval = prev })
 }
 
 func TestReplica_LagBasedThrottling(t *testing.T) {
@@ -66,12 +80,27 @@ func TestReplica_NeverPolledIsNotStale(t *testing.T) {
 	require.False(t, l.IsThrottled())
 }
 
+func TestReplica_BlockWaitReturnsImmediatelyWhenUnthrottled(t *testing.T) {
+	l := newTestReplica(t, 60*time.Second)
+	start := time.Now()
+	l.BlockWait(t.Context())
+	require.Less(t, time.Since(start), 50*time.Millisecond)
+}
+
+func TestReplica_BlockWaitRespectsContext(t *testing.T) {
+	l := newTestReplica(t, 60*time.Second)
+	l.applyLag(60_000)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	start := time.Now()
+	l.BlockWait(ctx)
+	require.Less(t, time.Since(start), 200*time.Millisecond)
+}
+
 func TestReplica_BlockWaitFailsClosedOnStaleSignal(t *testing.T) {
-	// Use a short blockWaitInterval so the test doesn't have to wait a full
-	// second per loop iteration. Save and restore.
-	prev := blockWaitInterval
-	blockWaitInterval = 10 * time.Millisecond
-	t.Cleanup(func() { blockWaitInterval = prev })
+	useReplicaBlockWaitTestInterval(t)
 
 	l := newTestReplica(t, 120*time.Second)
 	l.applyLag(5) // healthy baseline, well under the tolerance
@@ -81,37 +110,50 @@ func TestReplica_BlockWaitFailsClosedOnStaleSignal(t *testing.T) {
 	// must hold while lag is unobservable (the copier's enforcement path is
 	// BlockWait, not IsThrottled) and release once polling recovers.
 	go func() {
-		time.Sleep(30 * time.Millisecond)
+		time.Sleep(replicaBlockWaitRecoverAfter)
 		l.applyLag(5)
 	}()
 
 	start := time.Now()
 	l.BlockWait(t.Context())
 	elapsed := time.Since(start)
-	require.GreaterOrEqual(t, elapsed, 20*time.Millisecond, "BlockWait must block while lag is unobservable")
-	require.Less(t, elapsed, 500*time.Millisecond)
+	require.GreaterOrEqual(t, elapsed, replicaBlockWaitMinDuration, "BlockWait must block while lag is unobservable")
+	require.Less(t, elapsed, replicaBlockWaitMaxDuration)
 }
 
 func TestReplica_BlockWaitReturnsWhenLagRecovers(t *testing.T) {
-	// Use a short blockWaitInterval so the test doesn't have to wait a full
-	// second per loop iteration. Save and restore.
-	prev := blockWaitInterval
-	blockWaitInterval = 10 * time.Millisecond
-	t.Cleanup(func() { blockWaitInterval = prev })
+	useReplicaBlockWaitTestInterval(t)
 
 	l := newTestReplica(t, 60*time.Second)
 	l.applyLag(60_000) // exactly at the tolerance, so BlockWait must hold
 
 	go func() {
-		time.Sleep(30 * time.Millisecond)
+		time.Sleep(replicaBlockWaitRecoverAfter)
 		l.applyLag(59_999)
 	}()
 
 	start := time.Now()
 	l.BlockWait(t.Context())
 	elapsed := time.Since(start)
-	require.GreaterOrEqual(t, elapsed, 20*time.Millisecond, "BlockWait must block while lag is over budget")
-	require.Less(t, elapsed, 500*time.Millisecond)
+	require.GreaterOrEqual(t, elapsed, replicaBlockWaitMinDuration, "BlockWait must block while lag is over budget")
+	require.Less(t, elapsed, replicaBlockWaitMaxDuration)
+}
+
+func TestReplica_BlockWaitReturnsAfterGiveUpBudget(t *testing.T) {
+	useReplicaBlockWaitTestInterval(t)
+
+	l := newTestReplica(t, 60*time.Second)
+	l.applyLag(60_000)
+
+	start := time.Now()
+	l.BlockWait(t.Context())
+	elapsed := time.Since(start)
+
+	// BlockWait deliberately gives the caller a chance to make progress after
+	// 60 intervals even if the replica remains over budget. Pin that safety
+	// tradeoff so shortening the loop cannot silently weaken throttling.
+	require.GreaterOrEqual(t, elapsed, 60*replicaBlockWaitTestInterval)
+	require.True(t, l.IsThrottled())
 }
 
 func TestReplica_UpdateLagWrapsCause(t *testing.T) {

--- a/pkg/throttler/throttler_test.go
+++ b/pkg/throttler/throttler_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
-func TestThrottlerInterface(t *testing.T) {
+func TestReplicationThrottlerLiveQuery(t *testing.T) {
 	replicaDSN := os.Getenv("REPLICA_DSN")
 	if replicaDSN == "" {
 		t.Skip("skipping test because REPLICA_DSN not set")
@@ -29,21 +29,13 @@ func TestThrottlerInterface(t *testing.T) {
 	require.NoError(t, err)
 	defer utils.CloseAndLog(db)
 
-	//	NewReplicationThrottler will attach either MySQL 8.0 or MySQL 5.7 throttler
+	// Open performs an initial lag query against performance_schema. Keep this
+	// live coverage focused on connection and query compatibility: whether the
+	// shared CI replica is currently caught up depends on unrelated packages.
 	throttler, err := NewReplicationThrottler(db, 60*time.Second, slog.Default())
 	require.NoError(t, err)
 	require.NoError(t, throttler.Open(t.Context()))
-
-	throttler.BlockWait(t.Context()) // wait for catch up (there's no activity)
-	// The throttler computes lag asynchronously on its loop, so poll rather
-	// than asserting against a fixed settle time. With no write activity the
-	// replica should quickly report not-throttled.
-	require.Eventually(t, func() bool {
-		return !throttler.IsThrottled()
-	}, 5*time.Second, 10*time.Millisecond)
-
 	require.NoError(t, throttler.Close())
-
 }
 
 func TestNoopThrottler(t *testing.T) {

--- a/pkg/throttler/throttler_test.go
+++ b/pkg/throttler/throttler_test.go
@@ -35,7 +35,16 @@ func TestReplicationThrottlerLiveQuery(t *testing.T) {
 	throttler, err := NewReplicationThrottler(db, 60*time.Second, slog.Default())
 	require.NoError(t, err)
 	require.NoError(t, throttler.Open(t.Context()))
-	require.NoError(t, throttler.Close())
+	t.Cleanup(func() { require.NoError(t, throttler.Close()) })
+
+	replica, ok := throttler.(*Replica)
+	require.True(t, ok)
+	lag := replica.currentLagInMs.Load()
+	require.GreaterOrEqual(t, lag, int64(0))
+	// This fresh CI replica cannot predate the 10-minute package timeout. A
+	// larger value points to a unit-conversion or lag-query regression without
+	// requiring the shared replica to be caught up.
+	require.Less(t, lag, (10 * time.Minute).Milliseconds())
 }
 
 func TestNoopThrottler(t *testing.T) {


### PR DESCRIPTION
Closes #1211

## Summary

- keep the live replication throttler test focused on performance_schema query compatibility while retaining a generous lag-value sanity check
- remove dependency on the shared CI replica draining below the lag threshold
- cover BlockWait deterministically across its immediate, cancellation, recovery, stale-signal, and 60-interval give-up paths
- centralize the replica BlockWait test timings so their relationships remain explicit

## Testing

- go test ./pkg/throttler
- go test -race ./pkg/throttler
- race-enabled BlockWait tests repeated 20 times