### PR TITLE
feat: add --max-connections to move and sync

### DIFF
--- a/docs/move.md
+++ b/docs/move.md
@@ -83,7 +83,7 @@ Passing `--force` changes that recovery behaviour: instead of failing, Move wipe
 
 Sets the fixed size of each source and target connection pool, matching `migrate`. Read and write workers share these pools; increasing worker counts does not grow them. Dedicated monitoring and advisory-lock connections are separate.
 
-The explicit budget must cover `--threads` plus six connections of checksum headroom. During setup, read concurrency is fitted to the pool, accounting for table statistics queries and checksum snapshots. Write workers may wait for a connection. This is a per-pool limit, not a total across the move.
+The explicit budget must cover `--threads` plus six connections of checksum headroom. During setup, the reserve grows by one connection per source table beyond the first. For example, 20 tables reserve 25 connections, and a smaller pool lowers read concurrency to a minimum of one, allowing background queries to queue. Reusing a connection handle across targets also requires room for each target’s checksum snapshots and locks. Any reduction in read concurrency is logged at INFO. Write workers may wait for a connection. This is a per-pool limit, not a total across the move.
 
 ### reverse-window
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -83,7 +83,7 @@ Passing `--force` changes that recovery behaviour: instead of failing, Move wipe
 
 Sets the fixed size of each source and target connection pool, matching `migrate`. Read and write workers share these pools; increasing worker counts does not grow them. Dedicated monitoring and advisory-lock connections are separate.
 
-The explicit budget must cover `--threads` plus six connections of checksum headroom. During setup, read concurrency are fitted to the pool, accounting for table statistics queries and checksum snapshots. Write workers may wait for a connection. This is a per-pool limit, not a total across the move.
+The explicit budget must cover `--threads` plus six connections of checksum headroom. During setup, read concurrency is fitted to the pool, accounting for table statistics queries and checksum snapshots. Write workers may wait for a connection. This is a per-pool limit, not a total across the move.
 
 ### reverse-window
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -17,6 +17,7 @@ This will copy all tables from the source database to the target database, verif
 - [defer-cutover](#defer-cutover)
 - [defer-secondary-indexes](#defer-secondary-indexes)
 - [force](#force)
+- [max-connections](#max-connections)
 - [reverse-window](#reverse-window)
 - [source-dsn](#source-dsn)
 - [target-chunk-size](#target-chunk-size)
@@ -74,6 +75,15 @@ When set to `true`, target tables are created without secondary indexes. The ind
 When Move cannot resume from an existing checkpoint — for example the checkpoint was written by an incompatible Spirit version, or the target is in a state the resume path cannot validate — it fails rather than risk corrupting a partially-copied target (see [checkpoint-max-age](#checkpoint-max-age)).
 
 Passing `--force` changes that recovery behaviour: instead of failing, Move wipes the target tables and starts the copy fresh, checking for source-side failures before wiping and re-running the full post-setup checks against the cleaned target. Expired checkpoints and malformed or missing source positions are eligible for forced recovery; transient read or connection failures are not. Source and target must refer to different databases, even if different hostnames or credentials are used. Use it only when the target's current contents can safely be discarded.
+
+### max-connections
+
+- Type: Integer
+- Default value: `128`
+
+Sets the fixed size of each source and target connection pool, matching `migrate`. Read and write workers share these pools; increasing worker counts does not grow them. Dedicated monitoring and advisory-lock connections are separate.
+
+The explicit budget must cover `--threads` plus six connections of checksum headroom. During setup, read concurrency are fitted to the pool, accounting for table statistics queries and checksum snapshots. Write workers may wait for a connection. This is a per-pool limit, not a total across the move.
 
 ### reverse-window
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -191,3 +191,9 @@ File+offset checkpoints also record the source's `@@server_uuid`. Resume refuses
 coordinates from a different server or an older checkpoint without identity;
 use `--force` to discard the partial copy and start fresh. GTID checkpoints
 remain portable across servers, subject to the normal GTID resume checks.
+
+### max-connections
+
+`--max-connections` sets the fixed size of each source and target SQL pool (default `128`, matching `migrate` and `move`). Worker counts may exceed the budget and wait for connections. It also applies to a supplied target handle; additional connections owned by a custom applier are outside this limit. Zero in the Go API selects the default; negative values are rejected.
+
+Sync’s continuous checker uses ordinary reads rather than pinned snapshot pools, and sync has no cutover. It therefore does not require move’s checksum/cutover headroom or lower configured read concurrency to fit that headroom.

--- a/pkg/datasync/pool_test.go
+++ b/pkg/datasync/pool_test.go
@@ -1,0 +1,27 @@
+package datasync
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncMaxConnections(t *testing.T) {
+	r, err := NewRunner(&Sync{})
+	require.NoError(t, err)
+	require.Equal(t, dbconn.DefaultMaxConnections, r.sync.MaxConnections)
+	field, ok := reflect.TypeFor[Sync]().FieldByName("MaxConnections")
+	require.True(t, ok)
+	require.Equal(t, "128", field.Tag.Get("default"))
+	_, err = NewRunner(&Sync{MaxConnections: -1})
+	require.ErrorContains(t, err, "--max-connections must be non-negative")
+	// Sync has neither cutover nor pinned checksum snapshots. Workers may
+	// outnumber its connection budget without requiring snapshot headroom.
+	r, err = NewRunner(&Sync{MaxConnections: 2, Threads: 16, WriteThreads: 16})
+	require.NoError(t, err)
+	require.Equal(t, 2, r.sync.MaxConnections)
+	require.Equal(t, 16, r.sync.Threads)
+	require.Equal(t, 16, r.sync.WriteThreads)
+}

--- a/pkg/datasync/runner.go
+++ b/pkg/datasync/runner.go
@@ -151,6 +151,12 @@ var _ status.Task = (*Runner)(nil)
 // supplies defaults via kong; programmatic callers get the same defaults
 // applied here as a safety net.
 func NewRunner(s *Sync) (*Runner, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	if s.MaxConnections == 0 {
+		s.MaxConnections = dbconn.DefaultMaxConnections
+	}
 	if s.Source != nil && s.Applier == nil {
 		return nil, errors.New("Sync.Source requires Sync.Applier to also be set; the injected change.Source needs the same applier the copier uses")
 	}
@@ -253,7 +259,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	//     design (e.g. a Vitess/PlanetScale replica), so it must not fire.
 	r.sourceDBConfig.ForceKill = false
 	r.sourceDBConfig.RejectReadOnly = false
-	r.sourceDBConfig.MaxOpenConnections = 100
+	r.sourceDBConfig.MaxOpenConnections = r.sync.MaxConnections
 
 	// The target is written to (table creation, the copy/apply, the
 	// checkpoint, and CREATE DATABASE on the admin connection), so it keeps the
@@ -264,7 +270,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// the source are applied (no cutover here either, so ForceKill is left at
 	// its default but never fires).
 	r.targetDBConfig = dbconn.NewDBConfig()
-	r.targetDBConfig.MaxOpenConnections = 100
+	r.targetDBConfig.MaxOpenConnections = r.sync.MaxConnections
 
 	// Open the source SQL connection. Even when the change feed is an
 	// injected non-MySQL source, spirit still needs SQL access to the
@@ -306,6 +312,10 @@ func (r *Runner) Run(ctx context.Context) error {
 		r.target = applier.Target{KeyRange: "0", DB: tdb, Config: tcfg}
 		r.ownsTarget = true
 	}
+
+	// Apply the budget to an injected target handle as well. Custom appliers
+	// retain ownership of any additional connections they create.
+	dbconn.SetPoolSize(r.target.DB, r.sync.MaxConnections)
 
 	if err := dbconn.RequireDifferentDatabase(ctx, r.source.db, r.target.DB); err != nil {
 		return err

--- a/pkg/datasync/sync.go
+++ b/pkg/datasync/sync.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/utils"
 )
 
@@ -41,8 +42,10 @@ import (
 // programmatic callers (e.g. strata's Vitess/PlanetScale import) that
 // inject a non-MySQL change source and/or a custom applier.
 type Sync struct {
-	SourceDSN string `name:"source-dsn" help:"Where to sync the tables from." default:"spirit:spirit@tcp(127.0.0.1:3306)/src"`
-	TargetDSN string `name:"target-dsn" help:"Where to sync the tables to." default:"spirit:spirit@tcp(127.0.0.1:3306)/dest"`
+	// MaxConnections limits each SQL pool; worker counts do not expand it.
+	MaxConnections int    `name:"max-connections" help:"Size of each source and target SQL connection pool. Workers share the pool and contend for connections." default:"128"`
+	SourceDSN      string `name:"source-dsn" help:"Where to sync the tables from." default:"spirit:spirit@tcp(127.0.0.1:3306)/src"`
+	TargetDSN      string `name:"target-dsn" help:"Where to sync the tables to." default:"spirit:spirit@tcp(127.0.0.1:3306)/dest"`
 	// TargetChunkSize is the in-memory byte budget the buffered copier sizes each
 	// copy chunk against (see table.DefaultTargetChunkBytes). Sync always uses the
 	// buffered copier. A zero value means "use the default" (the runner fills it
@@ -116,7 +119,7 @@ func (s *Sync) Validate() error {
 	if s.FlushInterval < 0 {
 		return fmt.Errorf("--flush-interval must be non-negative, got %s", s.FlushInterval)
 	}
-	return nil
+	return dbconn.ValidateConnectionLimit(s.MaxConnections)
 }
 
 // Run is the kong CLI entry point. It runs the sync until the process

--- a/pkg/datasync/sync.go
+++ b/pkg/datasync/sync.go
@@ -119,6 +119,8 @@ func (s *Sync) Validate() error {
 	if s.FlushInterval < 0 {
 		return fmt.Errorf("--flush-interval must be non-negative, got %s", s.FlushInterval)
 	}
+	// Continuous sync has no cutover or pinned checksum snapshots, so it
+	// only needs the general limit validation, not finite-run headroom.
 	return dbconn.ValidateConnectionLimit(s.MaxConnections)
 }
 

--- a/pkg/datasync/sync_test.go
+++ b/pkg/datasync/sync_test.go
@@ -124,11 +124,13 @@ func TestSyncE2E(t *testing.T) {
 	}
 
 	s := &Sync{
-		SourceDSN:     sourceDSN,
-		TargetDSN:     targetDSN,
-		Threads:       2,
-		WriteThreads:  2,
-		FlushInterval: 100 * time.Millisecond,
+		SourceDSN:      sourceDSN,
+		TargetDSN:      targetDSN,
+		Threads:        2,
+		WriteThreads:   16,
+		MaxConnections: 2,
+		Target:         &applier.Target{DB: tgt, Config: dest},
+		FlushInterval:  100 * time.Millisecond,
 	}
 	runner, err := NewRunner(s)
 	require.NoError(t, err)
@@ -162,6 +164,10 @@ func TestSyncE2E(t *testing.T) {
 	case <-time.After(60 * time.Second):
 		t.Fatal("sync did not stop within 60s of cancellation")
 	}
+	require.Equal(t, 2, runner.source.db.Stats().MaxOpenConnections)
+	require.Equal(t, 2, runner.target.DB.Stats().MaxOpenConnections)
+	require.Equal(t, 2, runner.sourceDBConfig.MaxOpenConnections)
+	require.Equal(t, 2, runner.targetDBConfig.MaxOpenConnections)
 	require.NoError(t, runner.Close())
 }
 

--- a/pkg/dbconn/pool_budget.go
+++ b/pkg/dbconn/pool_budget.go
@@ -30,7 +30,9 @@ func ValidateMaxConnections(maxConnections, readers, reserve int) error {
 
 // ReadBoundsForPool fits BOTH bounds of a reader pool without growing the
 // connection pool. Checksums pre-open a snapshot transaction per ceiling slot:
-// fitting just the ceiling fails because consumers floor it back to the start.
+// fitting just the ceiling fails because consumers floor it back to the start
+// (see checksum.NewChecker and the copier's resolveReadCeiling). Snapshot
+// creation under one table lock is in SingleChecker.initConnPool.
 // The caller supplies its lifecycle-specific reserve. Unresolved connection
 // limits pass through; a small budget retains one reader so it can progress.
 func ReadBoundsForPool(start, ceiling, maxConnections, reserve int) (int, int) {
@@ -43,7 +45,7 @@ func ReadBoundsForPool(start, ceiling, maxConnections, reserve int) (int, int) {
 
 // ValidateConnectionLimit rejects negative limits, which database/sql would
 // otherwise interpret as unlimited. Zero means the runner should apply its
-// default. Continuous syncs do not require cutover or pinned-snapshot headroom.
+// default.
 func ValidateConnectionLimit(limit int) error {
 	if limit < 0 {
 		return fmt.Errorf("--max-connections must be non-negative, got %d", limit)

--- a/pkg/dbconn/pool_budget.go
+++ b/pkg/dbconn/pool_budget.go
@@ -1,0 +1,52 @@
+package dbconn
+
+import "fmt"
+
+// DefaultMaxConnections is the main pool default for migrations, moves and
+// continuous syncs. Monitor and advisory-lock connections use separate dedicated pools.
+const DefaultMaxConnections = 128
+
+// MinMigrationPoolSize covers the connections that cutover cannot serialize.
+const MinMigrationPoolSize = 5
+
+// ValidateMaxConnections validates an explicit pool budget against
+// pinned checksum readers and runner-specific headroom. Zero is unresolved and
+// is accepted so callers can apply their defaults after validation.
+func ValidateMaxConnections(maxConnections, readers, reserve int) error {
+	if err := ValidateConnectionLimit(maxConnections); err != nil {
+		return err
+	}
+	if maxConnections == 0 {
+		return nil
+	}
+	if maxConnections < MinMigrationPoolSize {
+		return fmt.Errorf("--max-connections must be at least %d for the cutover to run, got %d", MinMigrationPoolSize, maxConnections)
+	}
+	if maxConnections < readers+reserve {
+		return fmt.Errorf("--max-connections (%d) is below what the checksum phase needs: %d pinned read transactions plus %d reserved for off-pool queries, the control plane and the drain; use at least %d, or lower --threads", maxConnections, readers, reserve, readers+reserve)
+	}
+	return nil
+}
+
+// ReadBoundsForPool fits BOTH bounds of a reader pool without growing the
+// connection pool. Checksums pre-open a snapshot transaction per ceiling slot:
+// fitting just the ceiling fails because consumers floor it back to the start.
+// The caller supplies its lifecycle-specific reserve. Unresolved connection
+// limits pass through; a small budget retains one reader so it can progress.
+func ReadBoundsForPool(start, ceiling, maxConnections, reserve int) (int, int) {
+	if maxConnections <= 0 {
+		return start, ceiling
+	}
+	fit := max(1, maxConnections-reserve)
+	return min(start, fit), min(ceiling, fit)
+}
+
+// ValidateConnectionLimit rejects negative limits, which database/sql would
+// otherwise interpret as unlimited. Zero means the runner should apply its
+// default. Continuous syncs do not require cutover or pinned-snapshot headroom.
+func ValidateConnectionLimit(limit int) error {
+	if limit < 0 {
+		return fmt.Errorf("--max-connections must be non-negative, got %d", limit)
+	}
+	return nil
+}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/checksum"
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/migration/check"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
@@ -34,7 +35,7 @@ const defaultThreads = 4
 // This one matters more than most, because it is the pool size itself rather
 // than a knob on one: a programmatic caller that landed somewhere else would be
 // running with a differently-sized pool than the same migration from the CLI.
-const defaultMaxConnections = 128
+const defaultMaxConnections = dbconn.DefaultMaxConnections
 
 var (
 	defaultHost     = "127.0.0.1"
@@ -129,7 +130,7 @@ type Migration struct {
 // Nothing else gets a say. The copy, the checksum and the drain all queue on a
 // small pool and finish eventually, so a low --max-connections is the operator
 // asking for a slow migration, which is theirs to ask for.
-const minPoolSize = 5
+const minPoolSize = dbconn.MinMigrationPoolSize
 
 // Validate is called by Kong after parsing to reject invalid flag values.
 // Zero values mean "use the default" (normalizeOptions fills them in), so they
@@ -153,35 +154,11 @@ func (m *Migration) Validate() error {
 	if m.CheckpointMaxAge < 0 {
 		return fmt.Errorf("--checkpoint-max-age must be non-negative, got %s", m.CheckpointMaxAge)
 	}
-	if m.MaxConnections < 0 {
-		return fmt.Errorf("--max-connections must be non-negative, got %d", m.MaxConnections)
+	threads := m.Threads
+	if threads == 0 {
+		threads = defaultThreads
 	}
-	if m.MaxConnections > 0 {
-		if m.MaxConnections < minPoolSize {
-			return fmt.Errorf("--max-connections must be at least %d for the cutover to run, got %d",
-				minPoolSize, m.MaxConnections)
-		}
-		// The checksum's read transactions each pin a connection for the whole
-		// phase whether or not a worker has one checked out, so the pool has to
-		// hold them *plus* everything that has to keep running alongside them:
-		// the checksum's own off-pool queries, the control plane, and the drain
-		// (see checksumPhaseReserve). A pool that only just fits the
-		// transactions is not a slow checksum, it is a checksum during which the
-		// drain cannot check out a connection at all.
-		//
-		// Threads is read through defaultThreads because zero here means "use
-		// the default" and normalizeOptions has not run yet — validating the 0
-		// would accept a pool that the 4 it becomes cannot run on.
-		threads := m.Threads
-		if threads == 0 {
-			threads = defaultThreads
-		}
-		if pinned := threads + minChecksumPhaseReserve; m.MaxConnections < pinned {
-			return fmt.Errorf("--max-connections (%d) is below what the checksum phase needs: %d pinned read transactions plus %d reserved for off-pool queries, the control plane and the drain; use at least %d, or lower --threads",
-				m.MaxConnections, threads, minChecksumPhaseReserve, pinned)
-		}
-	}
-	return nil
+	return dbconn.ValidateMaxConnections(m.MaxConnections, threads, minChecksumPhaseReserve)
 }
 
 func (m *Migration) Run() error {

--- a/pkg/migration/runner.go
+++ b/pkg/migration/runner.go
@@ -256,44 +256,6 @@ func (r *Runner) checksumPhaseReserve() int {
 // runtime fit in setupCopierCheckerAndReplClient uses the real count.
 const minChecksumPhaseReserve = checksumOffPoolConns + controlPlaneFixedConns + 1 + drainReserveConns
 
-// readBoundsForPool fits a read start and ceiling into the connection pool.
-//
-// Read workers are the one kind that cannot simply queue. The checksum turns the
-// ceiling into transactions, opens all of them serially under the table lock
-// (they must share one snapshot instant, so none can be added later — see
-// SingleChecker.initConnPool), and each holds its connection for the whole phase
-// whether or not a worker has it checked out. A ceiling the pool cannot hold is
-// therefore not a slow checksum, it is one that blocks on connection checkout
-// with a table lock held.
-//
-// The start is fitted along with the ceiling, and that is the whole reason this
-// takes both. A ceiling alone does not survive its consumers: checksum.NewChecker
-// resolves max(Autoscale.MaxThreads, Concurrency) and the copier's
-// resolveReadCeiling does the same, because a pool that begins above its cap
-// cannot be controlled. Both are right on their own terms, so lowering only the
-// ceiling gets floored straight back up to the start and the fit becomes a no-op
-// in exactly the case it was written for — autoscaling, where the start is
-// instance-derived and can be larger than the pool the operator configured.
-//
-// Migration.Validate covers the configured thread count. It cannot cover this
-// one: under autoscaling both numbers come from an instance vCPU count that is
-// only known after the probe, long after flag parsing. And fitting the bounds
-// rather than growing the pool is the right way round, because these are numbers
-// spirit derived for itself while the pool is one the operator gave it.
-//
-// A non-positive maxConnections means no pool size was resolved (a Runner built
-// directly, bypassing normalizeOptions); there is nothing to fit to.
-func readBoundsForPool(start, ceiling, maxConnections, reserve int) (int, int) {
-	if maxConnections <= 0 {
-		return start, ceiling
-	}
-	// At least one reader, even on a pool too small to honour the reserve:
-	// zero read workers is a migration that cannot make progress at all, which
-	// is strictly worse than one contending with its own control plane.
-	fit := max(1, maxConnections-reserve)
-	return min(start, fit), min(ceiling, fit)
-}
-
 func (r *Runner) SetMetricsSink(sink metrics.Sink) {
 	r.metricsSink = sink
 }
@@ -945,7 +907,7 @@ func (r *Runner) setupCopierCheckerAndReplClient(ctx context.Context, resumePosi
 	// floor the ceiling back up to it (see readBoundsForPool). Under autoscaling
 	// this is the number the block above replaced with readStart, so it is
 	// instance-derived and has never been checked against the operator's pool.
-	if fitStart, fitCeiling := readBoundsForPool(r.migration.Threads, maxRead, r.migration.MaxConnections, r.checksumPhaseReserve()); fitStart != r.migration.Threads || fitCeiling != maxRead {
+	if fitStart, fitCeiling := dbconn.ReadBoundsForPool(r.migration.Threads, maxRead, r.migration.MaxConnections, r.checksumPhaseReserve()); fitStart != r.migration.Threads || fitCeiling != maxRead {
 		r.logger.Warn("read thread bounds do not fit the connection pool; capping them",
 			"threads", r.migration.Threads, "capped_threads", fitStart,
 			"read_ceiling", maxRead, "capped_read_ceiling", fitCeiling,

--- a/pkg/migration/runner_pool_test.go
+++ b/pkg/migration/runner_pool_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/block/spirit/pkg/autoscale"
 	"github.com/block/spirit/pkg/change"
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -149,40 +150,40 @@ func TestReadBoundsForPool(t *testing.T) {
 	const reserve = minChecksumPhaseReserve
 
 	// Room to spare: the bounds are whatever was derived.
-	start, ceiling := readBoundsForPool(16, 32, defaultMaxConnections, reserve)
+	start, ceiling := dbconn.ReadBoundsForPool(16, 32, defaultMaxConnections, reserve)
 	require.Equal(t, 16, start)
 	require.Equal(t, 32, ceiling)
 
 	// Exactly enough, counting the reserve the checksum phase cannot run without.
-	start, ceiling = readBoundsForPool(16, 32-reserve, 32, reserve)
+	start, ceiling = dbconn.ReadBoundsForPool(16, 32-reserve, 32, reserve)
 	require.Equal(t, 16, start)
 	require.Equal(t, 32-reserve, ceiling)
 
 	// One short. The ceiling gives way, not the pool: the ceiling is a number
 	// spirit derived for itself, the pool is one the operator set.
-	_, ceiling = readBoundsForPool(16, 32-reserve+1, 32, reserve)
+	_, ceiling = dbconn.ReadBoundsForPool(16, 32-reserve+1, 32, reserve)
 	require.Equal(t, 32-reserve, ceiling)
 
 	// The start is fitted too. This is the case that used to survive the fit:
 	// a 96-vCPU instance derives (24, 48) from autoscale.ReadBounds, the
 	// operator's pool is 20, and both consumers floor the ceiling back up to the
 	// start — so lowering only the ceiling changed nothing.
-	start, ceiling = readBoundsForPool(24, 48, 20, reserve)
+	start, ceiling = dbconn.ReadBoundsForPool(24, 48, 20, reserve)
 	require.Equal(t, 20-reserve, start)
 	require.Equal(t, 20-reserve, ceiling)
 
 	// Never zero readers. A pool too small to honour the reserve still has to
 	// run: contending with the control plane beats not copying at all.
-	start, ceiling = readBoundsForPool(24, 48, reserve, reserve)
+	start, ceiling = dbconn.ReadBoundsForPool(24, 48, reserve, reserve)
 	require.Equal(t, 1, start)
 	require.Equal(t, 1, ceiling)
 
 	// No pool size resolved (a Runner built directly, bypassing
 	// normalizeOptions): there is nothing to fit to, so nothing is changed.
-	start, ceiling = readBoundsForPool(24, 48, 0, reserve)
+	start, ceiling = dbconn.ReadBoundsForPool(24, 48, 0, reserve)
 	require.Equal(t, 24, start)
 	require.Equal(t, 48, ceiling)
-	start, ceiling = readBoundsForPool(24, 48, -1, reserve)
+	start, ceiling = dbconn.ReadBoundsForPool(24, 48, -1, reserve)
 	require.Equal(t, 24, start)
 	require.Equal(t, 48, ceiling)
 }
@@ -210,7 +211,7 @@ func TestReadBoundsSurviveTheirConsumers(t *testing.T) {
 	for _, vCPUs := range []int{16, 32, 64, 96, 128} {
 		for _, maxConnections := range []int{8, 16, 20, 32, 64, defaultMaxConnections} {
 			readStart, readCeiling := autoscale.ReadBounds(vCPUs)
-			start, ceiling := readBoundsForPool(readStart, readCeiling, maxConnections, reserve)
+			start, ceiling := dbconn.ReadBoundsForPool(readStart, readCeiling, maxConnections, reserve)
 
 			// What checksum.NewChecker and copier.resolveReadCeiling resolve to.
 			effective := max(ceiling, start)

--- a/pkg/move/move.go
+++ b/pkg/move/move.go
@@ -6,11 +6,16 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 )
 
 type Move struct {
+	// Each source/target *sql.DB owns a pool at this limit; worker counts do
+	// not grow it. Dedicated monitor/advisory pools are separate.
+	MaxConnections int `name:"max-connections" help:"Size of each source and target connection pool. Workers share the pool and contend for connections." optional:"" default:"128"`
+
 	SourceDSN string `name:"source-dsn" help:"Where to copy the tables from." default:"spirit:spirit@tcp(127.0.0.1:3306)/src"`
 	TargetDSN string `name:"target-dsn" help:"Where to copy the tables to." default:"spirit:spirit@tcp(127.0.0.1:3306)/dest"`
 	// TargetChunkSize is the in-memory byte budget the buffered copier sizes each
@@ -92,7 +97,11 @@ func (m *Move) Validate() error {
 	if m.ReverseWindow < 0 {
 		return fmt.Errorf("--reverse-window must be non-negative, got %s", m.ReverseWindow)
 	}
-	return nil
+	threads := m.Threads
+	if threads == 0 {
+		threads = defaultThreads
+	}
+	return dbconn.ValidateMaxConnections(m.MaxConnections, threads, minChecksumPhaseReserve)
 }
 
 func (m *Move) Run() error {

--- a/pkg/move/move_test.go
+++ b/pkg/move/move_test.go
@@ -52,13 +52,24 @@ func TestBasicMove(t *testing.T) {
 
 	// test
 	move := &Move{
-		SourceDSN:    sourceDSN,
-		TargetDSN:    targetDSN,
-		Threads:      2,
-		WriteThreads: 2,
-		DeferCutOver: false,
+		SourceDSN:      sourceDSN,
+		TargetDSN:      targetDSN,
+		Threads:        2,
+		WriteThreads:   16,
+		MaxConnections: 8,
+		DeferCutOver:   false,
 	}
-	require.NoError(t, move.Run())
+	runner, err := NewRunner(move)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, runner.Close()) })
+	require.NoError(t, runner.Run(t.Context()))
+	require.Equal(t, 8, runner.dbConfig.MaxOpenConnections)
+	for _, source := range runner.sources {
+		require.Equal(t, 8, source.db.Stats().MaxOpenConnections)
+	}
+	for _, target := range runner.targets {
+		require.Equal(t, 8, target.DB.Stats().MaxOpenConnections)
+	}
 }
 func TestResumeFromCheckpointE2E(t *testing.T) {
 	t.Run("deferFalse", func(t *testing.T) { // known to race.

--- a/pkg/move/pool.go
+++ b/pkg/move/pool.go
@@ -1,0 +1,50 @@
+package move
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/block/spirit/pkg/dbconn"
+)
+
+// As in migration, reserve checksum repair/prefetch, checkpoint/flush polling,
+// at least one statistics query, and a drain connection. The runtime reserve
+// adds the remaining per-table statistics queries on each source pool.
+const minChecksumPhaseReserve = 6
+
+func (r *Runner) fitReadThreadsToPools() error {
+	if r.move.MaxConnections <= 0 {
+		return nil
+	}
+	reserve := minChecksumPhaseReserve + max(0, len(r.sourceTables)-1)
+	// Usually each source/target owns a distinct *sql.DB, even when hosts are
+	// shared. Programmatic callers may reuse a handle across targets, however:
+	// DistributedChecker then pins multiple snapshot pools on that handle.
+	uses := make(map[*sql.DB]int)
+	for _, source := range r.sources {
+		uses[source.db]++
+	}
+	for _, target := range r.targets {
+		uses[target.DB]++
+	}
+	copies := 1
+	for db, n := range uses {
+		if db != nil {
+			copies = max(copies, n)
+		}
+	}
+	reserve = max(reserve, copies+2) // snapshot creation holds a lock per occurrence
+	if r.move.MaxConnections < 2*copies+1 {
+		return fmt.Errorf("--max-connections (%d) cannot hold %d checksum snapshot pools and their locks on a shared connection pool", r.move.MaxConnections, copies)
+	}
+	// Preserve at least one reader, matching migration; advisory control-plane
+	// queries may queue when the requested budget cannot cover all headroom.
+	available := max(1, (r.move.MaxConnections-reserve)/copies)
+	ceiling := r.move.Threads
+	start, ceiling := dbconn.ReadBoundsForPool(r.move.Threads, ceiling, available, 0)
+	if start != r.move.Threads || ceiling != r.move.Threads {
+		r.logger.Info("fitting read threads to the connection pool", "threads", start, "max_read_threads", ceiling, "max_connections", r.move.MaxConnections, "reserved", reserve)
+	}
+	r.move.Threads = start
+	return nil
+}

--- a/pkg/move/pool.go
+++ b/pkg/move/pool.go
@@ -3,8 +3,6 @@ package move
 import (
 	"database/sql"
 	"fmt"
-
-	"github.com/block/spirit/pkg/dbconn"
 )
 
 // As in migration, reserve checksum repair/prefetch, checkpoint/flush polling,
@@ -40,10 +38,9 @@ func (r *Runner) fitReadThreadsToPools() error {
 	// Preserve at least one reader, matching migration; advisory control-plane
 	// queries may queue when the requested budget cannot cover all headroom.
 	available := max(1, (r.move.MaxConnections-reserve)/copies)
-	ceiling := r.move.Threads
-	start, ceiling := dbconn.ReadBoundsForPool(r.move.Threads, ceiling, available, 0)
-	if start != r.move.Threads || ceiling != r.move.Threads {
-		r.logger.Info("fitting read threads to the connection pool", "threads", start, "max_read_threads", ceiling, "max_connections", r.move.MaxConnections, "reserved", reserve)
+	start := min(r.move.Threads, available)
+	if start != r.move.Threads {
+		r.logger.Info("fitting read threads to the connection pool", "threads", start, "max_connections", r.move.MaxConnections, "reserved", reserve)
 	}
 	r.move.Threads = start
 	return nil

--- a/pkg/move/pool_test.go
+++ b/pkg/move/pool_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/block/spirit/pkg/applier"
 	"github.com/block/spirit/pkg/dbconn"
+	"github.com/block/spirit/pkg/table"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +40,25 @@ func TestMoveSharedSnapshotPoolBudget(t *testing.T) {
 	require.Equal(t, 1, r.move.Threads)
 	r.targets = append(r.targets, applier.Target{DB: db}, applier.Target{DB: db})
 	require.ErrorContains(t, r.fitReadThreadsToPools(), "checksum snapshot pools")
+}
+
+func TestMoveSharedSnapshotLockReserve(t *testing.T) {
+	r, err := NewRunner(&Move{Threads: 2, MaxConnections: 16})
+	require.NoError(t, err)
+	db := new(sql.DB)
+	for range 5 {
+		r.targets = append(r.targets, applier.Target{DB: db})
+	}
+	// Five locks plus two spare connections reserve seven slots, leaving
+	// nine for five snapshot pools: one reader each, not two.
+	require.NoError(t, r.fitReadThreadsToPools())
+	require.Equal(t, 1, r.move.Threads)
+}
+
+func TestMoveTableStatisticsReserve(t *testing.T) {
+	r, err := NewRunner(&Move{Threads: 4, MaxConnections: 12})
+	require.NoError(t, err) // Parse-time headroom fits, before table discovery.
+	r.sourceTables = make([]*table.TableInfo, 20)
+	require.NoError(t, r.fitReadThreadsToPools())
+	require.Equal(t, 1, r.move.Threads)
 }

--- a/pkg/move/pool_test.go
+++ b/pkg/move/pool_test.go
@@ -1,0 +1,42 @@
+package move
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	"github.com/block/spirit/pkg/applier"
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMoveConnectionBudget(t *testing.T) {
+	r, err := NewRunner(&Move{})
+	require.NoError(t, err)
+	require.Equal(t, dbconn.DefaultMaxConnections, r.move.MaxConnections)
+	field, ok := reflect.TypeFor[Move]().FieldByName("MaxConnections")
+	require.True(t, ok)
+	require.Equal(t, "128", field.Tag.Get("default"))
+	for _, budget := range []int{-1, 4, 7} {
+		require.Error(t, (&Move{Threads: 2, MaxConnections: budget}).Validate())
+	}
+	require.NoError(t, (&Move{Threads: 2, MaxConnections: 8, WriteThreads: 100}).Validate())
+	r.move.MaxConnections = 8
+	r.move.Threads = 16
+	r.move.WriteThreads = 100
+	require.NoError(t, r.fitReadThreadsToPools())
+	require.Equal(t, 2, r.move.Threads)
+	require.Equal(t, 100, r.move.WriteThreads)
+	require.Equal(t, 8, r.move.MaxConnections)
+}
+
+func TestMoveSharedSnapshotPoolBudget(t *testing.T) {
+	r, err := NewRunner(&Move{Threads: 2, MaxConnections: 8})
+	require.NoError(t, err)
+	db := new(sql.DB) // Identity only; this test performs no database operations.
+	r.targets = []applier.Target{{DB: db}, {DB: db}}
+	require.NoError(t, r.fitReadThreadsToPools())
+	require.Equal(t, 1, r.move.Threads)
+	r.targets = append(r.targets, applier.Target{DB: db}, applier.Target{DB: db})
+	require.ErrorContains(t, r.fitReadThreadsToPools(), "checksum snapshot pools")
+}

--- a/pkg/move/runner.go
+++ b/pkg/move/runner.go
@@ -38,6 +38,7 @@ import (
 // Move.WriteThreads, so a programmatic caller that leaves the field unset lands
 // on the same value the CLI does.
 const defaultWriteThreads = 4
+const defaultThreads = 2
 
 var (
 	tableStatUpdateInterval = 5 * time.Minute
@@ -193,6 +194,16 @@ type Runner struct {
 var _ status.Task = (*Runner)(nil)
 
 func NewRunner(m *Move) (*Runner, error) {
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	if m.MaxConnections == 0 {
+		m.MaxConnections = dbconn.DefaultMaxConnections
+	}
+	if m.Threads == 0 {
+		m.Threads = defaultThreads
+	}
+
 	// Normalize CheckpointMaxAge here rather than in a Validate hook:
 	// orchestration callers construct Move programmatically (bypassing the
 	// Kong default of 168h), so a zero value means "use the default". This
@@ -207,16 +218,12 @@ func NewRunner(m *Move) (*Runner, error) {
 		m.TargetChunkSize = table.DefaultTargetChunkBytes
 	}
 	// WriteThreads has no "0 means auto" meaning any more, so fill in the Kong
-	// default; move does not autoscale, so nothing downstream would. Non-positive
-	// rather than zero: MaxOpenConnections is Threads + WriteThreads + 2 below, and
-	// a negative count would make that negative, which SetMaxOpenConns reads as
-	// *unlimited*. Warn on an explicit 0, which used to mean "size from the
-	// instance" and would otherwise silently become 4.
-	if m.WriteThreads <= 0 {
-		if m.WriteThreads == 0 {
-			slog.Default().Warn("--write-threads 0 no longer means auto-size; using the default",
-				"write_threads", defaultWriteThreads)
-		}
+	// default for programmatic callers as well. Warn on
+	// an explicit 0, which used to mean "size from the instance" and would
+	// otherwise silently become 4.
+	if m.WriteThreads == 0 {
+		slog.Default().Warn("--write-threads 0 no longer means auto-size; using the default",
+			"write_threads", defaultWriteThreads)
 		m.WriteThreads = defaultWriteThreads
 	}
 	r := &Runner{
@@ -643,16 +650,8 @@ func (r *Runner) setupDiscovery(ctx context.Context) error {
 func (r *Runner) setupUnderLocks(ctx context.Context) error {
 	var err error
 
-	// Grow connection pools to cover both the copy (read) threads and the apply
-	// (write) threads, in case the pool set before connecting was smaller.
-	if poolSize := r.move.Threads + r.move.WriteThreads + 2; poolSize > r.dbConfig.MaxOpenConnections {
-		r.dbConfig.MaxOpenConnections = poolSize
-		for i := range r.sources {
-			dbconn.SetPoolSize(r.sources[i].db, poolSize)
-		}
-		for i := range r.targets {
-			dbconn.SetPoolSize(r.targets[i].DB, poolSize)
-		}
+	if err := r.fitReadThreadsToPools(); err != nil {
+		return err
 	}
 
 	// Create a single applier instance shared by all repl clients and the copier.
@@ -1116,8 +1115,8 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 
 	r.dbConfig = dbconn.NewDBConfig()
 	// ForceKill is now true by default in NewDBConfig(), no need to set explicitly.
-	// Buffered copier needs more connections due to parallel read/write workers
-	r.dbConfig.MaxOpenConnections = r.move.Threads + r.move.WriteThreads + 2
+	// Worker counts do not grow the configured connection pools.
+	r.dbConfig.MaxOpenConnections = r.move.MaxConnections
 
 	// Build the list of source DSNs. If SourceDSNs is set (N:M), use it.
 	// Otherwise, use SourceDSN as the single source (backward compat).
@@ -1182,6 +1181,12 @@ func (r *Runner) Run(ctx context.Context) (retErr error) {
 			Config:   targetConfig,
 		}}
 		r.logger.Debug("Created single target from TargetDSN")
+	}
+	// Apply the same exact budget to caller-supplied target handles too.
+	for _, target := range r.targets {
+		if target.DB != nil {
+			dbconn.SetPoolSize(target.DB, r.move.MaxConnections)
+		}
 	}
 	// Sort targets by targetKey (addr/dbname/keyrange) for deterministic
 	// ordering. The checkpoint is written to targets[0], so the order must be


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Related to #1212; split out of #1216.

Adds `move --max-connections` and `sync --max-connections`, both defaulting to 128 per source/target SQL pool, matching migration. Worker counts no longer expand move's pools, and supplied target handles receive the same limit. Additional connections owned by custom appliers remain outside this budget.

Migration and move share validation in `pkg/dbconn`, which also hosts migration’s two-bound reader-budget helper. Move fits its single concurrency count directly. Move fits checksum readers to the fixed pool, including shared handles and per-table headroom. Datasync uses ordinary reads without pinned checksum snapshots or cutover, so it accepts smaller pools without applying the finite migration's reader reserve.

Validation: race-enabled MySQL tests cover an eight-connection move with 16 write workers, a two-connection sync with 16 write workers through initial copy and continuous INSERT/UPDATE/DELETE replication, checkpoint resume, configuration defaults/validation, and migration budget regressions. Repository-wide lint is clean.


Review follow-up: regression tests pin the lock reserve for five targets sharing one handle and the additional headroom discovered for a 20-table move. The fitter reports only the concurrency it actually computes; documentation explains runtime reserve growth and links the shared helper to its consumers. Targeted race tests and repository-wide lint pass.
