### PR TITLE
fix(sqlescape): use checked slice growth

### DIFF
--- a/pkg/dbconn/sqlescape/utils.go
+++ b/pkg/dbconn/sqlescape/utils.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -30,20 +31,9 @@ func reserveBuffer(buf []byte, appendSize int) []byte {
 	if appendSize < 0 || appendSize > maxInt-len(buf) {
 		panic("sqlescape: buffer size overflow")
 	}
-	newSize := len(buf) + appendSize
-	if cap(buf) < newSize {
-		// Preserve the historical doubling growth strategy when it is safe, but
-		// skip the extra capacity when doubling would overflow int. newSize
-		// itself was checked above.
-		newCapacity := newSize
-		if len(buf) <= maxInt-newSize {
-			newCapacity += len(buf)
-		}
-		newBuf := make([]byte, newCapacity)
-		copy(newBuf, buf)
-		buf = newBuf
-	}
-	return buf[:newSize]
+	originalLen := len(buf)
+	buf = slices.Grow(buf, appendSize)
+	return buf[:originalLen+appendSize]
 }
 
 // escapeBytesBackslash will escape []byte into the buffer, with backslash.

--- a/pkg/dbconn/sqlescape/utils_test.go
+++ b/pkg/dbconn/sqlescape/utils_test.go
@@ -34,7 +34,7 @@ func TestReserveBuffer(t *testing.T) {
 
 	res2 := reserveBuffer(res1, 9)
 	require.Len(t, res2, 12)
-	require.Equal(t, 15, cap(res2))
+	require.GreaterOrEqual(t, cap(res2), len(res2))
 	require.Equal(t, res1, res2[:3])
 
 	require.PanicsWithValue(t, "sqlescape: buffer size overflow", func() {


### PR DESCRIPTION
## Summary

Follow-up to #1213 for the successor `go/allocation-size-overflow` finding reported as [code-scanning alert #69](https://github.com/block/spirit/security/code-scanning/69).

- Replace hand-rolled capacity arithmetic with the standard library's checked `slices.Grow` implementation.
- Retain the explicit negative and combined-length overflow guard.
- Retain the caller-side guard that checks the escape-size multiplication before evaluating it.
- Preserve existing buffer contents and required capacity without depending on an exact implementation-specific growth factor.

## Testing

```text
go test ./pkg/dbconn/sqlescape -count=1
golangci-lint run ./pkg/dbconn/sqlescape/...
git diff --check
```
