### PR TITLE
fix(dbconn): read tinyint(1) as an integer, not a bool

### DIFF
--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -538,6 +538,12 @@ func NewWithConnectionType(inputDSN string, config *DBConfig, connectionType str
 // different one fails at connect time with "invalid value / unknown config
 // name", because TLS registries are per-driver package globals rather than
 // anything the DSN carries.
+//
+// This settles TLS and nothing else. The settings a spirit connection also
+// needs — interpolation, cleartext-password gating, integer tinyint(1) — are
+// applied by newDSN, so they reach a connection only via [New]. Spirit's own
+// replica path passes this result to [NewWithConnectionType] for exactly that
+// reason; a consumer that opens the result directly owns the rest itself.
 func EnhanceDSNWithTLS(inputDSN string, config *DBConfig) (string, error) {
 	// A nil config is "the caller said nothing about TLS", which is not the
 	// same as asking for none: leave the DSN alone and let whatever opens it

--- a/pkg/dbconn/conn.go
+++ b/pkg/dbconn/conn.go
@@ -392,6 +392,16 @@ func newDSN(dsn string, config *DBConfig) (string, error) {
 	// and its default-off are gone — so the blue/green and Aurora-failover
 	// protection spirit used to opt into is now simply how the driver behaves.
 	cfg.InterpolateParams = config.InterpolateParams
+	// Report tinyint(1) as an integer rather than a bool. The (1) is a display
+	// width, not a range — the column holds the whole signed tinyint range —
+	// but the driver maps every signed tinyint(1) to a Go bool by default,
+	// collapsing any non-zero value to true. The copier reads rows back into
+	// Go to build its INSERT, so that collapse would write 1 in place of a
+	// stored 2, and the information is gone by the time spirit sees the value:
+	// no amount of care further up can recover it.
+	if err := cfg.Apply(mysql.TinyInt1IsBool(false)); err != nil {
+		return "", fmt.Errorf("could not disable tinyInt1IsBool: %w", err)
+	}
 	// Allow cleartext password authentication only when the connection is
 	// actually encrypted (required for AWS RDS IAM auth, safe because the
 	// connection uses TLS).

--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -111,6 +111,32 @@ func TestNewDSNAllowNativePasswords(t *testing.T) {
 		"DSN must not contain allowNativePasswords=false")
 }
 
+func TestNewDSNDisablesTinyInt1IsBool(t *testing.T) {
+	// The driver maps a signed tinyint(1) to a Go bool by default, which
+	// collapses every non-zero value to true. The copier reads rows back into
+	// Go to build its INSERT, so spirit must always ask for integers: a stored
+	// 2 would otherwise be written as 1, and the value is unrecoverable by the
+	// time spirit sees it.
+	dsn := "root:password@tcp(127.0.0.1:3306)/test"
+
+	for _, tlsMode := range []string{"PREFERRED", "DISABLED"} {
+		t.Run(tlsMode, func(t *testing.T) {
+			config := NewDBConfig()
+			config.TLSMode = tlsMode
+			resp, err := newDSN(dsn, config)
+			require.NoError(t, err)
+			require.Contains(t, resp, "tinyInt1IsBool=false",
+				"DSN must disable the driver's tinyint(1)-to-bool mapping")
+
+			// Round-trip it: the flag has to survive parsing, since that is how
+			// the driver actually receives it.
+			cfg, err := mysql.ParseDSN(resp)
+			require.NoError(t, err)
+			require.Contains(t, cfg.FormatDSN(), "tinyInt1IsBool=false")
+		})
+	}
+}
+
 func TestNewDSNAllowCleartextPasswords(t *testing.T) {
 	// With TLS enabled (default PREFERRED mode), AllowCleartextPasswords should be true
 	dsn := "root:password@tcp(127.0.0.1:3306)/test"

--- a/pkg/dbconn/conn_test.go
+++ b/pkg/dbconn/conn_test.go
@@ -117,24 +117,72 @@ func TestNewDSNDisablesTinyInt1IsBool(t *testing.T) {
 	// Go to build its INSERT, so spirit must always ask for integers: a stored
 	// 2 would otherwise be written as 1, and the value is unrecoverable by the
 	// time spirit sees it.
-	dsn := "root:password@tcp(127.0.0.1:3306)/test"
+	//
+	// Assert on the presence of tinyInt1IsBool=false rather than the absence of
+	// =true: the driver's default is true, so FormatDSN only writes the
+	// parameter when it is false. An untouched DSN carries no parameter at all,
+	// which reads as "bool mapping on".
+	inputs := []struct {
+		name string
+		dsn  string
+	}{
+		{"unset", "root:password@tcp(127.0.0.1:3306)/test"},
+		// Spirit requires exact values, so it overrides a caller who asked for
+		// the bool mapping rather than deferring to them.
+		{"caller_asked_for_bool", "root:password@tcp(127.0.0.1:3306)/test?tinyInt1IsBool=true"},
+	}
 
 	for _, tlsMode := range []string{"PREFERRED", "DISABLED"} {
-		t.Run(tlsMode, func(t *testing.T) {
-			config := NewDBConfig()
-			config.TLSMode = tlsMode
-			resp, err := newDSN(dsn, config)
-			require.NoError(t, err)
-			require.Contains(t, resp, "tinyInt1IsBool=false",
-				"DSN must disable the driver's tinyint(1)-to-bool mapping")
+		for _, input := range inputs {
+			t.Run(tlsMode+"/"+input.name, func(t *testing.T) {
+				config := NewDBConfig()
+				config.TLSMode = tlsMode
+				resp, err := newDSN(input.dsn, config)
+				require.NoError(t, err)
+				require.Contains(t, resp, "tinyInt1IsBool=false",
+					"DSN must disable the driver's tinyint(1)-to-bool mapping")
 
-			// Round-trip it: the flag has to survive parsing, since that is how
-			// the driver actually receives it.
-			cfg, err := mysql.ParseDSN(resp)
-			require.NoError(t, err)
-			require.Contains(t, cfg.FormatDSN(), "tinyInt1IsBool=false")
-		})
+				// Round-trip it: the flag has to survive parsing, since that is
+				// how the driver actually receives it.
+				cfg, err := mysql.ParseDSN(resp)
+				require.NoError(t, err)
+				require.Contains(t, cfg.FormatDSN(), "tinyInt1IsBool=false")
+			})
+		}
 	}
+}
+
+// TestConnectionReadsTinyInt1AsInteger proves the setting changes what the
+// driver returns, not just what the DSN says. The assertions above check the
+// DSN text; this checks the behavior every connection spirit opens gets, since
+// New is the single door onto newDSN.
+func TestConnectionReadsTinyInt1AsInteger(t *testing.T) {
+	testutils.RunSQL(t, "DROP TABLE IF EXISTS conn_tinyint1_scan")
+	testutils.RunSQL(t, "CREATE TABLE conn_tinyint1_scan (id INT NOT NULL PRIMARY KEY, flags TINYINT(1) NOT NULL)")
+	testutils.RunSQL(t, "INSERT INTO conn_tinyint1_scan VALUES (1, 0), (2, 1), (3, 2), (4, 127), (5, -128)")
+
+	db, err := New(testutils.DSN(), NewDBConfig())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	rows, err := db.QueryContext(t.Context(), "SELECT id, flags FROM conn_tinyint1_scan ORDER BY id")
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+
+	// Scan into any: a bool here means the driver collapsed the value, which is
+	// exactly what the copier cannot tolerate.
+	want := map[int]int64{1: 0, 2: 1, 3: 2, 4: 127, 5: -128}
+	seen := 0
+	for rows.Next() {
+		var id int
+		var flags any
+		require.NoError(t, rows.Scan(&id, &flags))
+		require.IsType(t, int64(0), flags, "tinyint(1) came back as %T, not an integer", flags)
+		require.Equal(t, want[id], flags, "tinyint(1) value changed for id=%d", id)
+		seen++
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, want, seen, "not every seeded row was read back")
 }
 
 func TestNewDSNAllowCleartextPasswords(t *testing.T) {

--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -1378,3 +1378,91 @@ func requireVectorEquals(t *testing.T, db *sql.DB, info, want string) {
 		want, info).Scan(&got, &expected))
 	require.Equal(t, expected, got, "row %q must hold the vector %s", info, want)
 }
+
+func TestBooleanColumnConcurrentDML(t *testing.T) {
+	t.Parallel()
+
+	// tinyint(1) is the storage for BOOLEAN, and the binlog surfaces such
+	// columns as Go bools rather than integers. A table carrying one must
+	// still replicate writes made during the copy.
+	tt := testutils.NewTestTable(t, "boolean_dml", `CREATE TABLE boolean_dml (
+		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		info VARCHAR(255) NOT NULL,
+		is_active TINYINT(1) NOT NULL,
+		is_archived TINYINT(1) NOT NULL DEFAULT '0'
+	)`)
+
+	testutils.RunSQL(t, `INSERT INTO boolean_dml (info, is_active, is_archived) VALUES
+		('toggle-on', 0, 0),
+		('toggle-off', 1, 1)`)
+	tt.SeedRows(t, "INSERT INTO boolean_dml (info, is_active) SELECT 'bulk', 0", 2000)
+
+	// Adding a column and an index in one statement leaves Spirit unable to
+	// prove the combination is INSTANT-safe, so it falls back to the copy —
+	// which is what puts the boolean values through the binlog applier.
+	m := NewTestRunner(t, "boolean_dml",
+		"ADD COLUMN ref_code VARCHAR(64) COLLATE utf8mb4_bin NULL, ADD INDEX idx_ref_code (ref_code)",
+		WithThreads(1),
+		WithTestThrottler())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	dmlDone := make(chan struct{})
+	go func() {
+		defer close(dmlDone)
+		if !waitForCopyRows(t, ctx, m) {
+			return
+		}
+		for range 50 {
+			if ctx.Err() != nil {
+				return
+			}
+			// Both boolean values must cross the applier: the failure only
+			// reproduces for the value actually present in the row image.
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO boolean_dml (info, is_active, is_archived) VALUES ('insert-during', 1, 0)`)
+			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO boolean_dml (info, is_active, is_archived) VALUES ('insert-during', 0, 1)`)
+			_, _ = tt.DB.ExecContext(ctx, `UPDATE boolean_dml SET is_active = 1 WHERE info = 'toggle-on'`)
+			_, _ = tt.DB.ExecContext(ctx, `UPDATE boolean_dml SET is_active = 0 WHERE info = 'toggle-off'`)
+		}
+	}()
+
+	migrationErr := m.Run(ctx)
+	cancel()
+	<-dmlDone
+	require.NoError(t, m.Close())
+	require.NoError(t, migrationErr, "boolean values written during the copy must replicate through the applier")
+
+	// The UPDATE targets must hold their post-UPDATE values, proving the
+	// binlog UPDATE path replayed rather than the copier's initial image
+	// surviving.
+	requireBoolColumn(t, tt.DB, "toggle-on", 1)
+	requireBoolColumn(t, tt.DB, "toggle-off", 0)
+
+	// Rows inserted during the copy must be present — otherwise the binlog
+	// INSERT path was never exercised and the test is vacuous.
+	var insertCount int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM boolean_dml WHERE info = 'insert-during'`).Scan(&insertCount))
+	require.Positive(t, insertCount, "no concurrent INSERTs reached the binlog path — test is vacuous")
+
+	// Every inserted row must keep the exact pair it was written with, so a
+	// boolean coerced to a constant would fail here.
+	var mismatched int
+	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM boolean_dml
+		 WHERE info = 'insert-during' AND is_active = is_archived`).Scan(&mismatched))
+	require.Zero(t, mismatched, "boolean values inserted during the migration must survive unchanged")
+}
+
+// requireBoolColumn asserts the row identified by info holds want in its
+// is_active column.
+func requireBoolColumn(t *testing.T, db *sql.DB, info string, want int) {
+	t.Helper()
+	// Adding zero forces an integer result: tinyint(1) otherwise reaches the
+	// driver as a bool, which is the same ambiguity this test is about.
+	var got int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`SELECT is_active + 0 FROM boolean_dml WHERE info = ? LIMIT 1`, info).Scan(&got))
+	require.Equal(t, want, got, "row %q must hold is_active=%d", info, want)
+}

--- a/pkg/migration/datatype_test.go
+++ b/pkg/migration/datatype_test.go
@@ -1379,90 +1379,69 @@ func requireVectorEquals(t *testing.T, db *sql.DB, info, want string) {
 	require.Equal(t, expected, got, "row %q must hold the vector %s", info, want)
 }
 
-func TestBooleanColumnConcurrentDML(t *testing.T) {
+func TestTinyInt1ValuesSurviveCopy(t *testing.T) {
 	t.Parallel()
 
-	// tinyint(1) is the storage for BOOLEAN, and the binlog surfaces such
-	// columns as Go bools rather than integers. A table carrying one must
-	// still replicate writes made during the copy.
-	tt := testutils.NewTestTable(t, "boolean_dml", `CREATE TABLE boolean_dml (
+	// The (1) in tinyint(1) is a display width, not a range: the column holds
+	// the whole signed tinyint range. The copier reads rows back into Go to
+	// build its INSERT, and the driver reports a signed tinyint(1) as a Go
+	// bool, so every non-zero value arrives as true. Each value must reach the
+	// new table unchanged.
+	tt := testutils.NewTestTable(t, "tinyint1_copy", `CREATE TABLE tinyint1_copy (
 		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		info VARCHAR(255) NOT NULL,
-		is_active TINYINT(1) NOT NULL,
+		flags TINYINT(1) NOT NULL,
 		is_archived TINYINT(1) NOT NULL DEFAULT '0'
 	)`)
 
-	testutils.RunSQL(t, `INSERT INTO boolean_dml (info, is_active, is_archived) VALUES
-		('toggle-on', 0, 0),
-		('toggle-off', 1, 1)`)
-	tt.SeedRows(t, "INSERT INTO boolean_dml (info, is_active) SELECT 'bulk', 0", 2000)
+	testutils.RunSQL(t, `INSERT INTO tinyint1_copy (info, flags, is_archived) VALUES
+		('zero', 0, 0),
+		('one', 1, 1),
+		('two', 2, 0),
+		('max', 127, 1),
+		('min', -128, 0)`)
+	tt.SeedRows(t, "INSERT INTO tinyint1_copy (info, flags) SELECT 'bulk', 3", 2000)
 
 	// Adding a column and an index in one statement leaves Spirit unable to
-	// prove the combination is INSTANT-safe, so it falls back to the copy —
-	// which is what puts the boolean values through the binlog applier.
-	m := NewTestRunner(t, "boolean_dml",
+	// prove the combination is INSTANT-safe, so the table is copied — which is
+	// what puts every stored value through the driver and back.
+	m := NewTestRunner(t, "tinyint1_copy",
 		"ADD COLUMN ref_code VARCHAR(64) COLLATE utf8mb4_bin NULL, ADD INDEX idx_ref_code (ref_code)",
 		WithThreads(1),
 		WithTestThrottler())
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	dmlDone := make(chan struct{})
-	go func() {
-		defer close(dmlDone)
-		if !waitForCopyRows(t, ctx, m) {
-			return
-		}
-		for range 50 {
-			if ctx.Err() != nil {
-				return
-			}
-			// Both boolean values must cross the applier: the failure only
-			// reproduces for the value actually present in the row image.
-			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO boolean_dml (info, is_active, is_archived) VALUES ('insert-during', 1, 0)`)
-			_, _ = tt.DB.ExecContext(ctx, `INSERT INTO boolean_dml (info, is_active, is_archived) VALUES ('insert-during', 0, 1)`)
-			_, _ = tt.DB.ExecContext(ctx, `UPDATE boolean_dml SET is_active = 1 WHERE info = 'toggle-on'`)
-			_, _ = tt.DB.ExecContext(ctx, `UPDATE boolean_dml SET is_active = 0 WHERE info = 'toggle-off'`)
-		}
-	}()
-
-	migrationErr := m.Run(ctx)
-	cancel()
-	<-dmlDone
+	require.NoError(t, m.Run(t.Context()))
 	require.NoError(t, m.Close())
-	require.NoError(t, migrationErr, "boolean values written during the copy must replicate through the applier")
 
-	// The UPDATE targets must hold their post-UPDATE values, proving the
-	// binlog UPDATE path replayed rather than the copier's initial image
-	// surviving.
-	requireBoolColumn(t, tt.DB, "toggle-on", 1)
-	requireBoolColumn(t, tt.DB, "toggle-off", 0)
+	for _, tc := range []struct {
+		info string
+		want int
+	}{
+		{"zero", 0},
+		{"one", 1},
+		{"two", 2},
+		{"max", 127},
+		{"min", -128},
+	} {
+		requireTinyInt1(t, tt.DB, tc.info, tc.want)
+	}
 
-	// Rows inserted during the copy must be present — otherwise the binlog
-	// INSERT path was never exercised and the test is vacuous.
-	var insertCount int
+	// Every bulk row carries 3. Collapsing the column to a boolean rewrites
+	// them all to 1, which a single-row assertion could not distinguish from
+	// a chunk boundary effect.
+	var rewritten int
 	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
-		`SELECT COUNT(*) FROM boolean_dml WHERE info = 'insert-during'`).Scan(&insertCount))
-	require.Positive(t, insertCount, "no concurrent INSERTs reached the binlog path — test is vacuous")
-
-	// Every inserted row must keep the exact pair it was written with, so a
-	// boolean coerced to a constant would fail here.
-	var mismatched int
-	require.NoError(t, tt.DB.QueryRowContext(t.Context(),
-		`SELECT COUNT(*) FROM boolean_dml
-		 WHERE info = 'insert-during' AND is_active = is_archived`).Scan(&mismatched))
-	require.Zero(t, mismatched, "boolean values inserted during the migration must survive unchanged")
+		`SELECT COUNT(*) FROM tinyint1_copy WHERE info = 'bulk' AND flags <> 3`).Scan(&rewritten))
+	require.Zero(t, rewritten, "copied tinyint(1) values must not be coerced to 0/1")
 }
 
-// requireBoolColumn asserts the row identified by info holds want in its
-// is_active column.
-func requireBoolColumn(t *testing.T, db *sql.DB, info string, want int) {
+// requireTinyInt1 asserts the row identified by info holds want in its flags
+// column.
+func requireTinyInt1(t *testing.T, db *sql.DB, info string, want int) {
 	t.Helper()
 	// Adding zero forces an integer result: tinyint(1) otherwise reaches the
-	// driver as a bool, which is the same ambiguity this test is about.
+	// driver as a bool, which is the coercion under test.
 	var got int
 	require.NoError(t, db.QueryRowContext(t.Context(),
-		`SELECT is_active + 0 FROM boolean_dml WHERE info = ? LIMIT 1`, info).Scan(&got))
-	require.Equal(t, want, got, "row %q must hold is_active=%d", info, want)
+		`SELECT flags + 0 FROM tinyint1_copy WHERE info = ? LIMIT 1`, info).Scan(&got))
+	require.Equal(t, want, got, "row %q must hold flags=%d", info, want)
 }

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -96,10 +96,19 @@ func NewDatum(val any, tp datumTp) (Datum, error) {
 			// do nothing
 		case int:
 			val = int64(v)
+		case bool:
+			// BOOLEAN is an alias for tinyint(1), and the binlog surfaces such
+			// columns as Go bools. MySQL stores TRUE as 1 and FALSE as 0.
+			if v {
+				val = int64(1)
+			} else {
+				val = int64(0)
+			}
 		default:
-			val, err = strconv.ParseInt(fmt.Sprint(val), 10, 64)
+			original := val
+			val, err = strconv.ParseInt(fmt.Sprint(original), 10, 64)
 			if err != nil {
-				return Datum{}, fmt.Errorf("could not convert datum to int64: value=%v, error=%w", val, err)
+				return Datum{}, fmt.Errorf("could not convert datum to int64: value=%v, error=%w", original, err)
 			}
 		}
 	case unsignedType:
@@ -120,10 +129,19 @@ func NewDatum(val any, tp datumTp) (Datum, error) {
 			// For int64, a direct cast to uint64 is safe because both are 64-bit types
 			// and the underlying bit pattern is preserved without additional sign extension.
 			val = uint64(v)
+		case bool:
+			// BOOLEAN is an alias for tinyint(1), and the binlog surfaces such
+			// columns as Go bools. MySQL stores TRUE as 1 and FALSE as 0.
+			if v {
+				val = uint64(1)
+			} else {
+				val = uint64(0)
+			}
 		default:
-			val, err = strconv.ParseUint(fmt.Sprint(val), 10, 64)
+			original := val
+			val, err = strconv.ParseUint(fmt.Sprint(original), 10, 64)
 			if err != nil {
-				return Datum{}, fmt.Errorf("could not convert datum to uint64: value=%v, error=%w", val, err)
+				return Datum{}, fmt.Errorf("could not convert datum to uint64: value=%v, error=%w", original, err)
 			}
 		}
 	case binaryType, unknownType:

--- a/pkg/table/datum.go
+++ b/pkg/table/datum.go
@@ -96,14 +96,6 @@ func NewDatum(val any, tp datumTp) (Datum, error) {
 			// do nothing
 		case int:
 			val = int64(v)
-		case bool:
-			// BOOLEAN is an alias for tinyint(1), and the binlog surfaces such
-			// columns as Go bools. MySQL stores TRUE as 1 and FALSE as 0.
-			if v {
-				val = int64(1)
-			} else {
-				val = int64(0)
-			}
 		default:
 			original := val
 			val, err = strconv.ParseInt(fmt.Sprint(original), 10, 64)
@@ -129,14 +121,6 @@ func NewDatum(val any, tp datumTp) (Datum, error) {
 			// For int64, a direct cast to uint64 is safe because both are 64-bit types
 			// and the underlying bit pattern is preserved without additional sign extension.
 			val = uint64(v)
-		case bool:
-			// BOOLEAN is an alias for tinyint(1), and the binlog surfaces such
-			// columns as Go bools. MySQL stores TRUE as 1 and FALSE as 0.
-			if v {
-				val = uint64(1)
-			} else {
-				val = uint64(0)
-			}
 		default:
 			original := val
 			val, err = strconv.ParseUint(fmt.Sprint(original), 10, 64)

--- a/pkg/table/datum_test.go
+++ b/pkg/table/datum_test.go
@@ -182,6 +182,61 @@ func TestDatumInt64ToUnsigned(t *testing.T) {
 	require.Equal(t, uint64(math.MaxInt64), d3.Val)
 }
 
+func TestDatumBoolToInt(t *testing.T) {
+	// Test that bool values are correctly converted to integer datums.
+	// This simulates MySQL binlog sending BOOLEAN (tinyint(1)) columns as Go bools.
+
+	d1, err := NewDatum(true, signedType)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), d1.Val)
+	require.Equal(t, "1", d1.String())
+
+	d2, err := NewDatum(false, signedType)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), d2.Val)
+	require.Equal(t, "0", d2.String())
+
+	// An unsigned tinyint column reaches the unsignedType arm instead.
+	d3, err := NewDatum(true, unsignedType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), d3.Val)
+	require.Equal(t, "1", d3.String())
+
+	d4, err := NewDatum(false, unsignedType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), d4.Val)
+	require.Equal(t, "0", d4.String())
+
+	// The applier resolves the column type from the table definition, so
+	// exercise the same entry point it uses. tinyint(1) is signed.
+	d5, err := NewDatumFromValue(true, "tinyint(1)")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), d5.Val)
+	require.Equal(t, "1", d5.String())
+
+	d6, err := NewDatumFromValue(false, "tinyint(1)")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), d6.Val)
+	require.Equal(t, "0", d6.String())
+
+	d7, err := NewDatumFromValue(true, "tinyint(1) unsigned")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), d7.Val)
+	require.Equal(t, "1", d7.String())
+}
+
+func TestDatumConversionErrorReportsValue(t *testing.T) {
+	// A value that genuinely cannot be converted must name itself in the
+	// error, so the offending input is identifiable from the message alone.
+	_, err := NewDatum("not-a-number", signedType)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value=not-a-number")
+
+	_, err = NewDatum("not-a-number", unsignedType)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value=not-a-number")
+}
+
 func TestKeyBelowLowWatermarkWithNegativeInt32(t *testing.T) {
 	ti := &TableInfo{
 		SchemaName:        "test",

--- a/pkg/table/datum_test.go
+++ b/pkg/table/datum_test.go
@@ -182,49 +182,6 @@ func TestDatumInt64ToUnsigned(t *testing.T) {
 	require.Equal(t, uint64(math.MaxInt64), d3.Val)
 }
 
-func TestDatumBoolToInt(t *testing.T) {
-	// Test that bool values are correctly converted to integer datums.
-	// This simulates MySQL binlog sending BOOLEAN (tinyint(1)) columns as Go bools.
-
-	d1, err := NewDatum(true, signedType)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), d1.Val)
-	require.Equal(t, "1", d1.String())
-
-	d2, err := NewDatum(false, signedType)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), d2.Val)
-	require.Equal(t, "0", d2.String())
-
-	// An unsigned tinyint column reaches the unsignedType arm instead.
-	d3, err := NewDatum(true, unsignedType)
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), d3.Val)
-	require.Equal(t, "1", d3.String())
-
-	d4, err := NewDatum(false, unsignedType)
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), d4.Val)
-	require.Equal(t, "0", d4.String())
-
-	// The applier resolves the column type from the table definition, so
-	// exercise the same entry point it uses. tinyint(1) is signed.
-	d5, err := NewDatumFromValue(true, "tinyint(1)")
-	require.NoError(t, err)
-	require.Equal(t, int64(1), d5.Val)
-	require.Equal(t, "1", d5.String())
-
-	d6, err := NewDatumFromValue(false, "tinyint(1)")
-	require.NoError(t, err)
-	require.Equal(t, int64(0), d6.Val)
-	require.Equal(t, "0", d6.String())
-
-	d7, err := NewDatumFromValue(true, "tinyint(1) unsigned")
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), d7.Val)
-	require.Equal(t, "1", d7.String())
-}
-
 func TestDatumConversionErrorReportsValue(t *testing.T) {
 	// A value that genuinely cannot be converted must name itself in the
 	// error, so the offending input is identifiable from the message alone.


### PR DESCRIPTION
## Why

A signed `tinyint(1)` never reaches spirit as an integer. The driver maps it to a
Go `bool` by default (`tinyInt1IsBool`), and the copier reads rows back into Go to
build its `INSERT`, so `NewDatum` is handed a `bool` for a column it expects to be
numeric:

```
failed to convert value to datum for column is_active:
  could not convert datum to int64: strconv.ParseInt: parsing "false": invalid syntax
```

A table that merely *contains* a `tinyint(1)` therefore fails any copy-path ALTER,
whichever columns are being altered. It fails closed, so nothing is left
half-applied.

## Where the fix goes

Converting the `bool` to 1/0 inside `NewDatum` is the obvious fix and it is wrong.
The `(1)` in `tinyint(1)` is a *display width*, not a range: the column holds the
whole signed tinyint range, and the driver collapses every non-zero value to
`true`. By the time spirit sees the value the distinction is already gone, so
nothing above the driver can recover it — mapping `true` back to `1` would write
`1` over a stored `2`.

```
Before                              After

 tinyint(1) = 2                      tinyint(1) = 2
       │                                   │
       ▼                                   ▼
 driver: tinyInt1IsBool               driver: tinyInt1IsBool
   (default on)                         disabled
       │                                   │
       ▼                                   ▼
    Go bool true                       Go int64 2
       │                                   │
       ▼                                   ▼
 NewDatum: no bool case              NewDatum: signed arm
       │                                   │
       ▼                                   ▼
   ParseInt("true")                     Datum 2
     → migration fails                     │
                                           ▼
                                   _t_new gets 2
```

So the fix is to stop the coercion at the driver: spirit asks for integers on
every connection it opens. `NewDatum` is left alone — with the driver reporting
integers, a `bool` arriving there would mean an unknown new source of lossy
values, and hitting the `default` arm and failing loudly is the behavior we want.

## What

- `newDSN` applies `TinyInt1IsBool(false)`, so every spirit connection — copier,
  checksum recopy, binlog applier — reads `tinyint(1)` as an integer.
- The conversion error now reports its input. `val` was reassigned by `ParseInt`
  before the message was built, so it always read `value=0` and the offending
  value survived only inside the wrapped `strconv` error.

## Tests

`TestTinyInt1ValuesSurviveCopy` copies a table whose `tinyint(1)` column holds
`0, 1, 2, 127, -128` plus 2000 rows of `3`, and asserts every value is unchanged
afterwards. It distinguishes all three states:

| code | result |
|---|---|
| before this PR | `parsing "false": invalid syntax` — the reported failure |
| coercing bool→1/0 in `NewDatum` | checksum differs on all 3 attempts; migration fails after the full copy |
| this PR | passes |

`TestNewDSNDisablesTinyInt1IsBool` pins the DSN property directly, on both the
TLS-enabled and TLS-disabled paths, since that is the whole safety argument.
`TestDatumConversionErrorReportsValue` covers the error text.

---

*Opened by Claude (Opus 5).*
